### PR TITLE
EZP-28458: Styled position of translations switcher in Content view

### DIFF
--- a/src/bundle/Resources/public/scss/_field-group.scss
+++ b/src/bundle/Resources/public/scss/_field-group.scss
@@ -4,14 +4,19 @@
 
     .ez-raw-content-title {
         border-bottom: 1px solid $ez-color-secondary;
-        padding-bottom: .25rem;
         color: $ez-color-secondary;
 
         h2 {
-        font-size: 1.125rem;
-        font-weight: 400;  
+            margin-top: 1rem;
+            margin-bottom: 0;
+            padding-bottom: .5rem;
+            font-size: 1.125rem;
+            font-weight: 400;  
         }
 
+        .form-inline {
+            padding-bottom: .25rem;
+        }
     }    
 }
 
@@ -26,10 +31,6 @@
 
     .ez-content-field-name {
         background-color: $ez-color-base-pale;
-        // margin-bottom: 0;
-        // padding: .5rem 1.5rem;
-        // border-top-right-radius: 5px;
-        // border-top-left-radius: 5px;
     }
 
     h2.ez-fieldgroup-name {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28458](https://jira.ez.no/browse/EZP-28458)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Styled positioning of Translations switcher in Content view.

![screen shot 2017-12-16 at 3 51 21 pm](https://user-images.githubusercontent.com/9256718/34074259-72bf2acc-e279-11e7-9aa1-b1c6de38322e.png)
![screen shot 2017-12-16 at 3 50 40 pm](https://user-images.githubusercontent.com/9256718/34074264-8805e1b4-e279-11e7-8bb6-e6c42560041b.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
