### PR TITLE
EZP-28653: Add tooltip to all buttons with only icons

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -171,6 +171,11 @@
         <target state="new">Creating a new Content Type</target>
         <note>key: content_type.view.create.title</note>
       </trans-unit>
+      <trans-unit id="621f64c5f4acef41bca216c9d712860e3438f742" resname="content_type.view.edit.content_field_definition.delete">
+        <source>Delete Content field definition</source>
+        <target state="new">Delete Content field definition</target>
+        <note>key: content_type.view.edit.content_field_definition.delete</note>
+      </trans-unit>
       <trans-unit id="94367a951b897bc2964d0c45286b560c59ebb996" resname="content_type.view.edit.content_field_definitions">
         <source>Content field definitions</source>
         <target state="new">Content field definitions</target>
@@ -190,6 +195,11 @@
         <source>Create a Content Type</source>
         <target state="new">Create a Content Type</target>
         <note>key: content_type.view.list.action.add</note>
+      </trans-unit>
+      <trans-unit id="c3287b9fccc0b54216e50ba02e3d72e17cc1c92e" resname="content_type.view.list.action.delete">
+        <source>Delete Content Type</source>
+        <target state="new">Delete Content Type</target>
+        <note>key: content_type.view.list.action.delete</note>
       </trans-unit>
       <trans-unit id="1a2e4ef61d405d0628d8bacdb80d7bbaa11143d5" resname="content_type.view.list.action.edit">
         <source>Edit</source>
@@ -306,6 +316,11 @@
         <target state="new">Create a Content Type Group</target>
         <note>key: content_type_group.view.list.action.add</note>
       </trans-unit>
+      <trans-unit id="ceb2e962eccd99d66a600df886fb1ff3253c2f16" resname="content_type_group.view.list.action.delete">
+        <source>Delete Content Type Group</source>
+        <target state="new">Delete Content Type Group</target>
+        <note>key: content_type_group.view.list.action.delete</note>
+      </trans-unit>
       <trans-unit id="e078a8733eac84a6f85ccb7883df2767d357528e" resname="content_type_group.view.list.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
@@ -336,15 +351,20 @@
         <target state="new">%identifier%</target>
         <note>key: content_type_group.view.view.title</note>
       </trans-unit>
-      <trans-unit id="2a6703809d34ce1103cc6e1342e07a8a81848c01" resname="location_update_form.in">
-        <source>in</source>
-        <target state="new">in</target>
-        <note>key: location_update_form.in</note>
+      <trans-unit id="62ac918fce5389cd868b988e65b4ab96477a1344" resname="location_update_form.sort_field">
+        <source>Sort field</source>
+        <target state="new">Sort field</target>
+        <note>key: location_update_form.sort_field</note>
       </trans-unit>
-      <trans-unit id="53acad0127e4919fc2769ff04c46e1e66b7c601a" resname="location_update_form.order_by">
-        <source>Order by</source>
-        <target state="new">Order by</target>
-        <note>key: location_update_form.order_by</note>
+      <trans-unit id="7d29fb5b1206bd3313bd2eb6c078ab72c244545a" resname="location_update_form.sort_order">
+        <source>Sort order</source>
+        <target state="new">Sort order</target>
+        <note>key: location_update_form.sort_order</note>
+      </trans-unit>
+      <trans-unit id="2bb23a852a2a16458d2dad6931debc447564dff2" resname="location_update_form.update">
+        <source>Update</source>
+        <target state="new">Update</target>
+        <note>key: location_update_form.update</note>
       </trans-unit>
       <trans-unit id="7fe072f41348fb097b6bb018eec4f1b1bc9cffc3" resname="modal.cancel">
         <source>Cancel</source>

--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -31,6 +31,21 @@
         <target state="new">No content items. Media items you create will appear here</target>
         <note>key: dashboard.tab.my_media.empty</note>
       </trans-unit>
