### PR TITLE
EZP-28574: Updated dependencies paths after dropping support for Bower

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -49,7 +49,7 @@
 {% block javascripts %}
     {%  javascripts
         '@EzPlatformAdminUiBundle/Resources/public/js/alloyeditor/dist/*.js'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.js'
+        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.min.js'
         '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/taggify/src/js/taggify.js'
         '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.content.edit.js'

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -85,8 +85,8 @@
         </div>
 
         {%  javascripts
-            'bundles/ezplatformadminuiassets/vendors/react/react.min.js'
-            'bundles/ezplatformadminuiassets/vendors/react/react-dom.min.js'
+            'bundles/ezplatformadminuiassets/vendors/react/dist/react.min.js'
+            'bundles/ezplatformadminuiassets/vendors/react-dom/dist/react-dom.min.js'
             'bundles/ezplatformadminuiassets/vendors/jquery/dist/jquery.min.js'
             'bundles/ezplatformadminuiassets/vendors/popper.js/dist/umd/popper.min.js'
             'bundles/ezplatformadminuiassets/vendors/bootstrap/dist/js/bootstrap.min.js'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28574
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

**Requires:**
- https://github.com/ezsystems/ezplatform-admin-ui-assets/pull/6