### PR TITLE
EZP-28607: URL field type validation is not always working correctly

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezurl.js
@@ -9,15 +9,12 @@
             const input = event.currentTarget;
             const isRequired = input.required;
             const isEmpty = !input.value.trim();
-            const isValid = global.eZ.errors.urlRegexp.test(input.value);
-            const isError = (isEmpty && isRequired) || (!isEmpty && !isValid);
+            const isError = isEmpty && isRequired;
             const label = input.closest(SELECTOR_FIELD_LINK).querySelector(SELECTOR_LABEL).innerHTML;
             const result = { isError };
 
             if (isRequired && isEmpty) {
                 result.errorMessage = global.eZ.errors.emptyField.replace('{fieldName}', label);
-            } else if (!isEmpty && !isValid) {
-                result.errorMessage = global.eZ.errors.invalidUrl;
             }
 
             return result;

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -10,10 +10,8 @@
                 // needs translations
                 errors: {
                     emailRegexp: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-                    urlRegexp: /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})/,
                     emptyField: '{fieldName} field is required',
                     invalidEmail: 'A valid email address is required',
-                    invalidUrl: 'A valid URL is required',
                     tooLong: '{fieldName} value should be less than or equal to {maxLength} characters',
                     tooShort: '{fieldName} value should be greater than or equal to {minLength} characters',
                     isNotInteger: '{fieldName} value should be an integer',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28607
| Bug fix?      | yes/
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
