### PR TITLE
EZP-28660: Top menu is not adding sections when there is no children which breaks extensibility

### DIFF
--- a/src/bundle/Resources/views/parts/menu/top_menu.html.twig
+++ b/src/bundle/Resources/views/parts/menu/top_menu.html.twig
@@ -3,7 +3,7 @@
 {% block root %}
     {% set listAttributes = item.childrenAttributes %}
     {% set currentItem = item %}
-    {% for item in currentItem.children %}
+    {% for item in currentItem.children if item.children|length > 0 %}
         {{ block('item') }}
     {% endfor %}
 {% endblock %}

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -83,16 +83,12 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         $menu = $this->factory->createItem('root');
 
         $contentMenuItems = $this->getContentMenuItems();
-        if (!empty($contentMenuItems)) {
-            $menu->addChild($this->factory->createItem(self::ITEM_CONTENT, []));
-            $menu[self::ITEM_CONTENT]->setChildren($contentMenuItems);
-        }
+        $menu->addChild($this->factory->createItem(self::ITEM_CONTENT, []));
+        $menu[self::ITEM_CONTENT]->setChildren($contentMenuItems);
 
         $adminMenuItems = $this->getAdminMenuItems();
-        if (!empty($adminMenuItems)) {
-            $menu->addChild($this->factory->createItem(self::ITEM_ADMIN, []));
-            $menu[self::ITEM_ADMIN]->setChildren($adminMenuItems);
-        }
+        $menu->addChild($this->factory->createItem(self::ITEM_ADMIN, []));
+        $menu[self::ITEM_ADMIN]->setChildren($adminMenuItems);
 
         return $menu;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28660
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
