### PR TITLE
EZP-28150: In preview of Content type, field Container shows "yes_no"

### DIFF
--- a/src/bundle/Resources/translations/content.en.xliff
+++ b/src/bundle/Resources/translations/content.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,7 +10,7 @@
         <source>New Version Draft for '%name%' created.</source>
         <target state="new">New Version Draft for '%name%' created.</target>
         <note>key: content.create_draft.success</note>
-        <jms:reference-file line="128">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentController.php</jms:reference-file>
+        <jms:reference-file line="128">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentController.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,306 +10,306 @@
         <source>Creating a new Content Type</source>
         <target state="new">Creating a new Content Type</target>
         <note>key: content_type.breadcrumb.create</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7dd9e32add81dba08bfbaefaac9442a7e7dbb6ae" resname="content_type.breadcrumb.edit">
         <source>Editing Content Type "%identifier%"</source>
         <target state="new">Editing Content Type "%identifier%"</target>
         <note>key: content_type.breadcrumb.edit</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5626938e64bdad8be0c090d0018c868960859d0a" resname="content_type.breadcrumb.view">
         <source>%identifier%</source>
         <target state="new">%identifier%</target>
         <note>key: content_type.breadcrumb.view</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9206d413d4ca7266dace54fde2e1f8d85a4d557" resname="content_type.container">
         <source>Container</source>
         <target state="new">Container</target>
         <note>key: content_type.container</note>
-        <jms:reference-file line="57">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="693f9ade0c2bb6a7c19b6f9b818d96aa23f1e013" resname="content_type.default_availability">
         <source>Default availability</source>
         <target state="new">Default availability</target>
         <note>key: content_type.default_availability</note>
-        <jms:reference-file line="72">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3b3fc626a669a5462ec9fa7c94280a3573d8b106" resname="content_type.default_availability.help">
         <source>Default availability in primary language, if translation is absent</source>
         <target state="new">Default availability in primary language, if translation is absent</target>
         <note>key: content_type.default_availability.help</note>
-        <jms:reference-file line="74">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="74">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d14799b2ac8854ab3f0bb9976258c3db39213d09" resname="content_type.default_availability.value">
         <source>{0} Not available|{1} Available</source>
         <target state="new">{0} Not available|{1} Available</target>
         <note>key: content_type.default_availability.value</note>
-        <jms:reference-file line="77">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="77">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ebf6515da27060877064931a5ac1d5a8540e28d" resname="content_type.default_children_sorting">
         <source>Default property for sorting children</source>
         <target state="new">Default property for sorting children</target>
         <note>key: content_type.default_children_sorting</note>
-        <jms:reference-file line="61">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cefc13177fd81d4c9df6f8e86eb5278fccbe5a5a" resname="content_type.default_sort">
         <source>Default sort order</source>
         <target state="new">Default sort order</target>
         <note>key: content_type.default_sort</note>
-        <jms:reference-file line="67">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="67">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ecc210ad42274409db7ec4e56ba286b487639c6" resname="content_type.delete.success">
         <source>Content type '%name%' deleted.</source>
         <target state="new">Content type '%name%' deleted.</target>
         <note>key: content_type.delete.success</note>
-        <jms:reference-file line="178">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeController.php</jms:reference-file>
+        <jms:reference-file line="178">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2a3cc77cdadcff8883b0022e006e24918307687" resname="content_type.description">
         <source>Description</source>
         <target state="new">Description</target>
         <note>key: content_type.description</note>
-        <jms:reference-file line="45">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="238db0c5dee8ec13199b073f7cc78728f53ffa36" resname="content_type.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: content_type.identifier</note>
-        <jms:reference-file line="41">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="41">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7fddd251857df821bd536dd680e1edbc921790a2" resname="content_type.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: content_type.name</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9e9628fc59643f3167ebe81dfed3e40eecd281c9" resname="content_type.name_schema">
         <source>Content name schema</source>
         <target state="new">Content name schema</target>
         <note>key: content_type.name_schema</note>
-        <jms:reference-file line="49">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="49">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="48d3eb66c0f8928777189eab11eae254866852b2" resname="content_type.update.success">
         <source>Content type '%name%' updated.</source>
         <target state="new">Content type '%name%' updated.</target>
         <note>key: content_type.update.success</note>
-        <jms:reference-file line="138">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeController.php</jms:reference-file>
+        <jms:reference-file line="138">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ab7362c77b22ff8bc0d14eeaae8514b0a683473" resname="content_type.url_alias_schema">
         <source>URL alias name pattern</source>
         <target state="new">URL alias name pattern</target>
         <note>key: content_type.url_alias_schema</note>
-        <jms:reference-file line="53">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f63ade40ae91a9ad39e4be7b9e4f51003f1f4b3" resname="content_type.view.create.title">
         <source>Creating a new Content Type</source>
         <target state="new">Creating a new Content Type</target>
         <note>key: content_type.view.create.title</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7eee653a60490713df6bcf4b847853020b79a1ee" resname="content_type.view.edit.title">
         <source>Editing Content Type "%name%"</source>
         <target state="new">Editing Content Type "%name%"</target>
         <note>key: content_type.view.edit.title</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="803a61fc8cf4e7bdfcf27432bb35e379a4971134" resname="content_type.view.list.action.add">
         <source>Create a Content Type</source>
         <target state="new">Create a Content Type</target>
         <note>key: content_type.view.list.action.add</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c3287b9fccc0b54216e50ba02e3d72e17cc1c92e" resname="content_type.view.list.action.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: content_type.view.list.action.delete</note>
-        <jms:reference-file line="56">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1a2e4ef61d405d0628d8bacdb80d7bbaa11143d5" resname="content_type.view.list.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: content_type.view.list.action.edit</note>
-        <jms:reference-file line="52">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="52">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bef02fc3d41e74bf002af93b413a2a203a04db1a" resname="content_type.view.list.column.id">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: content_type.view.list.column.id</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5a5fe831f20f47949b0a54d76cfa897898794b77" resname="content_type.view.list.column.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: content_type.view.list.column.identifier</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="234d8921b4886a1d76feed234bec3123db55fed4" resname="content_type.view.list.column.modification_date">
         <source>Modification date</source>
         <target state="new">Modification date</target>
         <note>key: content_type.view.list.column.modification_date</note>
-        <jms:reference-file line="18">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="288545756241beae1bdb8aa600b829506bb7acaf" resname="content_type.view.list.column.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: content_type.view.list.column.name</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c8c43d61131312dbeeeac5dc536a4f95154f33d" resname="content_type.view.list.title">
         <source>Content Types</source>
         <target state="new">Content Types</target>
         <note>key: content_type.view.list.title</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc7335e54d834bb6a342bf0bcb113850de4b69f9" resname="content_type.view.view.title">
         <source>"%name%" Content Type</source>
         <target state="new">"%name%" Content Type</target>
         <note>key: content_type.view.view.title</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d74d01091280ceabfb457980ddd459dc841ad957" resname="content_type_group.breadcrumb.add">
         <source>Creating a new Content Type Group</source>
         <target state="new">Creating a new Content Type Group</target>
         <note>key: content_type_group.breadcrumb.add</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="20ee2fba1b6d560dd296bbe696975e92b78ce578" resname="content_type_group.breadcrumb.edit">
         <source>Editing Content Type Group "%identifier%"</source>
         <target state="new">Editing Content Type Group "%identifier%"</target>
         <note>key: content_type_group.breadcrumb.edit</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="83a16866c8ff14a4966553088657aafbb9db8edb" resname="content_type_group.breadcrumb.list">
         <source>Content Types</source>
         <target state="new">Content Types</target>
         <note>key: content_type_group.breadcrumb.list</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="541e02854f7e561d84637ce99ec6fd6e8404bce4" resname="content_type_group.breadcrumb.view">
         <source>%identifier%</source>
         <target state="new">%identifier%</target>
         <note>key: content_type_group.breadcrumb.view</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="03339a9ed2c7a92f0168e1bfbb276e17dcf52794" resname="content_type_group.create.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: content_type_group.create.identifier</note>
-        <jms:reference-file line="27">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b04a9c80f0219d1a12813a8aa4bc532e97653b28" resname="content_type_group.create.submit">
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: content_type_group.create.submit</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="00f7021226b49438a6e4b36cfd212b9553deb762" resname="content_type_group.create.success">
         <source>Content type group '%name%' created.</source>
         <target state="new">Content type group '%name%' created.</target>
         <note>key: content_type_group.create.success</note>
-        <jms:reference-file line="102">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
+        <jms:reference-file line="102">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="eec79e4a9109f28892797768f085eab39eaedc31" resname="content_type_group.delete.submit">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: content_type_group.delete.submit</note>
-        <jms:reference-file line="27">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupDeleteType.php</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d3672fcf2f0e1982152c4e6759bd03143f9f028" resname="content_type_group.delete.success">
         <source>Content type group '%name%' deleted.</source>
         <target state="new">Content type group '%name%' deleted.</target>
         <note>key: content_type_group.delete.success</note>
-        <jms:reference-file line="178">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
+        <jms:reference-file line="178">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2215ce796f8eb3bfc45224e4773b571e71429c3d" resname="content_type_group.update.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: content_type_group.update.identifier</note>
-        <jms:reference-file line="27">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d44e2ddf0ee9d2e6fcb0b4f2c49a2b579d629588" resname="content_type_group.update.submit">
         <source>Update</source>
         <target state="new">Update</target>
         <note>key: content_type_group.update.submit</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ff50d4b8d26d81f538b0ebabc392cbb05b6da162" resname="content_type_group.update.success">
         <source>Content type group '%name%' updated.</source>
         <target state="new">Content type group '%name%' updated.</target>
         <note>key: content_type_group.update.success</note>
-        <jms:reference-file line="141">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
+        <jms:reference-file line="141">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/ContentTypeGroupController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1bd4c745d76ae79ef7e95baea27281fff04e77f6" resname="content_type_group.view.add.title">
         <source>Creating a new Content Type Group</source>
         <target state="new">Creating a new Content Type Group</target>
         <note>key: content_type_group.view.add.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1b6ebace1ed08d4e8de6a84a5523e19b53dfd443" resname="content_type_group.view.edit.title">
         <source>Editing Content Type Group "%identifier%"</source>
         <target state="new">Editing Content Type Group "%identifier%"</target>
         <note>key: content_type_group.view.edit.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8eb8668549f90436db605805680144f4b87c7fc0" resname="content_type_group.view.list.action.add">
         <source>Create a Content Type Group</source>
         <target state="new">Create a Content Type Group</target>
         <note>key: content_type_group.view.list.action.add</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e078a8733eac84a6f85ccb7883df2767d357528e" resname="content_type_group.view.list.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: content_type_group.view.list.action.edit</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd462ce30cd4d0b21393e24ca2c9e974369c1f57" resname="content_type_group.view.list.column.id">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: content_type_group.view.list.column.id</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37d17dd014cd573541f83d4b5b0c4909b66ac7be" resname="content_type_group.view.list.column.identifier">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: content_type_group.view.list.column.identifier</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9522e89ad894375dcf878ae282bdd793946fc375" resname="content_type_group.view.list.title">
         <source>Content Type Groups</source>
         <target state="new">Content Type Groups</target>
         <note>key: content_type_group.view.list.title</note>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1769b5258d896d9ccb207c09e04534ce9a01c571" resname="content_type_group.view.view.title">
         <source>"%identifier%" Content Type Group</source>
         <target state="new">"%identifier%" Content Type Group</target>
         <note>key: content_type_group.view.view.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5cf420af18fd4a8d856fd30bc13aea5039369f9b" resname="form.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
