### PR TITLE
Corrected assets paths

### DIFF
--- a/src/bundle/Resources/public/scss/ezplatform-bootstrap.scss
+++ b/src/bundle/Resources/public/scss/ezplatform-bootstrap.scss
@@ -1,8 +1,7 @@
 
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans:400,400i,700,700i');
 @import 'custom';
-//I know, I know... Darek will handle this one
-@import '../../../../../../../../web/assets/vendor/bootstrap/scss/bootstrap.scss';
+@import '../../../../../../ezplatform-admin-ui-assets/Resources/public/vendors/bootstrap/scss/bootstrap.scss';
 
 .form-group {
     margin: 0;

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -68,11 +68,11 @@
         </div>
 
         {%  javascripts
-            'assets/vendor/react/react.min.js'
-            'assets/vendor/react/react-dom.min.js'
-            'assets/vendor/jquery/dist/jquery.min.js'
-            'assets/vendor/popper.js/dist/umd/popper.js'
-            'assets/vendor/bootstrap/dist/js/bootstrap.min.js'
+            'bundles/ezplatformadminuiassets/vendors/react/react.min.js'
+            'bundles/ezplatformadminuiassets/vendors/react/react-dom.min.js'
+            'bundles/ezplatformadminuiassets/vendors/jquery/dist/jquery.min.js'
+            'bundles/ezplatformadminuiassets/vendors/popper.js/dist/umd/popper.min.js'
+            'bundles/ezplatformadminuiassets/vendors/bootstrap/dist/js/bootstrap.min.js'
             'bundles/ezplatformadminuimodules/js/UniversalDiscovery.module.js'
             'bundles/ezplatformadminui/js/scripts/button.trigger.js'
             'bundles/ezplatformadminui/js/scripts/udw/browse.js'


### PR DESCRIPTION
Corrected assets paths. Now the assets come with `ezplatform-admin-ui-assets` instead of being installed while running `bower install` command in the meta repo.