### PR TITLE
EZP-28309: Twig template for eztime is incorrectly parsing time value

### DIFF
--- a/src/bundle/Resources/views/content_fields.html.twig
+++ b/src/bundle/Resources/views/content_fields.html.twig
@@ -11,16 +11,3 @@
         {% endif %}
     {% endspaceless %}
 {% endblock %}
-
-{% block eztime_field %}
-    {% spaceless %}
-        {% if not ez_is_field_empty( content, field ) %}
-            {% if fieldSettings.useSeconds %}
-                {% set field_value = field.value.time|localizeddate( 'none', 'medium', parameters.locale, 'UTC') %}
-            {% else %}
-                {% set field_value = field.value.time|localizeddate( 'none', 'short', parameters.locale, 'UTC') %}
-            {% endif %}
-            {{ block( 'simple_block_field' ) }}
-        {% endif %}
-    {% endspaceless %}
-{% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28309

# Description
This PR reverses #87 as we decided to fix the issue in kernel instead: https://github.com/ezsystems/ezpublish-kernel/pull/2162