### PR TITLE
EZP-28296: Inconsistent ezdatetime value across timezones

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -56,14 +56,6 @@
     };
     const updateInputValue = (sourceInput, date) => {
         date = new Date(date);
-        date = new Date(Date.UTC(
-            date.getFullYear(),
-            date.getMonth(),
-            date.getDate(),
-            date.getHours(),
-            date.getMinutes(),
-            date.getSeconds()
-        ));
 
         sourceInput.value = Math.floor(date.getTime() / 1000);
         sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28296

# Description
This PR fixes timezone issue for ezdatetime. The issue was caused by invalid assumption that selected date should is in UTC timezone which is incorrect - date is in user's local timezone.