### PR TITLE
EZP-28664: Enabled checkbox should be a part of ezuser fieldtype in Content Edit

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezuser.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezuser.js
@@ -11,6 +11,20 @@
 
     class EzUserValidator extends global.eZ.BaseFieldValidator {
         /**
+         * Updates the state of checkbox indicator.
+         *
+         * @method updateState
+         * @param {Event} event
+         * @memberof EzUserValidator
+         */
+        updateState(event) {
+            const methodName = event.currentTarget.checked ? 'add' : 'remove';
+            const label = event.currentTarget.closest(SELECTOR_LABEL);
+
+            label.classList[methodName]('is-checked');
+        }
+
+        /**
          * Validates the input field value
          *
          * @method validateInput
@@ -121,6 +135,11 @@
                 callback: 'validateEmailInput',
                 invalidStateSelectors: [`${SELECTOR_FIELD_EMAIL} ${SELECTOR_LABEL}`],
                 errorNodeSelectors: [`${SELECTOR_FIELD_EMAIL} ${SELECTOR_LABEL_WRAPPER}`],
+            }, {
+                isValueValidator: false,
+                selector: `.ez-data-source__input[type="checkbox"]`,
+                eventName: 'change',
+                callback: 'updateState',
             },
         ]
     });

--- a/src/bundle/Resources/public/scss/_mixins.scss
+++ b/src/bundle/Resources/public/scss/_mixins.scss
@@ -62,6 +62,7 @@
         background-color: $ez-color-base-pale;
         margin-left: calc((#{$size} + .25rem) / 2);
         cursor: pointer;
+        z-index: 1;
 
         input {
             opacity: 0;

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
@@ -8,5 +8,7 @@
         }
     }
 
-    .ez-data-source__input-wrapper {@include checkbox-switcher()}
+    .ez-data-source__input-wrapper {
+    	@include checkbox-switcher();
+    }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
@@ -7,4 +7,6 @@
             max-width: 30%;
         }
     }
+
+    .ez-data-source__input-wrapper {@include checkbox-switcher()}
 }

--- a/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
+++ b/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
@@ -151,10 +151,25 @@
         <target state="new">E-mail</target>
         <note>key: ezuser.email</note>
       </trans-unit>
+      <trans-unit id="09acf9d3220515cf63f284525c54ed3f88b7a396" resname="ezuser.enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note>key: ezuser.enabled</note>
+      </trans-unit>
+      <trans-unit id="26b99946e7309fcdd54dd12a959fee7d666b82f9" resname="ezuser.no">
+        <source>No</source>
+        <target state="new">No</target>
+        <note>key: ezuser.no</note>
+      </trans-unit>
       <trans-unit id="fc4b6b718b2cee2f8a91703c070fd69756d5c4cd" resname="ezuser.username">
         <source>Username</source>
         <target state="new">Username</target>
         <note>key: ezuser.username</note>
+      </trans-unit>
+      <trans-unit id="0e86a412baba94a10cf9d1b03332c9f8f1d5e1bb" resname="ezuser.yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note>key: ezuser.yes</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -15,6 +15,7 @@
 {% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezgmaplocation.html.twig' %}
 {% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezobjectrelationlist.html.twig' %}
 {% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezobjectrelation.html.twig' %}
+{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezuser.html.twig' %}
 
 {% trans_default_domain 'content_edit' %}
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezuser.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezuser.html.twig
@@ -1,0 +1,10 @@
+{% block switcher_widget %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ez-data-source__label')|trim }) %}
+    {% if checked %}
+        {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' is-checked')|trim }) %}
+    {% endif %}
+    <label {% with {'attr': label_attr} %}{{ block('widget_attributes') }}{% endwith %}>
+        <span class="ez-data-source__indicator"></span>
+        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    </label>
+{% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -182,7 +182,11 @@
         </tr>
         <tr>
             <td class="ez-user__type">{{ 'ezuser.email'|trans|desc('E-mail') }}:</td>
-            <td><a href="mailto:{{ field.value.email|escape( 'url' ) }}">{{ field.value.email }}</td>
+            <td><a href="mailto:{{ field.value.email|escape( 'url' ) }}">{{ field.value.email }}</a></td>
+        </tr>
+        <tr>
+            <td class="ez-user__type">{{ 'ezuser.enabled'|trans|desc('Enabled') }}:</td>
+            <td>{{ field.value.enabled ? 'ezuser.yes'|trans|desc('Yes') : 'ezuser.no'|trans|desc('No') }}</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
**Requires: https://github.com/ezsystems/repository-forms/pull/208**

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28664
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
