### PR TITLE
EZP-27052: Added redirect to current tab after performing unsuccessful actions

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -34,6 +34,8 @@ use Symfony\Component\Translation\Exception\InvalidArgumentException as Translat
 
 class LocationController extends Controller
 {
+    const LOCATION_TAB_URI_FRAGMENT = 'ez-tab-location-view-locations';
+
     /** @var NotificationHandlerInterface */
     private $notificationHandler;
 
@@ -250,7 +252,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $newLocation->id,
-                    '_fragment' => 'ez-tab-location-view-locations',
+                    '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -261,7 +263,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $location->id,
-            '_fragment' => 'ez-tab-location-view-locations',
+            '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
         ]));
     }
 
@@ -342,7 +344,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $contentInfo->mainLocationId,
-                    '_fragment' => 'ez-tab-location-view-locations',
+                    '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -353,6 +355,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $contentInfo->mainLocationId,
+            '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
         ]));
     }
 
@@ -392,7 +395,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $contentInfo->mainLocationId,
-                    '_fragment' => 'ez-tab-location-view-locations',
+                    '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -403,6 +406,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $contentInfo->mainLocationId,
+            '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
         ]));
     }
 
@@ -454,7 +458,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $contentInfo->mainLocationId,
-                    '_fragment' => 'ez-tab-location-view-locations',
+                    '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -465,6 +469,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $contentInfo->mainLocationId,
+            '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
         ]));
     }
 
@@ -500,7 +505,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                         'locationId' => $location->getContentInfo()->mainLocationId,
-                        '_fragment' => 'ez-tab-location-view-details',
+                        '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
                     ]));
             });
 
@@ -511,6 +516,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $location->getContentInfo()->mainLocationId,
+            '_fragment' => self::LOCATION_TAB_URI_FRAGMENT,
         ]));
     }
 }

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -19,6 +19,8 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class TranslationController extends Controller
 {
+    const TRANSLATION_TAB_URI_FRAGMENT = 'ez-tab-location-view-translations';
+
     /** @var NotificationHandlerInterface */
     private $notificationHandler;
 
@@ -87,7 +89,7 @@ class TranslationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $contentInfo->mainLocationId,
-                    '_fragment' => 'ez-tab-location-view-translations',
+                    '_fragment' => self::TRANSLATION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -98,6 +100,7 @@ class TranslationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $contentInfo->mainLocationId,
+            '_fragment' => self::TRANSLATION_TAB_URI_FRAGMENT,
         ]));
     }
 }

--- a/src/bundle/Controller/VersionController.php
+++ b/src/bundle/Controller/VersionController.php
@@ -25,6 +25,8 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class VersionController extends Controller
 {
+    const VERSION_TAB_URI_FRAGMENT = 'ez-tab-location-view-versions';
+
     /** @var NotificationHandlerInterface */
     private $notificationHandler;
 
@@ -111,7 +113,7 @@ class VersionController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                     'locationId' => $contentInfo->mainLocationId,
-                    '_fragment' => 'ez-tab-location-view-versions',
+                    '_fragment' => self::VERSION_TAB_URI_FRAGMENT,
                 ]));
             });
 
@@ -122,6 +124,7 @@ class VersionController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $contentInfo->mainLocationId,
+            '_fragment' => self::VERSION_TAB_URI_FRAGMENT,
         ]));
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28324
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


After perform unsuccessful action on content tab, user should be redirected to proper tab.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
