### PR TITLE
EZP-28686: Error 500 while user is going to dashboard after deleting another user

### DIFF
--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -56,6 +56,11 @@
         <target state="new">Contributor</target>
         <note>key: dashboard.table.contributor</note>
       </trans-unit>
+      <trans-unit id="e7790665f417ad7d9479f8b7c0920d212e4e24f6" resname="dashboard.table.contributor.not_found">
+        <source>Can’t fetch contributor</source>
+        <target state="new">Can’t fetch contributor</target>
+        <note>key: dashboard.table.contributor.not_found</note>
+      </trans-unit>
       <trans-unit id="93a5fc53032106ea0ae1658261fd187e5c9c6a94" resname="dashboard.table.draft.edit">
         <source>Edit Draft</source>
         <target state="new">Edit Draft</target>

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -17,8 +17,11 @@
                 <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td>{{ row.type }}</td>
                 <td>
-                    {{ ez_render_field(row.contributor, 'first_name') }}
-                    {{ ez_render_field(row.contributor, 'last_name') }}
+                    {% if row.contributor is not null %}
+                        {{ row.contributor.name }}
+                    {% else %}
+                        {{ 'dashboard.table.contributor.not_found'|trans|desc('Can’t fetch contributor') }}
+                    {% endif %}
                 </td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -17,8 +17,11 @@
                 <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td>{{ row.type }}</td>
                 <td>
-                    {{ ez_render_field(row.contributor, 'first_name') }}
-                    {{ ez_render_field(row.contributor, 'last_name') }}
+                    {% if row.contributor is not null %}
+                        {{ row.contributor.name }}
+                    {% else %}
+                        {{ 'dashboard.table.contributor.not_found'|trans|desc('Can’t fetch contributor') }}
+                    {% endif %}
                 </td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Tab\Dashboard;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\UserService;
 use Pagerfanta\Pagerfanta;
 
@@ -51,11 +52,17 @@ class PagerContentToDataMapper
         foreach ($pager as $content) {
             $contentInfo = $this->contentService->loadContentInfo($content->id);
 
+            try {
+                $contributor = $this->userService->loadUser($contentInfo->ownerId);
+            } catch (NotFoundException $e) {
+                $contributor = null;
+            }
+
             $data[] = [
                 'contentId' => $content->id,
                 'name' => $contentInfo->name,
                 'language' => $contentInfo->mainLanguageCode,
-                'contributor' => $this->userService->loadUser($contentInfo->ownerId),
+                'contributor' => $contributor,
                 'version' => $content->versionInfo->versionNo,
                 'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
                 'modified' => $content->versionInfo->modificationDate,


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28686
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)



Fixed error 500 while user is going to dashboard after deleting another user. After user deletion we will display text "Can not fetch contributor" in a "Contributor" cell.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
