### PR TITLE
[EZP-28782] Remove extra div classes

### DIFF
--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -21,7 +21,7 @@
         {% endblock left_sidebar %}
 
         <div class="col-sm-10 px-0 pb-4">
-            <div class="ez-header pt-1 pb-2">
+            <div class="ez-header">
                 <div class="container">
                     {% set items = [] %}
                     {% for pathLocation in pathLocations %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28782
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Removed classes which moves whole breadcrumbs + title container.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
