### PR TITLE
EZP-28634: Top menu disappear on Search and Trash

### DIFF
--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -110,7 +110,15 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         $contentStructureItem = $this->factory->createLocationMenuItem(
             self::ITEM_CONTENT__CONTENT_STRUCTURE,
             $rootContentId,
-            ['label' => self::ITEM_CONTENT__CONTENT_STRUCTURE]
+            [
+                'label' => self::ITEM_CONTENT__CONTENT_STRUCTURE,
+                'extras' => [
+                    'routes' => [
+                        'search' => 'ezplatform.search',
+                        'trash' => 'ezplatform.trash.list',
+                    ],
+                ],
+            ]
         );
         $mediaItem = $this->factory->createLocationMenuItem(
             self::ITEM_CONTENT__MEDIA,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28634
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Top menu disappeared on Search and Trash. Current solution is to show top menu always with selected position "Content" -> "Content structure selected"

<img width="1426" alt="screen shot 2017-12-21 at 10 12 47 am" src="https://user-images.githubusercontent.com/1654712/34248796-97d6f562-e637-11e7-9f98-38741413e692.png">
<img width="1427" alt="screen shot 2017-12-21 at 10 12 32 am" src="https://user-images.githubusercontent.com/1654712/34248797-97f177e8-e637-11e7-86ef-6f698d9f57af.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