+      <trans-unit id="749d4759e304735bcec6ef6ec10af43e70f1f289" resname="dashboard.table.all.content.edit">
+        <source>Edit Content</source>
+        <target state="new">Edit Content</target>
+        <note>key: dashboard.table.all.content.edit</note>
+      </trans-unit>
+      <trans-unit id="d55b4e897f7b7f5748c600e865a61eae6c9fe3da" resname="dashboard.table.all.media.edit">
+        <source>Edit Media</source>
+        <target state="new">Edit Media</target>
+        <note>key: dashboard.table.all.media.edit</note>
+      </trans-unit>
+      <trans-unit id="f0adf5df30310686ce6864bef32325c9a6988b49" resname="dashboard.table.content.edit">
+        <source>Edit Content</source>
+        <target state="new">Edit Content</target>
+        <note>key: dashboard.table.content.edit</note>
+      </trans-unit>
       <trans-unit id="e17a8999c9e44b7e8ea1ba0f5cff596ece264da5" resname="dashboard.table.content_type">
         <source>Content Type</source>
         <target state="new">Content Type</target>
@@ -41,10 +56,20 @@
         <target state="new">Contributor</target>
         <note>key: dashboard.table.contributor</note>
       </trans-unit>
+      <trans-unit id="93a5fc53032106ea0ae1658261fd187e5c9c6a94" resname="dashboard.table.draft.edit">
+        <source>Edit Draft</source>
+        <target state="new">Edit Draft</target>
+        <note>key: dashboard.table.draft.edit</note>
+      </trans-unit>
       <trans-unit id="3a857cc58c009830e22845ef1edbd43794206aed" resname="dashboard.table.last_saved">
         <source>Last Saved</source>
         <target state="new">Last Saved</target>
         <note>key: dashboard.table.last_saved</note>
+      </trans-unit>
+      <trans-unit id="ec988391649c3e25028a629b4e38dc426f4c4615" resname="dashboard.table.media.edit">
+        <source>Edit Media</source>
+        <target state="new">Edit Media</target>
+        <note>key: dashboard.table.media.edit</note>
       </trans-unit>
       <trans-unit id="0ccebfdea2e8be0bcae0f3cab3f3db5ef47d71c8" resname="dashboard.table.modified_language">
         <source>Modified Language</source>

--- a/src/bundle/Resources/translations/ezrepoforms_content.en.xliff
+++ b/src/bundle/Resources/translations/ezrepoforms_content.en.xliff
@@ -26,6 +26,21 @@
         <target state="new">Player settings</target>
         <note>key: content.field_type.ezmedia.player_settings</note>
       </trans-unit>
+      <trans-unit id="b244ed2b3b30d53cd73ea9d25c21c7d938e97973" resname="ezbinaryfile.action.preview">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note>key: ezbinaryfile.action.preview</note>
+      </trans-unit>
+      <trans-unit id="936018db97b7f60296d65482bc41f138e787b5c9" resname="ezbinaryfile.action.remove">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note>key: ezbinaryfile.action.remove</note>
+      </trans-unit>
+      <trans-unit id="b388b6cf9e8d44856fed11bc8ff3f4decb177449" resname="ezgmaplocation.action.search">
+        <source>Search</source>
+        <target state="new">Search</target>
+        <note>key: ezgmaplocation.action.search</note>
+      </trans-unit>
       <trans-unit id="f95e95b9cb063f060b0e8ea74c0e11409643316d" resname="ezobjectrelationlist.cta.limit">
         <source>Set up multiple relations with up to %limit% content items</source>
         <target state="new">Set up multiple relations with up to %limit% content items</target>

--- a/src/bundle/Resources/translations/language.en.xliff
+++ b/src/bundle/Resources/translations/language.en.xliff
@@ -21,6 +21,11 @@
         <target state="new">Language '%name%' created.</target>
         <note>key: language.create.success</note>
       </trans-unit>
+      <trans-unit id="8390c7c1adbff8a264583f6f060256c993023787" resname="language.delete">
+        <source>Delete Language</source>
+        <target state="new">Delete Language</target>
+        <note>key: language.delete</note>
+      </trans-unit>
       <trans-unit id="7c8fcdc1c11d3c1cf2a4380f440ef3d157b68c12" resname="language.delete.success">
         <source>Language '%name%' removed.</source>
         <target state="new">Language '%name%' removed.</target>

