### PR TITLE
EZP-28514: It's possible to save section with identifier containing spaces

### DIFF
--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -374,7 +374,7 @@ class SectionController extends Controller
         );
         $form->handleRequest($request);
 
-        if ($form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $result = $this->submitHandler->handle($form, function (SectionCreateData $data) {
                 $sectionCreateStruct = $this->sectionCreateMapper->reverseMap($data);
                 $section = $this->sectionService->createSection($sectionCreateStruct);
@@ -416,7 +416,7 @@ class SectionController extends Controller
         );
         $form->handleRequest($request);
 
-        if ($form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $result = $this->submitHandler->handle($form, function (SectionUpdateData $data) {
                 $sectionUpdateStruct = $this->sectionUpdateMapper->reverseMap($data);
                 $section = $this->sectionService->updateSection($data->getSection(), $sectionUpdateStruct);

--- a/src/bundle/Resources/config/validation/section.yml
+++ b/src/bundle/Resources/config/validation/section.yml
@@ -1,0 +1,19 @@
+EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionCreateData:
+    properties:
+        identifier:
+            - NotBlank: ~
+            - Regex:
+                pattern: "/^[[:alnum:]_]+$/"
+                message: "ez.section.identifier.format"
+        name:
+            - NotBlank: ~
+
+EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionUpdateData:
+    properties:
+        identifier:
+            - NotBlank: ~
+            - Regex:
+                pattern: "/^[[:alnum:]_]+$/"
+                message: "ez.section.identifier.format"
+        name:
+            - NotBlank: ~


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28514
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


It's possible to save section with identifier containing spaces


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
