### PR TITLE
EZP-28483: Modal is not visible in user menu on safari

### DIFF
--- a/src/bundle/Resources/public/scss/_user-menu.scss
+++ b/src/bundle/Resources/public/scss/_user-menu.scss
@@ -52,6 +52,7 @@
         &--hidden {
             height: 0;
             overflow: hidden;
+            z-index: initial;
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28483
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)



#### Checklist:
- [x] Ready for Code Review