--- a/src/bundle/Resources/translations/linkmanager.en.xliff
+++ b/src/bundle/Resources/translations/linkmanager.en.xliff
@@ -6,6 +6,16 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="44ab49e25d0037a06f7c26582462d2d876e9546c" resname="url.action.edit">
+        <source>Edit URL</source>
+        <target state="new">Edit URL</target>
+        <note>key: url.action.edit</note>
+      </trans-unit>
+      <trans-unit id="f561064964d324f7697c98336f2e4ef5a247e7db" resname="url.action.item.edit">
+        <source>Edit Item</source>
+        <target state="new">Edit Item</target>
+        <note>key: url.action.item.edit</note>
+      </trans-unit>
       <trans-unit id="6a23ab14fca2c76fe7ea84f53221ed5caf907f45" resname="url.detail">
         <source>Link detail</source>
         <target>Link detail</target>

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -121,6 +121,16 @@
         <target state="new">Name</target>
         <note>key: tab.details.state_name</note>
       </trans-unit>
+      <trans-unit id="8ddd1c9e60bd352b4395e1753ede6534db2aac8b" resname="tab.details.sub_items_listing_by.in">
+        <source>in</source>
+        <target state="new">in</target>
+        <note>key: tab.details.sub_items_listing_by.in</note>
+      </trans-unit>
+      <trans-unit id="c7f8179865bd73db9d2f07c39ae4a364668476c5" resname="tab.details.sub_items_listing_by.order_by">
+        <source>Order by</source>
+        <target state="new">Order by</target>
+        <note>key: tab.details.sub_items_listing_by.order_by</note>
+      </trans-unit>
       <trans-unit id="fe4321b1de5be805ed8224c8cf442a89e9fa38b4" resname="tab.details.sub_items_listing_by_set">
         <source>Set</source>
         <target state="new">Set</target>
@@ -140,6 +150,16 @@
         <source>Translations</source>
         <target state="new">Translations</target>
         <note>key: tab.details.translations</note>
+      </trans-unit>
+      <trans-unit id="8eb3feb6461dacdbd425ef30fc4848a94ab3db0d" resname="tab.locations.action.add">
+        <source>Add Location</source>
+        <target state="new">Add Location</target>
+        <note>key: tab.locations.action.add</note>
+      </trans-unit>
+      <trans-unit id="80808d78f600e925ec3e2dd4b2a0e7570169fd83" resname="tab.locations.action.delete">
+        <source>Delete Location</source>
+        <target state="new">Delete Location</target>
+        <note>key: tab.locations.action.delete</note>
       </trans-unit>
       <trans-unit id="7ac57e88d1f970747986392b6689075ba64cf270" resname="tab.locations.content_locations">
         <source>Content locations</source>
@@ -266,6 +286,16 @@
         <target state="new">Link</target>
         <note>key: tab.relations.table.relation_type.link</note>
       </trans-unit>
+      <trans-unit id="492cea0fd67c4af8e41d21710668239c9db66cfc" resname="tab.translations.action.add">
+        <source>Add Translation</source>
+        <target state="new">Add Translation</target>
+        <note>key: tab.translations.action.add</note>
+      </trans-unit>
+      <trans-unit id="8c29b038407b67badc381aca362d4770d299df8b" resname="tab.translations.action.delete">
+        <source>Delete Translation</source>
+        <target state="new">Delete Translation</target>
+        <note>key: tab.translations.action.delete</note>
+      </trans-unit>
       <trans-unit id="5022ce879be6a69956541173bf658dccff5d7280" resname="tab.translations.add.base_language">
         <source>Base this translation on an existing translation</source>
         <target state="new">Base this translation on an existing translation</target>
@@ -351,6 +381,11 @@
         <target state="new">URL</target>
         <note>key: tab.urls.url</note>
       </trans-unit>
