### PR TITLE
EZP-28190: ContentView should never be cached

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -52,6 +52,8 @@ class ContentViewController extends Controller
 
     public function locationViewAction(ContentView $view)
     {
+        $view->setCacheEnabled(false);
+
         $this->supplyPathLocations($view);
         $this->supplyContentType($view);
         $this->supplyContentActionForms($view);


### PR DESCRIPTION
We can't (and we should not) cache ContentView in admin as it contains CSRF tokens.

Symfony Documentation ref: https://symfony.com/doc/current/http_cache/form_csrf_caching.html