### PR TITLE
EZP-28360: Design consistency for tables across the whole application

### DIFF
--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -37,9 +37,16 @@
 }
 
 .ez-table-header {
-    .ez-icon-create,
-    .ez-icon-trash {
+    .btn {
+        line-height: .85;
+        padding: .5rem .55rem;
+        margin-left: .15rem;
         margin-right: 0;
+
+        .ez-icon-create,
+        .ez-icon-trash {
+            margin-right: 0;
+        }
     }
 }
 

--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -49,6 +49,14 @@
     width: 1rem;
 }
 
+.ez-table-header {
+    .ez-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+        fill: $white;
+    }
+}
+
 .ez-btn--extra-actions {
     .ez-icon {
         pointer-events: none;

--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -5,30 +5,15 @@
     justify-content: space-between;
     background-color: $ez-ground-primary;
     align-items: center;
-    padding: .5rem 1rem;
+    padding: 0 1.25rem;
+    min-height: 50px;
+    border-radius: .25rem .25rem 0 0;
 
-    h5 {
+    &__headline {
+        font-size: 1.0625rem;
         margin-bottom: 0;
         font-weight: bold;
         color: $ez-black;
-    }
-
-    .ez-icon {
-        width: 1rem;
-        height: 1rem;
-        fill: $white;
-    }
-
-    &.round {
-        border-radius: 4px 4px 0 0;
-    }
-
-    &--label {
-        margin: 0;
-        padding: 0 .4375rem;
-        font-size: 1rem;
-        line-height: 2;
-        font-weight: bold;
     }
 }
 
@@ -36,22 +21,41 @@
     background-color: $ez-color-base-pale;
 }
 
+.table {
+    margin-bottom: 3rem;
+    
+    th, td {
+        padding: .7rem 1.4rem;
+        line-height: 20px;
+    }
+
+    thead th {
+        font-size: .9375rem;
+        vertical-align: top;
+    }
+
+    td {
+        font-size: .875rem;
+        vertical-align: middle;
+
+        .checkbox label {
+            margin-bottom: 0;
+        }
+    }
+}
+
 .ez-dashboard {
     .table {
+        margin-bottom: 0;
+
         thead {
-            background-color: $ez-ground-primary-inverted-light;
-            color: $white;
+            background-color: $ez-ground-primary;
+            color: $ez-black;
 
             th {
                 border-bottom: none;
             }
         }
-    }
-}
-
-.ez-content-view {
-    .table {
-        margin-bottom: 3rem;
     }
 }
 
@@ -63,12 +67,6 @@
 }
 
 .ez-info-view {
-    .table {
-        th, td {
-            padding: .8rem 1.4rem;
-        }
-    }
-
     .ez-table {
         &--list {
             background: none;

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -2,14 +2,14 @@
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
-        <h4>{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</h4>
+        <div class="ez-table-header__headline">{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
 
         <a href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}" class="btn btn-primary">
             {{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}
         </a>
     </div>
 
-    <table class="table table-striped table-hover">
+    <table class="table">
         <thead>
             <tr>
                 <th>{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -25,10 +25,10 @@
 {% block content %}
     <section class="container mt-4 px-5">
         <header class="ez-table-header">
-            <h4>Global properties</h4>
+            <div class="ez-table-header__headline">Global properties</div>
         </header>
 
-        <table class="table table-striped table-hover">
+        <table class="table">
             <colgroup>
                 <col width="30%"/>
                 <col />
@@ -84,15 +84,15 @@
 
 <section class="container mt-4 px-5">
     <header class="ez-table-header">
-        <h4>Field definitions</h4>
+        <div class="ez-table-header__headline">Content field definitions</div>
     </header>
 
     {% for group, field_definitions in field_definitions_by_group %}
         <header class="ez-table-header">
-            <h5>{{ group }}</h5>
+            <div class="ez-table-header__headline">{{ group }}</div>
         </header>
 
-        <table class="table table-striped table-hover">
+        <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -21,7 +21,7 @@
 {% block content %}
     <section class="container mt-4 px-5">
         <div class="ez-table-header">
-            <h5>{{ 'content_type_group.view.list.title'|trans|desc('Content Type Groups') }}</h5>
+            <div class="ez-table-header__headline">{{ 'content_type_group.view.list.title'|trans|desc('Content Type Groups') }}</div>
             <div>
                 <a href="{{ path('ezplatform.content_type_group.create') }}" class="btn btn-primary">
                     {{ 'content_type_group.view.list.action.add'|trans|desc('Create a Content Type Group') }}
@@ -29,7 +29,7 @@
             </div>
         </div>
 
-        <table class="table table-hover">
+        <table class="table">
             <thead>
                 <tr>
                     <th>{{ 'content_type_group.view.list.column.identifier'|trans|desc('Name') }}</th>

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -22,8 +22,8 @@
 
 {% block content %}
     <section class="container mt-4 px-5">
-        <div class="ez-table-header round">
-            <h5>{{ 'language.list'|trans|desc('Languages') }}</h5>
+        <div class="ez-table-header">
+            <div class="ez-table-header__headline">{{ 'language.list'|trans|desc('Languages') }}</div ="ez-table-header__headline">
             <div>
                 <a title="{{ 'language.new'|trans|desc('Create a new Language') }}"
                    href="{{ path('ezplatform.language.create') }}"

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'role' %}
 
 <section class="container mt-4 px-5">
-    <div class="ez-table-header round">
-        <h5>{{ 'policy.view.list.title.count'|trans({'%count%': role.policies|length})|desc('Policies (%count%)') }}</h5>
+    <div class="ez-table-header">
+        <div class="ez-table-header__headline">{{ 'policy.view.list.title.count'|trans({'%count%': role.policies|length})|desc('Policies (%count%)') }}</div>
         <div>
             <a title="{{ 'policy.view.list.action.add'|trans|desc('Add a new Policy') }}"
                href="{{ path('ezplatform.policy.create', {roleId: role.id}) }}"
@@ -24,7 +24,7 @@
         'action': path('ezplatform.policy.bulk_delete', {"roleId": role.id} ),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-policies' }
     }) }}
-    <table class="table table-hover">
+    <table class="table">
         <thead>
         <tr>
             <th></th>

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -26,8 +26,8 @@
             'action': path('ezplatform.role.bulk_delete'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-roles' }
         }) }}
