### PR TITLE
EZP-28678: Unnecessary inactive edit button in Relations tab

### DIFF
--- a/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
@@ -8,7 +8,6 @@
         <th>{{ 'tab.relations.table.name'|trans()|desc('Name') }}</th>
         <th>{{ 'tab.relations.table.content_type'|trans()|desc('Content type') }}</th>
         <th>{{ 'tab.relations.table.relation_type'|trans()|desc('Relation type') }}</th>
-        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -22,13 +21,6 @@
                 {% if (relation.relationFieldDefinitionName) %}
                     ({{ relation.relationFieldDefinitionName }})
                 {% endif %}
-            </td>
-            <td>
-                <a href="#" class="btn btn-icon disabled">
-                    <svg class="ez-icon ez-icon-edit">
-                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                    </svg>
-                </a>
             </td>
         </tr>
     {% endfor %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -8,7 +8,6 @@
         <th>{{ 'tab.relations.table.name'|trans()|desc('Name') }}</th>
         <th>{{ 'tab.relations.table.content_type'|trans()|desc('Content type') }}</th>
         <th>{{ 'tab.relations.table.relation_type'|trans()|desc('Relation type') }}</th>
-        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -22,13 +21,6 @@
                 {% if (relation.relationFieldDefinitionName) %}
                     ({{ relation.relationFieldDefinitionName }})
                 {% endif %}
-            </td>
-            <td>
-                <a href="#" class="btn btn-icon disabled">
-                    <svg class="ez-icon ez-icon-edit">
-                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                    </svg>
-                </a>
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28678
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


Removed unnecessary inactive edit button in Relations tab.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
