### PR TITLE
EZP-26238: eZPlatform login screen redirecting to the link the user entered initially

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/SecurityLoginPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SecurityLoginPass.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformAdminUi\Security\Authentication\RedirectToDashboardAuthenticationSuccessHandler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SecurityLoginPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $successHandlerDef = $container->getDefinition('security.authentication.success_handler');
+        $successHandlerDef->setClass(RedirectToDashboardAuthenticationSuccessHandler::class);
+        $successHandlerDef->addArgument($container->getParameter('ezpublish.siteaccess.groups'));
+        $successHandlerDef->addArgument('ezplatform.dashboard');
+    }
+}

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformAdminUiBundle;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ComponentPass;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SecurityLoginPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SystemInfoTabGroupPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\TabPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UiConfigProviderPass;
@@ -43,5 +44,6 @@ class EzPlatformAdminUiBundle extends Bundle
         $container->addCompilerPass(new UiConfigProviderPass());
         $container->addCompilerPass(new SystemInfoTabGroupPass());
         $container->addCompilerPass(new ComponentPass());
+        $container->addCompilerPass(new SecurityLoginPass());
     }
 }

--- a/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.php
+++ b/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Security\Authentication;
+
+use eZ\Publish\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler;
+use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+class RedirectToDashboardAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    use TargetPathTrait;
+
+    /** @var array */
+    private $siteAccessGroups;
+
+    /** @var string */
+    private $defaultTargetPath;
+
+    /**
+     * @param \Symfony\Component\Security\Http\HttpUtils $httpUtils
+     * @param array $options
+     * @param array $siteAccessGroups
+     * @param string $defaultTargetPath
+     */
+    public function __construct(
+        HttpUtils $httpUtils,
+        array $options = [],
+        array $siteAccessGroups = [],
+        string $defaultTargetPath
+    ) {
+        parent::__construct($httpUtils, $options);
+        $this->siteAccessGroups = $siteAccessGroups;
+        $this->defaultTargetPath = $defaultTargetPath;
+    }
+
+    /**
+     * Builds the target URL according to the defined options.
+     * Overwrites default page after login for admin siteaccess.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return string
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     */
+    protected function determineTargetUrl(Request $request)
+    {
+        if ((new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($request->attributes->get('siteaccess'))) {
+            $this->options['default_target_path'] = $this->defaultTargetPath;
+            $target = $this->getTargetPath($request->getSession(), $this->providerKey);
+            if (null !== $target && 1 === count(explode('/', trim(parse_url($target)['path'], '/')))) {
+                $this->options['always_use_default_target_path'] = true;
+            }
+        }
+
+        return parent::determineTargetUrl($request);
+    }
+}

--- a/src/lib/Specification/SiteAccess/IsAdmin.php
+++ b/src/lib/Specification/SiteAccess/IsAdmin.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification\SiteAccess;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
+use EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle;
+
+class IsAdmin extends AbstractSpecification
+{
+    /** @var array */
+    private $siteAccessGroups;
+
+    /**
+     * @param array $siteAccessGroups
+     */
+    public function __construct(array $siteAccessGroups)
+    {
+        $this->siteAccessGroups = $siteAccessGroups;
+    }
+
+    /**
+     * @param $item
+     *
+     * @return bool
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        if (!$item instanceof SiteAccess) {
+            throw new InvalidArgumentException($item, sprintf('Must be instance of %s', SiteAccess::class));
+        }
+
+        return in_array($item->name, $this->siteAccessGroups[EzPlatformAdminUiBundle::ADMIN_GROUP_NAME], true);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-26238
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This solves correct redirecting for admin_sitegroups after login, without messing up frontend login redirect. Resolves /admin redirect to /dashboard.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
