### PR TITLE
EZP-28589: Added information about number of Content Types on CTG list

### DIFF
--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -76,6 +76,7 @@ class ContentTypeGroupController extends Controller
     public function listAction(): Response
     {
         $deletableContentTypeGroup = [];
+        $count = [];
 
         $contentTypeGroupList = $this->contentTypeService->loadContentTypeGroups();
 
@@ -84,13 +85,16 @@ class ContentTypeGroupController extends Controller
         );
 
         foreach ($contentTypeGroupList as $contentTypeGroup) {
-            $deletableContentTypeGroup[$contentTypeGroup->id] = !(bool)count($this->contentTypeService->loadContentTypes($contentTypeGroup));
+            $contentTypesCount = count($this->contentTypeService->loadContentTypes($contentTypeGroup));
+            $deletableContentTypeGroup[$contentTypeGroup->id] = !(bool)$contentTypesCount;
+            $count[$contentTypeGroup->id] = $contentTypesCount;
         }
 
         return $this->render('@EzPlatformAdminUi/admin/content_type_group/list.html.twig', [
             'content_type_groups' => $contentTypeGroupList,
             'form_content_type_groups_delete' => $deleteContentTypeGroupsForm->createView(),
             'deletable' => $deletableContentTypeGroup,
+            'content_types_count' => $count,
         ]);
     }
 

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -311,6 +311,11 @@
         <target state="new">Edit</target>
         <note>key: content_type_group.view.list.action.edit</note>
       </trans-unit>
+      <trans-unit id="125bee275441fe2bd28cb9388b790c634d8ae3c6" resname="content_type_group.view.list.column.content_types_count">
+        <source>Content Types count</source>
+        <target state="new">Content Types count</target>
+        <note>key: content_type_group.view.list.column.content_types_count</note>
+      </trans-unit>
       <trans-unit id="cd462ce30cd4d0b21393e24ca2c9e974369c1f57" resname="content_type_group.view.list.column.id">
         <source>ID</source>
         <target state="new">ID</target>

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -57,6 +57,7 @@
                     <th></th>
                     <th>{{ 'content_type_group.view.list.column.identifier'|trans|desc('Name') }}</th>
                     <th>{{ 'content_type_group.view.list.column.id'|trans|desc('ID') }}</th>
+                    <th>{{ 'content_type_group.view.list.column.content_types_count'|trans|desc('Content Types count') }}</th>
                     <th></th>
                 </tr>
             </thead>
@@ -74,6 +75,7 @@
                         <a href="{{ view_url }}">{{ content_type_group.identifier }}</a>
                     </td>
                     <td>{{ content_type_group.id }}</td>
+                    <td>{{ content_types_count[content_type_group.id] }}</td>
                     <td class="text-right">
                         {% set edit_url = path('ezplatform.content_type_group.update', {
                             contentTypeGroupId: content_type_group.id


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28589
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Added information about number of Content Types on CTG list

<img width="1434" alt="screen shot 2017-12-18 at 4 27 48 pm" src="https://user-images.githubusercontent.com/1654712/34113575-6bd80e52-e410-11e7-94a9-739da2dbb1f4.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
