### PR TITLE
As an Editor I want language choices to be ordered by SiteAccess settings

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -54,6 +54,10 @@ services:
     EzSystems\EzPlatformAdminUi\Form\DataMapper\:
         resource: '../../../lib/Form/DataMapper'
 
+    EzSystems\EzPlatformAdminUi\Form\Type\Language\LanguageChoiceType:
+        arguments:
+            $siteAccessLanguages: '$languages$'
+
     EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyChoiceType:
         arguments:
             $policyMap: "%ezpublish.api.role.policy_map%"

--- a/src/lib/Form/Type/Language/LanguageChoiceType.php
+++ b/src/lib/Form/Type/Language/LanguageChoiceType.php
@@ -46,7 +46,7 @@ class LanguageChoiceType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'choice_loader' => new CallbackChoiceLoader(function() {
+                'choice_loader' => new CallbackChoiceLoader(function () {
                     $saLanguages = [];
                     $languagesByCode = [];
 

--- a/src/lib/Form/Type/Language/LanguageChoiceType.php
+++ b/src/lib/Form/Type/Language/LanguageChoiceType.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Language;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
 use eZ\Publish\API\Repository\LanguageService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
@@ -24,12 +25,16 @@ class LanguageChoiceType extends AbstractType
     /** @var LanguageService */
     protected $languageService;
 
+    /** @var ConfigResolver */
+    protected $configResolver;
+
     /**
      * @param LanguageService $languageService
      */
-    public function __construct(LanguageService $languageService)
+    public function __construct(LanguageService $languageService, ConfigResolver $configResolver)
     {
         $this->languageService = $languageService;
+        $this->configResolver = $configResolver;
     }
 
     public function getParent()
@@ -39,9 +44,29 @@ class LanguageChoiceType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+        $languageService = $this->languageService;
+        $siteAccessLanguages = $this->configResolver->getParameter('languages');
         $resolver
             ->setDefaults([
-                'choice_loader' => new CallbackChoiceLoader([$this->languageService, 'loadLanguages']),
+                'choice_loader' => new CallbackChoiceLoader(function () use ($languageService, $siteAccessLanguages) {
+                    // Order languages by siteaccess languages first, then the rest
+                    $siteAccessLanguages[] = null;
+                    $languages = [];
+                    $repoLanguages = $languageService->loadLanguages();
+                    foreach ($siteAccessLanguages as $siteAccessLanguage) {
+                        foreach ($repoLanguages as $key => $repoLanguage) {
+                            if ($siteAccessLanguage === null) {
+                                $languages[] = $repoLanguage;
+                            } elseif ($repoLanguage->languageCode === $siteAccessLanguage) {
+                                $languages[] = $repoLanguage;
+                                unset($repoLanguages[$key]);
+                                break;
+                            }
+                        }
+                    }
+
+                    return $languages;
+                }),
                 'choice_label' => 'name',
                 'choice_name' => 'languageCode',
                 'choice_value' => 'languageCode',

--- a/src/lib/Form/Type/Language/LanguageChoiceType.php
+++ b/src/lib/Form/Type/Language/LanguageChoiceType.php
@@ -56,7 +56,7 @@ class LanguageChoiceType extends AbstractType
                     foreach ($siteAccessLanguages as $siteAccessLanguage) {
                         foreach ($repoLanguages as $key => $repoLanguage) {
                             if (!$repoLanguage->enabled) {
-                              continue;
+                                continue;
                             } elseif ($siteAccessLanguage === null) {
                                 $languages[] = $repoLanguage;
                             } elseif ($repoLanguage->languageCode === $siteAccessLanguage) {

--- a/src/lib/Form/Type/Language/LanguageChoiceType.php
+++ b/src/lib/Form/Type/Language/LanguageChoiceType.php
@@ -55,7 +55,9 @@ class LanguageChoiceType extends AbstractType
                     $repoLanguages = $languageService->loadLanguages();
                     foreach ($siteAccessLanguages as $siteAccessLanguage) {
                         foreach ($repoLanguages as $key => $repoLanguage) {
-                            if ($siteAccessLanguage === null) {
+                            if (!$repoLanguage->enabled) {
+                              continue;
+                            } elseif ($siteAccessLanguage === null) {
                                 $languages[] = $repoLanguage;
                             } elseif ($repoLanguage->languageCode === $siteAccessLanguage) {
                                 $languages[] = $repoLanguage;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | n/a
| Doc needed?   | unsure
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


E.g. If I configure admin to be [nor-NO, eng-GB], then I expect norwegian to be the default
choice so I don't need to click to change it when I create new content.

Review note:
- I'm unsure if this is right layer to do this, but until we move forward on SiteAccess aware
  Repo PR, this is currently only place we can do it.
- As class is autowired with no service config, I opted for type hinting for full config resolver
- EDIT: And besides, we need to filter out disabled languages here anyway


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
