### PR TITLE
EZP-27786: I want to see a draft conflict window when I edit a content item which has existing drafts

### DIFF
--- a/src/bundle/Controller/Content/VersionDraftConflictController.php
+++ b/src/bundle/Controller/Content/VersionDraftConflictController.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Controller\Content;
+
+use eZ\Publish\API\Repository\ContentService;
+use EzSystems\EzPlatformAdminUi\Specification\Content\ContentDraftHasConflict;
+use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
+use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class VersionDraftConflictController extends Controller
+{
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var DatasetFactory
+     */
+    private $datasetFactory;
+
+    /**
+     * @param ContentService $contentService
+     * @param DatasetFactory $datasetFactory
+     */
+    public function __construct(ContentService $contentService, DatasetFactory $datasetFactory)
+    {
+        $this->contentService = $contentService;
+        $this->datasetFactory = $datasetFactory;
+    }
+
+    /**
+     * @param int $contentId
+     *
+     * @return Response
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \InvalidArgumentException
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function draftHasNoConflictAction(int $contentId): Response
+    {
+        $contentInfo = $this->contentService->loadContentInfo($contentId);
+
+        if ((new ContentDraftHasConflict($this->contentService))->isSatisfiedBy($contentInfo)) {
+            $versionsDataset = $this->datasetFactory->versions();
+            $versionsDataset->load($contentInfo);
+            $conflictedDrafts = $versionsDataset->getConflictedDraftVersions($contentInfo->currentVersionNo);
+
+            $modalContent = $this->renderView('@EzPlatformAdminUi/content/modal_draft_conflict.html.twig', [
+                'conflicted_drafts' => $conflictedDrafts,
+            ]);
+
+            return new Response($modalContent, Response::HTTP_CONFLICT);
+        }
+
+        return new Response();
+    }
+}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -420,10 +420,16 @@ ezplatform.version.remove:
 
 ezplatform.version.has_no_conflict:
     path: /version/has-no-conflict/{contentId}/{versionNo}/{languageCode}
-    options:
     defaults:
         _controller: 'EzPlatformAdminUiBundle:Version\VersionConflict:versionHasNoConflict'
         languageCode: ~
+
+ezplatform.version_draft.has_no_conflict:
+    path: /version-draft/has-no-conflict/{contentId}
+    options:
+        expose: true
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Content\VersionDraftConflict:draftHasNoConflict'
 
 # LocationView / Locations tab
 

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -1,7 +1,34 @@
-(function () {
-    const editActions = document.querySelector('.ez-extra-actions--edit');
+(function (global, doc) {
+    const editActions = doc.querySelector('.ez-extra-actions--edit');
     const btns = [...editActions.querySelectorAll('.form-check [type="radio"]')];
     const form = editActions.querySelector('form');
+    const contentId = form.querySelector('#content_edit_content_info').value;
+    const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId });
+    const resetRadioButtons = () => btns.forEach(btn => btn.checked = false);
+    const addDraft = () => {
+        form.submit();
+        $('#version-draft-conflict-modal').modal('hide');
+    };
 
-    btns.forEach(btn => btn.addEventListener('change', () => form.submit(), false));
-})();
+    const changeHandler = () => {
+        const showModal = (modalHtml) => {
+            const wrapper = doc.querySelector('.ez-version-draft-conflict-modal-wrapper');
+            wrapper.innerHTML = modalHtml;
+            wrapper.querySelector('.ez-btn--add-draft').addEventListener('click', addDraft, false);
+            [...wrapper.querySelectorAll('.ez-btn--prevented')].forEach(btn => btn.addEventListener('click', event => event.preventDefault(), false));
+            $('#version-draft-conflict-modal').modal('show').on('hidden.bs.modal', resetRadioButtons);
+        };
+
+        fetch(checkVersionDraftLink, {
+            credentials: 'same-origin'
+        }).then(function (response) {
+            if (response.status === 409) {
+                response.text().then(showModal);
+            } else if (response.status === 200) {
+                form.submit();
+            }
+        });
+    };
+
+    btns.forEach(btn => btn.addEventListener('change', changeHandler, false));
+})(window, document);

--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -60,7 +60,7 @@
 }
 
 .btn.disabled,
-.btn:disabled {
+.btn[disabled] {
     opacity: .3;
 }
 

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -138,3 +138,8 @@ button {
 .ez-dashboard-row {
     flex-direction: column;
 }
+
+.ez-scrollable-wrapper {
+    max-height: 60vh;
+    overflow: auto;
+}

--- a/src/bundle/Resources/translations/draft_conflict.en.xliff
+++ b/src/bundle/Resources/translations/draft_conflict.en.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="1020ca59a2c9fa207ebe162fd6727fd1a81027c0" resname="draft.conflict.choice">
+        <source>You can either edit any of your existing draft(s) or add a new one.</source>
+        <target state="new">You can either edit any of your existing draft(s) or add a new one.</target>
+        <note>key: draft.conflict.choice</note>
+      </trans-unit>
+      <trans-unit id="57ae8e493adef8a884a3f0c5e9e4501b7f2ec395" resname="draft.conflict.header">
+        <source>Draft conflict when editing</source>
+        <target state="new">Draft conflict when editing</target>
+        <note>key: draft.conflict.header</note>
+      </trans-unit>
+      <trans-unit id="d5fdbb680e6950e955c933e05f15f861c2020517" resname="draft.conflict.number">
+        <source>{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item</source>
+        <target state="new">{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item</target>
+        <note>key: draft.conflict.number</note>
+      </trans-unit>
+      <trans-unit id="a4297fe31e8eb3307caa2cf855328056c3b98962" resname="tab.versions.action.delete">
+        <source>Add draft</source>
+        <target state="new">Add draft</target>
+        <note>key: tab.versions.action.delete</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -82,6 +82,7 @@
             {% endif %}
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}
+            <div class="ez-version-draft-conflict-modal-wrapper"></div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
@@ -1,0 +1,46 @@
+{% trans_default_domain 'draft_conflict' %}
+
+{% import _self as version_modal_draft_conflict %}
+
+<div class="modal fade ez-modal ez-modal--version-draft-conflict" id="version-draft-conflict-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>{{ 'draft.conflict.header'|trans|desc('Draft conflict when editing') }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="ez-modal-body__main">
+                    {% set number = conflicted_drafts|length %}
+                    {{ 'draft.conflict.number'|transchoice(number, {'%number%': number })|desc(
+                    '{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item'
+                    ) }}
+                </p>
+                <p class="ez-modal-body__main">
+                    {{ 'draft.conflict.choice'|trans({})|desc('You can either edit any of your existing draft(s) or add a new one.') }}
+                </p>
+                {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: null, tools: version_modal_draft_conflict.table_header_tools() } %}
+                <div class="ez-scrollable-wrapper">
+                    {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
+                        'versions': conflicted_drafts,
+                        'is_draft': true,
+                        'haveToPaginate': false,
+                        'is_draft_conflict': true,
+                    }) }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% macro table_header_tools() %}
+    <button type="button" class="btn btn-primary ez-btn--add-draft"
+            title="{{ 'tab.versions.action.delete'|trans|desc('Add draft') }}">
+        <svg class="ez-icon ez-icon-create">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+        </svg>
+    </button>
+{% endmacro %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -2,6 +2,7 @@
 
 {% set is_draft = is_draft is defined and is_draft %}
 {% set is_archived = is_archived is defined and is_archived %}
+{% set is_draft_conflict = is_draft_conflict is defined and is_draft_conflict %}
 
 <table class="table {% if is_draft and haveToPaginate %} mb-3 {% endif %}">
     <thead>
@@ -12,7 +13,9 @@
         <th>{{ 'tab.versions.table.version'|trans()|desc('Version') }}</th>
         <th>{{ 'tab.versions.table.modified_language'|trans()|desc('Modified language') }}</th>
         <th>{{ 'tab.versions.table.contributor'|trans()|desc('Contributor') }}</th>
+        {% if not is_draft_conflict %}
         <th>{{ 'tab.versions.table.created'|trans()|desc('Created') }}</th>
+        {% endif %}
         <th>{{ 'tab.versions.table.last_saved'|trans()|desc('Last saved') }}</th>
         {% if is_draft or is_archived %}
             <th></th>
@@ -40,13 +43,27 @@
                     {{ 'tab.versions.table.author.not_found'|trans|desc('Can’t fetch contributor') }}
                 {% endif %}
             </td>
+            {% if not is_draft_conflict %}
             <td>
                 {{ version.creationDate|localizeddate('medium', 'short', app.request.locale) }}
             </td>
+            {% endif %}
             <td>
                 {{ version.modificationDate|localizeddate('medium', 'short', app.request.locale) }}
             </td>
-            {% if is_draft %}
+            {% if is_draft_conflict %}
+                <td>
+                    {% set edit_draft_disabled = version.author.id != admin_ui_config.user.user.id %}
+                    <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode }) }}"
+                       class="btn btn-icon {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
+                       title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}"
+                       {% if edit_draft_disabled %}disabled{% endif %}>
+                        <svg class="ez-icon ez-icon-edit">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                        </svg>
+                    </a>
+                </td>
+            {% elseif is_draft %}
                 <td>
                     <button
                         data-content-draft-edit-url="{{ path('ez_content_draft_edit', {

--- a/src/lib/Specification/Content/ContentDraftHasConflict.php
+++ b/src/lib/Specification/Content/ContentDraftHasConflict.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification\Content;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
+
+class ContentDraftHasConflict extends AbstractSpecification
+{
+    /** @var ContentService */
+    private $contentService;
+
+    /**
+     * @param ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Checks if Content has draft conflict.
+     *
+     * @param ContentInfo $contentInfo
+     *
+     * @return bool
+     *
+     * @throws UnauthorizedException
+     */
+    public function isSatisfiedBy($contentInfo): bool
+    {
+        $versions = $this->contentService->loadVersions($contentInfo);
+
+        foreach ($versions as $checkedVersionInfo) {
+            if ($checkedVersionInfo->isDraft() && $checkedVersionInfo->versionNo > $contentInfo->currentVersionNo) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/lib/UI/Dataset/VersionsDataset.php
+++ b/src/lib/UI/Dataset/VersionsDataset.php
@@ -72,6 +72,21 @@ class VersionsDataset
     }
 
     /**
+     * @param int $currentVersionNo
+     *
+     * @return array
+     */
+    public function getConflictedDraftVersions(int $currentVersionNo): array
+    {
+        return $this->filterVersions(
+            $this->data,
+            function (VersionInfo $versionInfo) use ($currentVersionNo) {
+                return $versionInfo->isDraft() && $versionInfo->versionNo > $currentVersionNo;
+            }
+        );
+    }
+
+    /**
      * @return UIValue\Content\VersionInfo[]
      */
     public function getPublishedVersions(): array


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-27786
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a Editor, I want to see a draft conflict window when I edit a content item which has existing drafts.

<img width="1437" alt="screen shot 2018-02-06 at 8 46 14 am" src="https://user-images.githubusercontent.com/1654712/35847423-b5de9bb6-0b1a-11e8-946e-9b95d60c5cb5.png">



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