+      <trans-unit id="a4297fe31e8eb3307caa2cf855328056c3b98962" resname="tab.versions.action.delete">
+        <source>Delete Version</source>
+        <target state="new">Delete Version</target>
+        <note>key: tab.versions.action.delete</note>
+      </trans-unit>
       <trans-unit id="699b5bf627b908f8d270984ab9a4734a48b28abe" resname="tab.versions.archived_versions">
         <source>Archived versions</source>
         <target state="new">Archived versions</target>
@@ -375,6 +410,16 @@
         <source>Published version</source>
         <target state="new">Published version</target>
         <note>key: tab.versions.published_version</note>
+      </trans-unit>
+      <trans-unit id="628c74bcc6328324ea1c084c8bbe686f7e572c16" resname="tab.versions.table.action.archived.delete">
+        <source>Delete Archived Version</source>
+        <target state="new">Delete Archived Version</target>
+        <note>key: tab.versions.table.action.archived.delete</note>
+      </trans-unit>
+      <trans-unit id="f7b4cf0de472a75da3ed9502ef8eedd21a02a266" resname="tab.versions.table.action.draft.delete">
+        <source>Delete Draft Version</source>
+        <target state="new">Delete Draft Version</target>
+        <note>key: tab.versions.table.action.draft.delete</note>
       </trans-unit>
       <trans-unit id="4c27637d649c221e58c6a9629f14a2f75aeed151" resname="tab.versions.table.contributor">
         <source>Contributor</source>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -71,6 +71,16 @@
         <target state="new">Something went wrong. Sorry!</target>
         <note>key: error.page.default.title</note>
       </trans-unit>
+      <trans-unit id="86a1d081394a7faba471dc5eaa4b1c112e9ff03a" resname="ezauthor.action.add">
+        <source>Add author</source>
+        <target state="new">Add author</target>
+        <note>key: ezauthor.action.add</note>
+      </trans-unit>
+      <trans-unit id="3a0389d073f00ef9a968a5cdc60e2794b434b381" resname="ezauthor.action.delete">
+        <source>Remove author</source>
+        <target state="new">Remove author</target>
+        <note>key: ezauthor.action.delete</note>
+      </trans-unit>
       <trans-unit id="5cf420af18fd4a8d856fd30bc13aea5039369f9b" resname="form.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
@@ -95,6 +105,11 @@
         <source>Search</source>
         <target state="new">Search</target>
         <note>key: search.perform</note>
+      </trans-unit>
+      <trans-unit id="9567771350aff93580f743089937b0c8fe31058e" resname="section.assign,content">
+        <source>Assign Content</source>
+        <target state="new">Assign Content</target>
+        <note>key: section.assign,content</note>
       </trans-unit>
       <trans-unit id="6a17e9f4ed416563fc8c3e188509b8eec8a6f7c0" resname="section.modal.message">
         <source>Do you want to delete section?</source>

--- a/src/bundle/Resources/translations/role.en.xliff
+++ b/src/bundle/Resources/translations/role.en.xliff
@@ -86,6 +86,11 @@
         <target state="new">Add a new Policy</target>
         <note>key: policy.view.list.action.add</note>
       </trans-unit>
+      <trans-unit id="abf42b328e259dc5ec851e70dad234636d0134fe" resname="policy.view.list.action.delete">
+        <source>Delete Policy</source>
+        <target state="new">Delete Policy</target>
+        <note>key: policy.view.list.action.delete</note>
+      </trans-unit>
       <trans-unit id="35aa96a30453aa7b604432885032fd961a7f508a" resname="policy.view.list.panel.policies.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
@@ -191,6 +196,11 @@
         <target state="new">Assign to Users/Groups</target>
         <note>key: role.view.list.action.assign_to_users_or_groups</note>
       </trans-unit>
+      <trans-unit id="e0b49df6c6b235f7eb4d03019d1f9505dd77a135" resname="role.view.list.action.delete">
+        <source>Delete Role</source>
+        <target state="new">Delete Role</target>
+        <note>key: role.view.list.action.delete</note>
+      </trans-unit>
       <trans-unit id="cb9d9934c021aa5f2b25bfa652279daa88c6086f" resname="role.view.list.action.edit">
         <source>Edit</source>
         <target state="new">Edit</target>