-        <jms:reference-file line="110">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
-        <jms:reference-file line="110">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="110">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="110">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e9deeb426f08a404990a6926d70558955272593" resname="yes_no">
-        <source>yes_no</source>
-        <target state="new">yes_no</target>
+        <source>{0}No|{1}Yes</source>
+        <target state="new">{0}No|{1}Yes</target>
         <note>key: yes_no</note>
-        <jms:reference-file line="58">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,122 +10,122 @@
         <source>No content items. Content items you create will appear here</source>
         <target state="new">No content items. Content items you create will appear here</target>
         <note>key: dashboard.tab.all_content.empty</note>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="50e7fa5609748dabc694245d5a54a77e9d5c7c1f" resname="dashboard.tab.all_media.empty">
         <source>No content items. Media items you create will appear here</source>
         <target state="new">No content items. Media items you create will appear here</target>
         <note>key: dashboard.tab.all_media.empty</note>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c6f10545440752bc7bc2e8142cbea5d265403cd" resname="dashboard.tab.my_content.empty">
         <source>No content items. Content items you create will appear here</source>
         <target state="new">No content items. Content items you create will appear here</target>
         <note>key: dashboard.tab.my_content.empty</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cf10aced822b4dfb2cb519a82ed0adabaa4e480e" resname="dashboard.tab.my_drafts.empty">
         <source>No content items. Draft items you create will appear here</source>
         <target state="new">No content items. Draft items you create will appear here</target>
         <note>key: dashboard.tab.my_drafts.empty</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ef83b3497fae569ba56b6a8ab96004f359ae918" resname="dashboard.tab.my_media.empty">
         <source>No content items. Media items you create will appear here</source>
         <target state="new">No content items. Media items you create will appear here</target>
         <note>key: dashboard.tab.my_media.empty</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e17a8999c9e44b7e8ea1ba0f5cff596ece264da5" resname="dashboard.table.content_type">
         <source>Content Type</source>
         <target state="new">Content Type</target>
         <note>key: dashboard.table.content_type</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="841a1c1c491e1adec03ce7e9476879c4bb32edb7" resname="dashboard.table.contributor">
         <source>Contributor</source>
         <target state="new">Contributor</target>
         <note>key: dashboard.table.contributor</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a857cc58c009830e22845ef1edbd43794206aed" resname="dashboard.table.last_saved">
         <source>Last Saved</source>
         <target state="new">Last Saved</target>
         <note>key: dashboard.table.last_saved</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ccebfdea2e8be0bcae0f3cab3f3db5ef47d71c8" resname="dashboard.table.modified_language">
         <source>Modified Language</source>
         <target state="new">Modified Language</target>
         <note>key: dashboard.table.modified_language</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8ba6a26d5deb87771ede293eccde417dfafb8c67" resname="dashboard.table.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: dashboard.table.name</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/all_media.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_content.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_media.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="783d5adc52cea6b0cc80c2083158297f31a8d59d" resname="dashboard.table.version">
         <source>Version</source>
         <target state="new">Version</target>
         <note>key: dashboard.table.version</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a49a78f944bf1f73f3f7ff9672463bb1abd4a402" resname="everyone">
         <source>Everyone</source>
         <target state="new">Everyone</target>
         <note>key: everyone</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b1c1d8736f20db3fb6c1c66bb1455ed43909f0d8" resname="me">
         <source>Me</source>
         <target state="new">Me</target>
         <note>key: me</note>
-        <jms:reference-file line="18">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/dashboard/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4d3f17636317e532c589f3008d82c263ab5c39d" resname="tab.name.everyone_content">
         <source>Content</source>
         <target state="new">Content</target>
         <note>key: tab.name.everyone_content</note>
-        <jms:reference-file line="53">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/EveryoneContentTab.php</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/EveryoneContentTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="73956c614b0e87aa1d4ae18abb82cdc6e2770bba" resname="tab.name.everyone_media">
         <source>Media</source>
         <target state="new">Media</target>
         <note>key: tab.name.everyone_media</note>
-        <jms:reference-file line="53">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/EveryoneMediaTab.php</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/EveryoneMediaTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fdd56e68fb3a108fce6f8ee4c5a191c0aa8f2996" resname="tab.name.my_content">
         <source>Content</source>
         <target state="new">Content</target>
         <note>key: tab.name.my_content</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyContentTab.php</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyContentTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="30243b16511a7800e3b72f9cd60854548a2cfe1b" resname="tab.name.my_drafts">
         <source>Drafts</source>
         <target state="new">Drafts</target>
         <note>key: tab.name.my_drafts</note>
-        <jms:reference-file line="55">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyDraftsTab.php</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyDraftsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3cd97096c4d5ea83d5591467ab43021b86c65f27" resname="tab.name.my_media">
         <source>Media</source>
         <target state="new">Media</target>
         <note>key: tab.name.my_media</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyMediaTab.php</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/Dashboard/MyMediaTab.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/ezrepoforms_role.en.xliff
+++ b/src/bundle/Resources/translations/ezrepoforms_role.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,49 +10,49 @@
         <source>Update</source>
         <target state="new">Update</target>
         <note>key: policy_create.save</note>
-        <jms:reference-file line="54">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
+        <jms:reference-file line="54">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="05cc1fd4658faa760de6e98cb71e1054157e63a0" resname="policy_delete.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: policy_delete.delete</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyDeleteType.php</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="deab5c91a76488732d0405e72c36702ed2aea3d6" resname="role.policy.all_functions">
         <source>All functions</source>
         <target state="new">All functions</target>
         <note>key: role.policy.all_functions</note>
-        <jms:reference-file line="98">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
+        <jms:reference-file line="98">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d29c07272fff793138cbb6f7dbb41b08a16ff815" resname="role.policy.all_modules">
         <source>All modules</source>
         <target state="new">All modules</target>
         <note>key: role.policy.all_modules</note>
-        <jms:reference-file line="97">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
+        <jms:reference-file line="97">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d4690e1d0c7d2cf0468ab5aa04caa891e1b5efbd" resname="role.policy.all_modules_all_functions">
         <source>All modules / All functions</source>
         <target state="new">All modules / All functions</target>
         <note>key: role.policy.all_modules_all_functions</note>
-        <jms:reference-file line="99">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
+        <jms:reference-file line="99">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyChoiceType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a8bdc606cd0c96a53e2f661f0585029840af4b9" resname="role.policy.available_limitations">
         <source>role.policy.available_limitations</source>
         <target state="new">role.policy.available_limitations</target>
         <note>key: role.policy.available_limitations</note>
-        <jms:reference-file line="68">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
+        <jms:reference-file line="68">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d3c70d265ab037db5ade02a8b738b5981353c7ac" resname="role.policy.type">
         <source>Type</source>
         <target state="new">Type</target>
         <note>key: role.policy.type</note>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca6964415cb051927cf1d4092e4a6f49de0748c0" resname="role.policy.type.choose">
         <source>Choose a type</source>
         <target state="new">Choose a type</target>
         <note>key: role.policy.type.choose</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyUpdateType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/fieldview.en.xliff
+++ b/src/bundle/Resources/translations/fieldview.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,7 +10,7 @@
         <source>This field is empty</source>
         <target state="new">This field is empty</target>
         <note>key: fieldview.field.empty</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/content.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,248 +10,248 @@
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: content_draft_create_type.create</note>
-        <jms:reference-file line="66">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Draft/ContentCreateType.php</jms:reference-file>
-        <jms:reference-file line="59">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Draft/ContentDraftCreateType.php</jms:reference-file>
+        <jms:reference-file line="66">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Draft/ContentCreateType.php</jms:reference-file>
+        <jms:reference-file line="59">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Draft/ContentDraftCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c5edf119facebac72a105963da8db6be47549180" resname="content_location_add_type.add">
         <source>Add location</source>
         <target state="new">Add location</target>
         <note>key: content_location_add_type.add</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Location/ContentLocationAddType.php</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Location/ContentLocationAddType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9e3c743fb052b12d69896a30ee9a6e1bb0c41427" resname="content_location_remove_form.remove">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: content_location_remove_form.remove</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Location/ContentLocationRemoveType.php</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Location/ContentLocationRemoveType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c3800a29144ab27e80a81e100212ccd5fd7e509" resname="content_translation_remove_form.remove">
         <source>Remove translation</source>
         <target state="new">Remove translation</target>
         <note>key: content_translation_remove_form.remove</note>
-        <jms:reference-file line="45">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Translation/TranslationRemoveType.php</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Content/Translation/TranslationRemoveType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ad9197dcdbe88b1a05f099c564dc2b5634f8aa5" resname="ezplatform.language.create.enabled">
         <source>Enabled</source>
         <target state="new">Enabled</target>
         <note>key: ezplatform.language.create.enabled</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="74b72ba5150cd449b231ca3441626aa46bd4622f" resname="ezplatform.language.create.language_code">
         <source>Language code</source>
         <target state="new">Language code</target>
         <note>key: ezplatform.language.create.language_code</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e920869e5863044fa54ffb855890d4e53f42c6b" resname="ezplatform.language.create.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: ezplatform.language.create.name</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ffd97ca1026795d6942cdff21e76596229baa2dd" resname="ezplatform.language.create.save">
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: ezplatform.language.create.save</note>
-        <jms:reference-file line="42">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
+        <jms:reference-file line="42">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aaacfc049425d3dc086d5548dac0a2bb2eabe404" resname="ezplatform.language.delete.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: ezplatform.language.delete.delete</note>
-        <jms:reference-file line="28">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageDeleteType.php</jms:reference-file>
+        <jms:reference-file line="28">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8812f90c2fc0831af508c0971285dc125a68efc7" resname="ezplatform.language.update.enabled">
         <source>Enabled</source>
         <target state="new">Enabled</target>
         <note>key: ezplatform.language.update.enabled</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2ec293c62175282c5a3ff7a75a56093446485dad" resname="ezplatform.language.update.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: ezplatform.language.update.name</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="87ed807e48a8c3fc19eba5338ddbaa91df68d19d" resname="ezplatform.language.update.save">
         <source>Save</source>
         <target state="new">Save</target>
         <note>key: ezplatform.language.update.save</note>
