### PR TITLE
[Content Translations] Replaced removeTranslation with deleteTranslation

### DIFF
--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -115,7 +115,7 @@ class TranslationController extends Controller
                 $contentInfo = $data->getContentInfo();
 
                 foreach ($data->getLanguageCodes() as $languageCode => $selected) {
-                    $this->contentService->removeTranslation($contentInfo, $languageCode);
+                    $this->contentService->deleteTranslation($contentInfo, $languageCode);
 
                     $this->notificationHandler->success(
                         $this->translator->trans(

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -9,7 +9,7 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationRemoveData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
@@ -104,14 +104,14 @@ class TranslationController extends Controller
      */
     public function removeAction(Request $request): Response
     {
-        $form = $this->formFactory->removeTranslation();
+        $form = $this->formFactory->deleteTranslation();
         $form->handleRequest($request);
 
         /** @var ContentInfo $contentInfo */
         $contentInfo = $form->getData()->getContentInfo();
 
         if ($form->isSubmitted()) {
-            $result = $this->submitHandler->handle($form, function (TranslationRemoveData $data) {
+            $result = $this->submitHandler->handle($form, function (TranslationDeleteData $data) {
                 $contentInfo = $data->getContentInfo();
 
                 foreach ($data->getLanguageCodes() as $languageCode => $selected) {

--- a/src/lib/Form/Data/Content/Translation/TranslationDeleteData.php
+++ b/src/lib/Form/Data/Content/Translation/TranslationDeleteData.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 
-class TranslationRemoveData
+class TranslationDeleteData
 {
     /** @var ContentInfo|null */
     protected $contentInfo;

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -56,7 +56,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentLocationAddTyp
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentLocationRemoveType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentMainLocationUpdateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\TranslationAddType;
-use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\TranslationRemoveType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\TranslationDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\ContentTypesDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentTypeGroup\ContentTypeGroupCreateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentTypeGroup\ContentTypeGroupDeleteType;
@@ -278,7 +278,7 @@ class FormFactory
     ): FormInterface {
         $name = $name ?: sprintf('delete-translations');
 
-        return $this->formFactory->createNamed($name, TranslationRemoveType::class, $data);
+        return $this->formFactory->createNamed($name, TranslationDeleteType::class, $data);
     }
 
     /**

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -14,7 +14,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentMainLocationUp
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentLocationAddData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentLocationRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationRemoveData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentType\ContentTypesDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupDeleteData;
@@ -265,15 +265,15 @@ class FormFactory
     }
 
     /**
-     * @param TranslationRemoveData|null $data
+     * @param TranslationDeleteData|null $data
      * @param null|string $name
      *
      * @return FormInterface
      *
      * @throws InvalidOptionsException
      */
-    public function removeTranslation(
-        TranslationRemoveData $data = null,
+    public function deleteTranslation(
+        TranslationDeleteData $data = null,
         ?string $name = null
     ): FormInterface {
         $name = $name ?: sprintf('delete-translations');

--- a/src/lib/Form/Type/Content/Translation/TranslationDeleteType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationDeleteType.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation;
 
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationRemoveData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TranslationRemoveType extends AbstractType
+class TranslationDeleteType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -50,7 +50,7 @@ class TranslationRemoveType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'data_class' => TranslationRemoveData::class,
+            'data_class' => TranslationDeleteData::class,
             'translation_domain' => 'forms',
         ]);
     }

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -84,7 +84,7 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
 
         $translationAddForm = $this->createTranslationAddForm($location);
 
-        $translationRemoveForm = $this->createTranslationRemoveForm(
+        $translationDeleteForm = $this->createTranslationDeleteForm(
             $location,
             $translationsDataset->getLanguageCodes()
         );
@@ -92,7 +92,7 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
         $viewParameters = [
             'translations' => $translationsDataset->getTranslations(),
             'form_translation_add' => $translationAddForm->createView(),
-            'form_translation_remove' => $translationRemoveForm->createView(),
+            'form_translation_remove' => $translationDeleteForm->createView(),
         ];
 
         return $this->twig->render(
@@ -123,7 +123,7 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
      *
      * @throws InvalidOptionsException
      */
-    private function createTranslationRemoveForm(Location $location, array $languageCodes): FormInterface
+    private function createTranslationDeleteForm(Location $location, array $languageCodes): FormInterface
     {
         $translationDeleteData = new TranslationDeleteData(
             $location->getContentInfo(),

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -110,9 +110,9 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
      */
     private function createTranslationAddForm(Location $location): FormInterface
     {
-        $translationRemoveData = new TranslationAddData($location);
+        $translationAddData = new TranslationAddData($location);
 
-        return $this->formFactory->addTranslation($translationRemoveData);
+        return $this->formFactory->addTranslation($translationAddData);
     }
 
     /**

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\Tab\LocationView;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
-use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationRemoveData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Tab\AbstractTab;
 use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
@@ -125,11 +125,11 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
      */
     private function createTranslationRemoveForm(Location $location, array $languageCodes): FormInterface
     {
-        $translationRemoveData = new TranslationRemoveData(
+        $translationDeleteData = new TranslationDeleteData(
             $location->getContentInfo(),
             array_combine($languageCodes, array_fill_keys($languageCodes, false))
         );
 
-        return $this->formFactory->removeTranslation($translationRemoveData);
+        return $this->formFactory->deleteTranslation($translationDeleteData);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | hopefully
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR:
1. Replaces usage of deprecated `ContentService::removeTranslation` with `ContentService::deleteTranslation` as the former one will be dropped in `7.x` (4d61694)
2. Aligns naming conventions to avoid further confusion.
3. Changes typo in variable related to adding Translation. (f43e938)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
