### PR TITLE
EZP-28892: User UI Config provider breaks when using Guard authentication

### DIFF
--- a/src/lib/UI/Config/Provider/User.php
+++ b/src/lib/UI/Config/Provider/User.php
@@ -11,7 +11,8 @@ use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\User\User as ApiUser;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 
 /**
  * Provides information about current user with resolved profile picture.
@@ -44,12 +45,15 @@ class User implements ProviderInterface
     public function getConfig(): array
     {
         $config = ['user' => null, 'profile_picture_field' => null];
+
         $token = $this->tokenStorage->getToken();
+        if (!$token instanceof TokenInterface) {
+            return $config;
+        }
 
-        if ($token instanceof UsernamePasswordToken) {
-            $user = $token->getUser();
+        $user = $token->getUser();
+        if ($user instanceof UserInterface) {
             $apiUser = $user->getAPIUser();
-
             $config['user'] = $apiUser;
             $config['profile_picture_field'] = $this->resolveProfilePictureField($apiUser);
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28892
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Using Guard, you get a `PostAuthenticationGuardToken`, which breaks the application.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
