### PR TITLE
EZP-28419: Fix breadcrumb order after reindex

### DIFF
--- a/src/lib/UI/Service/PathService.php
+++ b/src/lib/UI/Service/PathService.php
@@ -9,6 +9,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Service;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Location;
 
@@ -38,6 +39,7 @@ class PathService
     {
         $locationQuery = new LocationQuery([
             'filter' => new Ancestor($location->pathString),
+            'sortClauses' => [new Path()],
         ]);
 
         $searchResult = $this->searchService->findLocations($locationQuery);


### PR DESCRIPTION
Make `PathService::loadPathLocations` guarantee order.

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28419
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


PathService::loadPathLocations is used to get the paths but the returned locations are not guaranteed to be in any order. This corrects that.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
