### PR TITLE
EZP-28581: Cannot edit Content Object from Link Manager

### DIFF
--- a/src/bundle/Controller/LinkManagerController.php
+++ b/src/bundle/Controller/LinkManagerController.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
@@ -156,10 +157,15 @@ class LinkManagerController extends Controller
         $usages->setCurrentPage($request->query->getInt('page', 1));
         $usages->setMaxPerPage($request->query->getInt('limit', self::DEFAULT_MAX_PER_PAGE));
 
+        $editForm = $this->formFactory->contentEdit(
+            new ContentEditData()
+        );
+
         return $this->render('@EzPlatformAdminUi/link_manager/view.html.twig', [
             'url' => $url,
             'can_edit' => $this->isGranted(new Attribute('url', 'update')),
             'usages' => $usages,
+            'form_edit' => $editForm->createView(),
         ]);
     }
 

--- a/src/bundle/Resources/translations/linkmanager.en.xliff
+++ b/src/bundle/Resources/translations/linkmanager.en.xliff
@@ -116,6 +116,16 @@
         <target>Status</target>
         <note>key: url.usages.column.status</note>
       </trans-unit>
+      <trans-unit id="e7ae589ed6ce535328c6561f41bc0171f8fabeb8" resname="url.usages.content_status.draft">
+        <source>Draft</source>
+        <target state="new">Draft</target>
+        <note>key: url.usages.content_status.draft</note>
+      </trans-unit>
+      <trans-unit id="d831a1a74184672a12e3b9ae099692d1b4fd55b1" resname="url.usages.content_status.published">
+        <source>Published</source>
+        <target state="new">Published</target>
+        <note>key: url.usages.content_status.published</note>
+      </trans-unit>
       <trans-unit id="dce98314e5ba27c161d28c789d2b970180ea852c" resname="url.view">
         <source>Link %url%</source>
         <target>Link %url%</target>

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -83,8 +83,6 @@
             <tbody>
                 {% for content in usages %}
                     {% set view_url = path('_ez_content_view', { contentId: content.id }) %}
-                    {# TODO: Missing edit URL #}
-                    {% set edit_url = '' %}
 
                     <tr>
                         <td>
@@ -95,11 +93,14 @@
                         <td>{{ content.published ? 'Published' : 'Draft' }}</td>
                         <td class="text-right">
                             {% if can_edit %}
-                            <a href="{{ edit_url }}" class="btn btn-icon">
-                                <svg class="ez-icon ez-icon-edit">
-                                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                                </svg>
-                            </a>
+                                <button class="btn btn-icon btn-link ez-btn--content-edit"
+                                        data-content-id="{{ content.id }}"
+                                        data-version-no="{{ content.currentVersionNo }}"
+                                        data-language-code="{{ content.mainLanguageCode }}">
+                                    <svg class="ez-icon ez-icon-edit">
+                                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                                    </svg>
+                                </button>
                             {% endif %}
                         </td>
                     </tr>
@@ -112,8 +113,22 @@
                 {{ pagerfanta(usages, 'ez') }}
             </div>
         {% endif %}
+
+        {{ form_start(form_edit, {
+            'action': path('ezplatform.content.edit'),
+            'attr': { 'class': 'ez-edit-content-form'}
+        }) }}
+            {{ form_widget(form_edit.language, {'attr': {'hidden': 'hidden', 'class': 'language-input'}}) }}
+        {{ form_end(form_edit) }}
     </section>
 {%- endblock -%}
 
 {% block title %}{{ 'url.view'|trans({ '%url%': url.url|truncate(60) }) }}{% endblock %}
 
+{% block javascripts %}
+    {%  javascripts
+        'bundles/ezplatformadminui/js/scripts/button.content.edit.js'
+    %}
+        <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -90,7 +90,13 @@
                                 {{ ez_content_name(content) }}
                             </a>
                         </td>
-                        <td>{{ content.published ? 'Published' : 'Draft' }}</td>
+                        <td>
+                            {% if content.published %}
+                                {{ 'url.usages.content_status.published'|trans|desc('Published') }}
+                            {% else %}
+                                {{ 'url.usages.content_status.draft'|trans|desc('Draft') }}
+                            {% endif %}
+                        </td>
                         <td class="text-right">
                             {% if can_edit %}
                                 <button class="btn btn-icon btn-link ez-btn--content-edit"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28581
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR contains bugfix mentioned in JIRA ticket and missing translation for Content Object status in Link Manager.

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