@@ -240,6 +250,11 @@
         <source>Assign users/groups</source>
         <target state="new">Assign users/groups</target>
         <note>key: role_assignment.view.list.action.add</note>
+      </trans-unit>
+      <trans-unit id="76361d414c957ff63dcfdaf4490b3e9a2c632750" resname="role_assignment.view.list.action.delete">
+        <source>Delete Assignment</source>
+        <target state="new">Delete Assignment</target>
+        <note>key: role_assignment.view.list.action.delete</note>
       </trans-unit>
       <trans-unit id="5111796ffacfccc152f157c56a6e7219d35c3fd8" resname="role_assignment.view.list.header">
         <source>Users and Groups</source>

--- a/src/bundle/Resources/translations/section.en.xliff
+++ b/src/bundle/Resources/translations/section.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="128df491a522e7af4916cd002d9e11a3d2bc4078" resname="section.action.delete">
+        <source>Delete Section</source>
+        <target state="new">Delete Section</target>
+        <note>key: section.action.delete</note>
+      </trans-unit>
       <trans-unit id="84413bc1ae3385c0aac1af7ea5665cb0c1eaf3ba" resname="section.assign_content">
         <source>Assign content</source>
         <target state="new">Assign content</target>
@@ -55,6 +60,11 @@
         <source>Section '%name%' created.</source>
         <target state="new">Section '%name%' created.</target>
         <note>key: section.create.success</note>
+      </trans-unit>
+      <trans-unit id="48a0071d3b889cbfef3ff4ee5af8cf83b1e8b7f6" resname="section.delete">
+        <source>Delete Section</source>
+        <target state="new">Delete Section</target>
+        <note>key: section.delete</note>
       </trans-unit>
       <trans-unit id="663e1bfb8478f95028221190755c01441b2a8fde" resname="section.delete.success">
         <source>Section '%name%' removed.</source>

--- a/src/bundle/Resources/translations/trash.en.xliff
+++ b/src/bundle/Resources/translations/trash.en.xliff
@@ -61,11 +61,6 @@
         <target state="new">Type</target>
         <note>key: trash.type</note>
       </trans-unit>
-      <trans-unit id="9894fcfeef8935ecd3c257204fae8514b72961f1" resname="trash.viewing">
-        <source>Viewing %viewing% out of %total% items</source>
-        <target state="new">Viewing %viewing% out of %total% items</target>
-        <note>key: trash.viewing</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/translations/validators.en.xliff
+++ b/src/bundle/Resources/translations/validators.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="924826be1015d20c1f4524754c690e10935abaac" resname="ez.section.identifier.format">
+        <source>ez.section.identifier.format</source>
+        <target state="new">ez.section.identifier.format</target>
+        <note>key: ez.section.identifier.format</note>
+      </trans-unit>
       <trans-unit id="cf558f546b83d94f1272929f81c64bd33d2997bc" resname="js.error.address_not_found">
         <source>Provided address does not exist</source>
         <target state="new">Provided address does not exist</target>

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -54,6 +54,7 @@
                     </div>
 
                     <button type="button"
+                            title="{{ 'content_type.view.edit.content_field_definition.delete'|trans|desc('Delete Content field definition') }}"
                             class="btn btn-danger"
                             data-toggle="modal"
                             data-target="#delete-content-type-modal">

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -16,7 +16,7 @@
             </a>
             {% set modal_data_target = 'delete-content-types-modal' %}
             <button id="delete-content-types" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                    data-target="#{{ modal_data_target }}">
+                    data-target="#{{ modal_data_target }}" title="{{ 'content_type.view.list.action.delete'|trans|desc('Delete Content Type') }}">
                 <svg class="ez-icon ez-icon-trash">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink"
                          xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -35,7 +35,7 @@
                 </a>
                 {% set modal_data_target = 'delete-content-type-groups-modal' %}
                 <button id="delete-content-type-groups" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}">
+                        data-target="#{{ modal_data_target }}" title="{{ 'content_type_group.view.list.action.delete'|trans|desc('Delete Content Type Group') }}">
                     <svg class="ez-icon ez-icon-trash">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink"
                              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -37,7 +37,7 @@
                 </a>
                 {% set modal_data_target = 'delete-languages-modal' %}
                 <button id="delete-languages" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}">
