### PR TITLE
[EZP-28683] Removes asterisk sign from labels when content editing

### DIFF
--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -6,7 +6,14 @@ form:not(.form-inline) {
         margin-bottom: 0;
         margin-top: 20px;
 
-        @include label-required();
+        &:after {
+            content: ': ';
+        }
+
+        &:not(.ez-data-source__label) {
+            @include label-required();
+        }
+
     }
 
     .col-form-legend {

--- a/src/bundle/Resources/public/scss/_mixins.scss
+++ b/src/bundle/Resources/public/scss/_mixins.scss
@@ -172,15 +172,9 @@
         content: ': ';
     }
 
-    &.required:not(.ez-data-source__label) {
+    &.required {
         &:after {
             content: '*: ';
-        }
-    }
-
-    &.required.ez-data-source__label {
-        &:after {
-            content: ': ';
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_mixins.scss
+++ b/src/bundle/Resources/public/scss/_mixins.scss
@@ -172,9 +172,15 @@
         content: ': ';
     }
 
-    &.required {
+    &.required:not(.ez-data-source__label) {
         &:after {
             content: '*: ';
+        }
+    }
+
+    &.required.ez-data-source__label {
+        &:after {
+            content: ': ';
         }
     }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -1,7 +1,11 @@
 .ez-field-edit {
-    .ez-field-edit__label,
-    .ez-data-source__label {
+    .ez-field-edit__label {
         @include label-required();
+    }
+    .ez-data-source__label {
+        &:after {
+            content: ': ';
+        }
     }
 
     &--nontranslatable {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28676
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


At first wanted to edit in _base-fields.scss but then it turns out that asterisk is added also in _forms.scss. 
Dont know if it should be somehow excluded from .ez-data-source__label instead.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
