### PR TITLE
EZP-28600: Design improvements for Trash restore buttons

### DIFF
--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -236,16 +236,6 @@
         <target state="new">Delete permanently</target>
         <note>key: trash_empty_form.empty</note>
       </trans-unit>
-      <trans-unit id="1b05bfd460ef104fc79726b60f1b5872cb0cbc1d" resname="trash_item_restore_form.restore">
-        <source>Restore selected</source>
-        <target state="new">Restore selected</target>
-        <note>key: trash_item_restore_form.restore</note>
-      </trans-unit>
-      <trans-unit id="9842e86d98a92b6afb831334a75a562a239dd70a" resname="trash_item_restore_form.restore_under_new_parent">
-        <source>Restore under new parent</source>
-        <target state="new">Restore under new parent</target>
-        <note>key: trash_item_restore_form.restore_under_new_parent</note>
-      </trans-unit>
       <trans-unit id="3b2ae7aa286887e2fbd2b6e77ca237f9f9109e9b" resname="version_remove_form.remove">
         <source>Remove version</source>
         <target state="new">Remove version</target>

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -24,7 +24,12 @@
                         <div class="ez-table-header__headline">{{ 'trash.table.header'|trans|desc('Trash') }}</div>
                         <div>
                             {% if can_restore and form_trash_item_restore.trash_items is not empty %}
-                                {% set restore_under_new_parent_button_attr = form_trash_item_restore.location.select_content.vars.attr|merge({'attr': {'class': (form_trash_item_restore.location.select_content.vars.attr.class|default('') ~ ' d-inline-block')|trim, 'disabled': true}}) %}
+                                {% set restore_under_new_parent_button_attr = form_trash_item_restore.location.select_content.vars.attr|merge({
+                                    'attr': {
+                                        'class': (form_trash_item_restore.location.select_content.vars.attr.class|default('') ~ ' d-inline-block btn btn-secondary')|trim,
+                                        'disabled': true
+                                    }
+                                }) %}
                                 {{ form_widget(form_trash_item_restore.location.select_content, restore_under_new_parent_button_attr) }}
                                 {{ form_widget(form_trash_item_restore.location.location) }}
                                 {% do form_trash_item_restore.location.setRendered %}
@@ -76,12 +81,11 @@
                     </table>
                     {{ form_widget(form_trash_item_restore._token) }}
                     {{ form_end(form_trash_item_restore, { 'render_rest': false }) }}
-
-                    <div class="row justify-content-center align-items-center">
-                        <h6>{{ 'trash.viewing'|trans({'%viewing%': pager.currentPageResults|length, '%total%': pager.nbResults})|desc('Viewing %viewing% out of %total% items') }}</h6>
-                    </div>
                 </div>
                 {% if pager.haveToPaginate %}
+                    <div class="row justify-content-center align-items-center mb-2">
+                        <h6>{{ 'trash.viewing'|trans({'%viewing%': pager.currentPageResults|length, '%total%': pager.nbResults})|desc('Viewing %viewing% out of %total% items') }}</h6>
+                    </div>
                     <div class="row justify-content-center align-items-center">
                         {{ pagerfanta(pager, 'ez') }}
                     </div>

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -37,3 +37,43 @@
 {%- block trash_item_checkbox_widget -%}
     <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
 {%- endblock -%}
+
+{%- block _trash_item_restore_restore_widget -%}
+        {%- set type = type|default('submit') -%}
+        {%- if label is not same as(false) and label is empty -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <button type="{{ type }}" {{ block('button_attributes') }}>
+            <svg class="ez-icon">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#restore"></use>
+            </svg>
+            {{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}
+        </button>
+{%- endblock -%}
+
+{%- block _trash_item_restore_location_select_content_widget -%}
+        {%- set type = type|default('submit') -%}
+        {%- if label is not same as(false) and label is empty -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <button type="{{ type }}" {{ block('button_attributes') }}>
+            <svg class="ez-icon">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#restore-parent"></use>
+            </svg>
+            {{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}
+        </button>
+{%- endblock -%}

--- a/src/lib/Form/Type/Trash/TrashItemRestoreType.php
+++ b/src/lib/Form/Type/Trash/TrashItemRestoreType.php
@@ -34,14 +34,12 @@ class TrashItemRestoreType extends AbstractType
 
         $builder->add('location', UniversalDiscoveryWidgetType::class, [
             'multiple' => false,
-            'label' => /** @Desc("Restore under new parent") */
-                'trash_item_restore_form.restore_under_new_parent',
+            'label' => false,
             'attr' => $options['attr'],
         ]);
 
         $builder->add('restore', SubmitType::class, [
-            'label' => /** @Desc("Restore selected") */
-                'trash_item_restore_form.restore',
+            'label' => false,
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28600
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Design improvements for Trash restore buttons


<img width="1440" alt="screen shot 2017-12-19 at 9 40 23 am" src="https://user-images.githubusercontent.com/1654712/34148208-bb37d92e-e4a0-11e7-8bef-7e61107773b5.png">

<img width="1428" alt="screen shot 2017-12-19 at 9 40 14 am" src="https://user-images.githubusercontent.com/1654712/34148209-bb531950-e4a0-11e7-95b5-506be05f05b0.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