-        <jms:reference-file line="42">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
+        <jms:reference-file line="42">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Language/LanguageUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e1f039c692df803a42d90f2bcd4f763623241bb2" resname="location_copy.copy">
         <source>Copy</source>
         <target state="new">Copy</target>
         <note>key: location_copy.copy</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationCopyType.php</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationCopyType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9e312a8bdc3e0fbfab7bab370f59cb5e44a9af2f" resname="location_move.move">
         <source>Move</source>
         <target state="new">Move</target>
         <note>key: location_move.move</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationMoveType.php</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationMoveType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="796f8196b2bc086fe788e6689a6189c79b8e047e" resname="location_trash_form.trash">
         <source>Send to Trash</source>
         <target state="new">Send to Trash</target>
         <note>key: location_trash_form.trash</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationTrashType.php</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationTrashType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ba9078fe178bd49df6ada9d8357455ee8ff7b3" resname="policy_create.save">
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: policy_create.save</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d3c70d265ab037db5ade02a8b738b5981353c7ac" resname="role.policy.type">
         <source>Type</source>
         <target state="new">Type</target>
         <note>key: role.policy.type</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca6964415cb051927cf1d4092e4a6f49de0748c0" resname="role.policy.type.choose">
         <source>Choose a type</source>
         <target state="new">Choose a type</target>
         <note>key: role.policy.type.choose</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Policy/PolicyCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f11a379ba38d1a4e5fb7de3bc3a2fb76b72fe9dd" resname="role_assignment.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: role_assignment.delete</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentDeleteType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd67db3c5e3f56ce0c899e8858502933c1a5ed70" resname="role_assignment.groups">
         <source>Group</source>
         <target state="new">Group</target>
         <note>key: role_assignment.groups</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="710f8e6ab682db07141d71bc6df5246988a0560f" resname="role_assignment.locations">
         <source>Choose Locations</source>
         <target state="new">Choose Locations</target>
         <note>key: role_assignment.locations</note>
-        <jms:reference-file line="54">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
+        <jms:reference-file line="54">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="90266f1e47b42712e761c7fea00fb8e8c949f37e" resname="role_assignment.save">
         <source>Assign</source>
         <target state="new">Assign</target>
         <note>key: role_assignment.save</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bcd4dbd1300e2309dd541f817fef6bf5fc029d8" resname="role_assignment.sections">
         <source>Section</source>
         <target state="new">Section</target>
         <note>key: role_assignment.sections</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7ed8b44c2b610ecc43a5cc390335657ebf798ebc" resname="role_assignment.users">
         <source>User</source>
         <target state="new">User</target>
         <note>key: role_assignment.users</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleAssignmentCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e36e86d3568ccc02a097560444b35c69c469c531" resname="role_create.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: role_create.name</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleCreateType.php</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="776c77290a994aebb3c657ee11dd2c5cff117dca" resname="role_create.save">
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: role_create.save</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleCreateType.php</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="870a0a274b0ddf96ef4b6ce633dacad31e23e311" resname="role_delete.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: role_delete.delete</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleDeleteType.php</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4c228e578ee76e86bf13d3f8daa8fffa45d6387a" resname="role_update.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: role_update.name</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleUpdateType.php</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="453d030fbc11c10c842807ff213039adfffbe051" resname="role_update.save">
         <source>Update</source>
         <target state="new">Update</target>
         <note>key: role_update.save</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleUpdateType.php</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Role/RoleUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f3a2d2ec4f587435900fdec3f0fb973592b57147" resname="section_content_assign_form.assign">
         <source>Assign content</source>
         <target state="new">Assign content</target>
         <note>key: section_content_assign_form.assign</note>
-        <jms:reference-file line="45">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionContentAssignType.php</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionContentAssignType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="72b286dbf7ede406ec805d27d4ee834b8a159670" resname="section_content_assign_form.locations">
         <source>Assign content</source>
         <target state="new">Assign content</target>
         <note>key: section_content_assign_form.locations</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionContentAssignType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionContentAssignType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d1b71ebb6b86d78f0902fa5a6ef329c070efdad" resname="section_create_form.create">
         <source>Create</source>
         <target state="new">Create</target>
         <note>key: section_create_form.create</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionCreateType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionCreateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="157171a054bf3089d55c971b318b95a26a1cbb92" resname="section_delete_form.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: section_delete_form.delete</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionDeleteType.php</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="54b875a849e645c86904a2c3663c02b2aab86bb4" resname="section_form.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: section_form.identifier</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionType.php</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8e6cb63af5cccaf0b468435ce04fd304aa77e5c" resname="section_form.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: section_form.name</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionType.php</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ecaa9ee7b46159c99796726b8e14693d821e5500" resname="section_update_form.update">
         <source>Update</source>
         <target state="new">Update</target>
         <note>key: section_update_form.update</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionUpdateType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Section/SectionUpdateType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6880a88558bf821ff5ca3266f2f4f42b6d911283" resname="swap_location_form.swap">
         <source>Select content item</source>
         <target state="new">Select content item</target>
         <note>key: swap_location_form.swap</note>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationSwapType.php</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Location/LocationSwapType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="30b0c3c3e5e096a078005be2cc34bca6227ae381" resname="trash_empty_form.empty">
         <source>Delete permanently</source>
         <target state="new">Delete permanently</target>
         <note>key: trash_empty_form.empty</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashEmptyType.php</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashEmptyType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1b05bfd460ef104fc79726b60f1b5872cb0cbc1d" resname="trash_item_restore_form.restore">
         <source>Restore selected</source>
         <target state="new">Restore selected</target>
         <note>key: trash_item_restore_form.restore</note>
-        <jms:reference-file line="49">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashItemRestoreType.php</jms:reference-file>
+        <jms:reference-file line="49">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashItemRestoreType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9842e86d98a92b6afb831334a75a562a239dd70a" resname="trash_item_restore_form.restore_under_new_parent">
         <source>Restore under new parent</source>
         <target state="new">Restore under new parent</target>
         <note>key: trash_item_restore_form.restore_under_new_parent</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashItemRestoreType.php</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Trash/TrashItemRestoreType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3b2ae7aa286887e2fbd2b6e77ca237f9f9109e9b" resname="version_remove_form.remove">
         <source>Remove version</source>
         <target state="new">Remove version</target>
         <note>key: version_remove_form.remove</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Version/VersionRemoveType.php</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/Version/VersionRemoveType.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/language.en.xliff
+++ b/src/bundle/Resources/translations/language.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,163 +10,163 @@
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="afee1c14dce2b30b230a0de49867c19712c3685f" resname="language.code">
         <source>Language code</source>
         <target state="new">Language code</target>
         <note>key: language.code</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="670884ed109bd22b18847ccb016a0faf72470640" resname="language.code.label">
         <source>Language code</source>
         <target state="new">Language code</target>
         <note>key: language.code.label</note>
-        <jms:reference-file line="29">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f04e19e68e7ce4a6948c0b95bee0e28900b274a" resname="language.create.success">
         <source>Language '%name%' created.</source>
         <target state="new">Language '%name%' created.</target>
         <note>key: language.create.success</note>
-        <jms:reference-file line="162">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
+        <jms:reference-file line="162">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c8fcdc1c11d3c1cf2a4380f440ef3d157b68c12" resname="language.delete.success">
         <source>Language '%name%' removed.</source>
         <target state="new">Language '%name%' removed.</target>
         <note>key: language.delete.success</note>
-        <jms:reference-file line="134">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
+        <jms:reference-file line="134">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c028c20c9b353fbd7b71bfef8b4ae3dcbd0d7e4" resname="language.disabled">
         <source>Disabled</source>
         <target state="new">Disabled</target>
         <note>key: language.disabled</note>
-        <jms:reference-file line="49">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="49">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="67f5b766ec64104c9936dc826adf45bdf55f38f9" resname="language.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: language.edit</note>
-        <jms:reference-file line="57">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="61">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="43">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
-        <jms:reference-file line="45">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="43">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0bb8e1a1b26634c005357a45b948b0b28ae6d03" resname="language.edit.title">
         <source>Editing Language "%language%"</source>
         <target state="new">Editing Language "%language%"</target>
         <note>key: language.edit.title</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="065fdff561c25266ec49bbdaf8c5d0bdd6e9dd7f" resname="language.enabled">
         <source>Enabled</source>
         <target state="new">Enabled</target>
         <note>key: language.enabled</note>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="48">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="48">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="11f29ad3c27254c1fea1d685b1961546d4949553" resname="language.enabled.label">
         <source>Enabled</source>
         <target state="new">Enabled</target>
         <note>key: language.enabled.label</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0367aa925124b3d8db3ea8b85ae45ffecdafbf7c" resname="language.form.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: language.form.cancel</note>
-        <jms:reference-file line="64">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="64">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="06869c8162f8a2914b5a5b10af189b8b0a532e7d" resname="language.form.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: language.form.delete</note>
-        <jms:reference-file line="49">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="49">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="acf6ff41e3b9acb2cbbcd4a8e908cf52c08b86af" resname="language.id">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: language.id</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="60c35c78d83e0e32173bc6eda1bd696d223b49bd" resname="language.id.label">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: language.id.label</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec0418b84a04e7ba4b75a65cbd8a395144e8d8e8" resname="language.list">
         <source>Languages</source>
         <target state="new">Languages</target>
         <note>key: language.list</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="24">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="24">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a52961302ce7dfa4a21c5e0bcc239f5a9a36cfe" resname="language.modal.message">
         <source>Do you want to delete language?</source>
         <target state="new">Do you want to delete language?</target>
         <note>key: language.modal.message</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5194109109a1b0a7ac056729d9369fb757e8d9cf" resname="language.modal.title">
         <source>Please confirm</source>
         <target state="new">Please confirm</target>
         <note>key: language.modal.title</note>
-        <jms:reference-file line="54">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="54">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c0ccfb7e7bc6d434ca93e998637fe775ba4a2de0" resname="language.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: language.name</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e033c3bb99a4c1b19b1aaa80c637751afe1f474d" resname="language.name.label">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: language.name.label</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8e4642a0c879921e8bf31752abc577c4bf8d098b" resname="language.new">
         <source>Create a new Language</source>
         <target state="new">Create a new Language</target>
         <note>key: language.new</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ed7e6b485737184b494f399ea010f537c9a741f5" resname="language.new.title">
         <source>Creating a new Language</source>
         <target state="new">Creating a new Language</target>
         <note>key: language.new.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
