### PR TITLE
EZP-28922: Design consistency for modals across the whole application

### DIFF
--- a/src/bundle/Resources/public/scss/_add-translation.scss
+++ b/src/bundle/Resources/public/scss/_add-translation.scss
@@ -7,15 +7,32 @@
             display: inline-block;
             left: 50%;
             transform: translateX(-50%);
+            border-radius: .25rem;
         }
     }
 
     .modal-header {
-        background: $ez-ground-base;
+        background: $ez-color-base-pale;
+        border-bottom: none;
+
+        .modal-title {
+            font-size: 1.5rem;
+        }
+
+        .close {
+            margin-top: -.5625rem;
+        }
     }
 
     .modal-body {
         padding: 2rem;
+        background-color: $ez-ground-base-medium;
+        border-radius: 0 0 .25rem .25rem;
+    }
+
+    .modal-footer {
+        border-top: none;
+        padding: 1rem 1rem 0 1rem;
     }
 
     &__title {
@@ -34,7 +51,7 @@
 
     &__input-wrapper {
         width: 15rem;
-        background: $ez-ground-primary;
+        background: $ez-white;
         margin: .5rem;
         border-radius: 5px;
         line-height: 1;
@@ -64,6 +81,7 @@
 
             .ez-icon {
                 display: inline;
+                fill: $ez-white;
             }
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28922](https://jira.ez.no/browse/EZP-28922)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Design consistency for modals across the whole application:
- Updated styling for modals (Translations, Send to Trash and Send to Trash from Trash manager), background-colors.
- In Translations modal aligned colors for language selection for translations to the existing one in content-edit-language widget.


![screen shot 2018-03-08 at 1 28 06 pm](https://user-images.githubusercontent.com/9256718/37172280-57c33b96-22de-11e8-8c40-5fe4ccd01214.png)
<img width="1280" alt="screen shot 2018-03-08 at 1 40 34 pm" src="https://user-images.githubusercontent.com/9256718/37172151-01a37ba4-22de-11e8-88bd-2b2e8cb4aaee.png">
<img width="1280" alt="screen shot 2018-03-08 at 1 41 56 pm" src="https://user-images.githubusercontent.com/9256718/37172159-049c2626-22de-11e8-8d9b-af64f0021203.png">


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
