### PR TITLE
EZP-28529: Fixed deletion of Content Type Group on non-empty group

### DIFF
--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -75,15 +75,22 @@ class ContentTypeGroupController extends Controller
 
     public function listAction(): Response
     {
+        $deletableContentTypeGroup = [];
+
         $contentTypeGroupList = $this->contentTypeService->loadContentTypeGroups();
 
         $deleteContentTypeGroupsForm = $this->formFactory->deleteContentTypeGroups(
             new ContentTypeGroupsDeleteData($this->getContentTypeGroupsNumbers($contentTypeGroupList))
         );
 
+        foreach ($contentTypeGroupList as $contentTypeGroup) {
+            $deletableContentTypeGroup[$contentTypeGroup->id] = !(bool)count($this->contentTypeService->loadContentTypes($contentTypeGroup));
+        }
+
         return $this->render('@EzPlatformAdminUi/admin/content_type_group/list.html.twig', [
             'content_type_groups' => $contentTypeGroupList,
             'form_content_type_groups_delete' => $deleteContentTypeGroupsForm->createView(),
+            'deletable' => $deletableContentTypeGroup,
         ]);
     }
 

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -57,7 +57,7 @@
             {% for content_type_group in content_type_groups %}
                 <tr>
                     <td class="ez-checkbox-cell">
-                        {{ form_widget(form_content_type_groups_delete.content_type_groups[content_type_group.id]) }}
+                        {{ form_widget(form_content_type_groups_delete.content_type_groups[content_type_group.id], {"disabled": not deletable[content_type_group.id]}) }}
                     </td>
                     <td>
                         {% set view_url = path('ezplatform.content_type_group.view', {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28529
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Delete action can be run on non-empty group


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
