### PR TITLE
Add some useful blocks to main layout

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -4,6 +4,9 @@
         <meta charset="UTF-8" />
         <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
+
+        {% block pageHead %}{% endblock %}
+
         <script>
             window.eZ = {
                 adminUiConfig: {{ admin_ui_config|json_encode|raw }},

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -56,6 +56,7 @@
             </div>
         </div>
         <div class="container-fluid ez-main-container">
+            {% block contentWrapper %}
             {% block content %}
 
                 {% block left_sidebar %}
@@ -65,6 +66,7 @@
                 {% endblock left_sidebar %}
 
             {% endblock content %}
+            {% endblock contentWrapper %}
         </div>
         <div class="ez-notifications-container">
             {% for label, messages in app.flashes %}

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -5,7 +5,7 @@
         <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
 
-        {% block pageHead %}{% endblock %}
+        {% block page_head %}{% endblock %}
 
         <script>
             window.eZ = {
@@ -59,7 +59,7 @@
             </div>
         </div>
         <div class="container-fluid ez-main-container">
-            {% block contentWrapper %}
+            {% block content_wrapper %}
             {% block content %}
 
                 {% block left_sidebar %}
@@ -69,7 +69,7 @@
                 {% endblock left_sidebar %}
 
             {% endblock content %}
-            {% endblock contentWrapper %}
+            {% endblock content_wrapper %}
         </div>
         <div class="ez-notifications-container">
             {% for label, messages in app.flashes %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

When integrating third party solutions into Admin UI, sometimes, it's quite useful to inject a piece of markup just before and after `content` Twig block to further refine the integration, in cases where such modification is not possible in the files extending the main layout.

Also, `pageHead` block has been added to be able to inject stuff to page head, like meta tags and so on. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
