### PR TITLE
EZP-28766: Notification gets covered by radio-button in content editor

### DIFF
--- a/src/bundle/Resources/public/scss/_notifications.scss
+++ b/src/bundle/Resources/public/scss/_notifications.scss
@@ -3,6 +3,7 @@
     bottom: 0;
     width: 100%;
     line-height: 2.25;
+    z-index: 50000;
 
     .alert {
         padding: 0.75rem 5rem;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28766
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Notification gets covered by radio-button in content editor.

<img width="1419" alt="screen shot 2018-01-23 at 10 30 59 am" src="https://user-images.githubusercontent.com/1654712/35268203-c84cd0b2-0028-11e8-910f-1dbfd90d8222.png">

<img width="1415" alt="screen shot 2018-01-23 at 11 03 33 am" src="https://user-images.githubusercontent.com/1654712/35269711-202dcee0-002d-11e8-8402-2d9550f5dd75.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

