### PR TITLE
EZP-28616: Add pagination to the Content Type Groups and Content Type

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -45,6 +45,8 @@ class Pagination extends AbstractParser
                     ->scalarNode('section_limit')->isRequired()->end()
                     ->scalarNode('language_limit')->isRequired()->end()
                     ->scalarNode('role_limit')->isRequired()->end()
+                    ->scalarNode('content_type_group_limit')->isRequired()->end()
+                    ->scalarNode('content_type_limit')->isRequired()->end()
                 ->end()
             ->end();
     }
@@ -59,7 +61,15 @@ class Pagination extends AbstractParser
         }
 
         $settings = $scopeSettings['pagination'];
-        $keys = ['search_limit', 'trash_limit', 'section_limit', 'language_limit', 'role_limit'];
+        $keys = [
+            'search_limit',
+            'trash_limit',
+            'section_limit',
+            'language_limit',
+            'role_limit',
+            'content_type_group_limit',
+            'content_type_limit',
+        ];
 
         foreach ($keys as $key) {
             if (!isset($settings[$key]) || empty($settings[$key])) {

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -9,6 +9,8 @@ parameters:
     ezsettings.default.pagination.section_limit: 10
     ezsettings.default.pagination.language_limit: 10
     ezsettings.default.pagination.role_limit: 10
+    ezsettings.default.pagination.content_type_group_limit: 10
+    ezsettings.default.pagination.content_type_limit: 10
 
     # Subitems Module
     ezsettings.default.subitems_module.limit: 10

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -248,12 +248,14 @@ ezplatform.content_type_group.list:
         _controller: 'EzPlatformAdminUiBundle:ContentTypeGroup:list'
 
 ezplatform.content_type_group.view:
-    path: /contenttypegroup/{contentTypeGroupId}
+    path: /contenttypegroup/{contentTypeGroupId}/{page}
     methods: ['GET']
     defaults:
         _controller: 'EzPlatformAdminUiBundle:ContentTypeGroup:view'
+        page: 1
     requirements:
         contentTypeGroupId: \d+
+        page: \d+
 
 ezplatform.content_type_group.create:
     path: /contenttypegroup/create

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -18,11 +18,13 @@ services:
         arguments:
             $contentTypeActionDispatcher: '@ezrepoforms.action_dispatcher.content_type'
             $languages: '$languages$'
+            $defaultPaginationLimit: '$pagination.content_type_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentTypeGroupController:
         public: true
         arguments:
             $languages: '$languages$'
+            $defaultPaginationLimit: '$pagination.content_type_group_limit$'
 
 
     EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:

--- a/src/bundle/Resources/translations/pagination.en.xliff
+++ b/src/bundle/Resources/translations/pagination.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Back</target>
         <note>key: pagination.prev_message</note>
       </trans-unit>
+      <trans-unit id="663d5cd498c0849675ac4fd684d4270a1a3f1acb" resname="pagination.viewing">
+        <source><![CDATA[Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items]]></source>
+        <target state="new"><![CDATA[Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items]]></target>
+        <note>key: pagination.viewing</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -44,7 +44,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for content_type in content_types %}
+        {% for content_type in pager.currentPageResults %}
             <tr>
                 <td class="ez-checkbox-cell">
                     {{ form_widget(form_content_types_delete.content_types[content_type.id], {"disabled": not deletable[content_type.id]}) }}
@@ -79,6 +79,22 @@
         </tbody>
     </table>
     {{ form_end(form_content_types_delete) }}
+
+    {% if pager.haveToPaginate %}
+        <div class="row justify-content-center align-items-center mb-2">
+                <span>
+                    {{ 'pagination.viewing'|trans({
+                        '%viewing%': pager.currentPageResults|length,
+                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                </span>
+        </div>
+        <div class="row justify-content-center align-items-center">
+            {{ pagerfanta(pager, 'ez', {
+                'routeName': route_name,
+                'routeParams': {'contentTypeGroupId': group.id}
+            }) }}
+        </div>
+    {% endif %}
 </section>
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -62,7 +62,7 @@
                 </tr>
             </thead>
             <tbody>
-            {% for content_type_group in content_type_groups %}
+            {% for content_type_group in pager.currentPageResults %}
                 <tr>
                     <td class="ez-checkbox-cell">
                         {{ form_widget(form_content_type_groups_delete.content_type_groups[content_type_group.id], {"disabled": not deletable[content_type_group.id]}) }}
@@ -94,6 +94,19 @@
             </tbody>
         </table>
         {{ form_end(form_content_type_groups_delete) }}
+
+        {% if pager.haveToPaginate %}
+            <div class="row justify-content-center align-items-center mb-2">
+                <span>
+                    {{ 'pagination.viewing'|trans({
+                        '%viewing%': pager.currentPageResults|length,
+                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                </span>
+            </div>
+            <div class="row justify-content-center align-items-center">
+                {{ pagerfanta(pager, 'ez') }}
+            </div>
+        {% endif %}
     </section>
 {% endblock %}
 

--- a/src/bundle/Resources/views/admin/content_type_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/view.html.twig
@@ -21,6 +21,8 @@
 
 {% block content %}
     {{ render(controller('EzPlatformAdminUiBundle:ContentType:list', {
-        contentTypeGroupId: content_type_group.id
+        contentTypeGroupId: content_type_group.id,
+        page: page,
+        routeName: route_name
     })) }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28616
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Added pagination to the Content Type Groups and Content Type

<img width="1432" alt="screen shot 2017-12-20 at 12 22 40 pm" src="https://user-images.githubusercontent.com/1654712/34204862-8e134fa6-e580-11e7-958b-8ea63d347ed3.png">
<img width="1432" alt="screen shot 2017-12-20 at 12 22 28 pm" src="https://user-images.githubusercontent.com/1654712/34204863-8e3639d0-e580-11e7-88c3-883e53f9f142.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
