### PR TITLE
EZP-28730: Wrong tooltip messages for buttons

### DIFF
--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -411,15 +411,15 @@
         <target state="new">Published version</target>
         <note>key: tab.versions.published_version</note>
       </trans-unit>
-      <trans-unit id="628c74bcc6328324ea1c084c8bbe686f7e572c16" resname="tab.versions.table.action.archived.delete">
-        <source>Delete Archived Version</source>
-        <target state="new">Delete Archived Version</target>
-        <note>key: tab.versions.table.action.archived.delete</note>
+      <trans-unit id="d2e707023baa6830915c5d12b915974d627522e4" resname="tab.versions.table.action.archived.edit">
+        <source>Restore Archived Version</source>
+        <target state="new">Restore Archived Version</target>
+        <note>key: tab.versions.table.action.archived.edit</note>
       </trans-unit>
-      <trans-unit id="f7b4cf0de472a75da3ed9502ef8eedd21a02a266" resname="tab.versions.table.action.draft.delete">
-        <source>Delete Draft Version</source>
-        <target state="new">Delete Draft Version</target>
-        <note>key: tab.versions.table.action.draft.delete</note>
+      <trans-unit id="97721a4a6c33834bb6421c29ef72e8654f39a4ab" resname="tab.versions.table.action.draft.edit">
+        <source>Edit Draft</source>
+        <target state="new">Edit Draft</target>
+        <note>key: tab.versions.table.action.draft.edit</note>
       </trans-unit>
       <trans-unit id="4c27637d649c221e58c6a9629f14a2f75aeed151" resname="tab.versions.table.contributor">
         <source>Contributor</source>

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -47,7 +47,7 @@
             {% if is_draft %}
                 <td>
                     <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode }) }}"
-                       class="btn btn-icon" title="{{ 'tab.versions.table.action.draft.delete'|trans|desc('Delete Draft Version') }}">
+                       class="btn btn-icon" title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                         </svg>
@@ -57,7 +57,7 @@
             {% if is_archived %}
                 <td>
                     <button class="btn btn-icon ez-btn--content-edit"
-                            title="{{ 'tab.versions.table.action.archived.delete'|trans|desc('Delete Archived Version') }}"
+                            title="{{ 'tab.versions.table.action.archived.edit'|trans|desc('Restore Archived Version') }}"
                             data-content-id="{{ version.contentInfo.id }}"
                             data-version-no="{{ version.versionNo }}"
                             data-language-code="{{ version.initialLanguageCode }}">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28730
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fix tooltip messages for buttons in Content Version tab.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
