### PR TITLE
EZP-28311: There is no description, when translation is disabled for a field

### DIFF
--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -37,25 +37,23 @@
 {%- endblock %}
 
 {% block form_row_subfield -%}
-    {% set required_row_class = 'ez-data-source__field--required' %}
-    {% set label_class = 'ez-data-source__label' %}
-    {% set label_wrapper_class = 'ez-data-source__label-wrapper' %}
-    {% set widget_class = 'ez-data-source__input' %}
-    {% set widget_wrapper_class = 'ez-data-source__input-wrapper' %}
     {% set wrapper_class = 'ez-data-source__field ez-data-source__field--' ~ name %}
     {% set wrapper_class = wrapper_class|replace({'___name___': name}) %}
-    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ required_row_class)|trim %}{% endif %}
+    {% if required %}{% set wrapper_class = (wrapper_class ~ ' ez-data-source__field--required')|trim %}{% endif %}
+    {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' is-invalid')|trim %}{% endif %}
 
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ' ~ label_class)|trim}) %}
-    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ' ~ widget_class)|trim}) %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ez-data-source__label')|trim}) %}
+    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ ' ez-data-source__label-wrapper')|trim}) %}
+    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-data-source__input')|trim}) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({class: (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
+    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({class: (widget_wrapper_attr.class|default('') ~ ' ez-data-source__input-wrapper')|trim}) %}
 
     <div{% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
-        <div class="{{ label_wrapper_class }}">
+        <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {{- block('form_label') }}
             {{- block('form_errors') -}}
         </div>
-        <div class="{{ widget_wrapper_class }}">
+        <div{% with { attr: widget_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {{- form_widget(form, {'attr': attr}) -}}
         </div>
     </div>
@@ -67,35 +65,36 @@
     {% set translation_mode = fieldtype.vars.mainLanguageCode != fieldtype.vars.languageCode %}
     {% set fieldtype_is_not_translatable = translation_mode and not fieldtype.vars.value.fieldDefinition.isTranslatable %}
 
-    {% set required_row_class = 'ez-field-edit--required' %}
-    {% set invalid_row_class = 'is-invalid' %}
-    {% set nontranslatable_row_class = 'ez-field-edit--nontranslatable' %}
-    {% set label_class = 'ez-field-edit__label' %}
-    {% set label_wrapper_class = 'ez-field-edit__label-wrapper' %}
-    {% set widget_class = 'ez-data-source__input' %}
-    {% set widget_wrapper_class = 'ez-field-edit__data' %}
+    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ez-field-edit__data')|trim}) %}
     {% set wrapper_class = 'ez-field-edit ez-field-edit--' ~ fieldtype_identifier %}
-    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ required_row_class)|trim %}{% endif %}
-    {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ invalid_row_class)|trim %}{% endif %}
+    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ez-field-edit--required')|trim %}{% endif %}
+    {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' is-invalid')|trim %}{% endif %}
     {% if fieldtype_is_not_translatable %}
