### PR TITLE
EZP-28661: Add pagination to the Draft under edit

### DIFF
--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -13,7 +13,12 @@
         }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
         {% if draft_pager.currentPageResults is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', { 'versions': draft_pager.currentPageResults, 'is_draft': true, 'form': form_version_remove_draft }) }}
+            {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
+                'versions': draft_pager.currentPageResults,
+                'is_draft': true,
+                'form': form_version_remove_draft,
+                'haveToPaginate': draft_pager.haveToPaginate
+            }) }}
         {% else %}
             <p class="ez-relations-box-list-no-content">
                 {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
@@ -29,7 +34,7 @@
                         '%total%': draft_pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center mb-3">
                 {{ pagerfanta(draft_pager, 'ez',{
                     'routeName': draft_pagination_params.route_name,
                     'routeParams': {

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -3,7 +3,7 @@
 {% set is_draft = is_draft is defined and is_draft %}
 {% set is_archived = is_archived is defined and is_archived %}
 
-<table class="table">
+<table class="table {% if is_draft and haveToPaginate %} mb-3 {% endif %}">
     <thead>
     <tr>
         {% if form is defined %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28661
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Add pagination to the Draft under edit


<img width="1127" alt="screen shot 2017-12-22 at 10 28 03 am" src="https://user-images.githubusercontent.com/1654712/34293111-b001b682-e703-11e7-8995-0afb1cd50ea9.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
