### PR TITLE
EZEE-1877: Design improvement - Create Content widget

### DIFF
--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -45,6 +45,7 @@
         line-height: 45px;
         color: $ez-white;
         padding: 0 8px;
+        font-weight: 700;
     }
 
     &__content {
@@ -73,11 +74,11 @@
             padding: 0 16px;
             line-height: 45px;
             background: $ez-white;
-            color: $ez-color-secondary;
             text-decoration: none;
             cursor: pointer;
             transition: all .2s $ez-admin-transition;
             margin-bottom: 0;
+            font-size: .9375rem;
 
             &:hover,
             &:focus, 
@@ -114,14 +115,15 @@
 
     &__section-header {
         background: $ez-ground-base-dark;
-        color: $ez-color-base-dark;
-        padding-left: .5rem;
+        padding: .25rem 0 .25rem .5rem;
+        font-size: .9375rem;
+        font-weight: 700;
     }
 
     &__section-content {
         background: $ez-white;
-        color: $ez-color-base-dark;
         padding: 1rem .5rem;
+        font-size: .9375rem;
 
         select {
             display: inline-block;

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -7,8 +7,8 @@
     </header>
     <body>
       <trans-unit id="a4b9e9b4898dd285237fc60130970ce7ed988871" resname="content.create.choose_content_type">
-        <source>Choose content type</source>
-        <target state="new">Choose content type</target>
+        <source>Create your content</source>
+        <target state="new">Create your content</target>
         <note>key: content.create.choose_content_type</note>
       </trans-unit>
       <trans-unit id="f599001c1ab9442f20e23d535e1dad8f3b75c337" resname="content.create.select_content_type">

--- a/src/bundle/Resources/views/content/widgets/content_create.html.twig
+++ b/src/bundle/Resources/views/content/widgets/content_create.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'locationview' %}
 
 <div class="ez-extra-actions ez-extra-actions--create ez-extra-actions--hidden bg-secondary" data-actions="create">
-    <div class="ez-extra-actions__header">{{ 'content.create.choose_content_type'|trans|desc('Choose content type') }}</div>
+    <div class="ez-extra-actions__header">{{ 'content.create.choose_content_type'|trans|desc('Create your content') }}</div>
     <div class="ez-extra-actions__content">
         {{ form_start(form, { 'action': path('ezplatform.content.create') }) }}
             {% if form.language.vars.choices|length == 1 %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-1877](https://jira.ez.no/browse/EZEE-1877)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Design updates for Create Content widget according to UI Guidelines:
- Update the wording for the label of the Create Content widget:
   From "Choose content type" to "Create your content".
- Color contrast:
   Change font color, when not using white color, to $ez-black for better color contrast purposes.
- Font-size: 
   Changed font-size for content inside widget.
- Add padding top and bottom to the _header of .ez-extra-actions

![ez platform 23](https://user-images.githubusercontent.com/9256718/36278107-c2f0b256-1260-11e8-839e-3e5fe9d43601.png)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
