### PR TITLE
EZP-28674: performAccessCheck not called after EZP-28661 for ContentViewController

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -18,6 +18,12 @@ services:
         autoconfigure: true
         public: false
 
+    EzSystems\EzPlatformAdminUiBundle\Controller\Controller:
+        tags: ['controller.service_arguments']
+        calls:
+            - [setContainer, ["@service_container"]]
+            - [performAccessCheck, []]
+
     EzSystems\EzPlatformAdminUiBundle\ParamConverter\:
         resource: "../../ParamConverter/*"
         public: true

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -1,73 +1,63 @@
 services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-        public: false
-
     EzSystems\EzPlatformAdminUiBundle\Controller\:
         resource: "../../Controller/*"
         exclude: "../../Controller/{Controller}"
-        public: true
-        tags: ['controller.service_arguments']
-        calls:
-            - [setContainer, ["@service_container"]]
-            - [performAccessCheck, []]
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
 
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentTypeController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $contentTypeActionDispatcher: '@ezrepoforms.action_dispatcher.content_type'
             $languages: '$languages$'
             $defaultPaginationLimit: '$pagination.content_type_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentTypeGroupController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $languages: '$languages$'
             $defaultPaginationLimit: '$pagination.content_type_group_limit$'
 
-
     EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.search_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultSiteaccess: '%ezpublish.siteaccess.default%'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\TrashController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.trash_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\SectionController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.section_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\LanguageController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.language_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\RoleController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.role_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\RoleAssignmentController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.role_assignment_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\PolicyController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.policy_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentViewController:
-        public: true
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.version_draft_limit$'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28674
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
