### PR TITLE
EZP-28930: Labels are one line below checkbox/radiobutton

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -43,10 +43,10 @@
                 {{ form_row(form.description) }}
                 {{ form_row(form.nameSchema) }}
                 {{ form_row(form.urlAliasSchema) }}
-                {{ form_row(form.isContainer) }}
+                {{ form_row(form.isContainer, {'attr': {'class': 'checkbox-inline'}}) }}
                 {{ form_row(form.defaultSortField) }}
                 {{ form_row(form.defaultSortOrder) }}
-                {{ form_row(form.defaultAlwaysAvailable) }}
+                {{ form_row(form.defaultAlwaysAvailable, {'attr': {'class': 'checkbox-inline'}}) }}
             </div>
         </div>
     </section>
@@ -59,10 +59,10 @@
                 </div>
                 <div class="form-inline">
                     <div class="ez-card__field-control mr-2">
-                    {{ form_widget(form.fieldTypeSelection, { attr: { class: 'ez-field-selection'}}) }}
-                    {{ form_widget(form.addFieldDefinition, { attr: { class: 'btn btn-primary'}}) }}
+                    {{ form_widget(form.fieldTypeSelection, {'attr': {'class': 'ez-field-selection'}}) }}
+                    {{ form_widget(form.addFieldDefinition, {'attr': {'class': 'btn btn-primary'}}) }}
                     </div>
-                    {{ form_widget(form.removeFieldDefinition, { attr: { class: 'btn btn-danger'}}) }}
+                    {{ form_widget(form.removeFieldDefinition, {'attr': {'class': 'btn btn-danger'}}) }}
                 </div>
             </div>
             <div class="card-body">
@@ -73,7 +73,8 @@
                     <div class="card ez-card ez-card--fieldtype-container">
                         <div id="field-definition-{{ value.identifier }}" class="ez-card__header ez-card__header--secondary">
                             {{ form_widget(field_definition.selected, {
-                                label: '%s (%s)' | format(value.names[language_code], value.fieldTypeIdentifier)
+                                'label': '%s (%s)' | format(value.names[language_code], value.fieldTypeIdentifier),
+                                'label_attr': {class: 'checkbox-inline'}
                             }) }}
                         </div>
 
@@ -82,16 +83,16 @@
                             {{ form_row(field_definition.identifier) }}
                             {{ form_row(field_definition.position) }}
                             {{ form_row(field_definition.description) }}
