### PR TITLE
EZP-28831: Draft conflict window after clicking edit button of existing draft in Dashboard and Sub-items list

### DIFF
--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -10,15 +10,40 @@
         const versionInfoContentInfoInput = versionEditForm.querySelector('input[name="' + versionEditFormName+ '[version_info][content_info]"]');
         const versionInfoVersionNoInput = versionEditForm.querySelector('input[name="' + versionEditFormName + '[version_info][version_no]"]');
         const languageInput = versionEditForm.querySelector('#'+ versionEditFormName +'_language_' + languageCode);
+        const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId });
+        const submitVersionEditForm = () => {
+            contentInfoInput.value = contentId;
+            versionInfoContentInfoInput.value = contentId;
+            versionInfoVersionNoInput.value = versionNo;
+            languageInput.setAttribute('checked', true);
+            versionEditForm.submit();
+        };
+        const addDraft = () => {
+            submitVersionEditForm();
+            $('#version-draft-conflict-modal').modal('hide');
+        };
+        const showModal = (modalHtml) => {
+            const wrapper = doc.querySelector('.ez-modal-wrapper');
+
+            wrapper.innerHTML = modalHtml;
+            wrapper.querySelector('.ez-btn--add-draft').addEventListener('click', addDraft, false);
+            [...wrapper.querySelectorAll('.ez-btn--prevented')].forEach(btn => btn.addEventListener('click', event => event.preventDefault(), false));
+            $('#version-draft-conflict-modal').modal('show');
+        };
 
         event.preventDefault();
 
-        contentInfoInput.value = contentId;
-        versionInfoContentInfoInput.value = contentId;
-        versionInfoVersionNoInput.value = versionNo;
-        languageInput.setAttribute('checked', true);
-
-        versionEditForm.submit();
+        fetch(checkVersionDraftLink, {
+            credentials: 'same-origin'
+        }).then(function (response) {
+            // Status 409 means that a draft conflict has occurred and the modal must be displayed.
+            // Otherwise we can go to Content Item edit page.
+            if (response.status === 409) {
+                response.text().then(showModal);
+            } else if (response.status === 200) {
+                submitVersionEditForm();
+            }
+        });
     };
 
     [...doc.querySelectorAll('.ez-btn--content-edit')].forEach(button => button.addEventListener('click', editVersion, false));

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -12,7 +12,7 @@
 
     const changeHandler = () => {
         const showModal = (modalHtml) => {
-            const wrapper = doc.querySelector('.ez-version-draft-conflict-modal-wrapper');
+            const wrapper = doc.querySelector('.ez-modal-wrapper');
             wrapper.innerHTML = modalHtml;
             wrapper.querySelector('.ez-btn--add-draft').addEventListener('click', addDraft, false);
             [...wrapper.querySelectorAll('.ez-btn--prevented')].forEach(btn => btn.addEventListener('click', event => event.preventDefault(), false));

--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -45,7 +45,7 @@
 }
 
 .ez-dashboard {
-    .table {
+    .table:not(.ez-table__draft-conflict) {
         margin-bottom: 0;
 
         thead {

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -82,7 +82,6 @@
             {% endif %}
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}
-            <div class="ez-version-draft-conflict-modal-wrapper"></div>
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -4,7 +4,7 @@
 {% set is_archived = is_archived is defined and is_archived %}
 {% set is_draft_conflict = is_draft_conflict is defined and is_draft_conflict %}
 
-<table class="table {% if is_draft and haveToPaginate %} mb-3 {% endif %}">
+<table class="table {% if is_draft and haveToPaginate %} mb-3 {% endif %} {% if is_draft_conflict %} ez-table__draft-conflict {% endif %}">
     <thead>
     <tr>
         {% if form is defined %}

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -83,7 +83,7 @@
                 {% endfor %}
             {% endfor %}
         </div>
-
+        <div class="ez-modal-wrapper"></div>
         {%  javascripts
             'bundles/ezplatformadminuiassets/vendors/react/umd/react.production.min.js'
             'bundles/ezplatformadminuiassets/vendors/react-dom/umd/react-dom.production.min.js'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28831
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Draft conflict window after clicking edit button of existing draft in Dashboard, Sub-items list, Search results list and Content item using this URL in Link Manager.

![screen shot 2018-02-12 at 2 51 21 pm](https://user-images.githubusercontent.com/1654712/36100357-44435654-1006-11e8-87a6-4ec1fc109693.png)

![screen shot 2018-02-26 at 11 56 31 am](https://user-images.githubusercontent.com/1654712/36666844-2f4f42b2-1aec-11e8-8445-e0bc7e42186c.png)

![screen shot 2018-02-26 at 11 56 09 am](https://user-images.githubusercontent.com/1654712/36666846-2f6de6ae-1aec-11e8-861a-aab85529191b.png)

#### Checklist:
- [x] For Edit button in Dashboard
- [x] For Edit button on Sub-items list
- [x] For Edit button in Search results list
- [x] For Edit button in Content item using this URL in Link Manager
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
