### PR TITLE
EZP-28871: upload_max_filesize setting should be taken into account in the validation of uploaded files

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
@@ -4,7 +4,7 @@
 
 {%- block ezplatform_fieldtype_ezbinaryfile_row -%}
     {% set preview_block_name = 'ezbinaryfile_preview' %}
-    {% set max_file_size = (form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024)|round %}
+    {% set max_file_size = min((form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024), max_upload_size)|round %}
     {{ block('binary_base_row') }}
 {%- endblock -%}
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
@@ -4,7 +4,7 @@
 
 {%- block ezplatform_fieldtype_ezbinaryfile_row -%}
     {% set preview_block_name = 'ezbinaryfile_preview' %}
-    {% set max_file_size = min((form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024), max_upload_size)|round %}
+    {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size)|round %}
     {{ block('binary_base_row') }}
 {%- endblock -%}
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
@@ -4,7 +4,7 @@
 
 {%- block ezplatform_fieldtype_ezimage_row -%}
     {% set preview_block_name = 'ezimage_preview' %}
-    {% set max_file_size = form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize %}
+    {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize, max_upload_size) %}
     {% set attr = attr|merge({'accept': 'image/*'}) %}
     {{ block('binary_base_row') }}
 {%- endblock -%}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
@@ -4,7 +4,7 @@
 
 {%- block ezplatform_fieldtype_ezmedia_row -%}
     {% set preview_block_name = 'ezmedia_preview' %}
-    {% set max_file_size = (form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024)|round %}
+    {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size)|round %}
     {% set attr = attr|merge({'accept': 'video/*'}) %}
     {{ block('binary_base_row') }}
 {%- endblock -%}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28871
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The second part of https://github.com/ezsystems/repository-forms/pull/218

#### Checklist:
- [ ] Wait until related PR will be merged
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
