### PR TITLE
EZP-28572: Misleading message on Empty trash action

### DIFF
--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -86,7 +86,7 @@
                         {{ pagerfanta(pager, 'ez') }}
                     </div>
                 {% endif %}
-                {% include 'EzPlatformAdminUiBundle:admin/trash:empty_trash_confirmation_modal.html.twig' with {'form': form_trash_empty, 'trash_items_count': trash_items|length} %}
+                {% include 'EzPlatformAdminUiBundle:admin/trash:empty_trash_confirmation_modal.html.twig' with {'form': form_trash_empty, 'trash_items_count': pager.nbResults} %}
             </section>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28572
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Misleading message on Empty trash action about number of deleted items

<img width="1420" alt="screen shot 2017-12-18 at 12 58 35 pm" src="https://user-images.githubusercontent.com/1654712/34105041-3362a022-e3f3-11e7-9066-ac70984d2731.png">


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
