### PR TITLE
[Composer] Fixed ezpublish-kernel ^7.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ezsystems/ezpublish-kernel": "7.0.x-dev as 6.99.x-dev",
         "ezsystems/repository-forms": "^2.0@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.0@dev",
-        "ezsystems/ez-support-tools": "^0.1",
+        "ezsystems/ez-support-tools": "^0.1@dev",
         "knplabs/knp-menu-bundle": "^2.1"   
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4@beta",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "7.0.x-dev as 6.99.x-dev",
+        "ezsystems/ezpublish-kernel": "^7.0@dev",
         "ezsystems/repository-forms": "^2.0@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.0@dev",
         "ezsystems/ez-support-tools": "^0.1@dev",


### PR DESCRIPTION
So far we had to use workaround to require kernel 7.0 (`7.0.x-dev as 6.99.x-dev`).
Recent updates of version constraints via:
- ezsystems/ez-support-tools#24
- ezsystems/ezplatform-http-cache#16

allows to require simply `^7.0@dev`.
Note that `@dev` is needed for this package due to `minimum-stability`.

This is hopefully the last step before it can be fixed for `ezplatform:2.0` meta-repository.

**TODO**:
- [x] Update `ezpublish-kernel` dependency version constraint
- [x] Update `ez-support-tools` dependency version constraint to use `@dev` as recent change is in `master` only.