### PR TITLE
EZP-28850: Add optional location parameter to draft edit for more appropriate redirection

### DIFF
--- a/src/bundle/Controller/ContentEditController.php
+++ b/src/bundle/Controller/ContentEditController.php
@@ -8,9 +8,8 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformAdminUi\RepositoryForms\Data\Mapper\ContentTranslationMapper;
 use EzSystems\RepositoryForms\Content\View\ContentEditView;
@@ -34,22 +33,28 @@ class ContentEditController extends Controller
     /** @var ActionDispatcherInterface */
     private $contentActionDispatcher;
 
+    /** @var LocationService */
+    private $locationService;
+
     /**
      * @param ContentService $contentService
      * @param ContentTypeService $contentTypeService
      * @param LanguageService $languageService
      * @param ContentDispatcher $contentActionDispatcher
+     * @param LocationService $locationService
      */
     public function __construct(
         ContentService $contentService,
         ContentTypeService $contentTypeService,
         LanguageService $languageService,
-        ContentDispatcher $contentActionDispatcher
+        ContentDispatcher $contentActionDispatcher,
+        LocationService $locationService
     ) {
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->languageService = $languageService;
         $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->locationService = $locationService;
     }
 
     /**
@@ -57,23 +62,23 @@ class ContentEditController extends Controller
      * @param string|null $fromLanguageCode
      * @param string|null $toLanguageCode
      * @param Request $request
+     * @param int|null $locationId
      *
-     * @return ContentEditView|Response|null
-     *
-     * @throws UnauthorizedException
-     * @throws NotFoundException
+     * @return ContentEditView|Response
      */
     public function translateAction(
         Content $content,
         ?string $fromLanguageCode,
         ?string $toLanguageCode,
-        Request $request
+        Request $request,
+        ?int $locationId = null
     ) {
         /* @todo could be improved with ParamConverters */
         $fromLanguage = null === $fromLanguageCode ? null : $this->languageService->loadLanguage($fromLanguageCode);
         $toLanguage = $this->languageService->loadLanguage($toLanguageCode);
         $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
         $contentInfo = $content->contentInfo;
+        $location = $this->locationService->loadLocation($locationId ?? $contentInfo->mainLocationId);
 
         $contentUpdate = (new ContentTranslationMapper())->mapToFormData(
             $content,
@@ -95,7 +100,12 @@ class ContentEditController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->contentActionDispatcher->dispatchFormAction($form, $contentUpdate, $form->getClickedButton()->getName());
+            $this->contentActionDispatcher->dispatchFormAction(
+                $form,
+                $contentUpdate,
+                $form->getClickedButton()->getName(),
+                ['referrerLocation' => $location]
+            );
             if ($response = $this->contentActionDispatcher->getResponse()) {
                 return $response;
             }
@@ -103,6 +113,7 @@ class ContentEditController extends Controller
 
         return new ContentEditView(null, [
             'form' => $form->createView(),
+            'location' => $location,
             'language' => $toLanguage,
             'baseLanguage' => $fromLanguage ?: null,
             'content' => $this->contentService->loadContentByContentInfo($contentInfo, [$contentInfo->mainLanguageCode]),

--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -143,7 +143,7 @@ class ContentViewController extends Controller
         );
 
         $contentEditType = $this->formFactory->contentEdit(
-            new ContentEditData($content->contentInfo, $versionInfo)
+            new ContentEditData($content->contentInfo, $versionInfo, null, $location)
         );
 
         $subitemsContentEdit = $this->formFactory->contentEdit(

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -480,11 +480,12 @@ ezplatform.content.create:
         _controller: 'EzPlatformAdminUiBundle:Content:create'
 
 ezplatform.content.preview:
-    path: /content/{contentId}/preview/{versionNo}/{languageCode}
+    path: /content/{contentId}/preview/{versionNo}/{languageCode}/{locationId}
     methods: ['GET']
     defaults:
         _controller: 'EzPlatformAdminUiBundle:Content:preview'
         languageCode: ~
+        locationId: ~
 
 ezplatform.content.translate:
     path: /content/{contentId}/translate/{toLanguageCode}/{fromLanguageCode}

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -2,6 +2,12 @@
 
 {% trans_default_domain 'content_edit' %}
 
+{% set fallbackLocationId = content.versionInfo.contentInfo.mainLocationId is defined
+    ? content.versionInfo.contentInfo.mainLocationId
+    : (parentLocations|first).id
+%}
+{% set locationId = location is not null ? location.id : fallbackLocationId %}
+
 {% block details %}
     {% if baseLanguage is defined and baseLanguage is not null %}
         <h2 class="text-muted">{{ 'editing_in_language_based_on'|trans({'%contentName%': content.name, '%languageName%': language.name, '%baseLanguageName%': baseLanguage.name})|desc('Editing - %contentName% in %languageName% based on %baseLanguageName%') }}</h2>
@@ -16,7 +22,7 @@
     </h1>
 
     <div class="small">
-        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }}{% if content.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': content.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
+        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }}, {{ 'location_id'|trans({'%locationId%': locationId})|desc('Location ID: %locationId%') }}
     </div>
     {# @todo remove if statement once getDescription() bug is resolved in kernel #}
     {% if contentType.descriptions is not empty %}
@@ -37,10 +43,6 @@
 {% endblock %}
 
 {% block close_button %}
-    {% set locationId = content.versionInfo.contentInfo.mainLocationId
-        ? content.versionInfo.contentInfo.mainLocationId
-        : (parentLocations|first).id
-    %}
     <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': locationId }) }}"></a>
 {% endblock %}
 

--- a/src/bundle/Resources/views/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/content/content_preview.html.twig
@@ -10,7 +10,7 @@
 <div class="ez-preview">
     <div class="ez-preview__nav">
         <div class="ez-preview__item ez-preview__item--back">
-            <a href="{{ url('ez_content_draft_edit', {'contentId': content.id, 'versionNo': versionNo, 'language': language_code}) }}" >
+            <a href="{{ url('ez_content_draft_edit', {'contentId': content.id, 'versionNo': versionNo, 'language': language_code, 'locationId': location.id}) }}" >
                 <svg class="ez-icon ez-icon-back">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#caret-back"></use>
                 </svg>

--- a/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
@@ -25,6 +25,7 @@
                 <div class="ez-scrollable-wrapper">
                     {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
                         'versions': conflicted_drafts,
+                        'location': location,
                         'is_draft': true,
                         'haveToPaginate': false,
                         'is_draft_conflict': true,

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -54,7 +54,7 @@
             {% if is_draft_conflict %}
                 <td>
                     {% set edit_draft_disabled = version.author.id != admin_ui_config.user.user.id %}
-                    <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode }) }}"
+                    <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode, 'locationId': location.id }) }}"
                        class="btn btn-icon {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
                        title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}"
                        {% if edit_draft_disabled %}disabled{% endif %}>
