### PR TITLE
EZP-28938: Make TabGroupEvent and TabEvent aware of execution context

### DIFF
--- a/src/bundle/Templating/Twig/TabExtension.php
+++ b/src/bundle/Templating/Twig/TabExtension.php
@@ -74,11 +74,11 @@ class TabExtension extends Twig_Extension
         $template = $template ?? $this->defaultTemplate;
 
         $tabGroup = $this->tabService->getTabGroup($groupIdentifier);
-        $tabGroupEvent = $this->dispatchTabGroupPreRenderEvent($tabGroup);
+        $tabGroupEvent = $this->dispatchTabGroupPreRenderEvent($tabGroup, $parameters);
 
         $tabs = [];
         foreach ($tabGroupEvent->getData()->getTabs() as $tab) {
-            $tabEvent = $this->dispatchTabPreRenderEvent($tab);
+            $tabEvent = $this->dispatchTabPreRenderEvent($tab, $parameters);
             $tabs[] = $this->composeTabParameters($tabEvent->getData(), $parameters);
         }
 
@@ -90,13 +90,15 @@ class TabExtension extends Twig_Extension
 
     /**
      * @param TabGroup $tabGroup
+     * @param array $parameters
      *
      * @return TabGroupEvent
      */
-    private function dispatchTabGroupPreRenderEvent(TabGroup $tabGroup): TabGroupEvent
+    private function dispatchTabGroupPreRenderEvent(TabGroup $tabGroup, array $parameters = []): TabGroupEvent
     {
         $tabGroupEvent = new TabGroupEvent();
         $tabGroupEvent->setData($tabGroup);
+        $tabGroupEvent->setParameters($parameters);
 
         $this->eventDispatcher->dispatch(TabEvents::TAB_GROUP_PRE_RENDER, $tabGroupEvent);
 
@@ -105,13 +107,15 @@ class TabExtension extends Twig_Extension
 
     /**
      * @param TabInterface $tab
+     * @param array $parameters
      *
      * @return TabEvent
      */
-    private function dispatchTabPreRenderEvent(TabInterface $tab): TabEvent
+    private function dispatchTabPreRenderEvent(TabInterface $tab, array $parameters): TabEvent
     {
         $tabEvent = new TabEvent();
         $tabEvent->setData($tab);
+        $tabEvent->setParameters($parameters);
 
         $this->eventDispatcher->dispatch(TabEvents::TAB_PRE_RENDER, $tabEvent);
 

--- a/src/lib/Tab/Event/TabEvent.php
+++ b/src/lib/Tab/Event/TabEvent.php
@@ -16,6 +16,9 @@ class TabEvent extends Event
     /** @var TabInterface */
     private $data;
 
+    /** @var array */
+    private $parameters;
+
     /**
      * @return TabInterface
      */
@@ -30,5 +33,21 @@ class TabEvent extends Event
     public function setData(TabInterface $data)
     {
         $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
     }
 }

--- a/src/lib/Tab/Event/TabGroupEvent.php
+++ b/src/lib/Tab/Event/TabGroupEvent.php
@@ -16,6 +16,9 @@ class TabGroupEvent extends Event
     /** @var TabGroup */
     private $data;
 
+    /** @var array */
+    private $parameters;
+
     /**
      * @return TabGroup
      */
@@ -30,5 +33,21 @@ class TabGroupEvent extends Event
     public function setData(TabGroup $data)
     {
         $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28938
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review