+                        data-target="#{{ modal_data_target }}" title="{{ 'language.delete'|trans|desc('Delete Language') }}">
                     <svg class="ez-icon ez-icon-trash">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink"
                              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -35,6 +35,7 @@
                 <button type="button"
                         class="btn btn-danger"
                         data-toggle="modal"
+                        title="{{ 'language.delete'|trans|desc('Delete Language') }}"
                         data-target="#delete-language-modal">
                     <svg class="ez-icon">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -16,7 +16,7 @@
             </a>
             {% set modal_data_target = 'delete-policies-modal' %}
             <button id="delete-policies" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                    data-target="#{{ modal_data_target }}">
+                    data-target="#{{ modal_data_target }}" title="{{ 'policy.view.list.action.delete'|trans|desc('Delete Policy') }}">
                 <svg class="ez-icon ez-icon-trash">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink"
                          xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -37,7 +37,7 @@
                 </a>
                 {% set modal_data_target = 'delete-sections-modal' %}
                 <button id="delete-roles" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}">
+                        data-target="#{{ modal_data_target }}" title="{{ 'role.view.list.action.delete'|trans|desc('Delete Role') }}">
                     <svg class="ez-icon ez-icon-trash">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink"
                              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -16,7 +16,7 @@
             </a>
             {% set modal_data_target = 'delete-role-assignments-modal' %}
             <button id="delete-role-assignments" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                    data-target="#{{ modal_data_target }}">
+                    data-target="#{{ modal_data_target }}" title="{{ 'role_assignment.view.list.action.delete'|trans|desc('Delete Assignment') }}">
                 <svg class="ez-icon ez-icon-trash">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink"
                          xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -36,7 +36,7 @@
                 </a>
                 {% set modal_data_target = 'delete-sections-modal' %}
                 <button id="delete-sections" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}">
+                        data-target="#{{ modal_data_target }}" title="{{ 'section.delete'|trans|desc('Delete Section') }}">
                     <svg class="ez-icon ez-icon-trash">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink"
                              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -27,14 +27,14 @@
             <div>
                 {% if deletable %}
                     <button type="button" class="btn btn-danger" data-toggle="modal"
-                            data-target="#delete-section-modal">
+                            data-target="#delete-section-modal" title="{{ 'section.action.delete'|trans|desc('Delete Section') }}">
                         <svg class="ez-icon">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
                     {% include 'EzPlatformAdminUiBundle:admin/section:delete_confirmation_modal.html.twig' with {'form': form_section_delete} %}
                 {% else %}
-                    <button type="button" class="btn btn-danger disabled">
+                    <button type="button" class="btn btn-danger disabled" title="{{ 'section.action.delete'|trans|desc('Delete Section') }}">
                         <svg class="ez-icon">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -65,7 +65,7 @@
 {% include 'EzPlatformAdminUiBundle:content/tab/locations:panel_swap.html.twig' with {'form': form_content_location_swap} %}
 
 {% macro table_header_tools(form_add, form_remove) %}
-    <button class="btn btn-primary btn--udw-add">
+    <button class="btn btn-primary btn--udw-add" title="{{ 'tab.locations.action.add'|trans|desc('Add Location') }}">
         <svg class="ez-icon ez-icon-create">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
@@ -74,7 +74,7 @@
 
     {% set modal_data_target = 'delete-content-types-modal' %}
     <button id="delete-locations" type="button" class="btn btn-danger" disabled data-toggle="modal"
-            data-target="#{{ modal_data_target }}">
+            data-target="#{{ modal_data_target }}" title="{{ 'tab.locations.action.delete'|trans|desc('Delete Location') }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -33,7 +33,8 @@
 </section>
 
 {% macro table_header_tools(form_translation_remove) %}
-    <button class="btn btn-primary ez-btn--prevented ez-btn--add-translation" data-toggle="modal" data-target="#add-translation-modal" >
+    <button class="btn btn-primary ez-btn--prevented ez-btn--add-translation" data-toggle="modal" data-target="#add-translation-modal"
+            title="{{ 'tab.translations.action.add'|trans|desc('Add Translation') }}">
         <svg class="ez-icon ez-icon-create">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
