### PR TITLE
EZP-28621: List of option hides behind next field after expand

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
@@ -68,7 +68,6 @@
                         width: .1rem;
                         height: 1rem;
                         background-color: $ez-white;
-                        content: '';
                         position: absolute;
                         top: 50%;
                         left: 50%;
@@ -103,6 +102,7 @@
             border: 1px solid $ez-ground-primary;
             background-color: $ez-white;
             color: $ez-black;
+            z-index: 1;
 
             &--hidden {
                 transform: scaleY(0);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


List of option hides behind next field after expand


<img width="974" alt="screen shot 2017-12-22 at 1 23 15 pm" src="https://user-images.githubusercontent.com/1654712/34298053-07dbf4cc-e71c-11e7-8be6-86faf9e3a5c7.png">

<img width="972" alt="screen shot 2017-12-22 at 1 23 07 pm" src="https://user-images.githubusercontent.com/1654712/34298054-07fd15e4-e71c-11e7-871b-a69706124892.png">


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
