### PR TITLE
EZEE-1822: Fixed wrong header in language view

### DIFF
--- a/src/bundle/Resources/translations/language.en.xliff
+++ b/src/bundle/Resources/translations/language.en.xliff
@@ -111,10 +111,15 @@
         <target state="new">Language '%name%' updated.</target>
         <note>key: language.update.success</note>
       </trans-unit>
-      <trans-unit id="1fd8d969dd2111149c482ad69e7af580cb718195" resname="language.view">
+      <trans-unit id="451b73fc2ed5bb8b05754b0d293ea07293461ec9" resname="language.view.identifier">
         <source>%language%</source>
         <target state="new">%language%</target>
-        <note>key: language.view</note>
+        <note>key: language.view.identifier</note>
+      </trans-unit>
+      <trans-unit id="0a1cfca26e45dbcd8636d95297586e83f4d9f0f7" resname="language.view.page_title">
+        <source>Language: %language%</source>
+        <target state="new">Language: %language%</target>
+        <note>key: language.view.page_title</note>
       </trans-unit>
       <trans-unit id="8df2798a2851c0d43893e3862f8a2e6e4290b141" resname="language.view.title">
         <source>"%language%" Language</source>

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -8,7 +8,7 @@
     {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.language.list'), value: 'language.list'|trans|desc('Languages') },
-        { value: 'language.view'|trans({ '%language%': language.name })|desc('%language%') }
+        { value: 'language.view.identifier'|trans({ '%language%': language.name })|desc('%language%') }
     ]} %}
 {% endblock %}
 
@@ -16,7 +16,7 @@
 
 {% block pageTitle %}
     {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
-        title: 'language.view.title'|trans({ '%language%': language.name })|desc('"%language%" Language'),
+        title: 'language.view.page_title'|trans({ '%language%': language.name })|desc('Language: %language%'),
         iconName: 'languages'
     } %}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-1822
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixed wrong header in language view

<img width="1431" alt="screen shot 2017-12-15 at 9 08 32 pm" src="https://user-images.githubusercontent.com/1654712/34058668-2a73e80e-e1dc-11e7-899f-c76223ee55a6.png">

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