@@ -42,7 +43,7 @@
 
     {% set modal_data_target = 'delete-translations-modal' %}
     <button id="delete-translations" type="button" class="btn btn-danger" disabled data-toggle="modal"
-            data-target="#{{ modal_data_target }}">
+            data-target="#{{ modal_data_target }}" title="{{ 'tab.translations.action.delete'|trans|desc('Delete Translation') }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -64,7 +64,7 @@
 {% macro table_header_tools(form) %}
     {% set modal_data_target = 'modal-' ~ form.remove.vars.id %}
     <button id="delete-translations-{{ form.remove.vars.id }}" type="button" class="btn btn-danger" disabled data-toggle="modal"
-            data-target="#{{ modal_data_target }}">
+            data-target="#{{ modal_data_target }}" title="{{ 'tab.versions.action.delete'|trans|desc('Delete Version') }}">
         <svg class="ez-icon ez-icon-trash">
             <use xmlns:xlink="http://www.w3.org/1999/xlink"
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -47,7 +47,7 @@
             {% if is_draft %}
                 <td>
                     <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode }) }}"
-                       class="btn btn-icon">
+                       class="btn btn-icon" title="{{ 'tab.versions.table.action.draft.delete'|trans|desc('Delete Draft Version') }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                         </svg>
@@ -56,7 +56,11 @@
             {% endif %}
             {% if is_archived %}
                 <td>
-                    <button class="btn btn-icon ez-btn--content-edit" data-content-id="{{ version.contentInfo.id }}" data-version-no="{{ version.versionNo }}" data-language-code="{{ version.initialLanguageCode }}">
+                    <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'tab.versions.table.action.archived.delete'|trans|desc('Delete Archived Version') }}"
+                            data-content-id="{{ version.contentInfo.id }}"
+                            data-version-no="{{ version.versionNo }}"
+                            data-language-code="{{ version.initialLanguageCode }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#archive-restore"></use>
                         </svg>

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -23,6 +23,7 @@
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
                     <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'dashboard.table.all.content.edit'|trans|desc('Edit Content') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"
                             data-language-code="{{ row.language }}">

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -23,6 +23,7 @@
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
                     <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'dashboard.table.all.media.edit'|trans|desc('Edit Media') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"
                             data-language-code="{{ row.language }}">

--- a/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
@@ -18,6 +18,7 @@
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
                     <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'dashboard.table.content.edit'|trans|desc('Edit Content') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"
                             data-language-code="{{ row.language }}">

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -22,6 +22,7 @@
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
                     <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'dashboard.table.draft.edit'|trans|desc('Edit Draft') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"
                             data-language-code="{{ row.language }}">

--- a/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
@@ -18,6 +18,7 @@
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
                     <button class="btn btn-icon ez-btn--content-edit"
+                            title="{{ 'dashboard.table.media.edit'|trans|desc('Edit Media') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"
                             data-language-code="{{ row.language }}">

--- a/src/bundle/Resources/views/fieldtypes/ezauthor.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/ezauthor.html.twig
@@ -17,12 +17,14 @@
         {{- form_row(form.name, {'wrapper_attr': {'class': 'col'}}) -}}
         {{- form_row(form.email, {'wrapper_attr': {'class': 'col'}}) -}}
         <div class="col ez-data-source__actions">
-            <button type="button" class="ez-data-source__action ez-btn btn btn-secondary btn-icon ez-btn--secondary ez-btn--remove-author" disabled>
+            <button type="button" class="ez-data-source__action ez-btn btn btn-secondary btn-icon ez-btn--secondary ez-btn--remove-author"
+                    title="{{ 'ezauthor.action.delete'|trans|desc('Remove author') }}" disabled>
                 <svg class="ez-icon ez-icon-trash">
                     <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#trash"></use>
                 </svg>
             </button>