-        {% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ nontranslatable_row_class)|trim %}
+        {% set wrapper_class = (wrapper_class|default('') ~ ' ez-field-edit--nontranslatable')|trim %}
         {% set attr = attr|merge({'readonly': 'readonly'}) %}
     {% endif %}
 
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ' ~ label_class)|trim}) %}
-    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ' ~ widget_class)|trim}) %}
+    {% set label_wrapper_attr = label_wrapper_attr|default({})|merge({'class': (label_wrapper_attr.class|default('') ~ 'ez-field-edit__label-wrapper')|trim}) %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ez-field-edit__label')|trim}) %}
+    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-data-source__input')|trim}) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
 
     <div{% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
-        <div class="{{ label_wrapper_class }}">
+        <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {{ block('form_label') }}
             {{ block('form_errors') }}
         </div>
-        <div class="{{ widget_wrapper_class }}">
-            <div class="ez-data-source">
-                {{- form_widget(form, {'attr': attr}) -}}
+
+        {% if widget_container_block is defined %}
+            {{ widget_container_block|raw }}
+        {% else %}
+            <div{% with { attr: widget_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
+                <div class="ez-data-source">
+                    {{- form_widget(form, {'attr': attr}) -}}
+                </div>
             </div>
-        </div>
+        {% endif %}
+
         {% if fieldtype_is_not_translatable %}
             <p class="ez-field-edit__nontranslatable text-secondary">{{ 'fieldtype.translation_is_disabled'|trans({'%fieldName%': label})|desc('Translation for %fieldName% is disabled') }}</p>
         {% endif %}

--- a/src/bundle/Resources/views/fieldtypes/binary_base.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/binary_base.html.twig
@@ -1,50 +1,47 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
 {% block binary_base_row %}
-    {% set fieldtype_identifier = form.parent.vars.value.fieldDefinition.fieldTypeIdentifier %}
     {% set file_is_empty = form.parent.vars.value.value.fileName is null or form.parent.vars.value.value.fileSize is null %}
+    {% set attr = attr|merge({'data-max-file-size': max_file_size}) %}
+    {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ez-field-edit--with-preview')|trim}) %}
+    {% set preview_attr = preview_attr|default({})|merge({'class': (preview_attr.class|default('') ~ ' ez-field-edit__preview')|trim}) %}
+    {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ez-field-edit__data')|trim}) %}
+    {% if file_is_empty %}
+        {% set preview_attr = preview_attr|default({})|merge({'hidden': 'hidden'}) %}
+    {% else %}
+        {% set widget_wrapper_attr = widget_wrapper_attr|merge({'hidden': 'hidden'}) %}
+    {% endif %}
 
-    {% set wrapper_class = 'ez-field-edit ez-field-edit--with-preview ez-field-edit--' ~ fieldtype_identifier %}
-    {% set widget_class = 'ez-data-source__input' %}
-    {% set required_row_class = 'ez-field-edit--required' %}
-    {% set invalid_row_class = 'is-invalid' %}
-    {% set label_wrapper_class = 'ez-field-edit__label-wrapper' %}
-    {% set label_class = 'ez-field-edit__label' %}
-    {% set widget_wrapper_class = 'ez-field-edit__data'%}
-    {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ required_row_class)|trim %}{% endif %}
-    {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' ' ~ invalid_row_class)|trim %}{% endif %}
+    {% set widget_container_block = block('binary_base_widget_container') %}
 
-    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ' ~ label_class)|trim}) %}
-    {% set new_attributes = {'class': (attr.class|default('') ~ ' ' ~ widget_class)|trim, 'data-max-file-size': max_file_size} %}
-    {% set attr = attr|merge(new_attributes) %}
-    {% set wrapper_attr = wrapper_attr|default({})|merge({class: (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
+    {{ block('form_row_fieldtype') }}
+{% endblock %}
 
-    <div{% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
-        <div class="{{ label_wrapper_class }}">
-            {{ form_label(form) }}
-            {{ block('form_errors') }}
-        </div>
-        <div class="ez-field-edit__preview"{% if file_is_empty %} hidden{% endif %}>
-            {{ block(preview_block_name) }}
-        </div>
-        <div class="{{ widget_wrapper_class }}"{% if not file_is_empty %} hidden{% endif %}>
-            <div class="ez-data-source">
-                <div class="ez-data-source__message--main">{{ 'fieldtype.binary_base.drag_drop'|trans|desc('Drag and drop your files on browser window or upload them') }}</div>
-                <div class="ez-data-source__btn-add">
-                    <svg class="ez-icon">
-                        <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#upload"></use>
-                    </svg>
-                    <span class="ez-data-source__btn-label">{{ 'fieldtype.binary_base.upload_file'|trans|desc('Upload file') }}</span>
-                </div>
-                {% if max_file_size is defined and max_file_size > 0 %}
-                    <div class="ez-data-source__message--filesize">{{ 'fieldtype.binary_base.max_file_size'|trans({'%size%': max_file_size|default(0)|ez_file_size(2)})|desc('Max file size: %size%') }}</div>
-                {% endif %}
-                {{- form_widget(form.file, {'attr': attr}) -}}
-                {{- form_widget(form.remove, {'attr': {
-                    'hidden': 'hidden',
-                    'class': 'ez-field-edit__option--remove-media'
-                }, 'label_attr': {'hidden': 'hidden'}}) -}}
-            </div>
+{% block binary_base_widget %}
+    <div class="ez-data-source__message--main">{{ 'fieldtype.binary_base.drag_drop'|trans|desc('Drag and drop your files on browser window or upload them') }}</div>
+    <div class="ez-data-source__btn-add">
+        <svg class="ez-icon">
+            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#upload"></use>
+        </svg>
+        <span class="ez-data-source__btn-label">{{ 'fieldtype.binary_base.upload_file'|trans|desc('Upload file') }}</span>
+    </div>
+    {% if max_file_size is defined and max_file_size > 0 %}
+        <div class="ez-data-source__message--filesize">{{ 'fieldtype.binary_base.max_file_size'|trans({'%size%': max_file_size|default(0)|ez_file_size(2)})|desc('Max file size: %size%') }}</div>
+    {% endif %}
+    {{- form_widget(form.file, {'attr': attr}) -}}
+    {{- form_widget(form.remove, {'attr': {
+        'hidden': 'hidden',
+        'class': 'ez-field-edit__option--remove-media'
+    }, 'label_attr': {'hidden': 'hidden'}}) -}}
+{% endblock %}
+
+{% block binary_base_widget_container %}
+    <div{% with { attr: preview_attr } %}{{ block('attributes') }}{% endwith %}>
+        {{ block(preview_block_name) }}
+    </div>
+    <div{% with { attr: widget_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
+        <div class="ez-data-source">
+            {{ block('binary_base_widget') }}
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/binary_base_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/binary_base_fields.html.twig
@@ -1,13 +1,13 @@
 {% block checkbox_row %}
-<div class="ez-field-edit-preview__info ez-field-edit-preview__info--{{ name }}">
-    <div class="ez-field-edit-preview__input-wrapper">
-        <label class="ez-data-source__label">
-            <span class="ez-data-source__indicator"></span>
-            <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
-        </label>
-        <span class="ez-data-source__label-text">{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</span>
+    <div class="ez-field-edit-preview__info ez-field-edit-preview__info--{{ name }}">
+        <div class="ez-field-edit-preview__input-wrapper">
+            <label class="ez-data-source__label{% if checked %} is-checked{% endif %}">
+                <span class="ez-data-source__indicator"></span>
+                <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
+            </label>
+            <span class="ez-data-source__label-text">{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</span>
+        </div>
     </div>
-</div>
 {% endblock %}
 
 {% block integer_row %}

--- a/src/bundle/Resources/views/fieldtypes/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/ezbinaryfile.html.twig
@@ -9,23 +9,23 @@
 {%- endblock -%}
 
 {% block ezbinaryfile_preview %}
-<div class="ez-field-edit-preview">
-    <div class="ez-field-edit-preview__visual">
-        <div class="ez-field-edit-preview__file-icon"></div>
-        <div class="ez-field-edit-preview__file-name">{{ form.parent.vars.value.value.fileName }}</div>
-        <div class="ez-field-edit-preview__file-size">{{ form.parent.vars.value.value.fileSize|ez_file_size(2) }}</div>
+    <div class="ez-field-edit-preview">
+        <div class="ez-field-edit-preview__visual">
+            <div class="ez-field-edit-preview__file-icon"></div>
+            <div class="ez-field-edit-preview__file-name">{{ form.parent.vars.value.value.fileName }}</div>
+            <div class="ez-field-edit-preview__file-size">{{ form.parent.vars.value.value.fileSize|ez_file_size(2) }}</div>
+        </div>
+        <div class="ez-field-edit-preview__actions">
+            <a class="ez-field-edit-preview__action--preview" href="{{ form.parent.vars.value.value.uri }}" download>
+                <svg class="ez-icon">
+                    <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#download"></use>
+                </svg>
+            </a>
+            <button class="ez-field-edit-preview__action--remove">
+                <svg class="ez-icon">
+                    <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#trash"></use>
+                </svg>
+            </button>
+        </div>
     </div>
-    <div class="ez-field-edit-preview__actions">
-        <a class="ez-field-edit-preview__action--preview" href="{{ form.parent.vars.value.value.uri }}" download>
-            <svg class="ez-icon">
-                <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#download"></use>
-            </svg>
-        </a>
-        <button class="ez-field-edit-preview__action--remove">
-            <svg class="ez-icon">
-                <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#trash"></use>
-            </svg>
-        </button>
-    </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28311
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR simplifies fieldtypes twig templates and removes duplicated code from binary based fieldtypes.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
