### PR TITLE
[Tabs] Fixed Dashboard Tabs services definition

### DIFF
--- a/src/bundle/Resources/config/services/tabs/dashboard.yml
+++ b/src/bundle/Resources/config/services/tabs/dashboard.yml
@@ -1,27 +1,34 @@
 services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-        public: false
-
     EzSystems\EzPlatformAdminUi\Tab\Dashboard\MyDraftsTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        public: false
         tags:
             - { name: ezplatform.tab, group: dashboard-my }
 
     EzSystems\EzPlatformAdminUi\Tab\Dashboard\MyContentTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        public: false
         tags:
             - { name: ezplatform.tab, group: dashboard-my }
 
     EzSystems\EzPlatformAdminUi\Tab\Dashboard\MyMediaTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        public: false
         tags:
             - { name: ezplatform.tab, group: dashboard-my }
 
     EzSystems\EzPlatformAdminUi\Tab\Dashboard\EveryoneMediaTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        public: false
         tags:
             - { name: ezplatform.tab, group: dashboard-everyone }
 
     EzSystems\EzPlatformAdminUi\Tab\Dashboard\EveryoneContentTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        public: false
         tags:
             - { name: ezplatform.tab, group: dashboard-everyone }
 
-    EzSystems\EzPlatformAdminUi\Tab\Dashboard\PagerContentToDataMapper: ~
+    EzSystems\EzPlatformAdminUi\Tab\Dashboard\PagerContentToDataMapper:
+        autowire: true
+        public: false


### PR DESCRIPTION
This PR adds required `parent` definition to services handling rendering Dashboard Tabs.
Unfortunately this means we cannot use `_defaults` in this file and make all services private manually.

This stopped working since Symfony `3.4.0-BETA3` tag, but seems that worked for us by accident as `parent` is needed AFAIK