### PR TITLE
EZP-28845: Fix conflict between ezselection and ezboolean

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
@@ -102,7 +102,7 @@
             border: 1px solid $ez-ground-primary;
             background-color: $ez-white;
             color: $ez-black;
-            z-index: 1;
+            z-index: 2;
 
             &--hidden {
                 transform: scaleY(0);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28845
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | N/A
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fix a conflict between ezselection and ezboolean due to a zindex trouble. If a ezboolean field follows a ezselection field then the ezboolean field goes over the options drop down. See screenshots.

**Before**:
![image](https://user-images.githubusercontent.com/7839911/36202414-0536e5c8-1184-11e8-887e-be84721755b4.png)

**After**:
![image](https://user-images.githubusercontent.com/7839911/36202433-174c3a1a-1184-11e8-884d-a49b1b352115.png)



#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review