-        <div class="ez-table-header round">
-            <h5>{{ 'role.view.list.title'|trans|desc('Roles') }}</h5>
+        <div class="ez-table-header">
+            <div class="ez-table-header__headline">{{ 'role.view.list.title'|trans|desc('Roles') }}</div>
             <div>
                 <a title="{{ 'role.view.list.action.add'|trans|desc('Create a Role') }}" href="{{ path('ezplatform.role.create') }}" class="btn btn-primary">
                     <svg class="ez-icon ez-icon-create">
@@ -44,7 +44,7 @@
             </div>
         </div>
 
-        <table class="table table-hover">
+        <table class="table">
             <thead>
                 <tr>
                     <th></th>

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'role' %}
 
 <section class="container mt-4 px-5">
-    <div class="ez-table-header round">
-        <h5>{{ 'role_assignment.view.list.header'|trans|desc('Users and Groups') }}</h5>
+    <div class="ez-table-header">
+        <div class="ez-table-header__headline">{{ 'role_assignment.view.list.header'|trans|desc('Users and Groups') }}</div>
         <div>
             <a href="{{ path('ezplatform.role_assignment.create', {roleId: role.id}) }}" class="btn btn-secondary">
                 <svg class="ez-icon ez-icon-relations ez-icon--secondary">
@@ -23,7 +23,7 @@
         'action': path('ezplatform.role_assignment.bulk_delete', {"roleId": role.id} ),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-role-assignments' }
     }) }}
-    <table class="table table-hover round">
+    <table class="table">
         <thead>
         <tr>
             <th></th>

--- a/src/bundle/Resources/views/admin/search/list.html.twig
+++ b/src/bundle/Resources/views/admin/search/list.html.twig
@@ -18,7 +18,7 @@
                 {% include '@EzPlatformAdminUi/admin/search/search_form.html.twig' with { form: form } %}
 
                 <div class="ez-table-header mt-3">