@@ -69,7 +69,8 @@
                         data-content-draft-edit-url="{{ path('ez_content_draft_edit', {
                             'contentId': version.contentInfo.id,
                             'versionNo': version.versionNo,
-                            'language': version.translations[0].languageCode
+                            'language': version.translations[0].languageCode,
+                            'locationId': location.id
                         }) }}"
                         data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
                             'contentId': version.contentInfo.id,

--- a/src/lib/Form/Data/Content/Draft/ContentEditData.php
+++ b/src/lib/Form/Data/Content/Draft/ContentEditData.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
 /**
@@ -17,7 +18,14 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo;
  */
 class ContentEditData
 {
-    /** @var ContentInfo|null */
+    /** @var Location|null */
+    protected $location;
+
+    /**
+     * @deprecated Deprecated in 1.1 and will be removed in 2.0. Please use ContentEditData::$location instead.
+     *
+     * @var ContentInfo|null
+     * */
     protected $contentInfo;
 
     /** @var VersionInfo|null */
@@ -30,18 +38,41 @@ class ContentEditData
      * @param ContentInfo|null $contentInfo
      * @param VersionInfo|null $versionInfo
      * @param Language|null $language
+     * @param Location|null $location
      */
     public function __construct(
         ?ContentInfo $contentInfo = null,
         ?VersionInfo $versionInfo = null,
-        ?Language $language = null
+        ?Language $language = null,
+        ?Location $location = null
     ) {
         $this->contentInfo = $contentInfo;
         $this->versionInfo = $versionInfo;
         $this->language = $language;
+        $this->location = $location;
     }
 
     /**
+     * @return Location|null
+     */
+    public function getLocation(): ?Location
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param Location|null $location
+     */
+    public function setLocation(Location $location): self
+    {
+        $this->location = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated Deprecated in 1.1 and will be removed in 2.0. Please use ContentEditData::getLocation instead.
+     *
      * @return ContentInfo|null
      */
     public function getContentInfo(): ?ContentInfo
@@ -50,6 +81,8 @@ class ContentEditData
     }
 
     /**
+     * @deprecated Deprecated in 1.1 and will be removed in 2.0. Please use ContentEditData::setLocation instead.
+     *
      * @param ContentInfo|null $contentInfo
      *
      * @return self

--- a/src/lib/Form/Type/Content/Draft/ContentEditType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentEditType.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft;
 use eZ\Publish\API\Repository\LanguageService;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\LocationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\VersionInfoType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Language\LanguageChoiceType;
 use Symfony\Component\Form\AbstractType;
@@ -35,6 +36,11 @@ class ContentEditType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add(
+                'location',
+                LocationType::class,
+                ['label' => false, 'attr' => ['hidden' => true]]
+            )
             ->add(
                 'content_info',
                 ContentInfoType::class,

--- a/src/lib/RepositoryForms/Form/Processor/PreviewFormProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/PreviewFormProcessor.php
@@ -87,10 +87,14 @@ class PreviewFormProcessor implements EventSubscriberInterface
         $data = $event->getData();
         $form = $event->getForm();
         $languageCode = $form->getConfig()->getOption('languageCode');
+        $referrerLocation = $event->getOption('referrerLocation');
 
         try {
             $contentDraft = $this->saveDraft($data, $languageCode);
             $url = $this->urlGenerator->generate('ezplatform.content.preview', [
+                'locationId' => null !== $referrerLocation
+                    ? $referrerLocation->id
+                    : $contentDraft->contentInfo->mainLocationId,
                 'contentId' => $contentDraft->id,
                 'versionNo' => $contentDraft->getVersionInfo()->versionNo,
                 'languageCode' => $languageCode,
@@ -98,11 +102,7 @@ class PreviewFormProcessor implements EventSubscriberInterface
         } catch (Exception $e) {
             $this->notificationHandler->error(
                 /** @Desc("Cannot save content draft.") */
-                $this->translator->trans(
-                    'error.preview',
-                    [],
-                    'content_preview'
-                )
+                $this->translator->trans('error.preview', [], 'content_preview')
             );
             $url = $this->getContentEditUrl($data, $languageCode);
         }

--- a/src/lib/Tab/LocationView/VersionsTab.php
+++ b/src/lib/Tab/LocationView/VersionsTab.php
@@ -115,7 +115,7 @@ class VersionsTab extends AbstractTab implements OrderedTabInterface
             false
         );
         $archivedVersionRestoreForm = $this->formFactory->contentEdit(
-            new ContentEditData($contentInfo),
+            new ContentEditData($contentInfo, null, null, $location),
             'archived_version_restore'
         );
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28850
| Requires:  | https://github.com/ezsystems/repository-forms/pull/214
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Adapting AdminUI to https://github.com/ezsystems/repository-forms/pull/214. With this change it's now possible to use location context when editing the content. This means we are now able to provide proper redirection for Close button in draft edit mode. Previously it was always redirecting to the main location.

# QA
Please retest content edit, all edit buttons, version/draft conflict popups, subitems, dashboard, translations etc.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
