### PR TITLE
EZP-28624: Content structure link in top menu should not rely on root_tree.location_id setting

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/LocationIds.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/LocationIds.php
@@ -21,6 +21,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *   system:
  *      default: # configuration per siteaccess or siteaccess group
  *          location_ids:
+ *              content_structure: 2
  *              media: 43
  *              users: 5
  * ```
@@ -38,6 +39,7 @@ class LocationIds extends AbstractParser
             ->arrayNode('location_ids')
                 ->info('System locations id configuration')
                 ->children()
+                    ->scalarNode('content_structure')->isRequired()->end()
                     ->scalarNode('media')->isRequired()->end()
                     ->scalarNode('users')->isRequired()->end()
                 ->end()
@@ -54,7 +56,7 @@ class LocationIds extends AbstractParser
         }
 
         $settings = $scopeSettings['location_ids'];
-        $keys = ['media', 'users'];
+        $keys = ['content_structure', 'media', 'users'];
 
         foreach ($keys as $key) {
             if (!isset($settings[$key]) || empty($settings[$key])) {

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -1,5 +1,6 @@
 parameters:
     # System Location IDs
+    ezsettings.default.location_ids.content_structure: 2
     ezsettings.default.location_ids.media: 43
     ezsettings.default.location_ids.users: 5
 

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -104,7 +104,7 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
     {
         $menuItems = [];
 
-        $rootContentId = $this->configResolver->getParameter('content.tree_root.location_id');
+        $rootContentId = $this->configResolver->getParameter('location_ids.content_structure');
         $rootMediaId = $this->configResolver->getParameter('location_ids.media');
 
         $contentStructureItem = $this->factory->createLocationMenuItem(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28624
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
