### PR TITLE
Fix menu item voter conflicting with other voters

### DIFF
--- a/src/lib/Menu/Voter/LocationVoter.php
+++ b/src/lib/Menu/Voter/LocationVoter.php
@@ -43,7 +43,5 @@ class LocationVoter implements VoterInterface
                 return true;
             }
         }
-
-        return false;
     }
 }

--- a/src/lib/Menu/Voter/LocationVoter.php
+++ b/src/lib/Menu/Voter/LocationVoter.php
@@ -43,5 +43,7 @@ class LocationVoter implements VoterInterface
                 return true;
             }
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
Voters should return `null` if they can't decide if menu item is active or not, rather than `false`, because returning `false` prevents other voters from functioning properly.

This messes up the voter implemented in Tags Bundle for example.

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28626
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
