### PR TITLE
EZP-28884: Removing click when editing content in one single language

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/content.edit.js
@@ -1,0 +1,13 @@
+(function (global, doc) {
+    const editButton = doc.querySelector('.ez-btn--edit');
+    const languageRadioOption = doc.querySelector('.ez-extra-actions--edit.ez-extra-actions--prevent-show [type="radio"]');
+
+    if (!languageRadioOption) {
+        return;
+    }
+
+    editButton.addEventListener('click', () => {
+        languageRadioOption.checked = true;
+        languageRadioOption.dispatchEvent(new CustomEvent('change'))
+    }, false);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -1,13 +1,16 @@
 (function () {
     const CLASS_HIDDEN = 'ez-extra-actions--hidden';
+    const CLASS_PREVENT_SHOW = 'ez-extra-actions--prevent-show';
     const btns = [...document.querySelectorAll('.ez-btn--extra-actions')];
 
     btns.forEach(btn => {
         btn.addEventListener('click', () => {
             const actions = document.querySelector(`.ez-extra-actions[data-actions="${btn.dataset.actions}"]`);
-            const cssMethodName = actions.classList.contains(CLASS_HIDDEN) ? 'remove' : 'add';
+            const haveHiddenPart = (element) => {
+                return element.classList.contains(CLASS_HIDDEN) && !element.classList.contains(CLASS_PREVENT_SHOW)
+            };
+            const methodName = haveHiddenPart(actions) ? 'remove' : 'add';
             const clickOutsideMethodName = actions.classList.contains(CLASS_HIDDEN) ? 'addEventListener' : 'removeEventListener';
-            const btnRect = btn.getBoundingClientRect();
             const focusElement = actions.querySelector(btn.dataset.focusElement);
             const detectClickOutside = (event) => {
                 const isNotButton = !event.target.contains(btn);
@@ -21,7 +24,7 @@
             };
 
             actions.style.top = btn.offsetTop + 'px';
-            actions.classList[cssMethodName](CLASS_HIDDEN);
+            actions.classList[methodName](CLASS_HIDDEN);
             document.body[clickOutsideMethodName]('click', detectClickOutside, false);
 
             if (focusElement) {

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -122,6 +122,7 @@
         'bundles/ezplatformadminui/js/scripts/sidebar/instant.filter.js'
         '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/leaflet/dist/leaflet.js'
         'bundles/ezplatformadminui/js/scripts/admin.location.load.map.js'
+        'bundles/ezplatformadminui/js/scripts/sidebar/btn/content.edit.js'
     %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/content/widgets/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/widgets/content_edit.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'locationview' %}
 
-<div class="ez-extra-actions ez-extra-actions--edit ez-extra-actions--hidden bg-secondary" data-actions="edit">
+<div class="ez-extra-actions ez-extra-actions--edit ez-extra-actions--hidden bg-secondary {% if form.language.vars.choices|length == 1 %} ez-extra-actions--prevent-show {% endif %}" data-actions="edit">
     <div class="ez-extra-actions__header">{{ 'content.edit.select_language'|trans|desc('Select language') }}</div>
     <div class="ez-extra-actions__content">
         {{ form_start(form, { 'action': path('ezplatform.content.edit') }) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28884
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This probably could be done more on backend part, but I think that would involve modifications in menu build since we would have to inject content services there to build correct uri. And there are already events for language select form submission.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
