### PR TITLE
EZP-28159: Missing CSRF token field in the content type create/edit form

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -121,5 +121,6 @@
         </div>
     </section>
 
+    {{ form_widget(form._token) }}
     {{ form_end(form, {'render_rest': false }) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -121,5 +121,6 @@
         </div>
     </section>
 
+    {{ form_widget(form._token) }}
     {{ form_end(form, {'render_rest': false }) }}
 {% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28159

## Description

This PR adds missing CSRF token field in the content type create/edit form. 

## Steps to reproduce 

1. Go to *Admin* > *Content Types* > *Content*
2. Click *Edit* button right to *Article* 
3. Click *Add field definition*
4. Changed wasn't saved because of missing CSRF token
 