### PR TITLE
EZP-28520: Design improvements for icons in Content tabs

### DIFF
--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -60,10 +60,16 @@
 {% include 'EzPlatformAdminUiBundle:content/tab/locations:panel_swap.html.twig' with {'form': form_content_location_swap} %}
 
 {% macro table_header_tools(form_add, form_remove) %}
-    <button class="btn btn-secondary btn--udw-add">
-        {{ form_add.add.vars.label|trans({}, form_add.add.vars.translation_domain) }}
+    <button class="btn btn-primary btn--udw-add">
+        <svg class="ez-icon ez-icon-create">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+        </svg>
     </button>
     <button class="btn btn-danger btn--trigger" data-click="#{{ form_remove.remove.vars.id }}">
-        {{ form_remove.remove.vars.label|trans({}, form_remove.remove.vars.translation_domain) }}
+        <svg class="ez-icon ez-icon-trash">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+        </svg>
     </button>
 {% endmacro %}

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -37,6 +37,9 @@
         </svg>
     </button>
     <button class="btn btn-danger btn--trigger" data-click="#{{ form_translation_remove.remove.vars.id }}">
-        {{ form_translation_remove.remove.vars.label|trans({}, form_translation_remove.remove.vars.translation_domain) }}
+        <svg class="ez-icon ez-icon-trash">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+        </svg>
     </button>
 {% endmacro %}

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -46,6 +46,9 @@
 
 {% macro table_header_tools(form) %}
     <button class="btn btn-danger btn--trigger" data-click="#{{ form.remove.vars.id }}">
-        {{ form.remove.vars.label|trans({}, form.remove.vars.translation_domain) }}
+        <svg class="ez-icon ez-icon-trash">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+        </svg>
     </button>
 {% endmacro %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28520
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Design improvements for icons in content tabs (locations, versions, translations)

<img width="1432" alt="screen shot 2017-12-13 at 9 45 53 pm" src="https://user-images.githubusercontent.com/1654712/33961629-13ff9bc4-e04f-11e7-9a47-87a6a5126251.png">
<img width="1424" alt="screen shot 2017-12-13 at 9 45 41 pm" src="https://user-images.githubusercontent.com/1654712/33961630-1430ff20-e04f-11e7-90c4-8a382588100d.png">
<img width="1434" alt="screen shot 2017-12-13 at 9 45 24 pm" src="https://user-images.githubusercontent.com/1654712/33961631-1455f6c2-e04f-11e7-894d-f1945e82a603.png">

#### Checklist:
- [x] Locations tab
- [x] versions tab
- [x] Translations tab
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
