### PR TITLE
[EZP-28683] Replace apostrophes (`) with single quote(')

### DIFF
--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -119,7 +119,7 @@ class TranslationController extends Controller
 
                     $this->notificationHandler->success(
                         $this->translator->trans(
-                            /** @Desc("Translation '%languageCode%' removed from content `%name%`.") */
+                            /** @Desc("Translation '%languageCode%' removed from content '%name%'.") */
                             'translation.remove.success',
                             ['%languageCode%' => $languageCode, '%name%' => $contentInfo->name],
                             'translation'

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -221,7 +221,7 @@ class TrashController extends Controller
                     } else {
                         $this->notificationHandler->success(
                             $this->translator->trans(
-                                /** @Desc("Items restored under `%location%` location.") */
+                                /** @Desc("Items restored under '%location%' location.") */
                                 'trash.restore_new_location.success',
                                 ['%location%' => $newParentLocation->getContentInfo()->name],
                                 'trash'

--- a/src/bundle/Resources/translations/translation.en.xliff
+++ b/src/bundle/Resources/translations/translation.en.xliff
@@ -7,8 +7,8 @@
     </header>
     <body>
       <trans-unit id="e4b8188e898e654dae14fc6b18133958f8e56084" resname="translation.remove.success">
-        <source>Translation '%languageCode%' removed from content `%name%`.</source>
-        <target state="new">Translation '%languageCode%' removed from content `%name%`.</target>
+        <source>Translation '%languageCode%' removed from content '%name%'.</source>
+        <target state="new">Translation '%languageCode%' removed from content '%name%'.</target>
         <note>key: translation.remove.success</note>
       </trans-unit>
     </body>

--- a/src/bundle/Resources/translations/trash.en.xliff
+++ b/src/bundle/Resources/translations/trash.en.xliff
@@ -42,8 +42,8 @@
         <note>key: trash.original_location</note>
       </trans-unit>
       <trans-unit id="a8c2da925faa48def8e407037a6115f1340070c7" resname="trash.restore_new_location.success">
-        <source>Items restored under `%location%` location.</source>
-        <target state="new">Items restored under `%location%` location.</target>
+        <source>Items restored under '%location%' location.</source>
+        <target state="new">Items restored under '%location%' location.</target>
         <note>key: trash.restore_new_location.success</note>
       </trans-unit>
       <trans-unit id="d4e8ddb6a84d9ca3a3b39485e9b7c5ef2860d879" resname="trash.restore_original_location.success">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28683
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Replace apostrophes ( ` ) with single quote ( ' ). Probably this could be (and maybe should be for future cases) solved on css level but  this way it is unified across bundle.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