-                            {{ form_row(field_definition.isRequired) }}
-                            {{ form_row(field_definition.isSearchable) }}
-                            {{ form_row(field_definition.isTranslatable) }}
+                            {{ form_row(field_definition.isRequired, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                            {{ form_row(field_definition.isSearchable, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                            {{ form_row(field_definition.isTranslatable, {'label_attr': {'class': 'checkbox-inline'}}) }}
                             {{ form_row(field_definition.fieldGroup) }}
 
                             {# Field type specific fields below #}
                             {{ ez_render_fielddefinition_edit(value, {
-                                "languageCode": language_code,
-                                "form": field_definition,
-                                "group_class": value.group_class|default("")
+                                'languageCode': language_code,
+                                'form': field_definition,
+                                'group_class': value.group_class|default('')
                             }) }}
 
                             {# Default rendering #}

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -33,10 +33,10 @@
                 {{ form_row(form.description) }}
                 {{ form_row(form.nameSchema) }}
                 {{ form_row(form.urlAliasSchema) }}
-                {{ form_row(form.isContainer) }}
+                {{ form_row(form.isContainer, {'label_attr': {'class': 'checkbox-inline'}}) }}
                 {{ form_row(form.defaultSortField) }}
                 {{ form_row(form.defaultSortOrder) }}
-                {{ form_row(form.defaultAlwaysAvailable) }}
+                {{ form_row(form.defaultAlwaysAvailable, {'label_attr': {'class': 'checkbox-inline'}}) }}
             </div>
         </div>
     </section>
@@ -74,7 +74,8 @@
                     <div class="card ez-card ez-card--fieldtype-container mb-3">
                         <div id="field-definition-{{ value.identifier }}" class="ez-card__header ez-card__header--secondary">
                             {{ form_widget(field_definition.selected, {
-                                label: '%s (%s)' | format(value.names[language_code], value.fieldTypeIdentifier)
+                                'label': '%s (%s)' | format(value.names[language_code], value.fieldTypeIdentifier),
+                                'label_attr': {'class': 'checkbox-inline'}
                             }) }}
                         </div>
 
@@ -83,16 +84,16 @@
                             {{ form_row(field_definition.identifier) }}
                             {{ form_row(field_definition.position) }}
                             {{ form_row(field_definition.description) }}
-                            {{ form_row(field_definition.isRequired) }}
-                            {{ form_row(field_definition.isSearchable) }}
-                            {{ form_row(field_definition.isTranslatable) }}
+                            {{ form_row(field_definition.isRequired, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                            {{ form_row(field_definition.isSearchable, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                            {{ form_row(field_definition.isTranslatable, {'label_attr': {'class': 'checkbox-inline'}}) }}
                             {{ form_row(field_definition.fieldGroup) }}
 
                             {# Field type specific fields below #}
                             {{ ez_render_fielddefinition_edit(value, {
-                                "languageCode": language_code,
-                                "form": field_definition,
-                                "group_class": value.group_class|default("")
+                                'languageCode': language_code,
+                                'form': field_definition,
+                                'group_class': value.group_class|default('')
                             }) }}
 
                             {# Default rendering #}
@@ -113,8 +114,8 @@
         </div>
     </section>
 
-    {{ form_widget(form.publishContentType, { 'attr': { 'hidden': 'hidden' }}) }}
-    {{ form_widget(form.removeDraft, { 'attr': { 'hidden': 'hidden' }}) }}
+    {{ form_widget(form.publishContentType, {'attr': { 'hidden': 'hidden' }}) }}
+    {{ form_widget(form.removeDraft, {'attr': { 'hidden': 'hidden' }}) }}
 
     {{ form_widget(form._token) }}
     {{ form_end(form, {'render_rest': false }) }}

--- a/src/bundle/Resources/views/admin/language/create.html.twig
+++ b/src/bundle/Resources/views/admin/language/create.html.twig
@@ -29,7 +29,7 @@
             <div class="card-body">
                 {{ form_row(form.name) }}
                 {{ form_row(form.languageCode) }}
-                {{ form_row(form.enabled) }}
+                {{ form_row(form.enabled, {'label_attr': {'class': 'checkbox-inline'}}) }}
             </div>
         </div>
     </section>

--- a/src/bundle/Resources/views/admin/language/edit.html.twig
+++ b/src/bundle/Resources/views/admin/language/edit.html.twig
@@ -28,7 +28,7 @@
         <div class="card ez-card">
             <div class="card-body">
                 {{ form_row(form.name) }}
-                {{ form_row(form.enabled) }}
+                {{ form_row(form.enabled, {'label_attr': {'class': 'checkbox-inline'}}) }}
             </div>
         </div>
     </section>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28930
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

# TODO

### ADMIN/CONTENT TYPES/CONTENT/CREATING A NEW CONTENT TYPE:

Global Properties:
- [x] Contaner
- [x] Default content availability

Fields:
- [x] New field definition
- [x] Required/Searchable/Translatable

ezboolean:
- [ ] Default value

ezcountry:
- [ ] multiple choice

ezdate:
- [ ] default value: empty/current date

ezdatetime:
- [ ] Use seconds
- [ ] Default value: empty/Current date/Adjusted current dateime

ezselection:
- [ ] multiple choice

### CREATING/EDITING A NEW LANGUAGE
- [ ] Enabled

### ADDING LIMITATONS
- [ ] no limitations
- [ ] sections
- [ ] subtree