### PR TITLE
EZP-28360: Tables consistency, standardized message when no content displayed

### DIFF
--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -59,11 +59,13 @@
     }
 }
 
-.ez-relations-box-list-no-content {
+.ez-table-no-content {
     margin-bottom: 3rem;
-    padding: 0.75rem 0.5rem;
+    padding: 0.75rem 1rem;
     background-color: $ez-white;
     font-style: italic;
+    font-size: .875rem;
+    color: $ez-color-base-dark;
 }
 
 .ez-info-view {

--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -51,8 +51,8 @@
         {% else %}
             <tr>
                 <td colspan="3">
-                    <p class="font-italic">
-                        <strong>{{ 'section.assigned_content.empty'|trans|desc('No content items.') }}</strong>
+                    <p class="ez-table-no-content mb-0 pl-0 py-1">
+                        {{ 'section.assigned_content.empty'|trans|desc('No content items.') }}
                         {{ 'section.assigned_content.empty_desc'|trans|desc('Content items you assign to this section will appear here.') }}
                     </p>
                 </td>

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -48,7 +48,7 @@
                         {% if trash_items is empty %}
                             <tr>
                                 <td colspan="4">
-                                    <span>{{ 'trash.empty'|trans|desc('Trash is empty. Any content item you send to trash will end up here.') }}</span>
+                                    <span class="ez-table-no-content mb-0 py-1 pl-0">{{ 'trash.empty'|trans|desc('Trash is empty. Any content item you send to trash will end up here.') }}</span>
                                 </td>
                             </tr>
                         {% else %}

--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -6,7 +6,7 @@
     {% if relations is not empty %}
         {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': relations}) }}
     {% else %}
-        <p class="ez-relations-box-list-no-content">
+        <p class="ez-table-no-content">
             {{ 'tab.relations.no_relations'|trans()|desc('This content item has no related content.') }}
         </p>
     {% endif %}
@@ -16,7 +16,7 @@
         {% if reverse_relations is not empty %}
             {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': reverse_relations}) }}
         {% else %}
-            <p class="ez-relations-box-list-no-content">
+            <p class="ez-table-no-content">
                 {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}
             </p>
         {% endif %}

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -32,7 +32,7 @@
         </tbody>
     </table>
 {% else %}
-    <p class="ez-relations-box-list-no-content">
+    <p class="ez-table-no-content">
         {{ 'tab.urls.no_custom_urls'|trans|desc('This content item has no custom url aliases.') }}
     </p>
 {% endif %}
@@ -59,7 +59,7 @@
         </tbody>
     </table>
 {% else %}
-    <p class="ez-relations-box-list-no-content">
+    <p class="ez-table-no-content">
         {{ 'tab.urls.no_system_urls'|trans|desc('This content item has no system urls.') }}
     </p>
 {% endif %}

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -35,5 +35,5 @@
         </tbody>
     </table>
 {% else %}
-    <p>{{ 'dashboard.tab.all_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
+    <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.all_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
 {% endif %}

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -35,5 +35,5 @@
         </tbody>
     </table>
 {% else %}
-    <p>{{ 'dashboard.tab.all_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
+    <p class"ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.all_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
 {% endif %}

--- a/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
@@ -30,5 +30,5 @@
         </tbody>
     </table>
 {% else %}
-    <p>{{ 'dashboard.tab.my_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
+    <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
 {% endif %}

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -34,5 +34,5 @@
         </tbody>
     </table>
 {% else %}
-    <p class="ez-table-empty">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
+    <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
 {% endif %}

--- a/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
@@ -30,5 +30,5 @@
         </tbody>
     </table>
 {% else %}
-    <p>{{ 'dashboard.tab.my_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
+    <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
 {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28360](https://jira.ez.no/browse/EZP-28360)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Standardized style of message shown when there's no content to be displayed.

![screen shot 2017-12-12 at 3 28 15 pm](https://user-images.githubusercontent.com/9256718/33907101-00e4bc3e-df52-11e7-87f6-17f2ab50b9c3.png)
<img width="642" alt="screen shot 2017-12-12 at 3 16 36 pm" src="https://user-images.githubusercontent.com/9256718/33907105-03dd0a7c-df52-11e7-94e0-16005a424bf1.png">
![screen shot 2017-12-12 at 3 16 14 pm](https://user-images.githubusercontent.com/9256718/33907107-074a488c-df52-11e7-86f1-107539450775.png)
![screen shot 2017-12-12 at 3 15 58 pm](https://user-images.githubusercontent.com/9256718/33907112-0c422b0c-df52-11e7-8b9c-a3d656918fc5.png)
![screen shot 2017-12-12 at 3 15 24 pm](https://user-images.githubusercontent.com/9256718/33907117-1013094a-df52-11e7-9fb9-7f07abbf28c8.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
