### PR TITLE
EZP-28875: User can't remove translation without content/all permission

### DIFF
--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -102,7 +102,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         );
         $canDelete = $this->permissionResolver->canUser(
             'content',
-            'delete',
+            'remove',
             $options['content']
         );
 

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -116,7 +116,7 @@ class ValueFactory
     public function createLanguage(Language $language, VersionInfo $versionInfo): UIValue\Content\Language
     {
         return new UIValue\Content\Language($language, [
-            'userCanRemove' => $this->permissionResolver->canUser('content', 'delete', $versionInfo),
+            'userCanRemove' => $this->permissionResolver->canUser('content', 'remove', $versionInfo),
             'main' => $language->languageCode === $versionInfo->getContentInfo()->mainLanguageCode,
         ]);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28875
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR contains the fix for removing content translation if a user doesn't have *content/all* permission.

As requested by @lserwatka https://github.com/ezsystems/ezplatform-admin-ui/pull/358/commits/d9ba6785e66f450ca3880b16636d56f947945f49 contains fix for a similar issue in case of removing a user account. 

## Steps to reproduce the issue solved in https://github.com/ezsystems/ezplatform-admin-ui/pull/358/commits/d9ba6785e66f450ca3880b16636d56f947945f49:
1. Do all the steps mentioned in JIRA ticket.
2. Go to the admin panel, log in as a user
3. Go to users list, select one, go to the view
4. You can see that the delete button on the right sidebar will be disabled even if a user has every permission needed to remove other users. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
