### PR TITLE
EZP-28598: Fixes no filtering langauge on create content UI

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -4,13 +4,13 @@ imports:
     - { resource: services/tabs.yml }
     - { resource: services/menu.yml }
     - { resource: services/application_config.yml }
-    - { resource: services/type_extensions.yml }
     - { resource: services/pagination.yml }
     - { resource: services/ui_config.yml }
     - { resource: services/components.yml }
     - { resource: services/dashboard.yml }
     - { resource: services/modules/subitems.yml }
     - { resource: services/form_processors.yml }
+    - { resource: services/form_types.yml }
 
 parameters:
 
@@ -43,9 +43,6 @@ services:
             - '%ezpublish.siteaccess.groups%'
         tags:
             - {name: kernel.event_subscriber}
-
-    EzSystems\EzPlatformAdminUi\Form\Type\:
-        resource: '../../../lib/Form/Type'
 
     EzSystems\EzPlatformAdminUi\Form\DataMapper\:
         resource: '../../../lib/Form/DataMapper'

--- a/src/bundle/Resources/config/services/form_types.yml
+++ b/src/bundle/Resources/config/services/form_types.yml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+
+    EzSystems\EzPlatformAdminUi\Form\Type\:
+        resource: '../../../lib/Form/Type'
+
+    EzSystems\EzPlatformAdminUi\Form\Type\Language\LimitedLanguageChoiceType:
+        arguments:
+            $siteaccessLanguages: '$languages$'

--- a/src/bundle/Resources/config/services/type_extensions.yml
+++ b/src/bundle/Resources/config/services/type_extensions.yml
@@ -1,5 +1,0 @@
-services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-        public: true

--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -12,7 +12,7 @@ use eZ\Publish\API\Repository\LanguageService;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\LocationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\ContentTypeChoiceType;
-use EzSystems\EzPlatformAdminUi\Form\Type\Language\LanguageChoiceType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Language\LimitedLanguageChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -50,7 +50,7 @@ class ContentCreateType extends AbstractType
             )
             ->add(
                 'language',
-                LanguageChoiceType::class,
+                LimitedLanguageChoiceType::class,
                 [
                     'label' => false,
                     'multiple' => false,

--- a/src/lib/Form/Type/Language/LimitedLanguageChoiceType.php
+++ b/src/lib/Form/Type/Language/LimitedLanguageChoiceType.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\Language;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form Type allowing to select Language.
+ *
+ * @todo: This can replace LanguageType in the future but it'd require some changes in the frontend as well.
+ */
+class LimitedLanguageChoiceType extends AbstractType
+{
+    /** @var LanguageService */
+    protected $languageService;
+
+    /** @var string[] */
+    protected $siteaccessLanguages;
+
+    /** @var PermissionResolver */
+    protected $permissionResolver;
+
+    /**
+     * @param LanguageService $languageService
+     * @param string[] $siteaccessLanguages
+     * @param PermissionResolver $permissionResolver
+     */
+    public function __construct(
+        LanguageService $languageService,
+        array $siteaccessLanguages,
+        PermissionResolver $permissionResolver
+    ) {
+        $this->languageService = $languageService;
+        $this->siteaccessLanguages = $siteaccessLanguages;
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'choice_loader' => $this->getChoiceLoader(),
+                'choice_label' => 'name',
+                'choice_name' => 'languageCode',
+                'choice_value' => 'languageCode',
+            ]);
+    }
+
+    /**
+     * @return CallbackChoiceLoader
+     */
+    private function getChoiceLoader(): CallbackChoiceLoader
+    {
+        return new CallbackChoiceLoader(
+            function () {
+                $systemLanguages = $this->languageService->loadLanguages();
+                $siteaccessLanguages = $this->siteaccessLanguages;
+                $availableLanguageCodes = array_intersect(
+                    array_column($systemLanguages, 'languageCode'),
+                    $siteaccessLanguages
+                );
+
+                $languages = array_filter($systemLanguages, function (Language $language) use ($availableLanguageCodes) {
+                    return $language->enabled && in_array($language->languageCode, $availableLanguageCodes, true);
+                });
+
+                return $languages;
+            }
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28598
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
