### PR TITLE
EZP-28284: Do not run admin siteaccess filter in there are no groups defined

### DIFF
--- a/src/lib/SiteAccess/AdminFilter.php
+++ b/src/lib/SiteAccess/AdminFilter.php
@@ -32,6 +32,10 @@ class AdminFilter implements SiteAccessConfigurationFilter
      */
     public function filter(array $configuration): array
     {
+        if (!isset($configuration['groups'])) {
+            return $configuration;
+        }
+
         $isMultisite = count($configuration['groups']) > 1;
 
         foreach (array_keys($configuration['groups']) as $groupName) {


### PR DESCRIPTION
It appears that this filter is ran for every file which has `ezpublish` configuration defined.

So, if there are any files with `ezpublish` configuration, but without siteaccess groups config, this causes an exception.