### PR TITLE
EZP-28709: Add unit tests to TrashItemAdapter, TabRegistry and TabGroup

### DIFF
--- a/src/lib/Tests/Pagination/Pagerfanta/TrashItemAdapterTest.php
+++ b/src/lib/Tests/Pagination/Pagerfanta/TrashItemAdapterTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Tests\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\TrashService;
+use EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta\TrashItemAdapter;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Trash\SearchResult;
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+
+class TrashItemAdapterTest extends TestCase
+{
+    /**
+     * @var \eZ\Publish\API\Repository\TrashService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $trashService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->trashService = $this->createMock(TrashService::class);
+    }
+
+    /**
+     * Returns the adapter to test.
+     *
+     * @param Query $query
+     * @param TrashService $trashService
+     *
+     * @return TrashItemAdapter
+     */
+    protected function getAdapter(Query $query, TrashService $trashService): TrashItemAdapter
+    {
+        return new TrashItemAdapter($query, $trashService);
+    }
+
+    public function testGetNbResults()
+    {
+        $nbResults = 123;
+        $query = new Query();
+        $query->query = $this->createMock(CriterionInterface::class);
+        $query->sortClauses = $this->getMockBuilder(SortClause::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        // Count query will necessarily have a 0 limit.
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+
+        $searchResult = new SearchResult(['count' => $nbResults]);
+        $this->trashService
+            ->expects($this->once())
+            ->method('findTrashItems')
+            ->with($this->equalTo($countQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query, $this->trashService);
+        $this->assertSame($nbResults, $adapter->getNbResults());
+
+        // Running a 2nd time to ensure SearchService::findContent() is called only once.
+        $this->assertSame($nbResults, $adapter->getNbResults());
+    }
+
+    public function testGetSlice()
+    {
+        $offset = 20;
+        $limit = 25;
+        $nbResults = 123;
+
+        $query = new Query();
+        $query->query = $this->createMock(CriterionInterface::class);
+        $query->sortClauses = $this->getMockBuilder(SortClause::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        // Injected query is being cloned to modify offset/limit,
+        // so we need to do the same here for our assertions.
+        $searchQuery = clone $query;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
+        $searchQuery->performCount = false;
+
+        $items = [];
+        for ($i = 0; $i < $limit; ++$i) {
+            $content = $this->getMockForAbstractClass(APIContent::class);
+            $items[] = $content;
+        }
+
+        $searchResult = new SearchResult(['items' => $items, 'count' => $nbResults]);
+
+        $this->trashService
+            ->expects($this->once())
+            ->method('findTrashItems')
+            ->with($this->equalTo($searchQuery))
+            ->will($this->returnValue($searchResult));
+
+        $adapter = $this->getAdapter($query, $this->trashService);
+
+        $this->assertSame($items, $adapter->getSlice($offset, $limit));
+        $this->assertSame($nbResults, $adapter->getNbResults());
+        // Running a 2nd time to ensure SearchService::findContent() is called only once.
+        $this->assertSame($nbResults, $adapter->getNbResults());
+    }
+}

--- a/src/lib/Tests/Tab/TabGroupTest.php
+++ b/src/lib/Tests/Tab/TabGroupTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Tab;
+
+use EzSystems\EzPlatformAdminUi\Tab\TabGroup;
+use EzSystems\EzPlatformAdminUi\Tab\TabInterface;
+use PHPUnit\Framework\TestCase;
+
+class TabGroupTest extends TestCase
+{
+    public function testAddTab()
+    {
+        $tabIdentifier = 'tab_identifier';
+
+        $tab = $this->createMock(TabInterface::class);
+        $tab->expects(self::once())
+            ->method('getIdentifier')
+            ->willReturn($tabIdentifier);
+
+        $tabGroup = new TabGroup('group_name');
+
+        $this->assertCount(0, $tabGroup->getTabs());
+
+        $tabGroup->addTab($tab);
+
+        $this->assertCount(1, $tabGroup->getTabs());
+    }
+
+    public function testAddTabWithSameIdentifier()
+    {
+        $tabIdentifier = 'tab_identifier';
+
+        $tab = $this->createMock(TabInterface::class);
+        $tab->expects(self::once())
+            ->method('getIdentifier')
+            ->willReturn($tabIdentifier);
+
+        $tabWithSameIdentifier = $this->createMock(TabInterface::class);
+        $tabWithSameIdentifier->expects(self::once())
+            ->method('getIdentifier')
+            ->willReturn($tabIdentifier);
+
+        $tabGroup = new TabGroup('group_name');
+        $tabGroup->addTab($tab);
+
+        $this->assertCount(1, $tabGroup->getTabs());
+        $tabGroup->addTab($tabWithSameIdentifier);
+        $this->assertCount(1, $tabGroup->getTabs());
+    }
+
+    public function testRemoveTab()
+    {
+        $tabIdentifier = 'tab_identifier';
+
+        $tab = $this->createMock(TabInterface::class);
+        $tab->expects(self::once())
+            ->method('getIdentifier')
+            ->willReturn($tabIdentifier);
+
+        $tabGroup = new TabGroup('group_name');
+        $tabGroup->addTab($tab);
+
+        $this->assertCount(1, $tabGroup->getTabs());
+        $tabGroup->removeTab($tabIdentifier);
+        $this->assertCount(0, $tabGroup->getTabs());
+    }
+
+    public function testRemoveTabWhenNotExist()
+    {
+        $tabIdentifier = 'tab_identifier';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Tab identified as "%s" is not found.', $tabIdentifier));
+
+        $tab = $this->createMock(TabInterface::class);
+        $tab->expects(self::never())->method(self::anything());
+
+        $tabGroup = new TabGroup('group_name');
+
+        $this->assertCount(0, $tabGroup->getTabs());
+        $tabGroup->removeTab($tabIdentifier);
+    }
+}

--- a/src/lib/Tests/Tab/TabRegistryTest.php
+++ b/src/lib/Tests/Tab/TabRegistryTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Tests\Tab;
+
+use EzSystems\EzPlatformAdminUi\Tab\AbstractTab;
+use EzSystems\EzPlatformAdminUi\Tab\TabGroup;
+use EzSystems\EzPlatformAdminUi\Tab\TabInterface;
+use EzSystems\EzPlatformAdminUi\Tab\TabRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
+
+class TabRegistryTest extends TestCase
+{
+    private $groupName;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->groupName = 'group_name';
+    }
+
+    public function testGetTabsByGroupNameWhenGroupDoesNotExist()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Requested group named "%s" is not found. Did you forget to tag the service?', $this->groupName));
+
+        $tabRegistry = new TabRegistry();
+        $tabRegistry->getTabsByGroupName($this->groupName);
+    }
+
+    public function testGetTabsByGroupName()
+    {
+        $tabs = ['tab1', 'tab2'];
+        $tabGroup = $this->createTabGroup($this->groupName, $tabs);
+        $tabRegistry = new TabRegistry();
+        $tabRegistry->addTabGroup($tabGroup);
+
+        $this->assertSame($tabs, $tabRegistry->getTabsByGroupName($this->groupName));
+    }
+
+    public function testGetTabFromGroup()
+    {
+        $twig = $this->createMock(Environment::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $tab1 = $this->createTab('tab1', $twig, $translator);
+        $tabs = [$tab1, $this->createTab('tab2', $twig, $translator)];
+
+        $tabRegistry = new TabRegistry();
+        $tabGroup = $this->createTabGroup($this->groupName, $tabs);
+        $tabRegistry->addTabGroup($tabGroup);
+
+        $this->assertSame($tab1, $tabRegistry->getTabFromGroup('tab1', $this->groupName));
+    }
+
+    public function testGetTabFromGroupWhenGroupDoesNotExist()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Requested group named "%s" is not found. Did you forget to tag the service?', $this->groupName));
+
+        $tabRegistry = new TabRegistry();
+        $tabRegistry->getTabFromGroup('tab1', $this->groupName);
+    }
+
+    public function testGetTabFromGroupWhenTabDoesNotExist()
+    {
+        $tabName = 'tab1';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Requested tab "%s" from group "%s" is not found. Did you forget to tag the service?', $tabName, $this->groupName));
+
+        $tabs = [];
+        $tabRegistry = new TabRegistry();
+        $tabGroup = $this->createTabGroup($this->groupName, $tabs);
+        $tabRegistry->addTabGroup($tabGroup);
+        $tabRegistry->getTabFromGroup($tabName, $this->groupName);
+    }
+
+    public function testAddTabGroup()
+    {
+        $tabRegistry = new TabRegistry();
+        $tabGroup = $this->createTabGroup();
+        $tabRegistry->addTabGroup($tabGroup);
+
+        self::assertSame($tabGroup, $tabRegistry->getTabGroup('lorem'));
+    }
+
+    public function testAddTabGroupWithSameIdentifier()
+    {
+        $tabGroup = $this->createTabGroup($this->groupName);
+        $tabGroupWithSameIdentifier = $this->createTabGroup($this->groupName);
+
+        $tabRegistry = new TabRegistry();
+        $tabRegistry->addTabGroup($tabGroup);
+
+        self::assertSame($tabGroup, $tabRegistry->getTabGroup($this->groupName));
+        $tabRegistry->addTabGroup($tabGroupWithSameIdentifier);
+        self::assertSame($tabGroupWithSameIdentifier, $tabRegistry->getTabGroup($this->groupName));
+    }
+
+    public function testAddTabToExistingGroup()
+    {
+        $twig = $this->createMock(Environment::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $existingTab = $this->createTab('existing_tab', $twig, $translator);
+        $addedTab = $this->createTab('added_tab', $twig, $translator);
+
+        $tabRegistry = new TabRegistry();
+        $tabGroup = $this->createTabGroup($this->groupName, [$existingTab]);
+        $tabRegistry->addTabGroup($tabGroup);
+
+        self::assertCount(1, $tabRegistry->getTabsByGroupName($this->groupName));
+        $tabRegistry->addTab($addedTab, $this->groupName);
+        self::assertCount(2, $tabRegistry->getTabsByGroupName($this->groupName));
+    }
+
+    public function testAddTabToNonExistentGroup()
+    {
+        $twig = $this->createMock(Environment::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $addedTab = $this->createTab('added_tab', $twig, $translator);
+
+        $tabRegistry = new TabRegistry();
+        $tabRegistry->addTab($addedTab, $this->groupName);
+
+        self::assertCount(1, $tabRegistry->getTabsByGroupName($this->groupName));
+    }
+
+    /**
+     * Returns Tab Group.
+     *
+     * @param string $name
+     * @param array $tabs
+     *
+     * @return TabGroup
+     */
+    private function createTabGroup(string $name = 'lorem', array $tabs = []): TabGroup
+    {
+        return new TabGroup($name, $tabs);
+    }
+
+    /**
+     * Returns Tab.
+     *
+     * @param string $name
+     * @param Environment|MockObject $twig
+     * @param TranslatorInterface|MockObject $translator
+     *
+     * @return TabInterface
+     */
+    private function createTab(string $name, Environment $twig, TranslatorInterface $translator): TabInterface
+    {
+        return new class($name, $twig, $translator) extends AbstractTab {
+            /** @var string */
+            protected $name;
+
+            /** @var Environment */
+            protected $twig;
+
+            /** @var TranslatorInterface */
+            protected $translator;
+
+            /**
+             * @param string $name
+             * @param Environment $twig
+             * @param TranslatorInterface $translator
+             */
+            public function __construct(string $name = 'tab', Environment $twig, TranslatorInterface $translator)
+            {
+                parent::__construct($twig, $translator);
+                $this->name = $name;
+            }
+
+            /**
+             * Returns identifier of the tab.
+             *
+             * @return string
+             */
+            public function getIdentifier(): string
+            {
+                return 'identifier';
+            }
+
+            /**
+             * Returns name of the tab which is displayed as a tab's title in the UI.
+             *
+             * @return string
+             */
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            /**
+             * Returns HTML body of the tab.
+             *
+             * @param array $parameters
+             *
+             * @return string
+             */
+            public function renderView(array $parameters): string
+            {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28709
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


Add unit tests to TrashItemAdapter, TabRegistry and TabGroup


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
