### PR TITLE
Missed reference to location_ids.content (EZP-28553)

### DIFF
--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -1,6 +1,5 @@
 parameters:
     # System Location IDs
-    ezsettings.default.location_ids.content: 2
     ezsettings.default.location_ids.media: 43
     ezsettings.default.location_ids.users: 5
 


### PR DESCRIPTION
EZP-28553: Adds Permission Awareness to all menus

| Question      | Answer
| ------------- | ---
| Tickets       | Related to EZP-28553
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