-        <jms:reference-file line="20">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fba43c054072899f63d3e09cfd9f0a07d8768234" resname="language.update.success">
         <source>Language '%name%' updated.</source>
         <target state="new">Language '%name%' updated.</target>
         <note>key: language.update.success</note>
-        <jms:reference-file line="203">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
+        <jms:reference-file line="203">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1fd8d969dd2111149c482ad69e7af580cb718195" resname="language.view">
         <source>%language%</source>
         <target state="new">%language%</target>
         <note>key: language.view</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8df2798a2851c0d43893e3862f8a2e6e4290b141" resname="language.view.title">
         <source>"%language%" Language</source>
         <target state="new">"%language%" Language</target>
         <note>key: language.view.title</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/location.en.xliff
+++ b/src/bundle/Resources/translations/location.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,37 +10,37 @@
         <source>Location '%name%' copied to location '%location%'</source>
         <target state="new">Location '%name%' copied to location '%location%'</target>
         <note>key: location.copy.success</note>
-        <jms:reference-file line="184">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="184">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9e3a80cf0b00f8a6b7d4e6ba0fa3ace6fe3f1f3" resname="location.create.success">
         <source>Location '%name%' created.</source>
         <target state="new">Location '%name%' created.</target>
         <note>key: location.create.success</note>
-        <jms:reference-file line="375">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="375">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db5b9465108df897937beb4a6fc71ccf1d7a4948" resname="location.delete.success">
         <source>Location '%name%' removed.</source>
         <target state="new">Location '%name%' removed.</target>
         <note>key: location.delete.success</note>
-        <jms:reference-file line="326">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="326">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d5d2fb830ae5b1806bcb908c01f115c93de4eda" resname="location.move.success">
         <source>Location '%name%' moved to location '%location%'</source>
         <target state="new">Location '%name%' moved to location '%location%'</target>
         <note>key: location.move.success</note>
-        <jms:reference-file line="120">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="120">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="20dae8cf8c7cf8972d802224728554706e2b4699" resname="location.swap.success">
         <source>Location '%name%' swaped with location '%location%'</source>
         <target state="new">Location '%name%' swaped with location '%location%'</target>
         <note>key: location.swap.success</note>
-        <jms:reference-file line="237">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="237">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="48699e3e0320623a7ac78df3b808f6341dd7d4c3" resname="location.trash.success">
         <source>Location '%name%' moved to trash.</source>
         <target state="new">Location '%name%' moved to trash.</target>
         <note>key: location.trash.success</note>
-        <jms:reference-file line="279">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
+        <jms:reference-file line="279">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/LocationController.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,395 +10,395 @@
         <source>Choose content type</source>
         <target state="new">Choose content type</target>
         <note>key: content.create.choose_content_type</note>
-        <jms:reference-file line="4">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f599001c1ab9442f20e23d535e1dad8f3b75c337" resname="content.create.select_content_type">
         <source>Select Content Type</source>
         <target state="new">Select Content Type</target>
         <note>key: content.create.select_content_type</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b5180d90c79245ed3e491e6f682842daaa0bec5" resname="content.create.select_language">
         <source>Select language</source>
         <target state="new">Select language</target>
         <note>key: content.create.select_language</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e8851497aae3ba774d163d5fd191fd69ac871c0" resname="content.edit.select_language">
         <source>Select language</source>
         <target state="new">Select language</target>
         <note>key: content.edit.select_language</note>
-        <jms:reference-file line="4">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_edit.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/widgets/content_edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c0b36efcf0ebbe2ac0f9861cae35e12e668cbcc0" resname="tab.details.content_details">
         <source>Content details</source>
         <target state="new">Content details</target>
         <note>key: tab.details.content_details</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e1488d3bb54efc176d8766d3c22751b06890e2f" resname="tab.details.content_id">
         <source>Content ID</source>
         <target state="new">Content ID</target>
         <note>key: tab.details.content_id</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d5236d13b41dc38ee965599754a05e3283b55ae2" resname="tab.details.content_remote_id">
         <source>Content remote ID</source>
         <target state="new">Content remote ID</target>
         <note>key: tab.details.content_remote_id</note>
-        <jms:reference-file line="41">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="41">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc195b32e812b751daa7a3321844c9712e1460ba" resname="tab.details.creator">
         <source>Creator</source>
         <target state="new">Creator</target>
         <note>key: tab.details.creator</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="acc17a8db8d00036233faa9948ad9a496cd621b3" resname="tab.details.last_contributor">
         <source>Last contributor</source>
         <target state="new">Last contributor</target>
         <note>key: tab.details.last_contributor</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="671c2d4e91244548b29e8f293cd8d4d97a3c23bd" resname="tab.details.location_id">
         <source>Location ID</source>
         <target state="new">Location ID</target>
         <note>key: tab.details.location_id</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c391debe9105c6823145ca6c5ec76a252ba5538c" resname="tab.details.location_remote_id">
         <source>Location remote ID</source>
         <target state="new">Location remote ID</target>
         <note>key: tab.details.location_remote_id</note>
-        <jms:reference-file line="42">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="42">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="26bd81ee7b010fa5846859eb4c2464764effeb81" resname="tab.details.published_version">
         <source>Published version</source>
         <target state="new">Published version</target>
         <note>key: tab.details.published_version</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd8ccac573601690d7e364174cf3fb8a931c805e" resname="tab.details.section_details">
         <source>Section details</source>
         <target state="new">Section details</target>
         <note>key: tab.details.section_details</note>
-        <jms:reference-file line="55">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="67ff5cca435b058142e77b820d5d72090fa26346" resname="tab.details.section_id">
         <source>Section ID</source>
         <target state="new">Section ID</target>
         <note>key: tab.details.section_id</note>
-        <jms:reference-file line="62">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="62">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ab2029f0a194849d3f90531f03e37780491d1a6" resname="tab.details.section_identifier">
         <source>Section identifier</source>
         <target state="new">Section identifier</target>
         <note>key: tab.details.section_identifier</note>
-        <jms:reference-file line="61">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="30775f4a9e0512f181cf857fb0f0ea23fe79320d" resname="tab.details.section_name">
         <source>Section name</source>
         <target state="new">Section name</target>
         <note>key: tab.details.section_name</note>
-        <jms:reference-file line="60">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="09fcd5ad39b9c2b778be171f88559f6c117ff48b" resname="tab.details.technical_details">
         <source>Technical details</source>
         <target state="new">Technical details</target>
         <note>key: tab.details.technical_details</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="69ca343732e6be688ff4606c3a9b15d83d531233" resname="tab.details.translations">
         <source>Translations</source>
         <target state="new">Translations</target>
         <note>key: tab.details.translations</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7ac57e88d1f970747986392b6689075ba64cf270" resname="tab.locations.content_locations">
         <source>Content locations</source>
         <target state="new">Content locations</target>
         <note>key: tab.locations.content_locations</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f3aa22262d10e0dcbc4ccfacbf060f9e98fcb05" resname="tab.locations.hidden">
         <source>Hidden</source>
         <target state="new">Hidden</target>
         <note>key: tab.locations.hidden</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd57f6ee339fa6c35e2a75cc760f391676fca490" resname="tab.locations.hidden_by_superior">
         <source>Hidden by superior</source>
         <target state="new">Hidden by superior</target>
         <note>key: tab.locations.hidden_by_superior</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="64554d66c71f33e7d3ac52c75b17717c334ef9dd" resname="tab.locations.main">
         <source>Main</source>
         <target state="new">Main</target>
         <note>key: tab.locations.main</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7514a2a1e82c82fa3a197dc3da8be56a9c68f136" resname="tab.locations.path">
         <source>Path</source>
         <target state="new">Path</target>
         <note>key: tab.locations.path</note>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b5d6fe3a752b0c391bfa751acb7c4c3ac82e2c0c" resname="tab.locations.subitems">
         <source>Sub-items</source>
         <target state="new">Sub-items</target>
         <note>key: tab.locations.subitems</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1932d409236634ffbe828e683f35db760ec25323" resname="tab.locations.visibility">
         <source>Visibility</source>
         <target state="new">Visibility</target>
         <note>key: tab.locations.visibility</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="775b3ea314e2c1d999a586f85fab657c30deaac3" resname="tab.locations.visible">
         <source>Visible</source>
         <target state="new">Visible</target>
         <note>key: tab.locations.visible</note>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7ebde5bee4476cd8cded5625dab8aa4afedf2985" resname="tab.name.content">
         <source>Content</source>
         <target state="new">Content</target>
         <note>key: tab.name.content</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/ContentTab.php</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/ContentTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5d92b84a6c78bd443010f172c47d01ce0dacacd7" resname="tab.name.details">
         <source>Details</source>
         <target state="new">Details</target>
         <note>key: tab.name.details</note>
-        <jms:reference-file line="68">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/DetailsTab.php</jms:reference-file>
+        <jms:reference-file line="68">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/DetailsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc992b410ec56cce18c994806d7518fd47da2caa" resname="tab.name.locations">
         <source>Locations</source>
         <target state="new">Locations</target>
         <note>key: tab.name.locations</note>
-        <jms:reference-file line="66">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/LocationsTab.php</jms:reference-file>
+        <jms:reference-file line="66">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/LocationsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8954433abc5d011c00f81f317c7eebec41fbb1c0" resname="tab.name.relations">
         <source>Relations</source>
         <target state="new">Relations</target>
         <note>key: tab.name.relations</note>
-        <jms:reference-file line="53">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/RelationsTab.php</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/RelationsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b83b391386f47130b2d3ac1869fe27aa8c45fb7" resname="tab.name.translations">
         <source>Translations</source>
         <target state="new">Translations</target>
         <note>key: tab.name.translations</note>
-        <jms:reference-file line="63">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/TranslationsTab.php</jms:reference-file>
+        <jms:reference-file line="63">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/TranslationsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="50741647d206010a8c2ac911901f3c31d6bbfc6a" resname="tab.name.urls">
         <source>URL</source>
         <target state="new">URL</target>
         <note>key: tab.name.urls</note>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/UrlsTab.php</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/UrlsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="337828c348b881920f84d17cc184f4c24e40c894" resname="tab.name.versions">
         <source>Versions</source>
         <target state="new">Versions</target>
         <note>key: tab.name.versions</note>
-        <jms:reference-file line="67">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/VersionsTab.php</jms:reference-file>
+        <jms:reference-file line="68">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/lib/Tab/LocationView/VersionsTab.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="373c6d223e1f346d71cf6cfd85f0fbc3d76ca1d5" resname="tab.relations.no_relations">
         <source>This content item has no related content.</source>
         <target state="new">This content item has no related content.</target>
         <note>key: tab.relations.no_relations</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1c95181a07cb4d7b83aa9b003eb4e8df95c8bfd9" resname="tab.relations.no_reverse_relations">
         <source>This content item has no reverse relations.</source>
         <target state="new">This content item has no reverse relations.</target>
         <note>key: tab.relations.no_reverse_relations</note>
