### PR TITLE
EZP-28523: Design improvements for Content Type Groups create and edit

### DIFF
--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -117,7 +117,7 @@ class ContentTypeGroupController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type_group/add.html.twig', [
+        return $this->render('@EzPlatformAdminUi/admin/content_type_group/create.html.twig', [
             'form' => $form->createView(),
         ]);
     }

--- a/src/bundle/Resources/config/services/menu.yml
+++ b/src/bundle/Resources/config/services/menu.yml
@@ -98,4 +98,14 @@ services:
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.language_edit.sidebar_right }
 
+    EzSystems\EzPlatformAdminUi\Menu\Admin\ContentType\ContentTypeGroupCreateRightSidebarBuilder:
+        public: true
+        tags:
+            - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.content_type_group_create.sidebar_right }
+
+    EzSystems\EzPlatformAdminUi\Menu\Admin\ContentType\ContentTypeGroupEditRightSidebarBuilder:
+        public: true
+        tags:
+            - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.content_type_group_edit.sidebar_right }
+
 

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -216,10 +216,10 @@
         <target state="new">%identifier%</target>
         <note>key: content_type_group.breadcrumb.view</note>
       </trans-unit>
-      <trans-unit id="03339a9ed2c7a92f0168e1bfbb276e17dcf52794" resname="content_type_group.create.identifier">
-        <source>Identifier</source>
-        <target state="new">Identifier</target>
-        <note>key: content_type_group.create.identifier</note>
+      <trans-unit id="e7cbc2b974608f280aa2b412d4c7836c7a56946d" resname="content_type_group.create.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note>key: content_type_group.create.name</note>
       </trans-unit>
       <trans-unit id="b04a9c80f0219d1a12813a8aa4bc532e97653b28" resname="content_type_group.create.submit">
         <source>Create</source>
@@ -241,10 +241,10 @@
         <target state="new">Content type group '%name%' deleted.</target>
         <note>key: content_type_group.delete.success</note>
       </trans-unit>
-      <trans-unit id="2215ce796f8eb3bfc45224e4773b571e71429c3d" resname="content_type_group.update.identifier">
-        <source>Identifier</source>
-        <target state="new">Identifier</target>
-        <note>key: content_type_group.update.identifier</note>
+      <trans-unit id="4c6dfb0b81f5b9d70fed0dda3840f0677ece9570" resname="content_type_group.update.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note>key: content_type_group.update.name</note>
       </trans-unit>
       <trans-unit id="d44e2ddf0ee9d2e6fcb0b4f2c49a2b579d629588" resname="content_type_group.update.submit">
         <source>Update</source>

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -71,6 +71,26 @@
         <target state="new">Save</target>
         <note>key: content_edit__sidebar_right__save_draft</note>
       </trans-unit>
+      <trans-unit id="ccdcdc5c7e006c865c33b29eee9c6b9e232a9308" resname="content_type_group_create__sidebar_right__cancel">
+        <source>Discard changes</source>
+        <target state="new">Discard changes</target>
+        <note>key: content_type_group_create__sidebar_right__cancel</note>
+      </trans-unit>
+      <trans-unit id="71e6fb2e4bbbcaaf043cdca260f6ba38f8ce2911" resname="content_type_group_create__sidebar_right__create">
+        <source>Create</source>
+        <target state="new">Create</target>
+        <note>key: content_type_group_create__sidebar_right__create</note>
+      </trans-unit>
+      <trans-unit id="0fa3cd41a8153814006c36b35a949d64576eaeea" resname="content_type_group_edit__sidebar_right__cancel">
+        <source>Discard changes</source>
+        <target state="new">Discard changes</target>
+        <note>key: content_type_group_edit__sidebar_right__cancel</note>
+      </trans-unit>
+      <trans-unit id="3951c5df8bf1c00b0dd99dc06acc76d1908ec825" resname="content_type_group_edit__sidebar_right__save">
+        <source>Save</source>
+        <target state="new">Save</target>
+        <note>key: content_type_group_edit__sidebar_right__save</note>
+      </trans-unit>
       <trans-unit id="65804c068820b5fa679357bc65c5862d0fc90701" resname="language_create__sidebar_right__cancel">
         <source>Discard changes</source>
         <target state="new">Discard changes</target>

--- a/src/bundle/Resources/views/admin/content_type_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/base.html.twig
@@ -1,0 +1,27 @@
+{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+
+{% trans_default_domain 'content_type' %}
+
+{% block content %}
+    <div class="row align-items-stretch ez-main-row">
+        <div class="col-sm-11 px-0 pb-4">
+            <div class="ez-header pt-4">
+                <div class="container">
+                    {% block breadcrumbs_admin %}
+                    {% endblock %}
+
+                    {% block page_title_admin %}
+                    {% endblock %}
+                </div>
+            </div>
+
+            <div class="container px-0 pb-4 mt-5">
+                {% block form %}
+                {% endblock %}
+            </div>
+        </div>
+        <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
+            {% block right_sidebar %}{% endblock %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/create.html.twig
@@ -1,8 +1,8 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
 
-{% block breadcrumbs %}
+{% block breadcrumbs_admin %}
     {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
@@ -10,31 +10,30 @@
     ]} %}
 {% endblock %}
 
