### PR TITLE
EZP-27992: Display the name and the email address separately in Content view for Author field

### DIFF
--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -13,11 +13,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzPlatformAdminUiBundle extends Bundle
 {
-    public function getParent()
-    {
-        return 'EzPublishCoreBundle';
-    }
-
     public function build(ContainerBuilder $container)
     {
         /** @var EzPublishCoreExtension $core */

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -1,5 +1,7 @@
 system:
     admin:
+        user:
+            login_template: "@EzPlatformAdminUi/Security/login.html.twig"
         content_view:
             full:
                 default:

--- a/src/bundle/Resources/views/content/tab/content.html.twig
+++ b/src/bundle/Resources/views/content/tab/content.html.twig
@@ -8,7 +8,9 @@
                     {% if ez_is_field_empty(content, fieldDefinition.identifier) %}
                         <em>{{'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty')}}</em>
                     {% else %}
-                        {{ ez_render_field(content, fieldDefinition.identifier) }}
+                        {{ ez_render_field(content, fieldDefinition.identifier, {
+                            template: '@EzPlatformAdminUi/content_fields.html.twig'
+                        }) }}
                     {% endif %}
                 </div>
             </div>

--- a/src/bundle/Resources/views/content_fields.html.twig
+++ b/src/bundle/Resources/views/content_fields.html.twig
@@ -1,0 +1,13 @@
+{% extends '@EzPublishCore/content_fields.html.twig' %}
+
+{% block ezauthor_field %}
+    {% spaceless %}
+        {% if field.value.authors|length() > 0 %}
+            <ul {{ block( 'field_attributes' ) }}>
+                {% for author in field.value.authors %}
+                    <li>{{ author.name }} &lt;<a href="mailto:{{ author.email|escape( 'url' ) }}">{{ author.email }}</a>&gt;</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27992

# Description
This PR contains patch for the EZP-27992: "Content view for Author field - Display the name and the email address separately"

Notes for reviewers:
* Original JIRA ticket don't take into consideration that editor can specify multiple authors
* Removed redundant inheritance from EzPublishCoreBundle, because it causes infinite recursion if `content fields.html.twig` extends `@EzPublishCore/content_fields.html.twig`