### PR TITLE
EZP-28556: Replace ContentDraftCreate with ContentEdit action handling optional draft creation

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentCreateData;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentDraftCreateData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationCopyData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationMoveData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashData;
@@ -101,8 +101,8 @@ class ContentViewController extends Controller
             new LocationTrashData($location)
         );
 
-        $contentDraftCreateType = $this->formFactory->createContentDraft(
-            new ContentDraftCreateData($content->contentInfo, $versionInfo)
+        $contentEditType = $this->formFactory->contentEdit(
+            new ContentEditData($content->contentInfo, $versionInfo)
         );
 
         $contentCreateType = $this->formFactory->createContent(
@@ -113,7 +113,7 @@ class ContentViewController extends Controller
             'form_location_copy' => $locationCopyType->createView(),
             'form_location_move' => $locationMoveType->createView(),
             'form_location_trash' => $locationTrashType->createView(),
-            'form_content_draft_create' => $contentDraftCreateType->createView(),
+            'form_content_edit' => $contentEditType->createView(),
             'form_content_create' => $contentCreateType->createView(),
         ]);
     }

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -447,11 +447,11 @@ ezplatform.content.update_main_location:
 # Content Edit
 #
 
-ezplatform.content_draft.create:
-    path: /content/draft/create # @todo change to /content/draft/create once route is removed from repository-forms
+ezplatform.content.edit:
+    path: /content/edit
     methods: ['POST']
     defaults:
-        _controller: 'EzPlatformAdminUiBundle:Content:createDraft'
+        _controller: 'EzPlatformAdminUiBundle:Content:edit'
 
 ezplatform.content.create:
     path: /content/create

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -4,7 +4,7 @@
 {% form_theme form_location_copy '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 {% form_theme form_location_move '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 {% form_theme form_location_trash '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_content_draft_create '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_content_edit '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 {% form_theme form_content_create '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' '@EzPlatformAdminUi/form_fields.html.twig' %}
 
 {% block bodyClass %}ez-content-view{% endblock %}
@@ -61,7 +61,7 @@
 
             <div class="ez-extra-actions-container">
                 {% include '@EzPlatformAdminUi/content/widgets/content_create.html.twig' with {'form': form_content_create} only %}
-                {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_draft_create} only %}
+                {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
             </div>
 
             {% include '@EzPlatformAdminUi/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}

--- a/src/bundle/Resources/views/content/widgets/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/widgets/content_edit.html.twig
@@ -3,7 +3,7 @@
 <div class="ez-extra-actions ez-extra-actions--edit ez-extra-actions--hidden bg-secondary" data-actions="edit">
     <div class="ez-extra-actions__header">{{ 'content.edit.select_language'|trans|desc('Select language') }}</div>
     <div class="ez-extra-actions__content">
-        {{ form_start(form, { 'action': path('ezplatform.content_draft.create') }) }}
+        {{ form_start(form, { 'action': path('ezplatform.content.edit') }) }}
         {{ form_widget(form.content_info, { 'attr': {
             'hidden': 'hidden',
             'class': 'ez-extra-actions__form-field'

--- a/src/lib/Form/Data/Content/Draft/ContentEditData.php
+++ b/src/lib/Form/Data/Content/Draft/ContentEditData.php
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 /**
  * @todo Add validation. $language have to be validated that $versionInfo indeed has this language
  */
-class ContentDraftCreateData
+class ContentEditData
 {
     /** @var ContentInfo|null */
     protected $contentInfo;

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Factory;
 
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentCreateData;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentDraftCreateData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentMainLocationUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentLocationAddData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentLocationRemoveData;
@@ -51,7 +51,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashEmptyData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashItemRestoreData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Version\VersionRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentCreateType;
-use EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentDraftCreateType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentEditType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentLocationAddType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentLocationRemoveType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentMainLocationUpdateType;
@@ -117,26 +117,26 @@ class FormFactory
     }
 
     /**
-     * @param ContentDraftCreateData|null $data
+     * @param ContentEditData|null $data
      * @param string|null $name
      *
      * @return FormInterface
      *
      * @throws InvalidOptionsException
      */
-    public function createContentDraft(
-        ?ContentDraftCreateData $data = null,
+    public function contentEdit(
+        ?ContentEditData $data = null,
         ?string $name = null
     ): FormInterface {
-        $name = $name ?: StringUtil::fqcnToBlockPrefix(ContentDraftCreateType::class);
-        $data = $data ?? new ContentDraftCreateData();
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(ContentEditType::class);
+        $data = $data ?? new ContentEditData();
         $options = null !== $data->getVersionInfo()
             ? ['language_codes' => $data->getVersionInfo()->languageCodes]
             : [];
 
         return $this->formFactory->createNamed(
             $name,
-            ContentDraftCreateType::class,
+            ContentEditType::class,
             $data,
             $options
         );

--- a/src/lib/Form/Type/Content/Draft/ContentEditType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentEditType.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft;
 
 use eZ\Publish\API\Repository\LanguageService;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentDraftCreateData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\VersionInfoType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Language\LanguageChoiceType;
@@ -19,7 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ContentDraftCreateType extends AbstractType
+class ContentEditType extends AbstractType
 {
     /** @var LanguageService */
     protected $languageService;
@@ -65,7 +65,7 @@ class ContentDraftCreateType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'data_class' => ContentDraftCreateData::class,
+                'data_class' => ContentEditData::class,
                 'translation_domain' => 'forms',
                 'language_codes' => false,
             ])


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28556
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
