### PR TITLE
EZP-28225: ezboolean's UI is ignoring default value

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/ezboolean.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/ezboolean.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {%- block ezplatform_fieldtype_ezboolean_widget -%}
-    <label class="ez-data-source__label">
+    <label class="ez-data-source__label{% if checked %} is-checked{% endif %}">
         <span class="ez-data-source__indicator"></span>
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
     </label>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28225

# Description
Fixes an issue with `ezboolean` in which it wasn't reflecting default value (or initial value in edit mode) in the UI. 