-        <jms:reference-file line="20">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="853cb6f02ff64af4dc6016318eff1c30bd16cc70" resname="tab.relations.related_content">
         <source>Related content (content items used by %contentName%)</source>
         <target state="new">Related content (content items used by %contentName%)</target>
         <note>key: tab.relations.related_content</note>
-        <jms:reference-file line="4">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="797eb29381132df5a71378b71b3237cf9a063b5c" resname="tab.relations.reverse_relations">
         <source>Reverse relations (content items using %contentName%)</source>
         <target state="new">Reverse relations (content items using %contentName%)</target>
         <note>key: tab.relations.reverse_relations</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d667f9ef2cf04ce8966bc908b8930be596925561" resname="tab.relations.table.content_type">
         <source>Content type</source>
         <target state="new">Content type</target>
         <note>key: tab.relations.table.content_type</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e649f067bcea898ef987cd5ebce6a9a6fca570f2" resname="tab.relations.table.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: tab.relations.table.name</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="06422c0c484b663ec929d1049a228a26b9d48476" resname="tab.relations.table.relation_type">
         <source>Relation type</source>
         <target state="new">Relation type</target>
         <note>key: tab.relations.table.relation_type</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8360b13746f836dc7c28998696a69b24ea30b18" resname="tab.relations.table.relation_type.content_level_relation">
         <source>Content level relation</source>
         <target state="new">Content level relation</target>
         <note>key: tab.relations.table.relation_type.content_level_relation</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="79779455bd3c932297c6b8cefdcd1251836525c5" resname="tab.relations.table.relation_type.embed">
         <source>Embed</source>
         <target state="new">Embed</target>
         <note>key: tab.relations.table.relation_type.embed</note>
-        <jms:reference-file line="41">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="41">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a9a16a9516cdda3bc3213bbdf77a02ff04b8fc8" resname="tab.relations.table.relation_type.field">
         <source>Field</source>
         <target state="new">Field</target>
         <note>key: tab.relations.table.relation_type.field</note>
-        <jms:reference-file line="45">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd43dc791bb87dda363d311d449b68d5876392d1" resname="tab.relations.table.relation_type.link">
         <source>Link</source>
         <target state="new">Link</target>
         <note>key: tab.relations.table.relation_type.link</note>
-        <jms:reference-file line="43">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
+        <jms:reference-file line="43">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/relations/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d494d753de03a08f7a10792b727ec88ca74d4913" resname="tab.translations.language_code">
         <source>Language code</source>
         <target state="new">Language code</target>
         <note>key: tab.translations.language_code</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0becdca42cbaa039a6166b8aa778a86657bb362f" resname="tab.translations.language_name">
         <source>Language name</source>
         <target state="new">Language name</target>
         <note>key: tab.translations.language_name</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="852ca97b78e55e9b7734ff3e5a6c1b3fde6eca6f" resname="tab.translations.translation_manger">
         <source>Translation manager</source>
         <target state="new">Translation manager</target>
         <note>key: tab.translations.translation_manger</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d244966cab8b41f92fd5553d8f33f0e1ca8bf85f" resname="tab.urls.custom_url_aliases">
         <source>Custom URL aliases for %contentName%</source>
         <target state="new">Custom URL aliases for %contentName%</target>
         <note>key: tab.urls.custom_url_aliases</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5a1947624cf55689d80d38b7583bac538da641bb" resname="tab.urls.language">
         <source>Language</source>
         <target state="new">Language</target>
         <note>key: tab.urls.language</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="56d218db883ed4cc59dbbca53364dc2e725013e4" resname="tab.urls.no_custom_urls">
         <source>This content item has no custom url aliases.</source>
         <target state="new">This content item has no custom url aliases.</target>
         <note>key: tab.urls.no_custom_urls</note>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c9fdd1434b44a4592626e8fe493c19141aab24d5" resname="tab.urls.no_system_urls">
         <source>This content item has no system urls.</source>
         <target state="new">This content item has no system urls.</target>
         <note>key: tab.urls.no_system_urls</note>
-        <jms:reference-file line="63">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="63">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="902beb4ac170382cb95bd554cb1e763d8fdd413c" resname="tab.urls.system.title">
         <source>System URL</source>
         <target state="new">System URL</target>
         <note>key: tab.urls.system.title</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0de66a25f1019287cf737f27622ca4d05f582764" resname="tab.urls.type">
         <source>Type</source>
         <target state="new">Type</target>
         <note>key: tab.urls.type</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d87d09bd23142580b88dfe4cf987cf0a6b2d993" resname="tab.urls.type.direct">
         <source>Direct</source>
         <target state="new">Direct</target>
         <note>key: tab.urls.type.direct</note>
-        <jms:reference-file line="27">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea8af6bc33d14986b233c0acb340bd122ff0c2bd" resname="tab.urls.type.redirect">
         <source>Redirect</source>
         <target state="new">Redirect</target>
         <note>key: tab.urls.type.redirect</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5028d3abfd74c419dc7a3daee4303b084c94d2e6" resname="tab.urls.url">
         <source>URL</source>
         <target state="new">URL</target>
         <note>key: tab.urls.url</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/urls.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="699b5bf627b908f8d270984ab9a4734a48b28abe" resname="tab.versions.archived_versions">
         <source>Archived versions</source>
         <target state="new">Archived versions</target>
         <note>key: tab.versions.archived_versions</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b098881c168c540aaa9e23417fa38934a70300d6" resname="tab.versions.draft_under_edit">
         <source>Draft under edit</source>
         <target state="new">Draft under edit</target>
         <note>key: tab.versions.draft_under_edit</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cf65ae83fb935858286b91006ff05b9d6d15c4a" resname="tab.versions.no_permission">
         <source>You don't have access to view the content item's versions</source>
         <target state="new">You don't have access to view the content item's versions</target>
         <note>key: tab.versions.no_permission</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f6c48627db1d026d9f3fbc3b5b1cb1b3c60af4b3" resname="tab.versions.published_version">
         <source>Published version</source>
         <target state="new">Published version</target>
         <note>key: tab.versions.published_version</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/tab.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4c27637d649c221e58c6a9629f14a2f75aeed151" resname="tab.versions.table.contributor">
         <source>Contributor</source>
         <target state="new">Contributor</target>
         <note>key: tab.versions.table.contributor</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4c6353b63f5bc2031c8380c4007edf9c5f6be456" resname="tab.versions.table.created">
         <source>Created</source>
         <target state="new">Created</target>
         <note>key: tab.versions.table.created</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="472157bdf440a9c6636057ac194d53029ac589dd" resname="tab.versions.table.last_saved">
         <source>Last saved</source>
         <target state="new">Last saved</target>
         <note>key: tab.versions.table.last_saved</note>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd780839249906bd141cccd8bc58c8043a50acfb" resname="tab.versions.table.modified_language">
         <source>Modified language</source>
         <target state="new">Modified language</target>
         <note>key: tab.versions.table.modified_language</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddc70b29ad8ac6544843566a146ed1ea4ddab817" resname="tab.versions.table.version">
         <source>Version</source>
         <target state="new">Version</target>
         <note>key: tab.versions.table.version</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/versions/table.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,143 +10,143 @@
         <source>Logout</source>
         <target state="new">Logout</target>
         <note>key: authentication.logout</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/parts/navigation.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/parts/navigation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="da44d8915172b0c8a874e26956f44aa5501c7e6b" resname="authentication.password">
         <source>Password</source>
         <target state="new">Password</target>
         <note>key: authentication.password</note>
-        <jms:reference-file line="19">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="19">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0aa238e83585dc76e14fd740d8bc411d7535e78a" resname="authentication.password.placeholder">
         <source>Enter password</source>
         <target state="new">Enter password</target>
         <note>key: authentication.password.placeholder</note>
-        <jms:reference-file line="20">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61bd7b1273177f4d5b83855f3c7afd49bcc73d52" resname="authentication.required">
         <source>Authentication required</source>
         <target state="new">Authentication required</target>
         <note>key: authentication.required</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8785f4abdfdf72fe9001fe0553c6e3a582cfcc08" resname="authentication.submit">
         <source>Login</source>
         <target state="new">Login</target>
         <note>key: authentication.submit</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9143793289ea0e20c3dc9f752d43cc727f2dba01" resname="authentication.username">
         <source>Username</source>
         <target state="new">Username</target>
         <note>key: authentication.username</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d0ee89d9a59fe951f568267da1e9b66f7803e6a1" resname="authentication.username.placeholder">
         <source>Enter login or email</source>
         <target state="new">Enter login or email</target>
         <note>key: authentication.username.placeholder</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d21d07085caa55b0fee2fc054a6878bbdb24ae78" resname="breadcrumb.admin">
         <source>Admin</source>
         <target state="new">Admin</target>
         <note>key: breadcrumb.admin</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
-        <jms:reference-file line="6">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/create.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type/view.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/add.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/list.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/content_type_group/view.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/create.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/list.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/language/view.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5cf420af18fd4a8d856fd30bc13aea5039369f9b" resname="form.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6fa93ef4dfbce97076a254427bb30bf7c5819c5d" resname="search.perform">
         <source>Search</source>
         <target state="new">Search</target>
         <note>key: search.perform</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search_form.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a17e9f4ed416563fc8c3e188509b8eec8a6f7c0" resname="section.modal.message">
         <source>Do you want to delete section?</source>
         <target state="new">Do you want to delete section?</target>
         <note>key: section.modal.message</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27faaef86f94894cd19f80c94148cebc1a5dbfc0" resname="section.modal.title">
         <source>Please confirm</source>
         <target state="new">Please confirm</target>
         <note>key: section.modal.title</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1152c93462d8bed85642b961f01ed63a6f2525ab" resname="tab.locations.location_content_swap">
         <source>Location Content Swap</source>
         <target state="new">Location Content Swap</target>
         <note>key: tab.locations.location_content_swap</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27d429c3dcff70494c4080957b05a9db5255f854" resname="tab.locations.swap_with_another">
         <source>Swap the content item at this location with another</source>
         <target state="new">Swap the content item at this location with another</target>
         <note>key: tab.locations.swap_with_another</note>
