### PR TITLE
EZP-28184: Location View / Relation Tab is broken

### DIFF
--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -4,7 +4,7 @@
     {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.related_content'|trans({'%contentName%' : ez_content_name(content)})|desc('Related content (content items used by %contentName%)') } %}
 
     {% if relations is not empty %}
-        {{ include('@EzPlatformAdminUiBundle:content/tab/relations:table.html.twig', {'relations': relations}) }}
+        {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': relations}) }}
     {% else %}
         <p class="ez-relations-box-list-no-content">
             {{ 'tab.relations.no_relations'|trans()|desc('This content item has no related content.') }}
@@ -14,7 +14,7 @@
     {% if reverse_relations is defined %}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.reverse_relations'|trans({'%contentName%' : ez_content_name(content)})|desc('Reverse relations (content items using %contentName%)') } %}
         {% if reverse_relations is not empty %}
-            {{ include('@EzPlatformAdminUiBundle:content/tab/relations:table.html.twig', {'relations': reverse_relations}) }}
+            {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': reverse_relations}) }}
         {% else %}
             <p class="ez-relations-box-list-no-content">
                 {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}

--- a/src/bundle/Resources/views/content/tab/relations/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table.html.twig
@@ -35,11 +35,11 @@
 </table>
 
 {% macro relation_type(relation) %}
-    {% if relation.type == constant('\eZ\Publish\API\Repository\Values\Content\Relation::COMMON') %}
+    {% if relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::COMMON') %}
         {{ 'tab.relations.table.relation_type.content_level_relation'|trans()|desc('Content level relation') }}
-    {% elseif relation.type == constant('\eZ\Publish\API\Repository\Values\Content\Relation::EMBED') %}
+    {% elseif relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::EMBED') %}
         {{ 'tab.relations.table.relation_type.embed'|trans()|desc('Embed') }}
-    {% elseif relation.type == constant('\eZ\Publish\API\Repository\Values\Content\Relation::LINK') %}
+    {% elseif relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::LINK') %}
         {{ 'tab.relations.table.relation_type.link'|trans()|desc('Link') }}
     {% else %}
         {{ 'tab.relations.table.relation_type.field'|trans()|desc('Field') }}


### PR DESCRIPTION
>JIRA: https://jira.ez.no/browse/EZP-28184

# Description
This PR fixes incorrect calls to `ValueFactory::createRelation` as well as some issues in twig i.e. incorrect constants access (single slashes instead of double), wrong bundle name in include template calls.