### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,6 +24,8 @@ return PhpCsFixer\Config::create()
             'location' => 'after_open',
             'separate' => 'top',
         ],
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "friendsofphp/php-cs-fixer": "~2.7.1",
         "phpunit/phpunit": "^6.4"
     },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "knplabs/knp-menu-bundle": "^2.1"   
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.7.1",
         "phpunit/phpunit": "^6.4"
     },
     "extra": {

--- a/src/lib/Form/Data/ContentTypeGroupData.php
+++ b/src/lib/Form/Data/ContentTypeGroupData.php
@@ -35,7 +35,7 @@ class ContentTypeGroupData
         $this->identifier = $identifier;
     }
 
-    public static function factory(ContentTypeGroup $group): ContentTypeGroupData
+    public static function factory(ContentTypeGroup $group): self
     {
         $data = new self();
         $data->identifier = $group->identifier;

--- a/src/lib/Form/Data/Language/LanguageCreateData.php
+++ b/src/lib/Form/Data/Language/LanguageCreateData.php
@@ -30,7 +30,7 @@ class LanguageCreateData
      *
      * @return LanguageCreateData
      */
-    public function setName(string $name): LanguageCreateData
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -50,7 +50,7 @@ class LanguageCreateData
      *
      * @return LanguageCreateData
      */
-    public function setLanguageCode(string $languageCode): LanguageCreateData
+    public function setLanguageCode(string $languageCode): self
     {
         $this->languageCode = $languageCode;
 
@@ -70,7 +70,7 @@ class LanguageCreateData
      *
      * @return LanguageCreateData
      */
-    public function setEnabled(bool $enabled): LanguageCreateData
+    public function setEnabled(bool $enabled): self
     {
         $this->enabled = $enabled;
 

--- a/src/lib/Form/Data/Policy/PolicyCreateData.php
+++ b/src/lib/Form/Data/Policy/PolicyCreateData.php
@@ -29,7 +29,7 @@ class PolicyCreateData
      *
      * @return PolicyCreateData
      */
-    public function setModule(string $module): PolicyCreateData
+    public function setModule(string $module): self
     {
         $this->module = $module;
 
@@ -49,7 +49,7 @@ class PolicyCreateData
      *
      * @return PolicyCreateData
      */
-    public function setFunction(string $function): PolicyCreateData
+    public function setFunction(string $function): self
     {
         $this->function = $function;
 
@@ -61,7 +61,7 @@ class PolicyCreateData
      *
      * @return PolicyCreateData
      */
-    public function setPolicy(array $policy): PolicyCreateData
+    public function setPolicy(array $policy): self
     {
         $this->setModule($policy['module']);
         $this->setFunction($policy['function']);

--- a/src/lib/Form/Data/PolicyData.php
+++ b/src/lib/Form/Data/PolicyData.php
@@ -72,7 +72,7 @@ class PolicyData
         return $this->function;
     }
 
-    public static function factory(Policy $policy): PolicyData
+    public static function factory(Policy $policy): self
     {
         $data = new self();
         $data->module = $policy->module;

--- a/src/lib/Form/Data/Role/RoleCreateData.php
+++ b/src/lib/Form/Data/Role/RoleCreateData.php
@@ -26,7 +26,7 @@ class RoleCreateData
      *
      * @return RoleCreateData
      */
-    public function setIdentifier(string $identifier): RoleCreateData
+    public function setIdentifier(string $identifier): self
     {
         $this->identifier = $identifier;
 

--- a/src/lib/Form/Data/Role/RoleUpdateData.php
+++ b/src/lib/Form/Data/Role/RoleUpdateData.php
@@ -44,7 +44,7 @@ class RoleUpdateData
      *
      * @return RoleUpdateData
      */
-    public function setRole(Role $role): RoleUpdateData
+    public function setRole(Role $role): self
     {
         $this->role = $role;
 
@@ -64,7 +64,7 @@ class RoleUpdateData
      *
      * @return RoleUpdateData
      */
-    public function setIdentifier(string $identifier): RoleUpdateData
+    public function setIdentifier(string $identifier): self
     {
         $this->identifier = $identifier;
 

--- a/src/lib/Form/Data/RoleData.php
+++ b/src/lib/Form/Data/RoleData.php
@@ -35,7 +35,7 @@ class RoleData
         $this->identifier = $identifier;
     }
 
-    public static function factory(Role $role): RoleData
+    public static function factory(Role $role): self
     {
         return new self($role->identifier);
     }

--- a/src/lib/Form/Data/Search/SearchData.php
+++ b/src/lib/Form/Data/Search/SearchData.php
@@ -50,7 +50,7 @@ class SearchData
      *
      * @return SearchData
      */
-    public function setLimit(int $limit): SearchData
+    public function setLimit(int $limit): self
     {
         $this->limit = $limit;
 
@@ -62,7 +62,7 @@ class SearchData
      *
      * @return SearchData
      */
-    public function setPage(int $page): SearchData
+    public function setPage(int $page): self
     {
         $this->page = $page;
 
@@ -74,7 +74,7 @@ class SearchData
      *
      * @return SearchData
      */
-    public function setQuery(?string $query): SearchData
+    public function setQuery(?string $query): self
     {
         $this->query = $query;
 

--- a/src/lib/Form/Data/Section/SectionCreateData.php
+++ b/src/lib/Form/Data/Section/SectionCreateData.php
@@ -42,7 +42,7 @@ class SectionCreateData
      *
      * @return SectionCreateData
      */
-    public function setIdentifier(?string $identifier): SectionCreateData
+    public function setIdentifier(?string $identifier): self
     {
         $this->identifier = $identifier;
 
@@ -62,7 +62,7 @@ class SectionCreateData
      *
      * @return SectionCreateData
      */
-    public function setName(?string $name): SectionCreateData
+    public function setName(?string $name): self
     {
         $this->name = $name;
 


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR updates `.php_cs` config to be compatible with `v2.7.1`.

To simplify fixing code it also adds dev dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`
- [x] Fix CS (`self_accessor` rule)