### PR TITLE
EZP-28570: Incorrect background for buttons in link toolbar in AlloyEditor

### DIFF
--- a/src/bundle/Resources/public/scss/_alloyeditor-buttons.scss
+++ b/src/bundle/Resources/public/scss/_alloyeditor-buttons.scss
@@ -35,11 +35,11 @@
 
                 &.ez-btn-ae--remove-link {
                     margin-right: 1rem;
-                    background-color: $ez-ground-base-dark;
+                    background-color: $ez-color-base-light;
                 }
 
                 &.ez-btn-ae--udw {
-                    background-color: $ez-ground-base-dark;
+                    background-color: $ez-color-base-light;
                 }
             }
 

--- a/src/bundle/Resources/public/scss/_alloyeditor-link-edit.scss
+++ b/src/bundle/Resources/public/scss/_alloyeditor-link-edit.scss
@@ -47,15 +47,15 @@
                     margin-bottom: 0;
 
                     span {
-                        background-color: $ez-color-base-medium;
+                        background-color: $ez-color-base-dark;
                         height: 2.25rem;
                         padding: .7rem .5rem;
                         display: block;
-                        color: $ez-color-base-dark;
+                        color: $ez-black;
                     }
 
                     input:checked + span {
-                        background-color: $ez-ground-base-dark;
+                        background-color: $ez-color-base-light;
                         color: $ez-white;
                     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28570
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
