### PR TITLE
EZP-28658: Reverse relations link to the object itself, instead of relating objects

### DIFF
--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -4,7 +4,7 @@
     {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.related_content'|trans({'%contentName%' : ez_content_name(content)})|desc('Related content (content items used by %contentName%)') } %}
 
     {% if relations is not empty %}
-        {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': relations}) }}
+        {{ include('@EzPlatformAdminUi/content/tab/relations/table_relations.html.twig', {'relations': relations}) }}
     {% else %}
         <p class="ez-table-no-content">
             {{ 'tab.relations.no_relations'|trans()|desc('This content item has no related content.') }}
@@ -14,7 +14,7 @@
     {% if reverse_relations is defined %}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.reverse_relations'|trans({'%contentName%' : ez_content_name(content)})|desc('Reverse relations (content items using %contentName%)') } %}
         {% if reverse_relations is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/relations/table.html.twig', {'relations': reverse_relations}) }}
+            {{ include('@EzPlatformAdminUi/content/tab/relations/table_relations_reverse.html.twig', {'relations': reverse_relations}) }}
         {% else %}
             <p class="ez-table-no-content">
                 {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
@@ -13,9 +13,10 @@
     </thead>
     <tbody>
     {% for relation in relations %}
+        {% set destination = relation.destinationContentInfo %}
         <tr>
-            <td><a href="{{ path(relation.relationLocation) }}">{{ relation.relationName }}</a></td>
-            <td>{{ relation.relationContentTypeName }}</td>
+            <td><a href="{{ path('_ezpublishLocation', { 'locationId': destination.mainLocationId }) }}">{{ destination.name }}</a></td>
+            <td>{{ contentTypes[destination.contentTypeId].name }}</td>
             <td>
                 {{ macros.relation_type(relation) }}
                 {% if (relation.relationFieldDefinitionName) %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -1,0 +1,48 @@
+{% trans_default_domain 'locationview' %}
+
+{% import _self as macros %}
+
+<table class="table">
+    <thead>
+    <tr>
+        <th>{{ 'tab.relations.table.name'|trans()|desc('Name') }}</th>
+        <th>{{ 'tab.relations.table.content_type'|trans()|desc('Content type') }}</th>
+        <th>{{ 'tab.relations.table.relation_type'|trans()|desc('Relation type') }}</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for relation in relations %}
+        {% set source = relation.sourceContentInfo %}
+        <tr>
+            <td><a href="{{ path('_ezpublishLocation', { 'locationId': source.mainLocationId }) }}">{{ source.name }}</a></td>
+            <td>{{ contentTypes[source.contentTypeId].name }}</td>
+            <td>
+                {{ macros.relation_type(relation) }}
+                {% if (relation.relationFieldDefinitionName) %}
+                    ({{ relation.relationFieldDefinitionName }})
+                {% endif %}
+            </td>
+            <td>
+                <a href="#" class="btn btn-icon disabled">
+                    <svg class="ez-icon ez-icon-edit">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                    </svg>
+                </a>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% macro relation_type(relation) %}
+    {% if relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::COMMON') %}
+        {{ 'tab.relations.table.relation_type.content_level_relation'|trans()|desc('Content level relation') }}
+    {% elseif relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::EMBED') %}
+        {{ 'tab.relations.table.relation_type.embed'|trans()|desc('Embed') }}
+    {% elseif relation.type == constant('eZ\\Publish\\API\\Repository\\Values\\Content\\Relation::LINK') %}
+        {{ 'tab.relations.table.relation_type.link'|trans()|desc('Link') }}
+    {% else %}
+        {{ 'tab.relations.table.relation_type.field'|trans()|desc('Field') }}
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28658
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review