### PR TITLE
EZP-28488: A new version of a draft is created every time a content item is edited

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -9,6 +9,7 @@
         color: $ez-black;
         width: 2rem;
         height: 2rem;
+        cursor: pointer;
 
         &:before,
         &:after {

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -37,11 +37,7 @@
 {% endblock %}
 
 {% block close_button %}
-    {% set locationId = content.versionInfo.contentInfo.mainLocationId
-        ? content.versionInfo.contentInfo.mainLocationId
-        : (parentLocations|first).id
-    %}
-    <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': locationId }) }}"></a>
+    <a class="ez-content-edit-container__close btn--trigger" data-click="#ezrepoforms_content_edit_cancel"></a>
 {% endblock %}
 
 {% block form_before %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28488
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   |yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


When close out the edit mode by clicking on the 'cross' symbol without saving the changes then a new Draft version should NOT be created.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
