### PR TITLE
EZP-28737: User account partially deleted

### DIFF
--- a/src/bundle/Controller/User/UserDeleteController.php
+++ b/src/bundle/Controller/User/UserDeleteController.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUiBundle\Controller\User;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use EzSystems\EzPlatformAdminUi\Form\Data\User\UserDeleteData;
+use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
+use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
+use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+use Symfony\Component\Translation\TranslatorInterface;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\LocationService;
+
+class UserDeleteController extends Controller
+{
+    /** @var NotificationHandlerInterface */
+    private $notificationHandler;
+
+    /** @var FormFactory */
+    private $formFactory;
+
+    /** @var SubmitHandler */
+    private $submitHandler;
+
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /** @var UserService */
+    private $userService;
+
+    /** @var LocationService */
+    private $locationService;
+
+    /**
+     * @param NotificationHandlerInterface $notificationHandler
+     * @param FormFactory $formFactory
+     * @param SubmitHandler $submitHandler
+     * @param TranslatorInterface $translator
+     * @param UserService $userService
+     * @param LocationService $locationService
+     */
+    public function __construct(
+        NotificationHandlerInterface $notificationHandler,
+        FormFactory $formFactory,
+        SubmitHandler $submitHandler,
+        TranslatorInterface $translator,
+        UserService $userService,
+        LocationService $locationService
+    ) {
+        $this->notificationHandler = $notificationHandler;
+        $this->formFactory = $formFactory;
+        $this->submitHandler = $submitHandler;
+        $this->translator = $translator;
+        $this->userService = $userService;
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @throws UnauthorizedException
+     * @throws NotFoundException
+     */
+    public function userDeleteAction(Request $request): Response
+    {
+        $form = $this->formFactory->deleteUser();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $result = $this->submitHandler->handle($form, function (UserDeleteData $data) {
+                $contentInfo = $data->getContentInfo();
+
+                $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
+
+                $user = $this->userService->loadUser($contentInfo->id);
+
+                $this->userService->deleteUser($user);
+
+                $this->notificationHandler->success(
+                    $this->translator->trans(
+                        /** @Desc("User with login '%login%' deleted.") */
+                        'user.delete.success',
+                        ['%login%' => $user->login],
+                        'content'
+                    )
+                );
+
+                return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
+                    'locationId' => $location->parentLocationId,
+                ]));
+            });
+
+            if ($result instanceof Response) {
+                return $result;
+            }
+        }
+
+        return $this->redirect($this->generateUrl('ezplatform.dashboard'));
+    }
+}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -512,3 +512,13 @@ ezplatform.link_manager.view:
         _controller: 'EzPlatformAdminUiBundle:LinkManager:view'
     requirements:
         urlId: \d+
+
+#
+# User
+#
+
+ezplatform.user.delete:
+    path: /user/delete
+    methods: ['POST']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:User\UserDelete:userDelete'

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -27,6 +27,9 @@ services:
         arguments:
             $defaultSiteaccess: '%ezpublish.siteaccess.default%'
 
+    EzSystems\EzPlatformAdminUiBundle\Controller\User\UserDeleteController:
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
+
     EzSystems\EzPlatformAdminUiBundle\Controller\TrashController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:

--- a/src/bundle/Resources/translations/content.en.xliff
+++ b/src/bundle/Resources/translations/content.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Main location for '%name%' updated.</target>
         <note>key: content.main_location_update.success</note>
       </trans-unit>
+      <trans-unit id="4492a79e25635e7612f98971e02b4d0e6a408394" resname="user.delete.success">
+        <source>User with login '%login%' deleted.</source>
+        <target state="new">User with login '%login%' deleted.</target>
+        <note>key: user.delete.success</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -236,6 +236,11 @@
         <target state="new">Delete permanently</target>
         <note>key: trash_empty_form.empty</note>
       </trans-unit>
+      <trans-unit id="7fb1cbcd94553ff377f8e1e4461246af38e14e85" resname="user_delete_form.delete">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note>key: user_delete_form.delete</note>
+      </trans-unit>
       <trans-unit id="3b2ae7aa286887e2fbd2b6e77ca237f9f9109e9b" resname="version_remove_form.remove">
         <source>Remove version</source>
         <target state="new">Remove version</target>

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Create</target>
         <note>key: content__sidebar_right__create</note>
       </trans-unit>
+      <trans-unit id="b3937ec2d3ae4980f8ae00ed20818d92bfab3407" resname="content__sidebar_right__delete">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note>key: content__sidebar_right__delete</note>
+      </trans-unit>
       <trans-unit id="c01e10e86b48dd064915bf18551985d47244c191" resname="content__sidebar_right__edit">
         <source>Edit</source>
         <target state="new">Edit</target>

