### PR TITLE
EZP-28445: Ezselection fills itself when required after publish

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezselection.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezselection.js
@@ -112,6 +112,8 @@
         };
         const handleClickOnOption = (event) => handleSelection(event.target, !event.target.classList.contains(CLASS_SELECTED));
 
+        selectFirstItem();
+
         container.querySelector(SELECTOR_SELECTED).addEventListener('click', handleClickOnInput, false);
         [...container.querySelectorAll(`${SELECTOR_OPTIONS} li`)].forEach(option => option.addEventListener('click', handleClickOnOption, false));
     });


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28445
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
