### PR TITLE
EZP-28743: Different behaviour of breadcrumbs when ezplatform is hidden

### DIFF
--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -37,7 +37,7 @@
                     {% if content.path|length > 1 %}
                         {% for location in content.path %}
                             {% if loop.revindex > 1 %}
-                                <a href="{{ path(location) }}">
+                                <a href="{{ path('_ezpublishLocation', {'locationId': location.id}) }}">
                                     {{ ez_content_name(location.contentInfo) }}
                                 </a>
 

--- a/src/bundle/Resources/views/parts/path.html.twig
+++ b/src/bundle/Resources/views/parts/path.html.twig
@@ -3,7 +3,7 @@
         {{ ez_content_name(location.contentInfo) }}
     {% else %}
         <a
-        href="{{ path(location) }}">{{ ez_content_name(location.contentInfo) }}</a>{% if loop.last is same as(false) %} /{% endif %}
+        href="{{ path('_ezpublishLocation', {'locationId': location.id}) }}">{{ ez_content_name(location.contentInfo) }}</a>{% if loop.last is same as(false) %} /{% endif %}
     {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28743
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)



Fix for different behaviour of breadcrumbs when ezplatform is hidden. Same issue was in Admin->Sections->Specific Section->Content items panel.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
