### PR TITLE
EZP-28299: Error 400 after publishing with Media field type without filling width and height

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -61,6 +61,12 @@
     }
 
     class EzMediaPreviewField extends global.eZ.BasePreviewField {
+        constructor(config) {
+            super(config);
+
+            this.fillMediaDimensionsInfo = this.fillMediaDimensionsInfo.bind(this);
+        }
+
         /**
          * Loads dropped file preview
          *
@@ -93,9 +99,12 @@
         updateMediaSource(file) {
             const preview = this.fieldContainer.querySelector(SELECTOR_PREVIEW);
             const videoUrl = URL.createObjectURL(file);
+            const video = preview.querySelector(SELECTOR_MEDIA);
+
+            video.addEventListener('loadedmetadata', this.fillMediaDimensionsInfo, false);
 
             preview.querySelector('.ez-field-edit-preview__action--preview').href = videoUrl;
-            preview.querySelector(SELECTOR_MEDIA).setAttribute('src', videoUrl)
+            video.setAttribute('src', videoUrl);
         }
 
         /**
@@ -127,9 +136,28 @@
          * @param {Event} event
          */
         handleRemoveFile(event) {
+            const preview = this.fieldContainer.querySelector(SELECTOR_PREVIEW);
+            const video = preview.querySelector(SELECTOR_MEDIA);
+
             super.handleRemoveFile(event);
 
+            video.removeEventListener('loadedmetadata', this.fillMediaDimensionsInfo);
+
             this.showMediaLoadingScreen();
+        }
+
+        /**
+         * Fills media dimensions meta data with an actual video size
+         *
+         * @method fillMediaDimensionsInfo
+         * @param {Event} event
+         */
+        fillMediaDimensionsInfo(event) {
+            const video = event.currentTarget;
+            const preview = this.fieldContainer.querySelector(SELECTOR_PREVIEW);
+
+            preview.querySelector('.ez-field-edit-preview__info--width .form-control').value = video.videoWidth;
+            preview.querySelector('.ez-field-edit-preview__info--height .form-control').value = video.videoHeight;
         }
 
         /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28299
| Requires    | https://github.com/ezsystems/repository-forms/pull/193
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The suggested approach in this bugfix is as follows:

1. Upload media file,
2. When file preview is loaded,
3. Prefill width and height input fields with actual video dimensions.

**Requires:**
- https://github.com/ezsystems/repository-forms/pull/193