-                    <h5>{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</h5>
+                    <div ="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</div>
                 </div>
 
                 {% if results is empty %}

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -20,7 +20,7 @@
 
                 {% if results is defined %}
                     <div class="ez-table-header mt-3">
-                        <h5>{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</h5>
+                        <div ="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
                     </div>
 
                     {% if results is empty %}

--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -4,12 +4,12 @@
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
-        <h5>
+        <div class="ez-table-header__headline">
             {{ 'section.assigned_content.header'|trans({
                 '%name%': section.name,
                 '%count%': pagerfanta.nbResults
             } )|desc('Content items in %name% (%count%)') }}
-        </h5>
+        </div>
 
         {{ form_start(form_section_content_assign, {
             'action': path("ezplatform.section.assign_content", {"sectionId": section.id}),

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -20,7 +20,7 @@
 {% block content %}
     <section class="container mt-4 px-5">
         <div class="ez-table-header">
-            <h5>{{ 'section.list.title'|trans|desc('Sections') }}</h5>
+            <div class="ez-table-header__headline">{{ 'section.list.title'|trans|desc('Sections') }}</div>
             <div>
                 <a href="{{ path('ezplatform.section.create') }}" class="btn btn-primary"
                    data-icon="&#xe616;"{% if not can_edit %} data-disabled{% endif %}>{{ 'section.new'|trans|desc('Create a new Section') }}</a>

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -24,7 +24,7 @@
 {% block content %}
     <section class="container mt-4 px-5">
         <header class="ez-table-header">
-            <h5>{{ 'section.information.header'|trans|desc('Section information') }}</h5>
+            <div class="ez-table-header__headline">{{ 'section.information.header'|trans|desc('Section information') }}</div>
 
             <div>
                 {% if deletable %}

--- a/src/bundle/Resources/views/admin/systeminfo/composer.html.twig
+++ b/src/bundle/Resources/views/admin/systeminfo/composer.html.twig
@@ -22,8 +22,8 @@
     </tbody>
 </table>
 
-<div class="ez-table-header round">
-    <h2 class="ez-table-header--label">{{ 'packages'|trans|desc('Packages') }}</h2>
+<div class="ez-table-header">
+    <div class="ez-table-header__headline">{{ 'packages'|trans|desc('Packages') }}</div>
 </div>
 <table class="table">
     <thead>

--- a/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig
+++ b/src/bundle/Resources/views/admin/systeminfo/symfony_kernel.html.twig
@@ -50,8 +50,8 @@
     </tbody>
 </table>
 
-<div class="ez-table-header round">
-    <h2 class="ez-table-header--label">{{ 'bundles'|trans|desc('Bundles') }}</h2>
+<div class="ez-table-header">
+    <div class="ez-table-header__headline">{{ 'bundles'|trans|desc('Bundles') }}</div>
 </div>
 <table class="table">
     <thead>

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -21,7 +21,7 @@
                 {{ form_start(form_trash_item_restore, {'action': path('ezplatform.trash.restore')}) }}
                 <div class="px-4">   
                     <div class="ez-table-header mt-3">
-                        <h5>{{ 'trash.table.header'|trans|desc('Trash') }}</h5>
+                        <div class="ez-table-header__headline">{{ 'trash.table.header'|trans|desc('Trash') }}</div>
                         <div>
                             {% if can_restore and form_trash_item_restore.trash_items is not empty %}
                                 {% set restore_under_new_parent_button_attr = form_trash_item_restore.location.select_content.vars.attr|merge({'attr': {'class': (form_trash_item_restore.location.select_content.vars.attr.class|default('') ~ ' d-inline-block')|trim, 'disabled': true}}) %}

--- a/src/bundle/Resources/views/parts/table_header.html.twig
+++ b/src/bundle/Resources/views/parts/table_header.html.twig
@@ -1,5 +1,5 @@
 <div class="ez-table-header {{ ground|default('') }}">
-    <h5>{{ headerText }}</h5>
+    <div class="ez-table-header__headline">{{ headerText }}</div>
     {% if tools is defined %}
         <div>
             {{ tools|raw }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28360](https://jira.ez.no/browse/EZP-28360)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Standardized style of `.ez-table-header` throughout the application (based also on HTML standards), as well as provided style for interactive icon buttons allocated within it;
- Updated style of Dashboard tables based on design specifications;
- Update design view for Admin > Content types > Specific Content type view based on specifications.

![screen shot 2017-12-12 at 2 11 03 am](https://user-images.githubusercontent.com/9256718/33873086-9c28b1f2-dee7-11e7-9c71-99fec16fd3d3.png)
<img width="641" alt="screen shot 2017-12-12 at 2 11 33 am" src="https://user-images.githubusercontent.com/9256718/33873092-a2da4ca4-dee7-11e7-92f7-3ddf1cd72946.png">
<img width="641" alt="screen shot 2017-12-12 at 2 12 00 am" src="https://user-images.githubusercontent.com/9256718/33873101-a8006a88-dee7-11e7-83fd-70cfa2527ef3.png">
![screen shot 2017-12-12 at 2 15 21 am](https://user-images.githubusercontent.com/9256718/33873111-affe1370-dee7-11e7-9928-62b22d29d95e.png)
![screen shot 2017-12-12 at 2 38 41 am](https://user-images.githubusercontent.com/9256718/33873116-b28d39ae-dee7-11e7-8004-8b07bc5e62e4.png)

Next steps:
- All buttons inside `.ez-table-header` should be styled as icon buttons;
- In tables, delete (icon) button should be placed within `.ez-table-header` too;
- Add hover states to icons within rows (Edit & Assign), as well as align them based on design specifications.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
