### PR TITLE
EZP-28448: Cannot change the value of player settings in a content containing multiple ezmedia field types

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-field.js
@@ -21,7 +21,9 @@
          * @memberof BaseFieldValidator
          */
         attachEvent(config) {
-            [...doc.querySelectorAll(config.selector)].forEach(item => {
+            const container = this.fieldContainer ? this.fieldContainer : doc;
+
+            [...container.querySelectorAll(config.selector)].forEach(item => {
                 const isValueValidator = typeof config.isValueValidator !== 'undefined' ? config.isValueValidator : true;
 
                 this.fieldsToValidate.push({
@@ -45,7 +47,9 @@
          * @memberof BaseFieldValidator
          */
         removeEvent(eventName, selector, callback) {
-            [...doc.querySelectorAll(selector)].forEach(item => {
+            const container = this.fieldContainer ? this.fieldContainer : doc;
+
+            [...container.querySelectorAll(selector)].forEach(item => {
                 item.removeEventListener('checkIsValid', this.isValid, false);
                 item.removeEventListener(eventName, callback, false);
             });

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
@@ -56,14 +56,14 @@
             fieldContainer,
             eventsMap: [
                 {
-                    selector: `${SELECTOR_FIELD} input[type="file"]`,
+                    selector: `input[type="file"]`,
                     eventName: 'change',
                     callback: 'validateInput',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 },
                 {
                     isValueValidator: false,
-                    selector: `${SELECTOR_FIELD} input[type="file"]`,
+                    selector: `input[type="file"]`,
                     eventName: 'invalidFileSize',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -75,13 +75,13 @@
             fieldContainer,
             eventsMap: [
                 {
-                    selector: `${SELECTOR_FIELD} ${SELECTOR_INPUT_FILE}`,
+                    selector: `${SELECTOR_INPUT_FILE}`,
                     eventName: 'change',
                     callback: 'validateInput',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 },
                 {
-                    selector: `${SELECTOR_FIELD} ${SELECTOR_ALT_WRAPPER} .ez-data-source__input`,
+                    selector: `${SELECTOR_ALT_WRAPPER} .ez-data-source__input`,
                     eventName: 'blur',
                     callback: 'validateAltInput',
                     invalidStateSelectors: ['.ez-data-source__field--alternativeText'],
@@ -89,7 +89,7 @@
                 },
                 {
                     isValueValidator: false,
-                    selector: `${SELECTOR_FIELD} ${SELECTOR_INPUT_FILE}`,
+                    selector: `${SELECTOR_INPUT_FILE}`,
                     eventName: 'invalidFileSize',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -149,23 +149,23 @@
             fieldContainer,
             eventsMap: [
                 {
-                    selector: `${SELECTOR_FIELD} [type="file"]`,
+                    selector: `[type="file"]`,
                     eventName: 'change',
                     callback: 'validateInput',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 }, {
                     isValueValidator: false,
-                    selector: `${SELECTOR_FIELD} ${SELECTOR_INFO_WRAPPER}`,
+                    selector: `${SELECTOR_INFO_WRAPPER}`,
                     eventName: 'click',
                     callback: 'updateState',
                 }, {
                     isValueValidator: false,
-                    selector: `${SELECTOR_FIELD} [type="file"]`,
+                    selector: `[type="file"]`,
                     eventName: 'invalidFileSize',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 }, {
-                    selector: `${SELECTOR_FIELD} .ez-field-edit-preview__dimensions .form-control`,
+                    selector: `.ez-field-edit-preview__dimensions .form-control`,
                     eventName: 'blur',
                     callback: 'validateDimensions',
                     errorNodeSelectors: [`${SELECTOR_INFO_WRAPPER} .ez-field-edit-preview__label-wrapper`],


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28448
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The fields: `ezmedia`, `ezbinaryfile` and `ezimage` should be retested with this fix.