### PR TITLE
Removed hardcoded language_code from content type create/edit/view templates

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -18,9 +18,6 @@
     } %}
 {% endblock %}
 
-{# FIXME: Hardcoded language code #}
-{% set language_code = 'eng-GB' %}
-
 {% block content %}
     {{ form_start(form) }}
 
@@ -46,6 +43,7 @@
                 Field definitions
             </div>
             <div class="card-body">
+                {% set language_code = content_type.mainLanguageCode %}
                 {% for field_definition in form.fieldDefinitionsData %}
                     {% set value = field_definition.vars.value %}
 

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -18,9 +18,6 @@
     } %}
 {% endblock %}
 
-{# FIXME: Hardcoded language code #}
-{% set language_code = 'eng-GB' %}
-
 {% block content %}
     {{ form_start(form) }}
 
@@ -46,6 +43,7 @@
                 Field definitions
             </div>
             <div class="card-body">
+                {% set language_code = content_type.mainLanguageCode %}
                 {% for field_definition in form.fieldDefinitionsData %}
                     {% set value = field_definition.vars.value %}
 

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -18,8 +18,7 @@
     } %}
 {% endblock %}
 
-{# FIXME: Hardcoded language code #}
-{% set language_code = 'eng-GB' %}
+{% set language_code = content_type.mainLanguageCode %}
 
 {% block content %}
     <section class="container mt-4">


### PR DESCRIPTION
> JIRA: -

## Description 

Removed hardcoded `language_code` from `src/bundle/Resources/admin/content_type/{create,edit,view}.html.twig`. 

Disclaimer: we don't support translating content types in UI yet, so in fact we always use `mainLanguageCode`  