### PR TITLE
EZP-28333: User can't add a content item based on specific content type

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -17,7 +17,7 @@
                 {% block form_fields %}
                     {% for field in form.fieldsData -%}
                         {% if field.value is defined %}
-                            {{- form_row(field.value) -}}
+                            {{- form_widget(field) -}}
                         {% else %}
                             <div>
                                 {{- form_label(field) -}}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28333
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->





#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
