### PR TITLE
EZP-28285: Fix typehints for core services

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -10,7 +10,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
-use eZ\Publish\Core\Repository\SearchService;
+use eZ\Publish\API\Repository\SearchService;
 use EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -9,7 +9,7 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
-use eZ\Publish\Core\Repository\SearchService;
+use eZ\Publish\API\Repository\SearchService;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionContentAssignData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionDeleteData;


### PR DESCRIPTION
Using `Core` namespace results in the following exception:

```
Cannot autowire service "EzSystems\EzPlatformAdminUiBundle\Controller\SearchController": argument
"$searchService" of method "__construct()" references class
"eZ\Publish\Core\Repository\SearchService" but no such service exists. Try changing the type-hint to
"eZ\Publish\API\Repository\SearchService" instead.
```