### PR TITLE
fix: Make Dashboard extensible

### DIFF
--- a/src/bundle/Resources/config/services/components.yml
+++ b/src/bundle/Resources/config/services/components.yml
@@ -22,8 +22,10 @@ services:
         lazy: true
 
     EzSystems\EzPlatformAdminUiBundle\Templating\Twig\ComponentExtension:
-        autowire: true
-        autoconfigure: true
-        public: false
         tags:
             - { name: twig.extension }
+
+    EzSystems\EzPlatformAdminUi\Component\Renderer\DefaultRenderer:
+        public: false
+
+    EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface: '@EzSystems\EzPlatformAdminUi\Component\Renderer\DefaultRenderer'

--- a/src/bundle/Resources/views/dashboard/block/all.html.twig
+++ b/src/bundle/Resources/views/dashboard/block/all.html.twig
@@ -2,7 +2,7 @@
 
 <div class="card border-light mb-4">
     <div class="card-body">
-        <h3 class="mb-3">{{ 'everyone'|trans|desc('Everyone') }}</h3>
+        <h2 class="mb-3">{{ 'everyone'|trans|desc('Everyone') }}</h2>
         {{ ez_platform_tabs('dashboard-everyone', []) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/dashboard/block/me.html.twig
+++ b/src/bundle/Resources/views/dashboard/block/me.html.twig
@@ -2,7 +2,7 @@
 
 <div class="card border-light my-4">
     <div class="card-body">
-        <h3 class="mb-3">{{ 'me'|trans|desc('Me') }}</h3>
+        <h2 class="mb-3">{{ 'me'|trans|desc('Me') }}</h2>
         {{ ez_platform_tabs('dashboard-my', []) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard/dashboard.html.twig
@@ -16,19 +16,7 @@
         </div>
         <div class="col-sm-12">
             <div class="container">
-                <div class="card border-light my-4">
-                    <div class="card-body">
-                        <h2 class="mb-3">{{ 'me'|trans|desc('Me') }}</h2>
-                        {{ ez_platform_tabs('dashboard-my', []) }}
-                    </div>
-                </div>
-
-                <div class="card border-light mb-4">
-                    <div class="card-body">
-                        <h2 class="mb-3">{{ 'everyone'|trans|desc('Everyone') }}</h2>
-                        {{ ez_platform_tabs('dashboard-everyone', []) }}
-                    </div>
-                </div>
+                {{ ezplatform_admin_ui_component_group('dashboard-blocks') }}
             </div>
         </div>
     </div>

--- a/src/bundle/Templating/Twig/ComponentExtension.php
+++ b/src/bundle/Templating/Twig/ComponentExtension.php
@@ -9,8 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
 
 use EzSystems\EzPlatformAdminUi\Component\Registry as ComponentRegistry;
-use EzSystems\EzPlatformAdminUi\Component\Renderable;
-use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface;
 use Twig_Extension;
 use Twig_SimpleFunction;
 
@@ -18,10 +17,14 @@ class ComponentExtension extends Twig_Extension
 {
     protected $registry;
 
+    protected $renderer;
+
     public function __construct(
-        ComponentRegistry $registry
+        ComponentRegistry $registry,
+        RendererInterface $renderer
     ) {
         $this->registry = $registry;
+        $this->renderer = $renderer;
     }
 
     public function getFunctions()
@@ -42,25 +45,11 @@ class ComponentExtension extends Twig_Extension
 
     public function renderComponentGroup(string $group, array $parameters = [])
     {
-        $components = $this->registry->getComponents($group);
-        $outputs = array_map(function (Renderable $component) use ($parameters) {
-            return $component->render($parameters);
-        }, $components);
-
-        return implode('', $outputs);
+        return implode('', $this->renderer->renderGroup($group, $parameters));
     }
 
     public function renderComponent(string $group, string $id, array $parameters = [])
     {
-        $components = $this->registry->getComponents($group);
-
-        if (!isset($components[$id])) {
-            throw new InvalidArgumentException('id', sprintf("Can't find Component '%s' in group '%s'", $id, $group));
-        }
-
-        /** @var Renderable $component */
-        $component = $components[$id];
-
-        return $component->render($parameters);
+        return $this->renderer->renderSingle($group, $id, $parameters);
     }
 }

--- a/src/lib/Component/Event/RenderGroupEvent.php
+++ b/src/lib/Component/Event/RenderGroupEvent.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Component\Event;
+
+use EzSystems\EzPlatformAdminUi\Component\Registry;
+use Symfony\Component\EventDispatcher\Event;
+
+class RenderGroupEvent extends Event
+{
+    const NAME = 'ezplatform_admin_ui.component.render_group';
+
+    /** @var Registry */
+    private $registry;
+
+    /** @var string */
+    private $groupName;
+
+    /** @var array */
+    private $parameters;
+
+    /**
+     * @param Registry $registry
+     * @param string $groupName
+     * @param array $parameters
+     */
+    public function __construct(Registry $registry, string $groupName, array $parameters = [])
+    {
+        $this->registry = $registry;
+        $this->groupName = $groupName;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGroupName(): string
+    {
+        return $this->groupName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getComponents(): array
+    {
+        return $this->registry->getComponents($this->getGroupName());
+    }
+
+    /**
+     * @param array $components
+     */
+    public function setComponents(array $components)
+    {
+        $this->registry->setComponents($this->getGroupName(), $components);
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/lib/Component/Event/RenderGroupEvent.php
+++ b/src/lib/Component/Event/RenderGroupEvent.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Component\Event;

--- a/src/lib/Component/Event/RenderSingleEvent.php
+++ b/src/lib/Component/Event/RenderSingleEvent.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Component\Event;
+
+use EzSystems\EzPlatformAdminUi\Component\Registry;
+use EzSystems\EzPlatformAdminUi\Component\Renderable;
+use Symfony\Component\EventDispatcher\Event;
+
+class RenderSingleEvent extends Event
+{
+    const NAME = 'ezplatform_admin_ui.component.render_single';
+
+    /** @var Registry */
+    private $registry;
+
+    /** @var string */
+    private $groupName;
+
+    /** @var string */
+    private $serviceId;
+
+    /** @var array */
+    private $parameters;
+
+    /**
+     * @param Registry $registry
+     * @param string $groupName
+     * @param array $parameters
+     */
+    public function __construct(Registry $registry, string $groupName, string $serviceId, array $parameters = [])
+    {
+        $this->registry = $registry;
+        $this->groupName = $groupName;
+        $this->serviceId = $serviceId;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGroupName(): string
+    {
+        return $this->groupName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->serviceId;
+    }
+
+    /**
+     * @return Renderable
+     */
+    public function getComponent(): Renderable
+    {
+        $group = $this->registry->getComponents($this->getGroupName());
+
+        return $group[$this->serviceId];
+    }
+
+    /**
+     * @param Renderable $component
+     */
+    public function setComponent(Renderable $component)
+    {
+        $this->registry->addComponent($this->getGroupName(), $this->getName(), $component);
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/lib/Component/Event/RenderSingleEvent.php
+++ b/src/lib/Component/Event/RenderSingleEvent.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Component\Event;

--- a/src/lib/Component/Registry.php
+++ b/src/lib/Component/Registry.php
@@ -40,4 +40,13 @@ class Registry
     {
         return $this->components[$group] ?? [];
     }
+
+    /**
+     * @param string $group
+     * @param array $components
+     */
+    public function setComponents(string $group, array $components)
+    {
+        $this->components[$group] = $components;
+    }
 }

--- a/src/lib/Component/Renderer/DefaultRenderer.php
+++ b/src/lib/Component/Renderer/DefaultRenderer.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Component\Renderer;
+
+use EzSystems\EzPlatformAdminUi\Component\Event\RenderGroupEvent;
+use EzSystems\EzPlatformAdminUi\Component\Event\RenderSingleEvent;
+use EzSystems\EzPlatformAdminUi\Component\Registry;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class DefaultRenderer implements RendererInterface
+{
+    protected $registry;
+
+    protected $eventDispatcher;
+
+    public function __construct(Registry $registry, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->registry = $registry;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function renderGroup(string $groupName, array $parameters = []): array
+    {
+        $this->eventDispatcher->dispatch(RenderGroupEvent::NAME, new RenderGroupEvent(
+            $this->registry,
+            $groupName,
+            $parameters
+        ));
+
+        $components = $this->registry->getComponents($groupName);
+
+        $rendered = [];
+        foreach ($components as $id => $component) {
+            $rendered[] = $this->renderSingle($id, $groupName, $parameters);
+        }
+
+        return $rendered;
+    }
+
+    public function renderSingle(string $name, $groupName, array $parameters = []): string
+    {
+        $this->eventDispatcher->dispatch(RenderSingleEvent::NAME, new RenderSingleEvent(
+            $this->registry,
+            $groupName,
+            $name,
+            $parameters
+        ));
+
+        $group = $this->registry->getComponents($groupName);
+
+        if (!isset($group[$name])) {
+            throw new InvalidArgumentException('id', sprintf("Can't find Component '%s' in group '%s'", $name, $group));
+        }
+
+        return $group[$name]->render($parameters);
+    }
+}

--- a/src/lib/Component/Renderer/DefaultRenderer.php
+++ b/src/lib/Component/Renderer/DefaultRenderer.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Component\Renderer;

--- a/src/lib/Component/Renderer/RendererInterface.php
+++ b/src/lib/Component/Renderer/RendererInterface.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Component\Renderer;

--- a/src/lib/Component/Renderer/RendererInterface.php
+++ b/src/lib/Component/Renderer/RendererInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Component\Renderer;
+
+interface RendererInterface
+{
+    public function renderGroup(string $groupName, array $parameters = []): array;
+
+    public function renderSingle(string $name, $groupName, array $parameters = []): string;
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Ping @DominikaK : 

Example EventSubscriber to demonstrate how to intercept and alter rendering of elements:

```php
<?php
declare(strict_types=1);

namespace EzSystems\EzPlatformAdminUi\EventListener;

use EzSystems\EzPlatformAdminUi\Component\Event\RenderGroupEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class DashboardEventSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [
            RenderGroupEvent::NAME => ['onRenderGroupEvent', 20],
        ];
    }

    public function onRenderGroupEvent(RenderGroupEvent $event)
    {
        if ($event->getGroupName() !== 'dashboard-blocks') {
            return;
        }

        $components = $event->getComponents();

        $reverseOrder = array_reverse($components);

        $event->setComponents($reverseOrder);
    }
}
```

Services.yml:

```yml
    EzSystems\EzPlatformAdminUi\EventListener\DashboardEventSubscriber:
        public: true
        tags:
            - { name: kernel.event_subscriber }
```

<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review