### PR TITLE
EZP-28273: Make v2 admin sidebar buttons sticky

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -32,6 +32,10 @@ a {
     padding-right: 0;
     padding-left: 0;
 
+    .ez-button-container {
+        position: fixed;
+    }
+
     .ez-icon {
         display: block;
         margin: 0 auto;

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -32,11 +32,6 @@ a {
     padding-right: 0;
     padding-left: 0;
 
-    .ez-button-container {
-        position: sticky;
-        top: 1em;
-    }
-
     .ez-icon {
         display: block;
         margin: 0 auto;
@@ -126,4 +121,9 @@ a {
 .ez-section-list-view,
 .ez-trash-list-view {
     background-color: $ez-ground-base-light;
+}
+
+.ez-sticky-container {
+    position: sticky;
+    top: 1rem;
 }

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -33,7 +33,8 @@ a {
     padding-left: 0;
 
     .ez-button-container {
-        position: fixed;
+        position: sticky;
+        top: 1em;
     }
 
     .ez-icon {

--- a/src/bundle/Resources/views/admin/base.html.twig
+++ b/src/bundle/Resources/views/admin/base.html.twig
@@ -19,7 +19,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/language/base.html.twig
+++ b/src/bundle/Resources/views/admin/language/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/policy/base.html.twig
+++ b/src/bundle/Resources/views/admin/policy/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/role/base.html.twig
+++ b/src/bundle/Resources/views/admin/role/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/role_assignment/base.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/section/base.html.twig
+++ b/src/bundle/Resources/views/admin/section/base.html.twig
@@ -21,7 +21,9 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -19,7 +19,7 @@
             <section class="container mt-5">
                 {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with { title: 'trash.headline'|trans|desc('Trash'), iconName: 'trash' } %}
                 {{ form_start(form_trash_item_restore, {'action': path('ezplatform.trash.restore')}) }}
-                <div class="px-4">   
+                <div class="px-4">
                     <div class="ez-table-header mt-3">
                         <div class="ez-table-header__headline">{{ 'trash.table.header'|trans|desc('Trash') }}</div>
                         <div>
@@ -90,8 +90,10 @@
             </section>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% set sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.trash.sidebar_right', []) %}
-            {{ knp_menu_render(sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+            <div class="ez-sticky-container">
+                {% set sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.trash.sidebar_right', []) %}
+                {{ knp_menu_render(sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -39,7 +39,9 @@
             {% block form_after %}{% endblock %}
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% block right_sidebar %}{% endblock %}
+            <div class="ez-sticky-container">
+                {% block right_sidebar %}{% endblock %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -58,14 +58,15 @@
             </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            {% set content_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content.sidebar_right', [], {'location': location, 'content': content, 'content_type': contentType}) %}
-            {{ knp_menu_render(content_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+            <div class="ez-sticky-container">
+                {% set content_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content.sidebar_right', [], {'location': location, 'content': content, 'content_type': contentType}) %}
+                {{ knp_menu_render(content_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
 
-            <div class="ez-extra-actions-container">
-                {% include '@EzPlatformAdminUi/content/widgets/content_create.html.twig' with {'form': form_content_create} only %}
-                {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
+                <div class="ez-extra-actions-container">
+                    {% include '@EzPlatformAdminUi/content/widgets/content_create.html.twig' with {'form': form_content_create} only %}
+                    {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
+                </div>
             </div>
-
             {% include '@EzPlatformAdminUi/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -63,7 +63,9 @@
 
                 {% block left_sidebar %}
                     <div class="col-sm-1 bg-dark pt-4 ez-side-menu"> {# @todo sidebars should be moved to layout.html.twig !! #}
-                        {{ knp_menu_render('ezplatform_admin_ui.menu.content.sidebar_left', {'template': '@EzPlatformAdminUi/parts/menu/sidebar_left.html.twig'}) }}
+                        <div class="ez-sticky-container">
+                            {{ knp_menu_render('ezplatform_admin_ui.menu.content.sidebar_left', {'template': '@EzPlatformAdminUi/parts/menu/sidebar_left.html.twig'}) }}
+                        </div>
                     </div>
                 {% endblock left_sidebar %}
 

--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -1,9 +1,11 @@
 {% extends '@KnpMenu/menu.html.twig' %}
 
 {% block root %}
+    <div class="ez-button-container">
     {% for item in item.children %}
         {{ block('item') }}
     {% endfor %}
+    </div>
 {% endblock %}
 
 {% block item -%}

--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -1,11 +1,9 @@
 {% extends '@KnpMenu/menu.html.twig' %}
 
 {% block root %}
-    <div class="ez-button-container">
     {% for item in item.children %}
         {{ block('item') }}
     {% endfor %}
-    </div>
 {% endblock %}
 
 {% block item -%}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-28273

In the administration interface the views can be very long. This causes the user to scroll down and then the sidebar buttons are lost. This is especially prominent when editing content with multiple field.

This PR adds a wrapper element and some styles to set the buttons in the sidebar to be sticky when scrolling. See video for a preview - sticky functionality in video has white border.

https://www.youtube.com/watch?v=GZoD7GJ99Y4