### PR TITLE
EZP-27995: Naming conventions for Content Types

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -187,13 +187,13 @@
         <note>key: content_type.view.list.column.name</note>
       </trans-unit>
       <trans-unit id="7c8c43d61131312dbeeeac5dc536a4f95154f33d" resname="content_type.view.list.title">
-        <source>Content Types</source>
-        <target state="new">Content Types</target>
+        <source>Content Types in %identifier%</source>
+        <target state="new">Content Types in %identifier%</target>
         <note>key: content_type.view.list.title</note>
       </trans-unit>
       <trans-unit id="dc7335e54d834bb6a342bf0bcb113850de4b69f9" resname="content_type.view.view.title">
-        <source>"%name%" Content Type</source>
-        <target state="new">"%name%" Content Type</target>
+        <source>%name%</source>
+        <target state="new">%name%</target>
         <note>key: content_type.view.view.title</note>
       </trans-unit>
       <trans-unit id="d74d01091280ceabfb457980ddd459dc841ad957" resname="content_type_group.breadcrumb.add">
@@ -292,8 +292,8 @@
         <note>key: content_type_group.view.list.title</note>
       </trans-unit>
       <trans-unit id="1769b5258d896d9ccb207c09e04534ce9a01c571" resname="content_type_group.view.view.title">
-        <source>"%identifier%" Content Type Group</source>
-        <target state="new">"%identifier%" Content Type Group</target>
+        <source>%identifier%</source>
+        <target state="new">%identifier%</target>
         <note>key: content_type_group.view.view.title</note>
       </trans-unit>
       <trans-unit id="5cf420af18fd4a8d856fd30bc13aea5039369f9b" resname="form.cancel">

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -2,7 +2,7 @@
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
-        <h4>{{ 'content_type.view.list.title'|trans|desc('Content Types') }}</h4>
+        <h4>{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</h4>
 
         <a href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}" class="btn btn-primary">
             {{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -15,8 +15,8 @@
 
 {% block pageTitle %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
-        title: 'content_type.view.view.title'|trans({ '%name%': content_type.name })|desc('"%name%" Content Type'),
-        iconName: 'content-types'
+        title: 'content_type.view.view.title'|trans({ '%name%': content_type.name })|desc('%name%'),
+        iconName: content_type.identifier
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -13,8 +13,8 @@
 
 {% block pageTitle %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
-        title: 'content_type_group.breadcrumb.list'|trans|desc('Content Types'),
-        iconName: 'content-types'
+        title: 'content_type_group.view.list.title'|trans|desc('Content Type Groups'),
+        iconName: 'content-type'
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/admin/content_type_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/view.html.twig
@@ -14,8 +14,8 @@
 
 {% block pageTitle %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
-        title: 'content_type_group.view.view.title'|trans({ '%identifier%': content_type_group.identifier })|desc('"%identifier%" Content Type Group'),
-        iconName: 'content-types'
+        title: 'content_type_group.view.view.title'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%'),
+        iconName: 'content-type'
     } %}
 {% endblock %}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-27995
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
Following the UI Guidelines, following elements have been updated:
- Breadcrumbs
- Page Title
- Table header
- Content Type Icons

In order to completely work, some of the Content Types icons have to be renamed: 
blog-post.svg -> blog_post.svg. 

#### Checklist:
- [x] Ready for Code Review
