### PR TITLE
EZP-27776: Version conflict window when I edit an existing draft base…

### DIFF
--- a/src/bundle/Controller/Version/VersionConflictController.php
+++ b/src/bundle/Controller/Version/VersionConflictController.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Controller\Version;
+
+use eZ\Publish\API\Repository\ContentService;
+use EzSystems\EzPlatformAdminUi\Specification\Version\VersionHasConflict;
+use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+
+class VersionConflictController extends Controller
+{
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    /**
+     * @param ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Checks if Version has conflict with another published Version.
+     *
+     * If Version has no conflict, return empty Response. If it has conflict return HTML with content of modal.
+     *
+     * @param int $contentId
+     * @param int $versionNo
+     *
+     * @return Response
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \InvalidArgumentException
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function versionHasNoConflictAction(int $contentId, int $versionNo): Response
+    {
+        $versionInfo = $this->contentService->loadVersionInfoById($contentId, $versionNo);
+
+        if (!$versionInfo->isDraft()) {
+            throw new BadStateException('Version status', 'status is not draft');
+        }
+
+        if ((new VersionHasConflict($this->contentService))->isSatisfiedBy($versionInfo)) {
+            return new Response('', Response::HTTP_CONFLICT);
+        }
+
+        return new Response();
+    }
+}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -418,6 +418,13 @@ ezplatform.version.remove:
     defaults:
         _controller: 'EzPlatformAdminUiBundle:Version:remove'
 
+ezplatform.version.has_no_conflict:
+    path: /version/has-no-conflict/{contentId}/{versionNo}/{languageCode}
+    options:
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Version\VersionConflict:versionHasNoConflict'
+        languageCode: ~
+
 # LocationView / Locations tab
 
 ezplatform.location.add:

--- a/src/bundle/Resources/public/js/scripts/admin.version.edit.conflict.js
+++ b/src/bundle/Resources/public/js/scripts/admin.version.edit.conflict.js
@@ -1,0 +1,22 @@
+(function (global, doc) {
+    const editVersion = (event) => {
+        const contentDraftEditUrl = event.currentTarget.dataset.contentDraftEditUrl;
+        const versionHasConflictUrl = event.currentTarget.dataset.versionHasConflictUrl;
+
+        event.preventDefault();
+
+        fetch(versionHasConflictUrl, {
+            credentials: 'same-origin'
+        }).then(function (response) {
+            if (response.status === 409) {
+                doc.querySelector('#edit-conflicted-draft').href = contentDraftEditUrl;
+                $('#version-conflict-modal').modal('show');
+            }
+            if (response.status === 200) {
+                global.location.href = contentDraftEditUrl;
+            }
+        })
+    };
+
+    [...doc.querySelectorAll('.ez-btn--content-draft-edit')].forEach(link => link.addEventListener('click', editVersion, false));
+})(window, document);

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -48,6 +48,7 @@ a {
 
 .btn {
     white-space: normal;
+    cursor: pointer;
 }
 
 button {

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -38,3 +38,9 @@
         }
     }
 }
+
+.ez-modal {
+    .close {
+        cursor: pointer;
+    }
+}

--- a/src/bundle/Resources/translations/version_conflict.en.xliff
+++ b/src/bundle/Resources/translations/version_conflict.en.xliff
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="e3134aea8177d5285a440a147f434f843d81e0dc" resname="version.conflict.are_you_sure">
+        <source>Are you sure you want to continue and overwrite the latest version?</source>
+        <target state="new">Are you sure you want to continue and overwrite the latest version?</target>
+        <note>key: version.conflict.are_you_sure</note>
+      </trans-unit>
+      <trans-unit id="f77f809ec953a9ee0a8fe642ab53e2763e5eaed2" resname="version.conflict.choices">
+        <source>To resolve the conflict, click Cancel and delete the draft. Then edit the published Content Item.</source>
+        <target state="new">To resolve the conflict, click Cancel and delete the draft. Then edit the published Content Item.</target>
+        <note>key: version.conflict.choices</note>
+      </trans-unit>
+      <trans-unit id="9fad7ad8b2a4215487f98fc67dd7d793dd0382e8" resname="version.conflict.consequences">
+        <source>If you continue, the previous version will be overwritten.</source>
+        <target state="new">If you continue, the previous version will be overwritten.</target>
+        <note>key: version.conflict.consequences</note>
+      </trans-unit>
+      <trans-unit id="5b6635730e66eb50ae26455406ca774eac8fd8e1" resname="version.conflict.form.cancel">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note>key: version.conflict.form.cancel</note>
+      </trans-unit>
+      <trans-unit id="c70ab0acdd2b67e3043949422191e75e6e09440e" resname="version.conflict.form.continue">
+        <source>Continue</source>
+        <target state="new">Continue</target>
+        <note>key: version.conflict.form.continue</note>
+      </trans-unit>
+      <trans-unit id="0fcf485b042da069359444e8395122974ad929fc" resname="version.conflict.header">
+        <source>Version conflict when editing</source>
+        <target state="new">Version conflict when editing</target>
+        <note>key: version.conflict.header</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/content/modal_version_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_version_conflict.html.twig
@@ -1,0 +1,42 @@
+{% trans_default_domain 'version_conflict' %}
+
+<div class="modal fade ez-modal ez-modal--version-conflict" id="version-conflict-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>{{ 'version.conflict.header'|trans|desc('Version conflict when editing') }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="ez-modal-body__explanation">
+                    <strong>
+                        {{ 'version.conflict.are_you_sure'|trans|desc(
+                        'Are you sure you want to continue and overwrite the latest version?'
+                        ) }}
+                    </strong>
+                </p>
+                <p class="ez-modal-body__explanation">
+                    {{ 'version.conflict.consequences'|trans|desc(
+                    'If you continue, the previous version will be overwritten.'
+                    ) }}
+                </p>
+                <p class="ez-modal-body__explanation">
+                    {{ 'version.conflict.choices'|trans|desc(
+                    'To resolve the conflict, click Cancel and delete the draft. Then edit the published Content Item.'
+                    ) }}
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                    {{ 'version.conflict.form.cancel'|trans|desc('Cancel') }}
+                </button>
+                <a id="edit-conflicted-draft" class="btn btn-primary"
+                   href="#">
+                    {{ 'version.conflict.form.continue'|trans|desc('Continue') }}
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -12,18 +12,12 @@
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_draft.remove.vars.id }
         }) }}
         {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
-        {% if draft_pager.currentPageResults is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
-                'versions': draft_pager.currentPageResults,
-                'is_draft': true,
-                'form': form_version_remove_draft,
-                'haveToPaginate': draft_pager.haveToPaginate
-            }) }}
-        {% else %}
-            <p class="ez-relations-box-list-no-content">
-                {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
-            </p>
-        {% endif %}
+        {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
+            'versions': draft_pager.currentPageResults,
+            'is_draft': true,
+            'form': form_version_remove_draft,
+            'haveToPaginate': draft_pager.haveToPaginate
+        }) }}
         {{ form_end(form_version_remove_draft) }}
 
         {% if draft_pager.haveToPaginate %}
@@ -47,6 +41,7 @@
             </div>
         {% endif %}
     </section>
+    {% include '@EzPlatformAdminUi/content/modal_version_conflict.html.twig' %}
 {% endif %}
 
 {% if published_versions is not empty %}
@@ -106,6 +101,7 @@
 {% block javascripts %}
     {% javascripts
     '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.version.edit.conflict.js'
     %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -48,12 +48,23 @@
             </td>
             {% if is_draft %}
                 <td>
-                    <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode }) }}"
-                       class="btn btn-icon" title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}">
+                    <button
+                        data-content-draft-edit-url="{{ path('ez_content_draft_edit', {
+                            'contentId': version.contentInfo.id,
+                            'versionNo': version.versionNo,
+                            'language': version.translations[0].languageCode
+                        }) }}"
+                        data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                            'contentId': version.contentInfo.id,
+                            'versionNo': version.versionNo,
+                            'languageCode': version.translations[0].languageCode
+                        }) }}"
+                        class="btn btn-icon ez-btn--content-draft-edit"
+                        title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                         </svg>
-                    </a>
+                    </button>
                 </td>
             {% endif %}
             {% if is_archived %}

--- a/src/lib/Specification/AbstractSpecification.php
+++ b/src/lib/Specification/AbstractSpecification.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+abstract class AbstractSpecification implements SpecificationInterface
+{
+    /**
+     * @param $item
+     *
+     * @return bool
+     */
+    abstract public function isSatisfiedBy($item): bool;
+
+    /**
+     * @param SpecificationInterface $other
+     *
+     * @return SpecificationInterface
+     */
+    public function and(SpecificationInterface $other): SpecificationInterface
+    {
+        return new AndSpecification($this, $other);
+    }
+
+    /**
+     * @param SpecificationInterface $other
+     *
+     * @return SpecificationInterface
+     */
+    public function or(SpecificationInterface $other): SpecificationInterface
+    {
+        return new OrSpecification($this, $other);
+    }
+
+    /**
+     * @return SpecificationInterface
+     */
+    public function not(): SpecificationInterface
+    {
+        return new NotSpecification($this);
+    }
+}

