### PR TITLE
EZP-28304: Fix meta CSRF token to be https namespace aware

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <meta name="CSRF-Token" content="{{ app.session.get('_csrf/authenticate') }}" />
+        <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
         <script>
             window.eZ = {


### PR DESCRIPTION
Use twig csrf_token to get the correct token.

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28304
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This uses the correct token regardless of http or https.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