-        <jms:reference-file line="6">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e7901a215220faba4d546cd3fb63f3e2a64e849" resname="trash.delete.all.confirm">
         <source>Are you sure you want to permanently delete %trashItemsCount% item(s)?</source>
         <target state="new">Are you sure you want to permanently delete %trashItemsCount% item(s)?</target>
         <note>key: trash.delete.all.confirm</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="48e20c2b09b340ca2e2020edaa30a57c8bc3f26b" resname="trash.delete.all.info">
         <source>This action cannot be reversed</source>
         <target state="new">This action cannot be reversed</target>
         <note>key: trash.delete.all.info</note>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e500e3f1d454e2775bbe89b6267cd77c766df3f1" resname="trash.delete.button.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: trash.delete.button.cancel</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="40288453ad3e95b36719b543af0ffeec57802003" resname="trash.form.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: trash.form.cancel</note>
-        <jms:reference-file line="19">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d207d407b17b38f0acb52606dd827c6b0fbd358b" resname="trash.form.title">
         <source>Please confirm</source>
         <target state="new">Please confirm</target>
         <note>key: trash.form.title</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2720e3018fc8b1158cb728b1d5dc377ef7293b57" resname="trash.modal.message">
         <source>Are you sure you want to send this content item to trash?</source>
         <target state="new">Are you sure you want to send this content item to trash?</target>
         <note>key: trash.modal.message</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/content/modal_location_trash.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/role.en.xliff
+++ b/src/bundle/Resources/translations/role.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,275 +10,275 @@
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d92993cb4cb3690f06c599b5f500a29fa23421c9" resname="policy.add.success">
         <source>New policies in role '%role%' created.</source>
         <target state="new">New policies in role '%role%' created.</target>
         <note>key: policy.add.success</note>
-        <jms:reference-file line="112">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
+        <jms:reference-file line="112">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="196c8d4eec96ca42ccdd3605621d51e2b34b6d85" resname="policy.breadcrumb.add">
         <source>Adding a new Policy</source>
         <target state="new">Adding a new Policy</target>
         <note>key: policy.breadcrumb.add</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a7079c136f19a37dc42a6192fb94a11d19105ad" resname="policy.breadcrumb.edit">
         <source>Editing Policy "%module% / %function%"</source>
         <target state="new">Editing Policy "%module% / %function%"</target>
         <note>key: policy.breadcrumb.edit</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a22274ebbfba3c96c4015fa64112db95d060525" resname="policy.delete.success">
         <source>Policies in role '%role%' removed.</source>
         <target state="new">Policies in role '%role%' removed.</target>
         <note>key: policy.delete.success</note>
-        <jms:reference-file line="201">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
+        <jms:reference-file line="201">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="41bcfef149f877e1abb0ce2cd2aa5afb713ea1de" resname="policy.limitation.identifier_tooltip">
         <source>"%identifier%" Limitation</source>
         <target state="new">"%identifier%" Limitation</target>
         <note>key: policy.limitation.identifier_tooltip</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77e814db3b3f1bd68101d274277bee08d164f0a2" resname="policy.limitation.none">
         <source>None</source>
         <target state="new">None</target>
         <note>key: policy.limitation.none</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
-        <jms:reference-file line="42">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="42">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bb8f2aa78c28aa25b5eade0c7f40c37110110ec5" resname="policy.update.success">
         <source>Policies in role '%role%' updated.</source>
         <target state="new">Policies in role '%role%' updated.</target>
         <note>key: policy.update.success</note>
-        <jms:reference-file line="157">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
+        <jms:reference-file line="157">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/PolicyController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ac24fa007363b4280663fba53f7a3b436ed4c8f" resname="policy.view.add.title">
         <source>policy.view.add.title</source>
         <target state="new">policy.view.add.title</target>
         <note>key: policy.view.add.title</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aefaf3a17b8493e63c82678611eb6eacbcc45d19" resname="policy.view.edit.title">
         <source>Editing Policy "%module% / %function%"</source>
         <target state="new">Editing Policy "%module% / %function%"</target>
         <note>key: policy.view.edit.title</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e182986ba1f94484d60ea6b1db7cc2707478f2a1" resname="policy.view.limitations.title">
         <source>Limitations</source>
         <target state="new">Limitations</target>
         <note>key: policy.view.limitations.title</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="84d0c2844a996fbfdc23872405533f92b6e6e2f6" resname="policy.view.list.action.add">
         <source>Add a new Policy</source>
         <target state="new">Add a new Policy</target>
         <note>key: policy.view.list.action.add</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="35aa96a30453aa7b604432885032fd961a7f508a" resname="policy.view.list.panel.policies.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: policy.view.list.panel.policies.action.edit</note>
-        <jms:reference-file line="51">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="51">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3023517b9c9a8a05563021a9ac95092fd60dac13" resname="policy.view.list.panel.policies.column.function">
         <source>Function</source>
         <target state="new">Function</target>
         <note>key: policy.view.list.panel.policies.column.function</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bdf2edd15ae0c2e4f9faae4d9aef849c3258767" resname="policy.view.list.panel.policies.column.module">
         <source>Module</source>
         <target state="new">Module</target>
         <note>key: policy.view.list.panel.policies.column.module</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ac73c4c771df2f5214122aa058b8bc36f2a61a2" resname="policy.view.list.title">
         <source>Policies</source>
         <target state="new">Policies</target>
         <note>key: policy.view.list.title</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e2b7ae0acb75f99dc7943574a63b36abbb6c42bf" resname="role.assignment_create.success">
         <source>Assignments on role '%role%' created.</source>
         <target state="new">Assignments on role '%role%' created.</target>
         <note>key: role.assignment_create.success</note>
-        <jms:reference-file line="146">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleAssignmentController.php</jms:reference-file>
+        <jms:reference-file line="146">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleAssignmentController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f684c343da285bc7273d4671a257d2731ccc83a2" resname="role.assignment_delete.success">
         <source>Assignment on role '%role%' removed.</source>
         <target state="new">Assignment on role '%role%' removed.</target>
         <note>key: role.assignment_delete.success</note>
-        <jms:reference-file line="183">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleAssignmentController.php</jms:reference-file>
+        <jms:reference-file line="183">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleAssignmentController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="43008c999ece1587436507732b3c1166c393f05c" resname="role.breadcrumb.add">
         <source>Creating a new Role</source>
         <target state="new">Creating a new Role</target>
         <note>key: role.breadcrumb.add</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9cdc3dd417b63308f19cadbe01f74c21565b9947" resname="role.breadcrumb.edit">
         <source>Editing Role "%identifier%"</source>
         <target state="new">Editing Role "%identifier%"</target>
         <note>key: role.breadcrumb.edit</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="03e72944d22126b885a65f885ebf8f1b8e2f8579" resname="role.breadcrumb.list">
         <source>Roles</source>
         <target state="new">Roles</target>
         <note>key: role.breadcrumb.list</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9756b39574125051ae4fcd1916f5ba8b065eceb9" resname="role.breadcrumb.view">
         <source>%identifier%</source>
         <target state="new">%identifier%</target>
         <note>key: role.breadcrumb.view</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/add.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="59754dcca61db396ef9de8abd3aa63645bd50f65" resname="role.create.success">
         <source>Role '%role%' created.</source>
         <target state="new">Role '%role%' created.</target>
         <note>key: role.create.success</note>
-        <jms:reference-file line="111">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
+        <jms:reference-file line="111">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="20c6318c88508393b9cb8413a6d7e61649f80ab3" resname="role.delete.success">
         <source>Role '%role%' removed.</source>
         <target state="new">Role '%role%' removed.</target>
         <note>key: role.delete.success</note>
-        <jms:reference-file line="189">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
+        <jms:reference-file line="189">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="75637482fd2563256da5423615ecfb241fc03a57" resname="role.update.success">
         <source>Role '%role%' updated.</source>
         <target state="new">Role '%role%' updated.</target>
         <note>key: role.update.success</note>
-        <jms:reference-file line="152">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
+        <jms:reference-file line="152">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/RoleController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="da907b734c3ae3df8e9c570dd8e9e7e6d0799105" resname="role.view.add.title">
         <source>Creating a new Role</source>
         <target state="new">Creating a new Role</target>
         <note>key: role.view.add.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d3938c40d50b4d6e972248900f2d43cda1fe02a3" resname="role.view.edit.title">
         <source>Editing Role "%identifier%"</source>
         <target state="new">Editing Role "%identifier%"</target>
         <note>key: role.view.edit.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/edit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="88d7426f344cc9d85b90903dad013d5806b82faa" resname="role.view.list.action.add">
         <source>Create a Role</source>
         <target state="new">Create a Role</target>
         <note>key: role.view.list.action.add</note>
-        <jms:reference-file line="24">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="24">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18990f93cd60432ec47a75934185b7edbd3d17bf" resname="role.view.list.action.assign_to_users_or_groups">
         <source>Assign to Users/Groups</source>
         <target state="new">Assign to Users/Groups</target>
         <note>key: role.view.list.action.assign_to_users_or_groups</note>
-        <jms:reference-file line="50">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb9d9934c021aa5f2b25bfa652279daa88c6086f" resname="role.view.list.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: role.view.list.action.edit</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4cb9b2e474c4584dd193e46214b68897ebc6350f" resname="role.view.list.column.id">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: role.view.list.column.id</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85577fbcec5644f2fd6eb88f26e1dc4343bb09d3" resname="role.view.list.column.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: role.view.list.column.identifier</note>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a0c33e3728b23f13b825e36808834a6930551873" resname="role.view.list.title">
         <source>Roles</source>
         <target state="new">Roles</target>
         <note>key: role.view.list.title</note>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d60c07614620d12e34a9d0a0d3b36fc565fe610" resname="role.view.view.actions.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: role.view.view.actions.edit</note>
-        <jms:reference-file line="51">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="51">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ed20cb1159498f2085d5df44b0d43c977abaa791" resname="role.view.view.title">
         <source>"%identifier%" Role</source>
         <target state="new">"%identifier%" Role</target>
         <note>key: role.view.view.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e7ff6be9f5a7368f2493f29eacfa1ee321d9c383" resname="role_assignment.view.add.panel.limitations.title">
         <source>Limitations</source>
         <target state="new">Limitations</target>
         <note>key: role_assignment.view.add.panel.limitations.title</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9465b09774c22747e887ffe9e6300fd02420546" resname="role_assignment.view.add.panel.users_and_groups.title">
         <source>Users and Groups</source>
         <target state="new">Users and Groups</target>
         <note>key: role_assignment.view.add.panel.users_and_groups.title</note>
