### PR TITLE
EZP-28852: Rework AdminUI content edit views to allow extending without using pagelayout

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -1,10 +1,12 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends viewbaseLayout is defined ? viewbaseLayout : 'EzPlatformAdminUiBundle::layout.html.twig' %}
 
 {% trans_default_domain 'content_edit' %}
 {% form_theme form with 'EzPlatformAdminUiBundle:content:form_fields.html.twig' %}
 
 {% block body_class %}ez-standalone-page ez-content-edit{% endblock %}
+
 {% block navigation %}{% endblock %}
+
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         {% block left_sidebar %}{% endblock left_sidebar %}
@@ -18,7 +20,7 @@
                 {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
 
                 {% block form_fields %}
-                    {% for field in form.fieldsData -%}
+                    {% for field in form.fieldsData if not field.rendered -%}
                         {% if field.value is defined %}
                             {{- form_widget(field) -}}
                         {% else %}
@@ -38,37 +40,20 @@
 
             {% block form_after %}{% endblock %}
         </div>
-        <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
-            <div class="ez-sticky-container">
-                {% block right_sidebar %}{% endblock %}
+        {% block right_sidebar_wrapper %}
+            <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
+                <div class="ez-sticky-container">
+                    {% block right_sidebar %}{% endblock %}
+                </div>
             </div>
-        </div>
+        {% endblock %}
     </div>
 {% endblock %}
 
 {% block javascripts %}
-    {%  javascripts
-        '@EzPlatformAdminUiBundle/Resources/public/js/alloyeditor/dist/*.js'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.min.js'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/taggify/src/js/taggify.js'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.content.edit.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-field.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-file-field.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/*'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/sidebar/extra.actions.js'
-    %}
-        <script type="text/javascript" src="{{ asset_url }}"></script>
-    {% endjavascripts %}
+    {% include 'EzPlatformAdminUiBundle:content/content_edit/parts:javascripts.html.twig' %}
 {% endblock %}
 
 {% block stylesheets %}
-    {% stylesheets
-        'bundles/ezplatformadminui/css/alloyeditor/alloyeditor-ez.css'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.min.css'
-        '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.css'
-    %}
-        <link rel="stylesheet" href="{{ asset_url }}" />
-    {% endstylesheets %}
+    {% include 'EzPlatformAdminUiBundle:content/content_edit/parts:stylesheets.html.twig' %}
 {% endblock %}

--- a/src/bundle/Resources/views/content/content_edit/parts/javascripts.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/parts/javascripts.html.twig
@@ -1,0 +1,14 @@
+{%  javascripts
+    '@EzPlatformAdminUiBundle/Resources/public/js/alloyeditor/dist/*.js'
+    '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.min.js'
+    '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/taggify/src/js/taggify.js'
+    '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.content.edit.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-field.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-file-field.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/fieldType/*'
+    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/sidebar/extra.actions.js'
+%}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+{% endjavascripts %}

--- a/src/bundle/Resources/views/content/content_edit/parts/stylesheets.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/parts/stylesheets.html.twig
@@ -1,0 +1,7 @@
+{% stylesheets
+    'bundles/ezplatformadminui/css/alloyeditor/alloyeditor-ez.css'
+    '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/flatpickr/dist/flatpickr.min.css'
+'@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.css'
+%}
+    <link rel="stylesheet" href="{{ asset_url }}" />
+{% endstylesheets %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28852
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Here comes twig madness but it's actually beneficial as we now can extend content edit/create templates from other bundles to embed them in different layout. It's will be required by Page Builder. I need someone to check on potential BC breaks as templates are usually risky to change.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review


# QA Testing
Please retest briefly content edit/create. 