-            <button type="button" class="ez-data-source__action ez-btn btn btn-secondary btn-icon ez-btn--secondary ez-btn--add-author">
+            <button type="button" class="ez-data-source__action ez-btn btn btn-secondary btn-icon ez-btn--secondary ez-btn--add-author"
+                    title="{{ 'ezauthor.action.add'|trans|desc('Add author') }}">
                 <svg class="ez-icon ez-icon-create">
                     <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#create"></use>
                 </svg>

--- a/src/bundle/Resources/views/fieldtypes/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/ezbinaryfile.html.twig
@@ -16,12 +16,13 @@
             <div class="ez-field-edit-preview__file-size">{{ form.parent.vars.value.value.fileSize|ez_file_size(2) }}</div>
         </div>
         <div class="ez-field-edit-preview__actions">
-            <a class="ez-field-edit-preview__action--preview" href="{{ form.parent.vars.value.value.uri }}" download>
+            <a class="ez-field-edit-preview__action--preview" href="{{ form.parent.vars.value.value.uri }}"
+               title="{{ 'ezbinaryfile.action.preview'|trans|desc('Preview') }}" download>
                 <svg class="ez-icon">
                     <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#download"></use>
                 </svg>
             </a>
-            <button class="ez-field-edit-preview__action--remove">
+            <button class="ez-field-edit-preview__action--remove" title="{{ 'ezbinaryfile.action.remove'|trans|desc('Remove') }}">
                 <svg class="ez-icon">
                     <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#trash"></use>
                 </svg>

--- a/src/bundle/Resources/views/fieldtypes/ezgmaplocation.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/ezgmaplocation.html.twig
@@ -14,7 +14,7 @@
         </div>
         <div class="ez-data-source__input-wrapper">
             {{ form_widget(form.address, {'attr': {'class': 'ez-data-source__input'}}) }}
-            <button class="btn btn-secondary btn--search-by-address">
+            <button class="btn btn-secondary btn--search-by-address" title="{{ 'ezgmaplocation.action.search'|trans|desc('Search') }}">
                 <svg class="ez-icon ez-icon-search">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#search"></use>
                 </svg>

--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -82,7 +82,7 @@
                     <td>{{ url.modified | date('M d, Y h:i:sA') }}</td>
                     <td class="text-right">
                         {% if can_edit %}
-                            <a href="{{ edit_url }}" class="btn btn-icon">
+                            <a href="{{ edit_url }}" class="btn btn-icon" title="{{ 'url.action.edit'|trans|desc('Edit URL') }}">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -33,7 +33,9 @@
                     <td>{{ 'url.label.address'|trans }}</td>
                     <td>
                         <a href="{{ url.url }}" target="_blank">{{ url.url }}</a>
-                        <a href="{{ path('ezplatform.link_manager.edit', { urlId: url.id }) }}" class="btn btn-icon float-right">
+                        <a href="{{ path('ezplatform.link_manager.edit', { urlId: url.id }) }}"
+                           class="btn btn-icon float-right "
+                           title="{{ 'url.action.edit'|trans|desc('Edit URL') }}">
                             <svg class="ez-icon ez-icon-edit">
                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                             </svg>
@@ -100,6 +102,7 @@
                         <td class="text-right">
                             {% if can_edit %}
                                 <button class="btn btn-icon btn-link ez-btn--content-edit"
+                                        title="{{ 'url.action.item.edit'|trans|desc('Edit Item') }}"
                                         data-content-id="{{ content.id }}"
                                         data-version-no="{{ content.currentVersionNo }}"
                                         data-language-code="{{ content.mainLanguageCode }}">

--- a/src/bundle/Resources/views/parts/form/assign_section_widget.html.twig
+++ b/src/bundle/Resources/views/parts/form/assign_section_widget.html.twig
@@ -9,7 +9,7 @@
             {% set label = name|humanize %}
         {%- endif -%}
     {%- endif -%}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
+    <button title="{{ 'section.assign,content'|trans|desc('Assign Content') }}" type="{{ type|default('button') }}" {{ block('button_attributes') }}>
         <svg class="ez-icon ez-icon--secondary">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#assign-section"></use>
         </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28653
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Added tooltip to all buttons with only icons


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
