### PR TITLE
EZP-28655: RelationList fieldtype view in AdminUI has invalid render call

### DIFF
--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -8,8 +8,8 @@ system:
                     controller: 'EzPlatformAdminUiBundle:ContentView:locationView'
                     template: '@EzPlatformAdminUi/content/locationview.html.twig'
                     match: true
-            embed:
-                preview_ezobjectrelationlist_row:
+            preview_ezobjectrelationlist_row:
+                default:
                     controller: 'EzPlatformAdminUiBundle:ContentView:locationView'
                     template: '@EzPlatformAdminUi\fieldtypes\preview\ezobjectrelationlist_row.html.twig'
                     match: true

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -288,7 +288,7 @@
             </thead>
             {% for contentId in field.value.destinationContentIds %}
             <tr>
-                {{ render(controller('ez_content:viewAction', {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1, 'layout': 'preview_ezobjectrelationlist_row'})) }}
+                {{ render(controller('ez_content:viewAction', {'contentId': contentId, 'viewType': 'preview_ezobjectrelationlist_row', 'layout': false})) }}
             </tr>
             {% endfor %}
         </table>
@@ -386,7 +386,7 @@
                 </tr>
             </thead>
             <tr>
-                {{ render(controller('ez_content:viewAction', {'contentId': field.value.destinationContentId, 'viewType': 'embed', 'noLayout': 1, 'layout': 'preview_ezobjectrelationlist_row'})) }}
+                {{ render(controller('ez_content:viewAction', {'contentId': field.value.destinationContentId, 'viewType': 'preview_ezobjectrelationlist_row', 'layout': false})) }}
             </tr>
         </table>
     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28655
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
