### PR TITLE
EZEE-1610: Change invalid comparison

### DIFF
--- a/src/lib/Behat/Helper/StudioUtility.php
+++ b/src/lib/Behat/Helper/StudioUtility.php
@@ -82,7 +82,7 @@ trait StudioUtility
                 sleep(5);
 
                 --$numberOfRetries;
-                if ($numberOfRetries > 0) {
+                if ($numberOfRetries < 0) {
                     throw $e;
                 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-1610](https://jira.ez.no/browse/EZEE-1610)
| Bug fix?      | sort-of
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Follow-up to https://github.com/ezsystems/ezplatform-admin-ui/pull/348 - the comparison was actually wrong, meaning the function was never retried. Thanks for @m-tyrala for catching it 👍 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review