### PR TITLE
EZP-28514: It's possible to save section with identifier containing spaces

### DIFF
--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\TranslatorInterface;
+use Exception;
 
 class SectionController extends Controller
 {
@@ -375,7 +376,8 @@ class SectionController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $result = $this->submitHandler->handle($form, function (SectionCreateData $data) {
+            $data = $form->getData();
+            try {
                 $sectionCreateStruct = $this->sectionCreateMapper->reverseMap($data);
                 $section = $this->sectionService->createSection($sectionCreateStruct);
 
@@ -391,10 +393,8 @@ class SectionController extends Controller
                 return new RedirectResponse($this->generateUrl('ezplatform.section.view', [
                     'sectionId' => $section->id,
                 ]));
-            });
-
-            if ($result instanceof Response) {
-                return $result;
+            } catch (Exception $e) {
+                $this->notificationHandler->error($e->getMessage());
             }
         }
 
@@ -417,7 +417,8 @@ class SectionController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $result = $this->submitHandler->handle($form, function (SectionUpdateData $data) {
+            $data = $form->getData();
+            try {
                 $sectionUpdateStruct = $this->sectionUpdateMapper->reverseMap($data);
                 $section = $this->sectionService->updateSection($data->getSection(), $sectionUpdateStruct);
 
@@ -433,10 +434,8 @@ class SectionController extends Controller
                 return new RedirectResponse($this->generateUrl('ezplatform.section.view', [
                     'sectionId' => $section->id,
                 ]));
-            });
-
-            if ($result instanceof Response) {
-                return $result;
+            } catch (Exception $e) {
+                $this->notificationHandler->error($e->getMessage());
             }
         }
 

--- a/src/lib/Form/Data/Section/SectionCreateData.php
+++ b/src/lib/Form/Data/Section/SectionCreateData.php
@@ -8,15 +8,29 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Form\Data\Section;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 /**
  * @todo add validation
  */
 class SectionCreateData
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank()
+     * @Assert\Regex(
+     *     pattern="/^[[:alnum:]_]+$/",
+     *     message="ez.section.identifier.format"
+     * )
+     */
     protected $identifier;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank()
+     */
     protected $name;
 
     /**

--- a/src/lib/Form/Data/Section/SectionUpdateData.php
+++ b/src/lib/Form/Data/Section/SectionUpdateData.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Data\Section;
 
 use eZ\Publish\API\Repository\Values\Content\Section;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @todo add validation
@@ -18,10 +19,22 @@ class SectionUpdateData
     /** @var Section|null */
     protected $section;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank()
+     * @Assert\Regex(
+     *     pattern="/^[[:alnum:]_]+$/",
+     *     message="ez.section.identifier.format"
+     * )
+     */
     protected $identifier;
 
-    /** @var string|null */
+    /**
+     * @var string|null
+     *
+     * @Assert\NotBlank()
+     */
     protected $name;
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28514
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


 It's possible to save section with identifier containing spaces


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
