### PR TITLE
EZP-28173: Return value of EzSystems\...\LanguageCreateData::isEnabled() must be of the type boolean, null returned

### DIFF
--- a/src/lib/Form/Data/Language/LanguageCreateData.php
+++ b/src/lib/Form/Data/Language/LanguageCreateData.php
@@ -15,7 +15,7 @@ class LanguageCreateData
     private $languageCode;
 
     /** @var bool */
-    private $enabled;
+    private $enabled = true;
 
     /**
      * @return string


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28173

## Description

This PR provide fix for the following error: `Return value of EzSystems\EzPlatformAdminUi\Form\Data\Language\LanguageCreateData::isEnabled() must be of the type boolean, null returned` on create language form.  Besides of this, by default language should be enabled. 

## Steps to reproduce
> 1. Go to Admin > Languages
> 2. Click Create a new Language
