### PR TITLE
[EZP-28776] Harmonize hover & active states for creating and editing …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
     "extra": {
         "_ezplatform_branch_for_behat_tests": "master",
         "branch-alias": {
-            "dev-tmp_ci_branch": "2.0.x-dev",
-            "dev-master": "1.0.x-dev"
+            "dev-tmp_ci_branch": "2.1.x-dev",
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -21,10 +21,19 @@
         transition: all .2s $ez-admin-transition;
 
         &:hover,
-        &:focus {
-            background: $ez-color-secondary;
-            color: $ez-white;
+        &:focus, 
+        &:active {
             text-decoration: none;
+        }
+
+        &:hover,
+        &:focus {
+            background: $ez-secondary-ground-pale;
+        }
+
+        &:active {
+            background: $ez-secondary-ground;
+            color: $ez-white;
         }
     }
 
@@ -71,10 +80,19 @@
             margin-bottom: 0;
 
             &:hover,
-            &:focus {
-                background: $ez-color-secondary;
-                color: $ez-white;
+            &:focus, 
+            &:active {
                 text-decoration: none;
+            }
+
+            &:hover,
+            &:focus {
+                background: $ez-secondary-ground-pale;
+            }
+
+            &:active {
+                background: $ez-secondary-ground;
+                color: $ez-white;
             }
 
             &:not(:last-child) {
@@ -128,7 +146,12 @@
 
             &:hover,
             &:focus {
-                background: $ez-color-secondary;
+                background: $ez-secondary-ground-pale;
+            }
+
+            &:active {
+                background: $ez-secondary-ground;
+                color: $ez-white;
             }
 
             label {


### PR DESCRIPTION
Harmonize hover & active states for creating and editing content

| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28776](https://jira.ez.no/browse/EZP-28776)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Currently in V.2.0.0 when the user creates or edits any given content item hover & focus, as well as active states are not harmonized with the states defined (see UDW's, for instance).
- Current PR corrects this also in order to improve usability due to a not proper color contrast solution defined.

![create_hover_state](https://user-images.githubusercontent.com/9256718/35302238-c5b8e9ac-005b-11e8-9bb2-eda6cd886fd5.png)
![create_active_state](https://user-images.githubusercontent.com/9256718/35302242-ca98ffc0-005b-11e8-9681-fc5bc45fd137.png)
![edit_hover_state](https://user-images.githubusercontent.com/9256718/35302245-cf349bf2-005b-11e8-99ba-2481291bb09b.png)
![edit_active_state](https://user-images.githubusercontent.com/9256718/35302250-d3f55370-005b-11e8-91ed-20aa294a3aad.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
