### PR TITLE
EZP-28810: Version conflict window after clicking edit button of existing draft in Dashboard

### DIFF
--- a/src/bundle/Resources/views/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard/dashboard.html.twig
@@ -32,6 +32,7 @@
     {%  javascripts
         'bundles/ezplatformadminui/js/scripts/udw/browse.js'
         'bundles/ezplatformadminui/js/scripts/button.content.edit.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.version.edit.conflict.js'
     %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -21,11 +21,18 @@
                 <td>{{ row.version }}</td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-edit"
+                    <button class="btn btn-icon ez-btn--content-draft-edit"
                             title="{{ 'dashboard.table.draft.edit'|trans|desc('Edit Draft') }}"
-                            data-content-id="{{ row.contentId }}"
-                            data-version-no="{{ row.version }}"
-                            data-language-code="{{ row.language }}">
+                            data-content-draft-edit-url="{{ path('ez_content_draft_edit', {
+                                'contentId': row.contentId,
+                                'versionNo': row.version,
+                                'language': row.language
+                            }) }}"
+                            data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                                'contentId': row.contentId,
+                                'versionNo': row.version,
+                                'languageCode': row.language
+                            }) }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                         </svg>
@@ -35,6 +42,7 @@
         {% endfor %}
         </tbody>
     </table>
+    {% include '@EzPlatformAdminUi/content/modal_version_conflict.html.twig' %}
 {% else %}
     <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
 {% endif %}


### PR DESCRIPTION


| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28810
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Version conflict window after clicking edit button of existing draft in Dashboard

![screen shot 2018-02-12 at 2 52 40 pm](https://user-images.githubusercontent.com/1654712/36100208-c45b9154-1005-11e8-8634-656d676a80a9.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