-        <jms:reference-file line="28">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="28">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61a5ec154d3f0620ec619d196611b011996128ff" resname="role_assignment.view.add.title">
         <source>Assigning to Users/Groups</source>
         <target state="new">Assigning to Users/Groups</target>
         <note>key: role_assignment.view.add.title</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/add.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a21a7a13956cadf2256095fbdd062f1b33dd05a8" resname="role_assignment.view.list.action.add">
         <source>Assign to Users/Groups</source>
         <target state="new">Assign to Users/Groups</target>
         <note>key: role_assignment.view.list.action.add</note>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7b9f2997c5eada07c20a0bde7e89cc0c688e1ea" resname="role_assignment.view.list.panel.assignments.column.limitation">
         <source>Limitation</source>
         <target state="new">Limitation</target>
         <note>key: role_assignment.view.list.panel.assignments.column.limitation</note>
-        <jms:reference-file line="16">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e978e250aa8284fa54c6f2a73cef9d3c8f0535c8" resname="role_assignment.view.list.panel.assignments.column.limitations">
         <source>Limitations</source>
         <target state="new">Limitations</target>
         <note>key: role_assignment.view.list.panel.assignments.column.limitations</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/policy/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bedf1e132292302ec09e4646d9a348a56e2c1ce8" resname="role_assignment.view.list.panel.assignments.column.user_group">
         <source>User/Group</source>
         <target state="new">User/Group</target>
         <note>key: role_assignment.view.list.panel.assignments.column.user_group</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b152833aa8e0248096e41ded7c2f10bb778e363b" resname="role_assignment.view.list.title">
         <source>Assignments</source>
         <target state="new">Assignments</target>
         <note>key: role_assignment.view.list.title</note>
-        <jms:reference-file line="27">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role/view.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/role_assignment/list.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,97 +10,97 @@
         <source>Search results (%total%)</source>
         <target state="new">Search results (%total%)</target>
         <note>key: search.header</note>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d83218940b91b2cc81ae9d0a694682f6cb04813" resname="search.headline">
         <source>Search</source>
         <target state="new">Search</target>
         <note>key: search.headline</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ceaf9887c3974130781c3dadfcb129926496770" resname="search.list">
         <source>search.list</source>
         <target state="new">search.list</target>
         <note>key: search.list</note>
-        <jms:reference-file line="72">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ea91510ce49731de30d4d412dc62c83c91b359d" resname="search.modified">
         <source>Modified</source>
         <target state="new">Modified</target>
         <note>key: search.modified</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6fc6d2e87716ae8feb2ff4536efa8c9db0904509" resname="search.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: search.name</note>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c11cc36acf58db9ff898f3a4cf02fd0fc293f67" resname="search.no_result">
         <source>Sorry, no results were found for "%query%".</source>
         <target state="new">Sorry, no results were found for "%query%".</target>
         <note>key: search.no_result</note>
-        <jms:reference-file line="29">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="29">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6fa93ef4dfbce97076a254427bb30bf7c5819c5d" resname="search.perform">
         <source>search.perform</source>
         <target state="new">search.perform</target>
         <note>key: search.perform</note>
-        <jms:reference-file line="74">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="74">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="777cc1ef279096d5a978aa3553e9434d828f8248" resname="search.tips.check_spelling">
         <source>Check spelling of keywords.</source>
         <target state="new">Check spelling of keywords.</target>
         <note>key: search.tips.check_spelling</note>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="36">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d89a8ff5c4b03f1dd7bd1ce3e3306862e1855751" resname="search.tips.different_keywords">
         <source>Try different keywords.</source>
         <target state="new">Try different keywords.</target>
         <note>key: search.tips.different_keywords</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="013ced9a3284ecebf5a5356397dc9a79eaf76496" resname="search.tips.fewer_keywords">
         <source>Try fewer keywords. Reducing keywords result in more matches.</source>
         <target state="new">Try fewer keywords. Reducing keywords result in more matches.</target>
         <note>key: search.tips.fewer_keywords</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4af1e76946070e5f61320621d12a171f4206e06c" resname="search.tips.headline">
         <source>Some helpful search tips:</source>
         <target state="new">Some helpful search tips:</target>
         <note>key: search.tips.headline</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dd61516edc919235a13e3cfadb5d961b8614b744" resname="search.tips.more_general_keywords">
         <source>Try more general keywords.</source>
         <target state="new">Try more general keywords.</target>
         <note>key: search.tips.more_general_keywords</note>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c9866a19fd5d3074bdb05b339df05b7c05a5661" resname="search.type">
         <source>Content Type</source>
         <target state="new">Content Type</target>
         <note>key: search.type</note>
-        <jms:reference-file line="48">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="48">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="48">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="48">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fe647ff0e12d67501403559464217be468dba3d8" resname="search.viewing">
         <source>Viewing %viewing% out of %total% sub-items</source>
         <target state="new">Viewing %viewing% out of %total% sub-items</target>
         <note>key: search.viewing</note>
-        <jms:reference-file line="59">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
-        <jms:reference-file line="59">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
+        <jms:reference-file line="59">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/list.html.twig</jms:reference-file>
+        <jms:reference-file line="59">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/search/search.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/section.en.xliff
+++ b/src/bundle/Resources/translations/section.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,137 +10,137 @@
         <source>Cancel</source>
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a6caa13cfd67503e2250af8e36f26a2f835a4a0" resname="section.assign_content.success">
         <source>%contentItemsCount% content items were assigned to '%name%'</source>
         <target state="new">%contentItemsCount% content items were assigned to '%name%'</target>
         <note>key: section.assign_content.success</note>
-        <jms:reference-file line="209">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
+        <jms:reference-file line="209">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bbcee03105f9504c94923b141d067d28d1d7ec54" resname="section.assigned.content">
         <source>Assignments count</source>
         <target state="new">Assignments count</target>
         <note>key: section.assigned.content</note>
