### PR TITLE
removed adding admin access to siteaccess groups (separate scopes for…

### DIFF
--- a/src/lib/SiteAccess/AdminFilter.php
+++ b/src/lib/SiteAccess/AdminFilter.php
@@ -44,7 +44,6 @@ class AdminFilter implements SiteAccessConfigurationFilter
                 ? str_replace('_group', '', $groupName) . '_admin'
                 : 'admin';
             $configuration['list'][] = $adminSiteAccessName;
-            $configuration['groups'][$groupName][] = $adminSiteAccessName;
             $configuration['groups'][self::ADMIN_GROUP_NAME][] = $adminSiteAccessName;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | not sure
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR removes the addition of the admin access to the regular group it is based on.
Currently the system adds the admin siteaccess to e.g. `frontend`-siteaccess group and therefore gets the override-configuration from this group.

This breaks the admin UI as soon as you have multiple siteaccess' using the same group for override definition.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
