### PR TITLE
EZP-28315: Cannot delete draft in case of nonpublished content

### DIFF
--- a/src/bundle/Resources/translations/content_edit.en.xliff
+++ b/src/bundle/Resources/translations/content_edit.en.xliff
@@ -11,6 +11,11 @@
         <target state="new">Field type is not editable</target>
         <note>key: content.field.non_editable</note>
       </trans-unit>
+      <trans-unit id="6a2083913f3647b44f205204e369f764e83233b1" resname="content_id">
+        <source>Content ID: %contentId%</source>
+        <target state="new">Content ID: %contentId%</target>
+        <note>key: content_id</note>
+      </trans-unit>
       <trans-unit id="71a8aeb31196db647608ffe1789be9400d61451d" resname="created_by">
         <source>Created by %name%</source>
         <target state="new">Created by %name%</target>
@@ -20,6 +25,11 @@
         <source>Editing - %contentType%</source>
         <target state="new">Editing - %contentType%</target>
         <note>key: editing</note>
+      </trans-unit>
+      <trans-unit id="876d7bdba03c72251ec4c2dc827fc54af7889091" resname="location_id">
+        <source>Location ID: %locationId%</source>
+        <target state="new">Location ID: %locationId%</target>
+        <note>key: location_id</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -12,7 +12,7 @@
     </h1>
 
     <div class="small">
-        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'full', app.request.locale) }} / Content ID: {{ content.id }}, Main Location ID: {{ content.versionInfo.contentInfo.mainLocationId }}
+        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }}{% if content.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': content.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
     </div>
     {# @todo remove if statement once getDescription() bug is resolved in kernel #}
     {% if contentType.descriptions is not empty %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28315

# Description
This PR fixes heading in content edit in case of nonpublished content. Previously it displayed empty location ID.