### PR TITLE
EZP-28547: SubItems should not redirect to form on edit item

### DIFF
--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -126,7 +126,11 @@ class ContentController extends Controller
      */
     public function editAction(Request $request): Response
     {
-        $form = $this->formFactory->contentEdit();
+        /* @todo it shouldn't rely on keys from request */
+        $requestKeys = $request->request->keys();
+        $formName = reset($requestKeys) ?: null;
+
+        $form = $this->formFactory->contentEdit(null, $formName);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -106,6 +106,11 @@ class ContentViewController extends Controller
             new ContentEditData($content->contentInfo, $versionInfo)
         );
 
+        $subitemsContentEdit = $this->formFactory->contentEdit(
+            null,
+            'form_subitems_content_edit'
+        );
+
         $contentCreateType = $this->formFactory->createContent(
             $this->getContentCreateData($location)
         );
@@ -116,6 +121,7 @@ class ContentViewController extends Controller
             'form_location_trash' => $locationTrashType->createView(),
             'form_content_edit' => $contentEditType->createView(),
             'form_content_create' => $contentCreateType->createView(),
+            'form_subitems_content_edit' => $subitemsContentEdit->createView(),
         ]);
     }
 

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -7,7 +7,7 @@
     const sortField = sortContainer.getAttribute('data-sort-field');
     const sortOrder = sortContainer.getAttribute('data-sort-order');
     const mfuAttrs = {
-        adminUiConfig: Object.assign({}, window.eZ.adminUiConfig, {
+        adminUiConfig: Object.assign({}, global.eZ.adminUiConfig, {
             token,
             siteaccess
         }),
@@ -17,6 +17,14 @@
             locationPath: mfuContainer.dataset.parentLocationPath,
             language: mfuContainer.dataset.parentContentLanguage
         },
+    };
+    const handleEditItem = (content) => {
+        doc.querySelector('#form_subitems_content_edit_content_info').value = content._id;
+        doc.querySelector('#form_subitems_content_edit_version_info_content_info').value = content._id;
+        doc.querySelector('#form_subitems_content_edit_version_info_version_no').value = content.CurrentVersion.Version.VersionInfo.versionNo;
+        doc.querySelector(`#form_subitems_content_edit_language_${content.mainLanguageCode}`).checked = true;
+
+        doc.querySelector('#form_subitems_content_edit_create').click();
     };
 
     listContainers.forEach(container => {
@@ -33,6 +41,7 @@
         }, {});
 
         global.ReactDOM.render(global.React.createElement(global.eZ.modules.SubItems, {
+            handleEditItem,
             parentLocationId: container.dataset.location,
             sortClauses: {[sortField]: sortOrder},
             restInfo: {token, siteaccess},

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -45,6 +45,8 @@
                     {{ ez_platform_tabs('location-view', {'content': content, 'location': location,  'contentType': contentType }, 'EzPlatformAdminUiBundle:parts/tab:locationview.html.twig') }}
 
                     {% if contentType.isContainer %}
+                    {{ form_start(form_subitems_content_edit, { 'action': path('ezplatform.content.edit'), 'attr': { 'hidden': 'hidden' }}) }}
+                    {{ form_end(form_subitems_content_edit) }}
                     <div class="container px-5">
                         <section class="ez-fieldgroup">
                             <h2 class="ez-fieldgroup-name">Sub-items</h2>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28547
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

**Description**
Fixed bug with handle submits form with a different name than the default. When the name of the form is set to some custom the submit creates a form with the wrong name. In my case I set name to `form_sub_items_content_edit` and the submit creates form with name `content_draft_create`

**Requires:** https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/28

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
