### PR TITLE
EZP-28638: All forms in AdminUI should use Bootstrap 4 theme

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/eztext.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztext.js
@@ -20,7 +20,7 @@
                 errorMessage
             };
         }
-    };
+    }
 
     const validator = new EzTextValidator({
         classInvalid: 'is-invalid',

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.create.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.create.js
@@ -1,6 +1,6 @@
 (function () {
     const createActions = document.querySelector('.ez-extra-actions--create');
-    const btns = [...createActions.querySelectorAll('.radio [type="radio"]')];
+    const btns = [...createActions.querySelectorAll('.form-check [type="radio"]')];
     const form = createActions.querySelector('form');
 
     btns.forEach(btn => btn.addEventListener('change', () => form.submit(), false));

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -1,6 +1,6 @@
 (function () {
     const editActions = document.querySelector('.ez-extra-actions--edit');
-    const btns = [...editActions.querySelectorAll('.radio [type="radio"]')];
+    const btns = [...editActions.querySelectorAll('.form-check [type="radio"]')];
     const form = editActions.querySelector('form');
 
     btns.forEach(btn => btn.addEventListener('change', () => form.submit(), false));

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -54,7 +54,7 @@
             overflow: auto;
         }
 
-        .radio {
+        .form-check {
             display: block;
             background: none;
             border: 0 none;
@@ -68,6 +68,7 @@
             text-decoration: none;
             cursor: pointer;
             transition: all .2s $ez-admin-transition;
+            margin-bottom: 0;
 
             &:hover,
             &:focus {
@@ -119,11 +120,11 @@
             padding: 0;
         }
 
-        .radio {
+        .form-check {
             cursor: pointer;
             background: $ez-white;
             transition: all .2s $ez-admin-transition;
-            padding-left: 1.5rem;
+            margin-bottom: 0;
 
             &:hover,
             &:focus {

--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -1,4 +1,4 @@
-*:not(.form-inline) {
+form:not(.form-inline) {
     .form-control-label {
         font-weight: 700;
         font-size: 14px;
@@ -34,7 +34,8 @@
 
 .ez-form-inline {
     .control-label,
-    .form-control {
+    .form-control,
+    .form-control-label {
         margin-right: .5rem;
     }
 }

--- a/src/bundle/Resources/views/Security/login.html.twig
+++ b/src/bundle/Resources/views/Security/login.html.twig
@@ -14,7 +14,10 @@
                 </svg>
                 <form action="{{ path( 'login_check' ) }}" method="post" role="form">
                     <fieldset>
-                        <div class="form-group">
+                        {% if error %}
+                            <span>{{ error.message }}</span>
+                        {% endif %}
+                        <div class="form-group{% if error %} has-error{% endif %}">
                             <label class="ez-login__form-label" for="username">{{ 'authentication.username'|trans|desc('Username') }}:</label>
                             <input type="text" id="username" class="ez-login__form-input form-control" name="_username" value="{{ last_username }}" required="required" autofocus="autofocus" autocomplete="on"/>
                         </div>

--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -2,7 +2,7 @@
 
 {% trans_default_domain 'content_type' %}
 
-{% form_theme form _self %}
+{% form_theme form _self '@EzPlatformAdminUi/form_fields.html.twig'  %}
 
 {% block _ezrepoforms_contenttype_update_removeFieldDefinition_widget %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -1,6 +1,7 @@
 {% extends "@EzPlatformAdminUi/admin/base.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
 
 {% block breadcrumbs_admin %}
     {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -1,5 +1,7 @@
 {% trans_default_domain 'content_type' %}
 
+{% form_theme form_content_types_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>

--- a/src/bundle/Resources/views/admin/content_type_group/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/create.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'content_type' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'content_type' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/layout.html.twig" %}
 
+{% form_theme form_content_type_groups_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'content_type' %}
 
 {% block body_class %}ez-content-type-group-list-view{% endblock %}

--- a/src/bundle/Resources/views/admin/language/create.html.twig
+++ b/src/bundle/Resources/views/admin/language/create.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle:admin/language:base.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'language' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/language/edit.html.twig
+++ b/src/bundle/Resources/views/admin/language/edit.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle:admin/language:base.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'language' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/layout.html.twig" %}
 
+{% form_theme form_languages_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'language' %}
 
 {% block body_class %}ez-language-list-view{% endblock %}

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/layout.html.twig" %}
 
+{% form_theme deleteForm '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'language' %}
 
 {% block body_class %}ez-language-view{% endblock %}

--- a/src/bundle/Resources/views/admin/policy/add.html.twig
+++ b/src/bundle/Resources/views/admin/policy/add.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/policy/edit.html.twig
+++ b/src/bundle/Resources/views/admin/policy/edit.html.twig
@@ -1,5 +1,7 @@
 {% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -1,5 +1,7 @@
 {% trans_default_domain 'role' %}
 
+{% form_theme form_policies_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">{{ 'policy.view.list.title.count'|trans({'%count%': role.policies|length})|desc('Policies (%count%)') }}</div>

--- a/src/bundle/Resources/views/admin/role/add.html.twig
+++ b/src/bundle/Resources/views/admin/role/add.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle:admin/role:base.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -2,7 +2,7 @@
 
 {% trans_default_domain 'role' %}
 
-{% form_theme form_roles_delete '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_roles_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
 
 {% block body_class %}ez-role-list-view{% endblock %}
 

--- a/src/bundle/Resources/views/admin/role_assignment/create.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/create.html.twig
@@ -1,5 +1,7 @@
 {% extends '@EzPlatformAdminUi/admin/role_assignment/base.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -1,3 +1,5 @@
+{% form_theme form_role_assignments_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'role' %}
 
 <section class="container mt-4 px-5">

--- a/src/bundle/Resources/views/admin/search/list.html.twig
+++ b/src/bundle/Resources/views/admin/search/list.html.twig
@@ -18,7 +18,7 @@
                 {% include '@EzPlatformAdminUi/admin/search/search_form.html.twig' with { form: form } %}
 
                 <div class="ez-table-header mt-3">
-                    <div ="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</div>
+                    <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</div>
                 </div>
 
                 {% if results is empty %}

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -22,7 +22,6 @@
 
                 {% if results is defined %}
 
-                    {% form_theme form_edit '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 
                     <div class="ez-table-header mt-3">
                         <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
@@ -70,6 +69,9 @@
                             </div>
                         {% endif %}
                     {% endif %}
+
+                    {% form_theme form_edit '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+
                     {{ form_start(form_edit, {
                         'action': path('ezplatform.content.edit'),
                         'attr': { 'class': 'ez-edit-content-form'}

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -1,6 +1,8 @@
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {{ form_start(form) }}
 <div class="input-group px-4">
-    {{ form_widget(form.query, {'attr': {'class': 'form-control'} }) }}
+    {{ form_widget(form.query) }}
 
     <span class="input-group-btn">
         <button type="submit" class="btn btn-primary">

--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'section' %}
 
-{% form_theme form_section_content_assign 'EzPlatformAdminUiBundle:parts/form:flat_widgets.html.twig' 'EzPlatformAdminUiBundle:parts/form:assign_section_widget.html.twig' %}
+{% form_theme form_section_content_assign '@EzPlatformAdminUi/form_fields.html.twig' '@EzPlatformAdminUi/parts/form/assign_section_widget.html.twig'  %}
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">

--- a/src/bundle/Resources/views/admin/section/create.html.twig
+++ b/src/bundle/Resources/views/admin/section/create.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle:admin/section:base.html.twig' %}
 
+{% form_theme form_section_create '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'section' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
@@ -1,3 +1,5 @@
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="delete-section-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -13,13 +15,13 @@
             </div>
             <div class="modal-footer">
                 {{ form_start(form, {
-                    "action": path("ezplatform.section.delete", {"sectionId": section.id}),
+                    "action": path('ezplatform.section.delete', {'sectionId': section.id}),
                     'attr': {'class': 'd-inline-block'}
                 }) }}
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'form.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.delete, {'attr': {'class': 'btn btn-danger', 'disabled': not deletable}}) }}
+                {{ form_widget(form.delete, {'attr': {'class': 'btn-danger', 'disabled': not deletable}}) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -1,4 +1,8 @@
 {% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+
+{% form_theme form_sections_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_section_content_assign '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'section' %}
 
 {% block body_class %}ez-section-list-view{% endblock %}

--- a/src/bundle/Resources/views/admin/section/update.html.twig
+++ b/src/bundle/Resources/views/admin/section/update.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle:admin/section:base.html.twig' %}
 
+{% form_theme form_section_update '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain 'section' %}
 
 {% block breadcrumbs_admin %}

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -2,8 +2,6 @@
 
 {% trans_default_domain 'section' %}
 
-{% form_theme form_section_delete 'EzPlatformAdminUiBundle:parts/form:flat_widgets.html.twig' %}
-
 {% block body_class %}ez-section-view{% endblock %}
 
 {% block breadcrumbs %}

--- a/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form 'EzPlatformAdminUiBundle:parts/form:flat_widgets.html.twig' %}
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
 
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="confirmEmptyTrash" tabindex="-1" role="dialog" aria-labelledby="confirmEmptyTrash"
      aria-hidden="true">
@@ -24,7 +24,7 @@
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">
                     {{ 'trash.delete.button.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.empty, {'attr': {'class': 'btn btn-danger'}}) }}
+                {{ form_widget(form.empty, {'attr': {'class': 'btn-danger'}}) }}
                 {{ form_widget(form.empty_trash, {'label_attr': {'class': 'checkbox-inline'}, 'attr': {'hidden': true}}) }}
                 {{ form_end(form) }}
             </div>

--- a/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
@@ -11,11 +11,11 @@
                 <p>{{ message }}</p>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-danger btn--trigger" data-click="{{ data_click }}">
-                    {{ 'modal.delete'|trans|desc('Delete') }}
-                </button>
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'modal.cancel'|trans|desc('Cancel') }}
+                </button>
+                <button class="btn btn-danger btn--trigger" data-click="{{ data_click }}">
+                    {{ 'modal.delete'|trans|desc('Delete') }}
                 </button>
             </div>
         </div>

--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -1,4 +1,4 @@
-{% use "bootstrap_4_layout.html.twig" %}
+{% use 'bootstrap_4_layout.html.twig' %}
 
 {# specific fieldtypes theming #}
 {% use 'EzPlatformAdminUiBundle:fieldtypes:ezauthor.html.twig' %}

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -3,9 +3,9 @@
 {% trans_default_domain 'locationview' %}
 {% form_theme form_location_copy '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 {% form_theme form_location_move '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_location_trash '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_content_edit '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_content_create '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_location_trash '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_content_edit '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_content_create '@EzPlatformAdminUi/form_fields.html.twig' %}
 
 {% block body_class %}ez-content-view{% endblock %}
 

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -16,7 +16,7 @@
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'trash.form.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.trash, {'attr': {'class': 'btn btn-danger'}}) }}
+                {{ form_widget(form.trash, {'attr': {'class': 'btn-danger'}}) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -2,7 +2,7 @@
 
 {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.content_details'|trans()|desc('Content details') } %}
 
-{% form_theme form_location_update '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_location_update '@EzPlatformAdminUi/form_fields.html.twig' %}
 
 <table class="table">
     <thead>
@@ -115,11 +115,13 @@
                 'attr': {'class': 'form-inline ez-form-inline'}
                 }) }}
 
-                {{ form_widget(form_location_update) }}
+                {{ form_label(form_location_update.sort_field, 'tab.details.sub_items_listing_by.order_by'|trans|desc('Order by')) }}
+                {{ form_widget(form_location_update.sort_field) }}
 
-                <button type="submit" class="btn btn-secondary ml-1">
-                    {{ 'tab.details.sub_items_listing_by_set'|trans|desc('Set') }}
-                </button>
+                {{ form_label(form_location_update.sort_order, 'tab.details.sub_items_listing_by.in'|trans|desc('in')) }}
+                {{ form_widget(form_location_update.sort_order) }}
+
+                {{ form_widget(form_location_update.update, { 'label': 'tab.details.sub_items_listing_by_set'|trans|desc('Set'), 'translation_domain': false, 'attr': {'class': 'btn-secondary ml-1'} }) }}
 
             {{ form_end(form_location_update) }}
         </td>

--- a/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
@@ -1,3 +1,5 @@
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
+
 {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with {
     headerText: 'tab.locations.location_content_swap'|trans()|desc('Location Content Swap'),
     ground: 'ground-base'
@@ -9,7 +11,7 @@
     <tr>
         <td>
             {{ 'tab.locations.swap_with_another'|trans()|desc('Swap the content item at this location with another') }}
-            {{ form_widget(form.swap, {'attr': {'class': 'btn btn-outline-secondary btn--udw-swap ml-5', 'data-root-location': '2'}}) }}
+            {{ form_widget(form.swap, {'attr': {'class': 'btn-outline-secondary btn--udw-swap ml-5', 'data-root-location': '1'}}) }}
             {{ form_widget(form.current_location) }}
             {{ form_widget(form.new_location) }}
         </td>

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -58,8 +58,8 @@
     {{ form_end(form_content_location_remove) }}
 
     {{ form(form_content_location_update_visibility, {'action': path('ezplatform.location.update_visibility')})}}
-
     {{ form(form_content_location_main_update, {'action': path('ezplatform.content.update_main_location')})}}
+
 </section>
 
 {% include 'EzPlatformAdminUiBundle:content/tab/locations:panel_swap.html.twig' with {'form': form_content_location_swap} %}

--- a/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain 'locationview' %}
-{% form_theme form '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' '@EzPlatformAdminUi/content/tab/translations/translation_add_form_fields.html.twig' %}
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' '@EzPlatformAdminUi/content/tab/translations/translation_add_form_fields.html.twig' %}
 
 <div class="modal fade ez-translation" id="add-translation-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -2,12 +2,14 @@
 
 {% import _self as tab %}
 {% form_theme form_archived_version_restore '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_version_remove_draft '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_version_remove_archived '@EzPlatformAdminUi/form_fields.html.twig' %}
 
 {% if draft_versions is not empty %}
     <section>
         {{ form_start(form_version_remove_draft, {
             'action': path('ezplatform.version.remove'),
-            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-'~form_version_remove_draft.remove.vars.id }
+            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_draft.remove.vars.id }
         }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
         {% if draft_versions is not empty %}
@@ -38,7 +40,7 @@
     <section>
         {{ form_start(form_version_remove_archived, {
             'action': path('ezplatform.version.remove'),
-            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-'~form_version_remove_archived.remove.vars.id }
+            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_archived.remove.vars.id }
         }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.archived_versions'|trans()|desc('Archived versions'), tools: tab.table_header_tools(form_version_remove_archived) } %}
         {% if archived_versions is not empty %}
@@ -60,7 +62,7 @@
 {{ form_end(form_archived_version_restore) }}
 
 {% macro table_header_tools(form) %}
-    {% set modal_data_target = 'delete-versions-modal' %}
+    {% set modal_data_target = 'modal-' ~ form.remove.vars.id %}
     <button id="delete-translations-{{ form.remove.vars.id }}" type="button" class="btn btn-danger" disabled data-toggle="modal"
             data-target="#{{ modal_data_target }}">
         <svg class="ez-icon ez-icon-trash">
@@ -72,7 +74,7 @@
     'id': modal_data_target,
     'message': 'tab.versions.modal.message'|trans|desc('Do you want to delete Versions?'),
     'data_click': '#' ~ form.remove.vars.id,
-    }%}
+    } %}
 {% endmacro %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -1,3 +1,5 @@
+{% extends 'bootstrap_4_layout.html.twig' %}
+
 {% block ezsystems_ezplatform_type_udw_widget %}
     {{ form_widget(form.location) }}
     {{ form_widget(form.select_content) }}
@@ -27,7 +29,7 @@
                 {{- block('content_type_choice_widget_options') -}}
             </div>
         {%- else -%}
-            <div class="radio ez-instant-filter__group-item">
+            <div class="form-check ez-instant-filter__group-item">
                 {{ form_widget(form[choice.value], {'parent_label_class': 'radio-inline'}) }}
             </div>
         {%- endif -%}

--- a/src/bundle/Resources/views/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/link_manager/edit.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain "linkmanager" %}
 
 {%- block content -%}

--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -1,5 +1,7 @@
 {% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
 
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
 {% trans_default_domain "linkmanager" %}
 
 {% block title %}{{ 'url.list'|trans }}{% endblock %}
@@ -19,8 +21,8 @@
 
 {%- block content -%}
     <section class="container mt-4">
-        {{ form_start(form) }}
-            <div class="row justify-content-between">
+        {{ form_start(form, {'attr': {'class': 'form-inline'}}) }}
+            <div class="row w-100 justify-content-between">
                 <div class="col-lg-6">
                     <div class="input-group">
                         {{ form_widget(form.searchQuery, { attr: {
@@ -35,7 +37,7 @@
                     </div>
                 </div>
                 <div class="col-auto">
-                    <div class="form-inline">
+                    <div class="d-inline-flex">
                         {{ form_label(form.status) }} &nbsp;
                         {{ form_widget(form.status) }}
                     </div>

--- a/src/lib/Form/Type/Location/LocationUpdateType.php
+++ b/src/lib/Form/Type/Location/LocationUpdateType.php
@@ -13,6 +13,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Content\LocationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\SortFieldChoiceType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\SortOrderChoiceType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,14 +28,19 @@ class LocationUpdateType extends AbstractType
                 ['label' => false]
             )
             ->add(
-                'sortField',
+                'sort_field',
                 SortFieldChoiceType::class,
-                ['label' => /** @Desc("Order by") */ 'location_update_form.order_by']
+                ['label' => /** @Desc("Sort field") */ 'location_update_form.sort_field']
             )
             ->add(
-                'sortOrder',
+                'sort_order',
                 SortOrderChoiceType::class,
-                ['label' => /** @Desc("in") */ 'location_update_form.in']
+                ['label' => /** @Desc("Sort order") */ 'location_update_form.sort_order']
+            )
+            ->add(
+                'update',
+                SubmitType::class,
+                ['label' => /** @Desc("Update") */ 'location_update_form.update']
             )
         ;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28638
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
