### PR TITLE
[Enhancement][Not TESTED] Allow conditional display of a tab based on the actual content of it

### DIFF
--- a/src/bundle/Resources/views/parts/tab/locationview.html.twig
+++ b/src/bundle/Resources/views/parts/tab/locationview.html.twig
@@ -1,3 +1,4 @@
+{% set tabViews = {} %}
 <div>
     <div class="ez-header px-4">
         <div class="container">
@@ -5,11 +6,15 @@
                 {% for tab in tabs %}
                     {% set id = group ~ '-' ~ tab.identifier %}
                     {% set active = loop.first %}
-                    <li class="nav-item">
-                        <a class="nav-link{% if active %} active{% endif %}" id="ez-tab-label-{{ group }}"
-                           data-toggle="tab" href="#ez-tab-{{ id }}" role="tab" aria-controls="ez-tab-{{ id }}"
-                           aria-expanded="{{ active }}">{{ tab.name }}</a>
-                    </li>
+                    {% set view = tab.view|raw|trim %}
+                    {% if view is not empty %}
+                        {% set tabViews = tabViews|merge({""~id:view}) %}
+                        <li class="nav-item">
+                            <a class="nav-link{% if active %} active{% endif %}" id="ez-tab-label-{{ group }}"
+                               data-toggle="tab" href="#ez-tab-{{ id }}" role="tab" aria-controls="ez-tab-{{ id }}"
+                               aria-expanded="{{ active }}">{{ tab.name }}</a>
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         </div>
@@ -18,11 +23,12 @@
         {% for tab in tabs %}
             {% set id = group ~ '-' ~ tab.identifier %}
             {% set active = loop.first %}
-
-            <div class="tab-pane{% if active %} active{% endif %}" id="ez-tab-{{ id }}" role="tabpanel"
-                 aria-labelledby="ez-tab-label-{{ group }}">
-                {{ tab.view|raw }}
-            </div>
+            {% if tabViews[id] is defined %}
+                <div class="tab-pane{% if active %} active{% endif %}" id="ez-tab-{{ id }}" role="tabpanel"
+                     aria-labelledby="ez-tab-label-{{ group }}">
+                    {{ tabViews[id] }}
+                </div>
+            {% endif %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
According to a discussion on slack with @wizhippo. I think a good idea would be to render the tab here: https://github.com/ezsystems/ezplatform-admin-ui/blob/master/src/bundle/Resources/views/parts/tab/locationview.html.twig#L8
only when it is NOT empty.

@wizhippo use case: you want to display a tab only on some conditions. Today you can add the tab but you can not decide to do not display it.

**I did not test** and I am unsure of line 11, but I will try later unless someone to do it before me.

And at least it opens the discussion ;) maybe there is a better way.

- [ ] Tested
- [ ] Ready for Code Review
