### PR TITLE
Fixed wrong policy check for Admin -> Languages Tab

### DIFF
--- a/src/bundle/Controller/LanguageController.php
+++ b/src/bundle/Controller/LanguageController.php
@@ -107,8 +107,8 @@ class LanguageController extends Controller
         return $this->render('@EzPlatformAdminUi/admin/language/list.html.twig', [
             'pager' => $pagerfanta,
             'form_languages_delete' => $deleteLanguagesForm->createView(),
-            'canEdit' => $this->isGranted(new Attribute('language', 'edit')),
-            'canAssign' => $this->isGranted(new Attribute('language', 'assign')),
+            'canEdit' => $this->isGranted(new Attribute('content', 'translations')),
+            'canAssign' => $this->isGranted(new Attribute('content', 'translations')),
         ]);
     }
 
@@ -128,8 +128,8 @@ class LanguageController extends Controller
         return $this->render('@EzPlatformAdminUi/admin/language/view.html.twig', [
             'language' => $language,
             'deleteForm' => $deleteForm->createView(),
-            'canEdit' => $this->isGranted(new Attribute('language', 'edit')),
-            'canAssign' => $this->isGranted(new Attribute('language', 'assign')),
+            'canEdit' => $this->isGranted(new Attribute('content', 'translations')),
+            'canAssign' => $this->isGranted(new Attribute('content', 'translations')),
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | TBD
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes wrong usage of non-existent policy when trying to view Admin -> Languages Tab.

The proper one is [`content / translations`](https://github.com/ezsystems/ezpublish-legacy/blob/master/settings/menu.ini#L363-L364).

#### Checklist:
- [x] Change policy name to `content / translations` in all relevant places.
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
