### PR TITLE
EZP-28548: Add missing translations for sub items order

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -336,15 +336,20 @@
         <target state="new">%identifier%</target>
         <note>key: content_type_group.view.view.title</note>
       </trans-unit>
-      <trans-unit id="2a6703809d34ce1103cc6e1342e07a8a81848c01" resname="location_update_form.in">
-        <source>in</source>
-        <target state="new">in</target>
-        <note>key: location_update_form.in</note>
+      <trans-unit id="62ac918fce5389cd868b988e65b4ab96477a1344" resname="location_update_form.sort_field">
+        <source>Sort field</source>
+        <target state="new">Sort field</target>
+        <note>key: location_update_form.sort_field</note>
       </trans-unit>
-      <trans-unit id="53acad0127e4919fc2769ff04c46e1e66b7c601a" resname="location_update_form.order_by">
-        <source>Order by</source>
-        <target state="new">Order by</target>
-        <note>key: location_update_form.order_by</note>
+      <trans-unit id="7d29fb5b1206bd3313bd2eb6c078ab72c244545a" resname="location_update_form.sort_order">
+        <source>Sort order</source>
+        <target state="new">Sort order</target>
+        <note>key: location_update_form.sort_order</note>
+      </trans-unit>
+      <trans-unit id="2bb23a852a2a16458d2dad6931debc447564dff2" resname="location_update_form.update">
+        <source>Update</source>
+        <target state="new">Update</target>
+        <note>key: location_update_form.update</note>
       </trans-unit>
       <trans-unit id="7fe072f41348fb097b6bb018eec4f1b1bc9cffc3" resname="modal.cancel">
         <source>Cancel</source>

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -121,6 +121,16 @@
         <target state="new">Name</target>
         <note>key: tab.details.state_name</note>
       </trans-unit>
+      <trans-unit id="8ddd1c9e60bd352b4395e1753ede6534db2aac8b" resname="tab.details.sub_items_listing_by.in">
+        <source>in</source>
+        <target state="new">in</target>
+        <note>key: tab.details.sub_items_listing_by.in</note>
+      </trans-unit>
+      <trans-unit id="c7f8179865bd73db9d2f07c39ae4a364668476c5" resname="tab.details.sub_items_listing_by.order_by">
+        <source>Order by</source>
+        <target state="new">Order by</target>
+        <note>key: tab.details.sub_items_listing_by.order_by</note>
+      </trans-unit>
       <trans-unit id="fe4321b1de5be805ed8224c8cf442a89e9fa38b4" resname="tab.details.sub_items_listing_by_set">
         <source>Set</source>
         <target state="new">Set</target>

--- a/src/bundle/Resources/translations/trash.en.xliff
+++ b/src/bundle/Resources/translations/trash.en.xliff
@@ -61,11 +61,6 @@
         <target state="new">Type</target>
         <note>key: trash.type</note>
       </trans-unit>
-      <trans-unit id="9894fcfeef8935ecd3c257204fae8514b72961f1" resname="trash.viewing">
-        <source>Viewing %viewing% out of %total% items</source>
-        <target state="new">Viewing %viewing% out of %total% items</target>
-        <note>key: trash.viewing</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28408
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Add missing translations for sub items order


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
