### PR TITLE
EZP-28335: Added modal with deleting confirmation in Content tabs and fixed delete button active state

### DIFF
--- a/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
@@ -1,0 +1,23 @@
+<div class="modal fade" id="{{ id }}" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{ 'modal.title'|trans|desc('Please confirm') }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>{{ message }}</p>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-danger btn--trigger" data-click="{{ data_click }}">
+                    {{ 'modal.delete'|trans|desc('Delete') }}
+                </button>
+                <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
+                    {{ 'modal.cancel'|trans|desc('Cancel') }}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -6,7 +6,10 @@
 <section>
     {{ form(form_content_location_add, {'action': path('ezplatform.location.add')}) }}
     {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.locations.content_locations'|trans()|desc('Content locations'), tools: tab.table_header_tools(form_content_location_add, form_content_location_remove) } %}
-    {{ form_start(form_content_location_remove, {'action': path('ezplatform.location.remove')}) }}
+    {{ form_start(form_content_location_remove, {
+        'action': path('ezplatform.location.remove'),
+        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-locations' }
+    }) }}
     <table class="table">
         <thead>
         <tr>
@@ -21,7 +24,9 @@
         {% if locations is not empty %}
             {% for location in locations %}
                 <tr>
-                    <td class="align-middle">{{ form_widget(form_content_location_remove.locations[location.id], {'attr': {'disabled': not location.canDelete}}) }}</td>
+                    <td class="align-middle ez-checkbox-cell">
+                        {{ form_widget(form_content_location_remove.locations[location.id], {'attr': {'disabled': not location.canDelete}}) }}
+                    </td>
                     <td class="align-middle">
                         {% include 'EzPlatformAdminUiBundle:parts:path.html.twig' with {'locations': location.pathLocations} %}
                     </td>
@@ -66,10 +71,26 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
         </svg>
     </button>
-    <button class="btn btn-danger btn--trigger" data-click="#{{ form_remove.remove.vars.id }}">
+
+    {% set modal_data_target = 'delete-content-types-modal' %}
+    <button id="delete-locations" type="button" class="btn btn-danger" disabled data-toggle="modal"
+            data-target="#{{ modal_data_target }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
+    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+        'id': modal_data_target,
+        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Location?'),
+        'data_click': '#' ~ form_remove.remove.vars.id,
+    }%}
 {% endmacro %}
+
+{% block javascripts %}
+    {% javascripts
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -4,7 +4,10 @@
 
 {% import _self as tab %}
 <section>
-    {{ form_start(form_translation_remove, {'action': path('ezplatform.translation.remove')}) }}
+    {{ form_start(form_translation_remove, {
+        'action': path('ezplatform.translation.remove'),
+        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations' }
+    }) }}
     {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.translations.translation_manger'|trans|desc('Translation manager'), tools: tab.table_header_tools(form_translation_remove) } %}
     <table class="table">
         <thead>
@@ -17,7 +20,7 @@
         <tbody>
         {% for translation in translations %}
             <tr>
-                <td>{{ form_widget(form_translation_remove.language_codes[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
+                <td class="ez-checkbox-cell">{{ form_widget(form_translation_remove.language_codes[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
                 <td>{{ translation.name }}</td>
                 <td>{{ translation.languageCode }}</td>
             </tr>
@@ -36,10 +39,26 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
         </svg>
     </button>
-    <button class="btn btn-danger btn--trigger" data-click="#{{ form_translation_remove.remove.vars.id }}">
+
+    {% set modal_data_target = 'delete-translations-modal' %}
+    <button id="delete-translations" type="button" class="btn btn-danger" disabled data-toggle="modal"
+            data-target="#{{ modal_data_target }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
+    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+        'id': modal_data_target,
+        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Translation?'),
+        'data_click': '#' ~ form_translation_remove.remove.vars.id,
+    }%}
 {% endmacro %}
+
+{% block javascripts %}
+    {% javascripts
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -3,7 +3,10 @@
 
 {% if draft_versions is not empty %}
     <section>
-        {{ form_start(form_version_remove_draft, {'action': path('ezplatform.version.remove')}) }}
+        {{ form_start(form_version_remove_draft, {
+            'action': path('ezplatform.version.remove'),
+            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-'~form_version_remove_draft.remove.vars.id }
+        }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
         {% if draft_versions is not empty %}
             {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', { 'versions': draft_versions, 'is_draft': true, 'form': form_version_remove_draft }) }}
@@ -31,7 +34,10 @@
 
 {% if archived_versions is not empty %}
     <section>
-        {{ form_start(form_version_remove_archived, {'action': path('ezplatform.version.remove')}) }}
+        {{ form_start(form_version_remove_archived, {
+            'action': path('ezplatform.version.remove'),
+            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-'~form_version_remove_archived.remove.vars.id }
+        }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.archived_versions'|trans()|desc('Archived versions'), tools: tab.table_header_tools(form_version_remove_archived) } %}
         {% if archived_versions is not empty %}
             {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', { 'versions': archived_versions, 'form': form_version_remove_archived }) }}
@@ -45,10 +51,25 @@
 {% endif %}
 
 {% macro table_header_tools(form) %}
-    <button class="btn btn-danger btn--trigger" data-click="#{{ form.remove.vars.id }}">
+    {% set modal_data_target = 'delete-versions-modal' %}
+    <button id="delete-translations-{{ form.remove.vars.id }}" type="button" class="btn btn-danger" disabled data-toggle="modal"
+            data-target="#{{ modal_data_target }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
+    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+    'id': modal_data_target,
+    'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Translation?'),
+    'data_click': '#' ~ form.remove.vars.id,
+    }%}
 {% endmacro %}
+
+{% block javascripts %}
+    {% javascripts
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -21,7 +21,7 @@
     {% for version in versions %}
         <tr>
             {% if form is defined %}
-                <td>{{ form_widget(form.versions[version.versionNo]) }}</td>
+                <td class="ez-checkbox-cell">{{ form_widget(form.versions[version.versionNo]) }}</td>
             {% endif %}
             <td>
                 {{ version.versionNo }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28335
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Added modal with deleting confirmation in Content tabs and fixed delete button active state in versions, locations and translations.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
