### PR TITLE
EZP-28874: Main Menu is not responsive under 992 pixels

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_create_draft.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create_draft.html.twig
@@ -6,13 +6,15 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         {% block left_sidebar %}{% endblock left_sidebar %}
-        <div class="container px-0 pb-4 mt-5">
-            {{ form_start(form) }}
-            {{ form_row(form.contentId, {'attr': {'readonly': 'readonly'}}) }}
-            {{ form_row(form.fromVersionNo, {'attr': {'readonly': 'readonly'}}) }}
-            {{ form_row(form.fromLanguage, {'attr': {'readonly': 'readonly'}}) }}
-            {{ form_widget(form.createDraft, {'attr': {'hidden': 'hidden'}}) }}
-            {{ form_end(form) }}
+        <div class="col-sm-11 px-0 pb-4 mt-5">
+            <div class="container">
+                {{ form_start(form) }}
+                {{ form_row(form.contentId, {'attr': {'readonly': 'readonly'}}) }}
+                {{ form_row(form.fromVersionNo, {'attr': {'readonly': 'readonly'}}) }}
+                {{ form_row(form.fromLanguage, {'attr': {'readonly': 'readonly'}}) }}
+                {{ form_widget(form.createDraft, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_end(form) }}
+            </div>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
             <button class="btn btn-secondary btn-block btn--trigger" data-click="#ezrepoforms_content_draft_create_createDraft">

--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -10,35 +10,37 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         {% block left_sidebar %}{% endblock left_sidebar %}
-        <div class="container px-0 pb-4 mt-5 ez-content-edit-container">
-            {% block close_button %}{% endblock %}
-            {% block details %}{% endblock %}
+        <div class="col-sm-11 px-0 pb-4 mt-5 ez-content-edit-container">
+            <div class="container">
+                {% block close_button %}{% endblock %}
+                {% block details %}{% endblock %}
 
-            {% block form_before %}{% endblock %}
+                {% block form_before %}{% endblock %}
 
-            {% block form %}
-                {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
+                {% block form %}
+                    {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
 
-                {% block form_fields %}
-                    {% for field in form.fieldsData if not field.rendered -%}
-                        {% if field.value is defined %}
-                            {{- form_widget(field) -}}
-                        {% else %}
-                            <div>
-                                {{- form_label(field) -}}
-                                <p class="non-editable">
-                                    {{ "content.field.non_editable"|trans|desc('Field type is not editable') }}
-                                </p>
-                                {% do field.setRendered() %}
-                            </div>
-                        {% endif %}
-                    {%- endfor %}
+                    {% block form_fields %}
+                        {% for field in form.fieldsData if not field.rendered -%}
+                            {% if field.value is defined %}
+                                {{- form_widget(field) -}}
+                            {% else %}
+                                <div>
+                                    {{- form_label(field) -}}
+                                    <p class="non-editable">
+                                        {{ "content.field.non_editable"|trans|desc('Field type is not editable') }}
+                                    </p>
+                                    {% do field.setRendered() %}
+                                </div>
+                            {% endif %}
+                        {%- endfor %}
+                    {% endblock %}
+
+                    {{ form_end(form) }}
                 {% endblock %}
 
-                {{ form_end(form) }}
-            {% endblock %}
-
-            {% block form_after %}{% endblock %}
+                {% block form_after %}{% endblock %}
+            </div>
         </div>
         {% block right_sidebar_wrapper %}
             <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">

--- a/src/bundle/Resources/views/parts/navigation.html.twig
+++ b/src/bundle/Resources/views/parts/navigation.html.twig
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light ez-main-nav" style="flex-wrap:wrap;">
+<nav class="navbar navbar-expand-sm navbar-light ez-main-nav" style="flex-wrap:wrap;">
     <div class="container-fluid">
         <a href="{{ url('ezplatform.dashboard') }}" class="navbar-brand">
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" xml:space="preserve" width="70" viewBox="0 0 822.59995 309.89998">
@@ -36,7 +36,7 @@
         </div>
     </div>
 </nav>
-<nav class="navbar navbar-expand-lg navbar-light ez-main-sub-nav" style="flex-wrap:wrap;">
+<nav class="navbar navbar-expand-sm navbar-light ez-main-sub-nav" style="flex-wrap:wrap;">
     {{ knp_menu_render('ezplatform_admin_ui.menu.main', {
         'depth': 2,
         'template': '@EzPlatformAdminUi/parts/menu/top_menu_2nd_level.html.twig',

--- a/src/lib/Behat/PageElement/UpperMenu.php
+++ b/src/lib/Behat/PageElement/UpperMenu.php
@@ -18,8 +18,8 @@ class UpperMenu extends Element
     {
         parent::__construct($context);
         $this->fields = [
-            'menuButton' => '.nav-link',
-            'submenuButton' => '.navbar-expand-lg .nav-link',
+            'menuButton' => '.ez-main-nav .nav-link',
+            'submenuButton' => '.ez-main-sub-nav .nav-link',
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28874
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

**THINGS FIXED:**
- [x] top nav menu not responsive under 992px,
- [x] the right sidebar breaking the content edit layout at specific width dimensions.

**HOW TO TEST IT?**
Just resize the browser window and watch if navbar and the sidebar are not breaking the layout. Test on all modern browsers.