### PR TITLE
EZP-28283: Double Assign content labels in Sections

### DIFF
--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -47,10 +47,13 @@
                     <td>{{ section.id }}</td>
                     <td>{{ content_count[section.id] }}</td>
                     <td class="text-right">
-                        {{ form(form_section_content_assign[section.id], {
+                        {{ form_start(form_section_content_assign[section.id], {
                             "action": path("ezplatform.section.assign_content", {"sectionId": section.id}),
                             'attr': {'class': 'd-inline-block'}
                         }) }}
+                        {{ form_widget(form_section_content_assign[section.id].locations.select_content, {'attr': {'class': 'btn--open-udw btn-secondary'}}) }}
+                        {{ form_widget(form_section_content_assign[section.id].locations.location, {'label': false}) }}
+                        {{ form_end(form_section_content_assign[section.id]) }}
                         <a href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
                            class="btn btn-secondary"{% if not can_edit %} data-disabled{% endif %}>{{ 'section.edit'|trans|desc('Edit') }}</a>
                         {{ form_start(delete_form, {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28283
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->