### PR TITLE
EZP-28626: Top menu disappear on CI, Media Item and Users detail views

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -89,3 +89,8 @@ services:
         class: \Twig_Extensions_Extension_Text
         tags:
             - { name: twig.extension }
+
+    EzSystems\EzPlatformAdminUi\Menu\Voter\LocationVoter:
+        arguments: [ '@request_stack' ]
+        tags:
+            - { name: knp_menu.voter }

--- a/src/lib/Menu/Voter/LocationVoter.php
+++ b/src/lib/Menu/Voter/LocationVoter.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Menu\Voter;
+
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Matcher\Voter\VoterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LocationVoter implements VoterInterface
+{
+    private const EZ_PUBLISH_LOCATION_ROUTE_NAME = '_ezpublishLocation';
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matchItem(ItemInterface $item)
+    {
+        $route = $item->getExtra('routes')[0];
+        $contentView = $this->requestStack->getCurrentRequest()->attributes->get('view');
+
+        if ($route['route'] === self::EZ_PUBLISH_LOCATION_ROUTE_NAME && $contentView instanceof ContentView) {
+            if ((int)$contentView->getLocation()->path[1] === $route['parameters']['locationId']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Top menu disappear on CI, Media Item and Users detail views. May need tests in another places.

<img width="1428" alt="screen shot 2017-12-20 at 4 33 51 pm" src="https://user-images.githubusercontent.com/1654712/34214788-c52108ee-e5a3-11e7-99d3-35246d50197d.png">
<img width="1427" alt="screen shot 2017-12-20 at 4 34 46 pm" src="https://user-images.githubusercontent.com/1654712/34214789-c544c3f6-e5a3-11e7-9b70-ca74f0ecb50c.png">
<img width="1428" alt="screen shot 2017-12-20 at 4 35 07 pm" src="https://user-images.githubusercontent.com/1654712/34214791-c5615ebc-e5a3-11e7-9e6a-1d80008541fd.png">

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