--- a/src/lib/Specification/AndSpecification.php
+++ b/src/lib/Specification/AndSpecification.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+class AndSpecification extends AbstractSpecification
+{
+    /** @var SpecificationInterface */
+    private $one;
+
+    /** @var SpecificationInterface */
+    private $two;
+
+    /**
+     * @param SpecificationInterface $one
+     * @param SpecificationInterface $two
+     */
+    public function __construct(SpecificationInterface $one, SpecificationInterface $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    /**
+     * @param $item
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        return $this->one->isSatisfiedBy($item) && $this->two->isSatisfiedBy($item);
+    }
+}

--- a/src/lib/Specification/NotSpecification.php
+++ b/src/lib/Specification/NotSpecification.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+class NotSpecification extends AbstractSpecification
+{
+    /**
+     * @var SpecificationInterface
+     */
+    private $specification;
+
+    /**
+     * @param SpecificationInterface $specification
+     */
+    public function __construct(SpecificationInterface $specification)
+    {
+        $this->specification = $specification;
+    }
+
+    /**
+     * @param $item
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        return !$this->specification->isSatisfiedBy($item);
+    }
+}

--- a/src/lib/Specification/OrSpecification.php
+++ b/src/lib/Specification/OrSpecification.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+class OrSpecification extends AbstractSpecification
+{
+    /** @var SpecificationInterface */
+    private $one;
+    /** @var SpecificationInterface */
+    private $two;
+
+    /**
+     * @param SpecificationInterface $one
+     * @param SpecificationInterface $two
+     */
+    public function __construct(SpecificationInterface $one, SpecificationInterface $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    /**
+     * @param $item
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        return $this->one->isSatisfiedBy($item) || $this->two->isSatisfiedBy($item);
+    }
+}

--- a/src/lib/Specification/SpecificationInterface.php
+++ b/src/lib/Specification/SpecificationInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification;
+
+interface SpecificationInterface
+{
+    /**
+     * @param $item
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($item): bool;
+
+    /**
+     * @param SpecificationInterface $other
+     *
+     * @return SpecificationInterface
+     */
+    public function and(SpecificationInterface $other): SpecificationInterface;
+
+    /**
+     * @param SpecificationInterface $other
+     *
+     * @return SpecificationInterface
+     */
+    public function or(SpecificationInterface $other): SpecificationInterface;
+
+    /**
+     * @return SpecificationInterface
+     */
+    public function not(): SpecificationInterface;
+}

--- a/src/lib/Specification/Version/VersionHasConflict.php
+++ b/src/lib/Specification/Version/VersionHasConflict.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification\Version;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
+
+class VersionHasConflict extends AbstractSpecification
+{
+    /** @var ContentService */
+    private $contentService;
+
+    /**
+     * @param ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Checks if $content has version conflict.
+     *
+     * @param VersionInfo $versionInfo
+     *
+     * @return bool
+     *
+     * @throws UnauthorizedException
+     */
+    public function isSatisfiedBy($versionInfo): bool
+    {
+        $versions = $this->contentService->loadVersions($versionInfo->getContentInfo());
+
+        foreach ($versions as $checkedVersionInfo) {
+            if ($checkedVersionInfo->versionNo > $versionInfo->versionNo && $checkedVersionInfo->isPublished()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/lib/Tests/Specification/VersionHasConflictTest.php
+++ b/src/lib/Tests/Specification/VersionHasConflictTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Specification;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\EzPlatformAdminUi\Specification\Version\VersionHasConflict;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+
+class VersionHasConflictTest extends TestCase
+{
+    public function testVersionWithStatusDraft()
+    {
+        /** @var ContentService|MockObject $contentServiceMock */
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadVersions')
+            ->willReturn([
+                $this->createVersionInfo(false),
+                $this->createVersionInfo(false, 2),
+                $this->createVersionInfo(false, 3),
+                $this->createVersionInfo(true, 4),
+            ]);
+
+        $versionHasConflict = new VersionHasConflict($contentServiceMock);
+
+        self::assertFalse($versionHasConflict->isSatisfiedBy($this->createVersionInfo(false, 5)));
+    }
+
+    public function testVersionWithStatusDraftAndVersionConflict()
+    {
+        /** @var ContentService|MockObject $contentServiceMock */
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadVersions')
+            ->willReturn([
+                $this->createVersionInfo(false),
+                $this->createVersionInfo(false, 3),
+                $this->createVersionInfo(true, 4),
+            ]);
+
+        $versionHasConflict = new VersionHasConflict($contentServiceMock);
+
+        self::assertTrue($versionHasConflict->isSatisfiedBy($this->createVersionInfo(false, 2)));
+    }
+
+    /**
+     * Returns VersionInfo.
+     *
+     * @param bool $isPublished
+     * @param int $versionNo
+     *
+     * @return VersionInfo|MockObject
+     */
+    private function createVersionInfo(bool $isPublished = false, int $versionNo = 1): VersionInfo
+    {
+        $contentInfo = $this->createMock(ContentInfo::class);
+
+        $versionInfo = $this->getMockForAbstractClass(VersionInfo::class, [], '', true, true, true, ['isPublished', '__get', 'getContentInfo']);
+        $versionInfo->method('isPublished')->willReturn($isPublished);
+        $versionInfo->method('__get')->with($this->equalTo('versionNo'))->willReturn($versionNo);
+        $versionInfo->method('getContentInfo')->willReturn($contentInfo);
+
+        return $versionInfo;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-27776
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


As a Editor, I want to see a draft conflict window when I edit a content item which has existing drafts

<img width="1438" alt="screen shot 2018-02-02 at 2 19 41 pm" src="https://user-images.githubusercontent.com/1654712/35735217-2d5447a8-0824-11e8-83bb-7b01db433b4a.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review