-{% block pageTitle %}
+{% block page_title_admin %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
         title: 'content_type_group.view.add.title'|trans|desc('Creating a new Content Type Group'),
         iconName: 'content-types'
     } %}
 {% endblock %}
 
-{% block content %}
+{% block form %}
     {{ form_start(form) }}
 
     <section class="container mt-4 px-5">
-        <div class="card">
+        <div class="card ez-card">
             <div class="card-body">
                 {{ form_row(form.identifier) }}
             </div>
         </div>
     </section>
 
-    <section class="container my-4 px-5">
-        <div class="btn-toolbar justify-content-end" role="toolbar" >
-            {{ form_widget(form.create, {
-                'attr': { 'class': 'btn btn-primary' }
-            }) }}
-        </div>
-    </section>
+    {{ form_widget(form.create, {'attr': {'hidden': 'hidden'}}) }}
 
     {{ form_end(form) }}
+{% endblock %}
+
+{% block right_sidebar %}
+    {% set content_type_group_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_group_create.sidebar_right') %}
+    {{ knp_menu_render(content_type_group_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
@@ -1,8 +1,8 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
 
-{% block breadcrumbs %}
+{% block breadcrumbs_admin %}
     {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
@@ -10,31 +10,30 @@
     ]} %}
 {% endblock %}
 
-{% block pageTitle %}
+{% block page_title_admin %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
         title: 'content_type_group.view.edit.title'|trans({'%identifier%': content_type_group.identifier})|desc('Editing Content Type Group "%identifier%"'),
         iconName: 'content-types'
     } %}
 {% endblock %}
 
-{% block content %}
+{% block form %}
     {{ form_start(form) }}
 
     <section class="container mt-4 px-5">
-        <div class="card">
+        <div class="card ez-card">
             <div class="card-body">
                 {{ form_row(form.identifier) }}
             </div>
         </div>
     </section>
 
-    <section class="container my-4 px-5">
-        <div class="btn-toolbar justify-content-end" role="toolbar" >
-            {{ form_widget(form.update, {
-                'attr': { 'class': 'btn btn-primary' }
-            }) }}
-        </div>
-    </section>
+    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
 
     {{ form_end(form) }}
+{% endblock %}
+
+{% block right_sidebar %}
+    {% set content_type_group_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_group_edit.sidebar_right', [], {'save_id': form.update.vars.id}) %}
+    {{ knp_menu_render(content_type_group_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php
+++ b/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupCreateType.php
@@ -24,7 +24,7 @@ class ContentTypeGroupCreateType extends AbstractType
     {
         $builder
             ->add('identifier', TextType::class, [
-                'label' => /** @Desc("Identifier") */ 'content_type_group.create.identifier',
+                'label' => /** @Desc("Name") */ 'content_type_group.create.name',
             ])
             ->add('create', SubmitType::class, [
                 'label' => /** @Desc("Create") */ 'content_type_group.create.submit',

--- a/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php
+++ b/src/lib/Form/Type/ContentTypeGroup/ContentTypeGroupUpdateType.php
@@ -24,7 +24,7 @@ class ContentTypeGroupUpdateType extends AbstractType
     {
         $builder
             ->add('identifier', TextType::class, [
-                'label' => /** @Desc("Identifier") */ 'content_type_group.update.identifier',
+                'label' => /** @Desc("Name") */ 'content_type_group.update.name',
             ])
             ->add('update', SubmitType::class, [
                 'label' => /** @Desc("Update") */ 'content_type_group.update.submit',

--- a/src/lib/Menu/Admin/ContentType/ContentTypeGroupCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeGroupCreateRightSidebarBuilder.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Menu\Admin\ContentType;
+
+use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
+use EzSystems\EzPlatformAdminUi\Menu\AbstractBuilder;
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use InvalidArgumentException;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Knp\Menu\ItemInterface;
+
+/**
+ * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
+ *
+ * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
+ */
+class ContentTypeGroupCreateRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+{
+    /* Menu items */
+    const ITEM__CREATE = 'content_type_group_create__sidebar_right__create';
+    const ITEM__CANCEL = 'content_type_group_create__sidebar_right__cancel';
+
+    /**
+     * @return string
+     */
+    protected function getConfigureEventName(): string
+    {
+        return ConfigureMenuEvent::CONTENT_TYPE_GROUP_CREATE_SIDEBAR_RIGHT;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return ItemInterface
+     *
+     * @throws ApiExceptions\InvalidArgumentException
+     * @throws ApiExceptions\BadStateException
+     * @throws InvalidArgumentException
+     */
+    public function createStructure(array $options): ItemInterface
+    {
+        /** @var ItemInterface|ItemInterface[] $menu */
+        $menu = $this->factory->createItem('root');
+
+        $menu->setChildren([
+            self::ITEM__CREATE => $this->createMenuItem(
+                self::ITEM__CREATE,
+                [
+                    'attributes' => [
+                        'class' => 'btn--trigger',
+                        'data-click' => '#content_type_group_create_create',
+                    ],
+                    'extras' => ['icon' => 'publish'],
+                ]
+            ),
+            self::ITEM__CANCEL => $this->createMenuItem(
+                self::ITEM__CANCEL,
+                [
+                    'route' => 'ezplatform.content_type_group.list',
+                    'extras' => ['icon' => 'circle-close'],
+                ]
+            ),
+        ]);
+
+        return $menu;
+    }
+
+    /**
+     * @return Message[]
+     */
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message(self::ITEM__CREATE, 'menu'))->setDesc('Create'),
+            (new Message(self::ITEM__CANCEL, 'menu'))->setDesc('Discard changes'),
+        ];
+    }
+}

--- a/src/lib/Menu/Admin/ContentType/ContentTypeGroupEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeGroupEditRightSidebarBuilder.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Menu\Admin\ContentType;
+
+use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
+use EzSystems\EzPlatformAdminUi\Menu\AbstractBuilder;
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use InvalidArgumentException;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Knp\Menu\ItemInterface;
+
+/**
+ * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
+ *
+ * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
+ */
+class ContentTypeGroupEditRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+{
+    /* Menu items */
+    const ITEM__SAVE = 'content_type_group_edit__sidebar_right__save';
+    const ITEM__CANCEL = 'content_type_group_edit__sidebar_right__cancel';
+
+    /**
+     * @return string
+     */
+    protected function getConfigureEventName(): string
+    {
+        return ConfigureMenuEvent::CONTENT_TYPE_GROUP_EDIT_SIDEBAR_RIGHT;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return ItemInterface
+     *
+     * @throws ApiExceptions\InvalidArgumentException
+     * @throws ApiExceptions\BadStateException
+     * @throws InvalidArgumentException
+     */
+    public function createStructure(array $options): ItemInterface
+    {
+        $saveId = $options['save_id'];
+
+        /** @var ItemInterface|ItemInterface[] $menu */
+        $menu = $this->factory->createItem('root');
+
+        $menu->setChildren([
+            self::ITEM__SAVE => $this->createMenuItem(
+                self::ITEM__SAVE,
+                [
+                    'attributes' => [
+                        'class' => 'btn--trigger',
+                        'data-click' => sprintf('#%s', $saveId),
+                    ],
+                    'extras' => ['icon' => 'save'],
+                ]
+            ),
+            self::ITEM__CANCEL => $this->createMenuItem(
+                self::ITEM__CANCEL,
+                [
+                    'route' => 'ezplatform.content_type_group.list',
+                    'extras' => ['icon' => 'circle-close'],
+                ]
+            ),
+        ]);
+
+        return $menu;
+    }
+
+    /**
+     * @return Message[]
+     */
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message(self::ITEM__SAVE, 'menu'))->setDesc('Save'),
+            (new Message(self::ITEM__CANCEL, 'menu'))->setDesc('Discard changes'),
+        ];
+    }
+}

--- a/src/lib/Menu/Event/ConfigureMenuEvent.php
+++ b/src/lib/Menu/Event/ConfigureMenuEvent.php
@@ -35,6 +35,8 @@ class ConfigureMenuEvent extends Event
     const ROLE_ASSIGNMENT_CREATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.role_assignment_create_sidebar_right';
     const LANGUAGE_CREATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.language_create_sidebar_right';
     const LANGUAGE_EDIT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.language_edit_sidebar_right';
+    const CONTENT_TYPE_GROUP_CREATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.content_type_group_create_sidebar_right';
+    const CONTENT_TYPE_GROUP_EDIT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.content_type_group_edit_sidebar_right';
 
     /** @var FactoryInterface */
     private $factory;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28523
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Design improvements for Content Type Groups create and edit

<img width="1422" alt="screen shot 2017-12-14 at 1 54 23 pm" src="https://user-images.githubusercontent.com/1654712/33993332-54bdf5ca-e0d6-11e7-970a-e8361916ed57.png">
<img width="1416" alt="screen shot 2017-12-14 at 1 54 12 pm" src="https://user-images.githubusercontent.com/1654712/33993333-54e25fd2-e0d6-11e7-8665-2177b398e158.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

