### PR TITLE
EZP-28586: Setting ordering of sub-items moves user to the location tab

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -24,6 +24,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Tab\LocationView\DetailsTab;
 use EzSystems\EzPlatformAdminUi\Tab\LocationView\LocationsTab;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -504,7 +505,7 @@ class LocationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
                         'locationId' => $location->getContentInfo()->mainLocationId,
-                        '_fragment' => LocationsTab::URI_FRAGMENT,
+                        '_fragment' => DetailsTab::URI_FRAGMENT,
                     ]));
             });
 
@@ -515,7 +516,7 @@ class LocationController extends Controller
 
         return $this->redirect($this->generateUrl('_ezpublishLocation', [
             'locationId' => $location->getContentInfo()->mainLocationId,
-            '_fragment' => LocationsTab::URI_FRAGMENT,
+            '_fragment' => DetailsTab::URI_FRAGMENT,
         ]));
     }
 }

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -23,6 +23,8 @@ use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 
 class DetailsTab extends AbstractTab implements OrderedTabInterface
 {
+    const URI_FRAGMENT = 'ez-tab-location-view-details';
+
     /** @var Repository\ContentTypeService */
     protected $contentTypeService;
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28586
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Setting ordering of sub-items moves user to the location tab


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