-        <jms:reference-file line="35">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b3a79602ff55ce138d41cd00a9d93ff6a6324604" resname="section.assigned.contentcount">
         <source>{0} Section not assigned to any content item.|[1,+Inf[ This section is assigned to %count% content items.</source>
         <target state="new">{0} Section not assigned to any content item.|[1,+Inf[ This section is assigned to %count% content items.</target>
         <note>key: section.assigned.contentcount</note>
-        <jms:reference-file line="37">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0a6c7f3919b09caa9eee957a4949d3c9b6dce16e" resname="section.create.success">
         <source>Section '%name%' created.</source>
         <target state="new">Section '%name%' created.</target>
         <note>key: section.create.success</note>
-        <jms:reference-file line="250">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
+        <jms:reference-file line="250">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="663e1bfb8478f95028221190755c01441b2a8fde" resname="section.delete.success">
         <source>Section '%name%' removed.</source>
         <target state="new">Section '%name%' removed.</target>
         <note>key: section.delete.success</note>
-        <jms:reference-file line="166">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
+        <jms:reference-file line="166">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c2d7a21eb806db794990d728749dde1592be63e" resname="section.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note>key: section.edit</note>
-        <jms:reference-file line="53">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
-        <jms:reference-file line="46">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="201c1849abe46fd6ea7013ec4bb1bc2630e46e0a" resname="section.form.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
         <note>key: section.form.delete</note>
-        <jms:reference-file line="52">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
-        <jms:reference-file line="56">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="52">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bcb0a8eedc29344eb4ad95a02dd684438aae1df6" resname="section.id">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: section.id</note>
-        <jms:reference-file line="34">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="63039a13119dd5a53e5eb66cd798b3c323b57a5b" resname="section.id.label">
         <source>ID</source>
         <target state="new">ID</target>
         <note>key: section.id.label</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="54e249fceb2f506942f7f0ae30107a734b9b3fe5" resname="section.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: section.identifier</note>
-        <jms:reference-file line="33">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a040adfce6771857aef17cf0dbb596f2dee2e70" resname="section.identifier.label">
         <source>Identifier</source>
         <target state="new">Identifier</target>
         <note>key: section.identifier.label</note>
-        <jms:reference-file line="30">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1f9b6e37416ff607de9d4fa280dce2f734ea622c" resname="section.list">
         <source>Sections</source>
         <target state="new">Sections</target>
         <note>key: section.list</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d0db9c352babe46e30354a78d9b3eccd226d7602" resname="section.list.title">
         <source>Sections</source>
         <target state="new">Sections</target>
         <note>key: section.list.title</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
-        <jms:reference-file line="22">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="376986256605f27a204911de172c7bca4bd8e3b6" resname="section.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: section.name</note>
-        <jms:reference-file line="32">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="32">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="801aa4a73e669a7f454798a3d5e44b40899e51f1" resname="section.name.label">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: section.name.label</note>
-        <jms:reference-file line="28">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="28">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="12023a25e9c04ceef708820416f14a5a1e188688" resname="section.new">
         <source>Create a new Section</source>
         <target state="new">Create a new Section</target>
         <note>key: section.new</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e771bfe2e0091aad8731fd441667fba59cbf59c3" resname="section.new.title">
         <source>Creating a new Section</source>
         <target state="new">Creating a new Section</target>
         <note>key: section.new.title</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b1bef1e1bf42cb3e7e7f9057fd710e5c91a15129" resname="section.update.success">
         <source>Section '%name%' updated.</source>
         <target state="new">Section '%name%' updated.</target>
         <note>key: section.update.success</note>
-        <jms:reference-file line="292">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
+        <jms:reference-file line="292">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/SectionController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2bfeef4370b18e469fba6df1d4d2888f9252c764" resname="section.update.title">
         <source>Editing Section "%identifier%"</source>
         <target state="new">Editing Section "%identifier%"</target>
         <note>key: section.update.title</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/update.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7ca9da842cdea433f0a9e05a8c6b135def0bc6e3" resname="section.view.title">
         <source>"%identifier%" Section</source>
         <target state="new">"%identifier%" Section</target>
         <note>key: section.view.title</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
-        <jms:reference-file line="18">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/section/view.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/systeminfo.en.xliff
+++ b/src/bundle/Resources/translations/systeminfo.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,221 +10,221 @@
         <source>Bundles</source>
         <target state="new">Bundles</target>
         <note>key: bundles</note>
-        <jms:reference-file line="25">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
-        <jms:reference-file line="31">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="874ad8df43111be5efde68a54160acf7badff6c9" resname="composer">
         <source>Composer</source>
         <target state="new">Composer</target>
         <note>key: composer</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d46743c0b44b0022d9e5743ffe753b2452c381a4" resname="composer.minimum_stability">
         <source>Minimum stability</source>
         <target state="new">Minimum stability</target>
         <note>key: composer.minimum_stability</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca49ca4bb6732ef61577364cb33b115854e88f06" resname="cpu">
         <source>CPU</source>
         <target state="new">CPU</target>
         <note>key: cpu</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6d613a1ee01eec4c0f8ca66df0db71dca0c6e1cf" resname="database">
         <source>Database</source>
         <target state="new">Database</target>
         <note>key: database</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5588036c51b3fff9557483e210bfd47187f54ac8" resname="database.host">
         <source>Host</source>
         <target state="new">Host</target>
         <note>key: database.host</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cda1c2cdc0936c26cd9a325835b49a27d2ddfcc3" resname="database.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: database.name</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3af131bd1d37e4242ca0c124312180ad31ee23e9" resname="database.type">
         <source>Type</source>
         <target state="new">Type</target>
         <note>key: database.type</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="512e470f98391ba6e8140ef7a85e27c71af6e6bc" resname="database.username">
         <source>Username</source>
         <target state="new">Username</target>
         <note>key: database.username</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="07596f183f5e91b1778d5e47b2752b8d42aa763d" resname="disabled">
         <source>Disabled</source>
         <target state="new">Disabled</target>
         <note>key: disabled</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="608cb271bb7fb52c99a1a8e003e0f80f57fb41e1" resname="hardware">
         <source>Hardware</source>
         <target state="new">Hardware</target>
         <note>key: hardware</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="81c5d49be9505089d8d248ea96f6d077fd0ab9bd" resname="memory">
         <source>Memory</source>
         <target state="new">Memory</target>
         <note>key: memory</note>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a5a3d389f27a890d41a05f33c37b2f6133497c88" resname="mhz">
         <source>mhz</source>
         <target state="new">mhz</target>
         <note>key: mhz</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8ae088aee969371bf4ed994e9106b5d3e799c35" resname="packages">
         <source>Packages</source>
         <target state="new">Packages</target>
         <note>key: packages</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5bfa5c4492601632e405273e2f7ea28977f108c3" resname="packages.empty">
         <source>No packages installed.</source>
         <target state="new">No packages installed.</target>
         <note>key: packages.empty</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="47425e4490d1548713efea3b8a6f5d778e4b1766" resname="php">
         <source>PHP</source>
         <target state="new">PHP</target>
         <note>key: php</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="43ebf283d294d1a15b5d590815cd893e52164ed9" resname="php.accelerator">
         <source>Accelerator</source>
         <target state="new">Accelerator</target>
         <note>key: php.accelerator</note>
-        <jms:reference-file line="12">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee982f9a979085f2f15b3ddc699bfada99429bb4" resname="php.info">
         <source>PHP Info</source>
         <target state="new">PHP Info</target>
         <note>key: php.info</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="98c89e1daa8c0a7c472af26752752299ff44ee23" resname="symfony_kernel">
         <source>Symfony kernel</source>
         <target state="new">Symfony kernel</target>
         <note>key: symfony_kernel</note>
-        <jms:reference-file line="5">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dbc3d622a5e78844eeb75f3e9477b90357984ad7" resname="symfony_kernel.bundles.empty">
         <source>No bundles installed.</source>
         <target state="new">No bundles installed.</target>
         <note>key: symfony_kernel.bundles.empty</note>
-        <jms:reference-file line="26">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8bce9f0cf5c9c698c1907808aa20cfa0b1ec9ecb" resname="symfony_kernel.cacheDir">
         <source>Cache directory</source>
         <target state="new">Cache directory</target>
         <note>key: symfony_kernel.cacheDir</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74d0f849585c3bfe67e3477d0773fd8f097bd54d" resname="symfony_kernel.charset">
         <source>Character set</source>
         <target state="new">Character set</target>
         <note>key: symfony_kernel.charset</note>
-        <jms:reference-file line="21">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8da408eada2e85ad98868421df6185d1c8e4bdb2" resname="symfony_kernel.debugMode">
         <source>Debug mode</source>
         <target state="new">Debug mode</target>
         <note>key: symfony_kernel.debugMode</note>
-        <jms:reference-file line="9">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b279d615747857a87b80e268ef4a8eefc631cd3c" resname="symfony_kernel.debugMode.disabled">
         <source>Disabled</source>
         <target state="new">Disabled</target>
         <note>key: symfony_kernel.debugMode.disabled</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edea137ff68106045aa74351ae612e2160700503" resname="symfony_kernel.debugMode.enabled">
         <source>Enabled</source>
         <target state="new">Enabled</target>
         <note>key: symfony_kernel.debugMode.enabled</note>
-        <jms:reference-file line="10">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae50a8c234dbf0d24521f3aec3a5f430b79ccb4c" resname="symfony_kernel.environment">
         <source>Environment</source>
         <target state="new">Environment</target>
         <note>key: symfony_kernel.environment</note>
-        <jms:reference-file line="7">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b04c158895f34062a8748223da67059fe45b3a60" resname="symfony_kernel.logDir">
         <source>Log directory</source>
         <target state="new">Log directory</target>
         <note>key: symfony_kernel.logDir</note>
-        <jms:reference-file line="19">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="19">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea20258358e7a0d4e8bc037d4e352ac2ad06b7fa" resname="symfony_kernel.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: symfony_kernel.name</note>
-        <jms:reference-file line="13">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="56014c7eba59799c182934e3a0eb97eff6fd8a97" resname="symfony_kernel.rootDir">
         <source>Root directory</source>
         <target state="new">Root directory</target>
         <note>key: symfony_kernel.rootDir</note>
-        <jms:reference-file line="15">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74fd4792096e74360c7508e16bbe7c1e121d393e" resname="symfony_kernel.version">
         <source>Version</source>
         <target state="new">Version</target>
         <note>key: symfony_kernel.version</note>
-        <jms:reference-file line="11">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="21ef9f0a078dbc4e4c45be12f1cfaf8a3864dfa7" resname="systeminfo">
         <source>System Info</source>
         <target state="new">System Info</target>
         <note>key: systeminfo</note>
-        <jms:reference-file line="14">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
-        <jms:reference-file line="8">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/info.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a2a92e9d0e41ea4a14c99ab0f702d5df3ea017c3" resname="tab.name.composer">
         <source>Composer</source>
         <target state="new">Composer</target>
         <note>key: tab.name.composer</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/composer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7a874a3b12fa965b16ed628878c5f6ce9c53b59f" resname="tab.name.database">
         <source>Database</source>
         <target state="new">Database</target>
         <note>key: tab.name.database</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/database.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="951e3ad18b17f0b2aa96fcb84f6eb25f208e1127" resname="tab.name.hardware">
         <source>Hardware</source>
         <target state="new">Hardware</target>
         <note>key: tab.name.hardware</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/hardware.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b71f0d567a424182b8c83a6b90a262b29819241b" resname="tab.name.php">
         <source>PHP</source>
         <target state="new">PHP</target>
         <note>key: tab.name.php</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/php.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b7989598c01fcae061f7917e563a9c0d66790a84" resname="tab.name.symfony_kernel">
         <source>Symfony kernel</source>
         <target state="new">Symfony kernel</target>
         <note>key: tab.name.symfony_kernel</note>
-        <jms:reference-file line="3">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
+        <jms:reference-file line="3">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/translation.en.xliff
+++ b/src/bundle/Resources/translations/translation.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,7 +10,7 @@
         <source>Translation '%languageCode%' removed from content `%name%`.</source>
         <target state="new">Translation '%languageCode%' removed from content `%name%`.</target>
         <note>key: translation.remove.success</note>
-        <jms:reference-file line="79">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TranslationController.php</jms:reference-file>
+        <jms:reference-file line="79">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TranslationController.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/trash.en.xliff
+++ b/src/bundle/Resources/translations/trash.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,61 +10,61 @@
         <source>Trash is empty. Any content item you send to trash will end up here.</source>
         <target state="new">Trash is empty. Any content item you send to trash will end up here.</target>
         <note>key: trash.empty</note>
-        <jms:reference-file line="47">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17b503b33de4f7e60958b7824dd959dd0144ae13" resname="trash.empty.success">
         <source>Trash empty.</source>
         <target state="new">Trash empty.</target>
         <note>key: trash.empty.success</note>
-        <jms:reference-file line="142">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
+        <jms:reference-file line="142">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb7cd78bb919141f66cabfea95a60e0e6b02e9f4" resname="trash.headline">
         <source>Trash</source>
         <target state="new">Trash</target>
         <note>key: trash.headline</note>
-        <jms:reference-file line="17">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5d4b7350cb3bfc77e9edd02190eb530d866c7565" resname="trash.item.ancesor_in_trash">
         <source>Ancestor is in the Trash</source>
         <target state="new">Ancestor is in the Trash</target>
         <note>key: trash.item.ancesor_in_trash</note>
-        <jms:reference-file line="61">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34525fc5da381111c2104d20a55021eb8b698c7c" resname="trash.name">
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: trash.name</note>
-        <jms:reference-file line="38">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c28510c675be753842996980b0e5d175cec4a8d8" resname="trash.original_location">
         <source>Original location</source>
         <target state="new">Original location</target>
         <note>key: trash.original_location</note>
-        <jms:reference-file line="40">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8c2da925faa48def8e407037a6115f1340070c7" resname="trash.restore_new_location.success">
         <source>Items restored under `%location%` location.</source>
         <target state="new">Items restored under `%location%` location.</target>
         <note>key: trash.restore_new_location.success</note>
-        <jms:reference-file line="194">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
+        <jms:reference-file line="194">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d4e8ddb6a84d9ca3a3b39485e9b7c5ef2860d879" resname="trash.restore_original_location.success">
         <source>Items restored under their original location.</source>
         <target state="new">Items restored under their original location.</target>
         <note>key: trash.restore_original_location.success</note>
-        <jms:reference-file line="185">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
+        <jms:reference-file line="185">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/TrashController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="06b530d8c8b3d7af7b3f2df9f5102927e7275de4" resname="trash.table.header">
         <source>Trash</source>
         <target state="new">Trash</target>
         <note>key: trash.table.header</note>
-        <jms:reference-file line="20">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="04098b87c58e41ab39820db75eee1d13856f9616" resname="trash.type">
         <source>Type</source>
         <target state="new">Type</target>
         <note>key: trash.type</note>
-        <jms:reference-file line="39">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/admin/trash/list.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/version.en.xliff
+++ b/src/bundle/Resources/translations/version.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-11-06T16:28:43Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T21:29:28Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,7 +10,7 @@
         <source>Versions removed from `%name%` content.</source>
         <target state="new">Versions removed from `%name%` content.</target>
         <note>key: version.delete.success</note>
-        <jms:reference-file line="90">/../../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/VersionController.php</jms:reference-file>
+        <jms:reference-file line="104">/../../../../../../vendor/ezsystems/ezplatform-admin-ui/src/bundle/Controller/VersionController.php</jms:reference-file>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28150

## Description 

I've regenerated translation by running in project root directory:  

```bash
bin/console translation:extract en --output-format=xliff --dir=vendor/ezsystems/ezplatform-admin-ui/src --output-dir=vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/
```
Also I've needed to manually set source and target to `{0}No|{1}Yes`, because `JMSTranslationBundle` wasn't able to do this automatically (not sure why).