--- a/src/bundle/Resources/translations/user_delete.en.xliff
+++ b/src/bundle/Resources/translations/user_delete.en.xliff
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="3816282a6673a4a07c0e56585b7c4215816951a9" resname="delete.form.cancel">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note>key: delete.form.cancel</note>
+      </trans-unit>
+      <trans-unit id="bd2693d22f74954ebfeec334da5b3a4816ea6c11" resname="delete.modal.message">
+        <source>Are you sure you want to delete this user?</source>
+        <target state="new">Are you sure you want to delete this user?</target>
+        <note>key: delete.modal.message</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -3,7 +3,6 @@
 {% trans_default_domain 'locationview' %}
 {% form_theme form_location_copy '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
 {% form_theme form_location_move '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_location_trash '@EzPlatformAdminUi/form_fields.html.twig' %}
 {% form_theme form_content_edit '@EzPlatformAdminUi/form_fields.html.twig' %}
 {% form_theme form_content_create '@EzPlatformAdminUi/form_fields.html.twig' %}
 
@@ -72,7 +71,12 @@
                     {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
                 </div>
             </div>
-            {% include '@EzPlatformAdminUi/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
+            {%  if form_location_trash is defined %}
+                {% include '@EzPlatformAdminUi/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
+            {% endif %}
+            {%  if form_user_delete is defined %}
+                {% include '@EzPlatformAdminUi/content/modal_user_delete.html.twig' with {'form': form_user_delete} only %}
+            {% endif %}
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}
         </div>

--- a/src/bundle/Resources/views/content/modal_user_delete.html.twig
+++ b/src/bundle/Resources/views/content/modal_user_delete.html.twig
@@ -1,6 +1,8 @@
+{% trans_default_domain 'user_delete' %}
+
 {% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
 
-<div class="modal fade ez-modal ez-modal--send-to-trash" id="trash-location-modal" tabindex="-1" role="dialog">
+<div class="modal fade ez-modal ez-modal--send-to-trash" id="delete-user-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -10,15 +12,15 @@
             </div>
             <div class="modal-body">
                 <p class="ez-modal-body__main">
-                    {{ 'trash.modal.message'|trans|desc('Are you sure you want to send this content item to trash?') }}
+                    {{ 'delete.modal.message'|trans|desc('Are you sure you want to delete this user?') }}
                 </p>
             </div>
             <div class="modal-footer">
-                {{ form_start(form, {'action': path('ezplatform.location.trash')}) }}
+                {{ form_start(form, {'action': path('ezplatform.user.delete')}) }}
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
-                    {{ 'trash.form.cancel'|trans|desc('Cancel') }}
+                    {{ 'delete.form.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.trash, {'attr': {'class': 'btn-danger'}}) }}
+                {{ form_widget(form.delete, {'attr': {'class': 'btn btn-danger'}}) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/lib/Form/Data/User/UserDeleteData.php
+++ b/src/lib/Form/Data/User/UserDeleteData.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Data\User;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+
+class UserDeleteData
+{
+    /** @var ContentInfo|null */
+    private $contentInfo;
+
+    /**
+     * @param ContentInfo|null $contentInfo
+     */
+    public function __construct(?ContentInfo $contentInfo = null)
+    {
+        $this->contentInfo = $contentInfo;
+    }
+
+    /**
+     * @return ContentInfo|null
+     */
+    public function getContentInfo(): ?ContentInfo
+    {
+        return $this->contentInfo;
+    }
+
+    /**
+     * @param ContentInfo|null $contentInfo
+     */
+    public function setContentInfo(?ContentInfo $contentInfo)
+    {
+        $this->contentInfo = $contentInfo;
+    }
+}

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -49,6 +49,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionsDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashEmptyData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashItemRestoreData;
+use EzSystems\EzPlatformAdminUi\Form\Data\User\UserDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Version\VersionRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentCreateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentEditType;
@@ -72,6 +73,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationSwapType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationUpdateVisibilityType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationTrashType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationUpdateType;
+use EzSystems\EzPlatformAdminUi\Form\Type\User\UserDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Policy\PoliciesDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyCreateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyDeleteType;
@@ -850,5 +852,20 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(SearchData::class);
 
         return $this->formFactory->createNamed($name, URLEditType::class, $data, $options);
+    }
+
+    /**
+     * @param UserDeleteData|null $data
+     * @param null|string $name
+     *
+     * @return FormInterface
+     */
+    public function deleteUser(
+        UserDeleteData $data = null,
+        ?string $name = null
+    ): FormInterface {
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(UserDeleteType::class);
+
+        return $this->formFactory->createNamed($name, UserDeleteType::class, $data);
     }
 }

--- a/src/lib/Form/Type/User/UserDeleteType.php
+++ b/src/lib/Form/Type/User/UserDeleteType.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\User;
+
+use EzSystems\EzPlatformAdminUi\Form\Data\User\UserDeleteData;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserDeleteType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'content_info',
+                ContentInfoType::class,
+                ['label' => false]
+            )
+            ->add(
+                'delete',
+                SubmitType::class,
+                ['label' => /** @Desc("Delete") */ 'user_delete_form.delete']
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => UserDeleteData::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+}

--- a/src/lib/Specification/ContentIsUser.php
+++ b/src/lib/Specification/ContentIsUser.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+
+class ContentIsUser implements ContentSpecification
+{
+    /** @var UserService */
+    private $userService;
+
+    /**
+     * @param UserService $userService
+     */
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    /**
+     * Checks if $contentId is an existing User content.
+     *
+     * @param Content $content
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy(Content $content): bool
+    {
+        try {
+            $this->userService->loadUser($content->id);
+
+            return true;
+        } catch (NotFoundException $e) {
+            return false;
+        }
+    }
+}

--- a/src/lib/Specification/ContentSpecification.php
+++ b/src/lib/Specification/ContentSpecification.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+
+interface ContentSpecification
+{
+    /**
+     * Check to see if the specification is satisfied.
+     *
+     * @param Content $content
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy(Content $content): bool;
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28737
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | yes
| Tests pass?   |no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


This PR fixed problem with partially deleted user. Now, if Content is a User, it can be only deleted via userService.

<img width="1420" alt="screen shot 2018-01-19 at 8 53 10 am" src="https://user-images.githubusercontent.com/1654712/35140154-7e526c90-fcf6-11e7-8569-eae590817ae5.png">


<img width="1418" alt="screen shot 2018-01-19 at 8 53 27 am" src="https://user-images.githubusercontent.com/1654712/35140206-b141abac-fcf6-11e7-9239-9d740a2ac3b8.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

