### PR TITLE
EZP-28839: AlloyEditor is not displayed on production

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -92,13 +92,19 @@
             'bundles/ezplatformadminuiassets/vendors/bootstrap/dist/js/bootstrap.min.js'
             'bundles/ezplatformadminuiassets/vendors/create-react-class/create-react-class.min.js'
             'bundles/ezplatformadminuiassets/vendors/prop-types/prop-types.min.js'
-            'bundles/ezplatformadminuiassets/vendors/alloyeditor/dist/alloy-editor/alloy-editor-no-react-min.js'
             'bundles/ezplatformadminuimodules/js/UniversalDiscovery.module.js'
             'bundles/ezplatformadminui/js/scripts/button.trigger.js'
             'bundles/ezplatformadminui/js/scripts/button.prevent.default.js'
             'bundles/ezplatformadminui/js/scripts/udw/browse.js'
             'bundles/ezplatformadminui/js/scripts/admin.user.menu.js'
 
+        %}
+            <script type="text/javascript" src="{{ asset_url }}"></script>
+        {% endjavascripts %}
+        {# CKEditor is not compatible with 'use strict' mode, React 16 force 'use strict' on the entire file.
+           CKEditor and React 16 cannot be compiled into one file by assetic #}
+        {%  javascripts
+            'bundles/ezplatformadminuiassets/vendors/alloyeditor/dist/alloy-editor/alloy-editor-no-react-min.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28839
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
