### PR TITLE
EZP-28386: Update Create & Edit design layout

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -1,14 +1,21 @@
+.ez-content-item-status {
+    font-size: 1.125rem;
+    color: $ez-color-base-light;
+}
+
 .ez-content-edit-container {
     position: relative;
 
     &__close {
         position: absolute;
-        right: 1rem;
-        top: 1rem;
+        left: 0;
+        top: 0;
         font-size: 2rem;
         color: $ez-black;
         width: 2rem;
         height: 2rem;
+        margin-left: .5rem;
+        padding: 1rem;
 
         &:before,
         &:after {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
@@ -66,13 +66,14 @@
 
     .btn--search-by-address {
         border-radius: 0 .25rem .25rem 0;
-        padding: .3rem .5rem;
+        padding: .075rem .5rem;
         cursor: pointer;
+        align-self: start;
 
         .ez-icon {
             width: 1.4rem;
             height: 1.4rem;
-            margin-top: 2px;
+            margin-top: 5px;
         }
     }
 }

--- a/src/bundle/Resources/views/content/content_edit/component/preview_unavailable.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/component/preview_unavailable.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'content_edit_component_preview_unavailable' %}
 
-<div class="alert alert-info mt-3 ez-alert ez-alert--info" role="alert">
+<div class="alert alert-info mt-3 mx-5 ez-alert ez-alert--info" role="alert">
     <svg class="ez-icon ez-icon--small ez-icon-warning">
         <use xmlns:xlink="http://www.w3.org/1999/xlink"
              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#warning"></use>

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -7,28 +7,36 @@
 {% endblock %}
 
 {% block details %}
-    <h2 class="text-muted">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
-    <h1>
-        <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
-        </svg>
-        {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
-    </h1>
+    <div class="container mt-5 px-5">
+        <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
+        <h1>
+            <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+            </svg>
+            {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
+        </h1>
 
-    <div class="small">
-        {{ contentType.name }} / Parent Location ID: {{ parentLocation.id }}
+        <div class="small">
+            {{ contentType.name }} / Parent Location ID: {{ parentLocation.id }}
+        </div>
+        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
+        {% if contentType.descriptions is not empty %}
+            <div class="small text-muted">{{ contentType.description }}</div>
+        {% endif %}
     </div>
-    {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-    {% if contentType.descriptions is not empty %}
-        <div class="small text-muted">{{ contentType.description }}</div>
-    {% endif %}
 {% endblock %}
 
 {% block form_fields %}
-    {{ parent() }}
-    {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+    <section class="container mt-4 px-5">
+        <div class="card ez-card">
+            <div class="card-body">
+                {{ parent() }}
+                {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+            </div>
+        </div>
+    </section>
 {% endblock %}
 
 {% block right_sidebar %}

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -13,32 +13,40 @@
 {% endblock %}
 
 {% block details %}
-    {% if baseLanguage is defined and baseLanguage is not null %}
-        <h2 class="text-muted">{{ 'editing_in_language_based_on'|trans({'%contentName%': content.name, '%languageName%': language.name, '%baseLanguageName%': baseLanguage.name})|desc('Editing - %contentName% in %languageName% based on %baseLanguageName%') }}</h2>
-    {% else %}
-        <h2 class="text-muted">{{ 'editing_in_language'|trans({'%contentName%': content.name, '%languageName%': language.name})|desc('Editing - %contentName% in %languageName%') }}</h2>
-    {% endif %}
-    <h1>
-        <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
-        </svg>
-        {{ content.name }}
-    </h1>
+    <div class="container mt-5 px-5">
+        {% if baseLanguage is defined and baseLanguage is not null %}
+            <h2 class="ez-content-item-status">{{ 'editing_in_language_based_on'|trans({'%contentName%': content.name, '%languageName%': language.name, '%baseLanguageName%': baseLanguage.name})|desc('Editing - %contentName% in %languageName% based on %baseLanguageName%') }}</h2>
+        {% else %}
+            <h2 class="ez-content-item-status">{{ 'editing_in_language'|trans({'%contentName%': content.name, '%languageName%': language.name})|desc('Editing - %contentName% in %languageName%') }}</h2>
+        {% endif %}
+        <h1>
+            <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+            </svg>
+            {{ content.name }}
+        </h1>
 
-    <div class="small">
-        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }}, {{ 'location_id'|trans({'%locationId%': locationId})|desc('Location ID: %locationId%') }}
+        <div class="small">
+            {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }}, {{ 'location_id'|trans({'%locationId%': locationId})|desc('Location ID: %locationId%') }}
+        </div>
+        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
+        {% if contentType.descriptions is not empty %}
+            <div class="small text-muted">{{ contentType.description }}</div>
+        {% endif %}
     </div>
-    {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-    {% if contentType.descriptions is not empty %}
-        <div class="small text-muted">{{ contentType.description }}</div>
-    {% endif %}
 {% endblock %}
 
 {% block form_fields %}
-    {{ parent() }}
-    {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+    <section class="container mt-4 px-5">
+        <div class="card ez-card">
+            <div class="card-body">
+                {{ parent() }}
+                {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+            </div>
+        </div>
+    </section>
 {% endblock %}
 
 {% block right_sidebar %}

--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -10,37 +10,35 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         {% block left_sidebar %}{% endblock left_sidebar %}
-        <div class="col-sm-11 px-0 pb-4 mt-5 ez-content-edit-container">
-            <div class="container">
-                {% block close_button %}{% endblock %}
-                {% block details %}{% endblock %}
+        <div class="container px-0 pb-4 mt-3 ez-content-edit-container">
+            {% block close_button %}{% endblock %}
+            {% block details %}{% endblock %}
 
-                {% block form_before %}{% endblock %}
+            {% block form_before %}{% endblock %}
 
-                {% block form %}
-                    {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
+            {% block form %}
+                {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
 
-                    {% block form_fields %}
-                        {% for field in form.fieldsData if not field.rendered -%}
-                            {% if field.value is defined %}
-                                {{- form_widget(field) -}}
-                            {% else %}
-                                <div>
-                                    {{- form_label(field) -}}
-                                    <p class="non-editable">
-                                        {{ "content.field.non_editable"|trans|desc('Field type is not editable') }}
-                                    </p>
-                                    {% do field.setRendered() %}
-                                </div>
-                            {% endif %}
-                        {%- endfor %}
-                    {% endblock %}
-
-                    {{ form_end(form) }}
+                {% block form_fields %}
+                    {% for field in form.fieldsData if not field.rendered -%}
+                        {% if field.value is defined %}
+                            {{- form_widget(field) -}}
+                        {% else %}
+                            <div>
+                                {{- form_label(field) -}}
+                                <p class="non-editable">
+                                    {{ "content.field.non_editable"|trans|desc('Field type is not editable') }}
+                                </p>
+                                {% do field.setRendered() %}
+                            </div>
+                        {% endif %}
+                    {%- endfor %}
                 {% endblock %}
 
-                {% block form_after %}{% endblock %}
-            </div>
+                {{ form_end(form) }}
+            {% endblock %}
+
+            {% block form_after %}{% endblock %}
         </div>
         {% block right_sidebar_wrapper %}
             <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">

--- a/src/bundle/Resources/views/content/content_edit/user_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_create.html.twig
@@ -3,27 +3,35 @@
 {% trans_default_domain 'user_create' %}
 
 {% block details %}
-    <h4 class="text-muted">{{ 'creating'|trans({'%contentType%': contentType.name})|desc('Creating - %contentType%') }}</h4>
-    <h1>
-        <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
-        </svg>
-        {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
-    </h1>
+    <div class="container mt-5 px-5">
+        <h4 class="ez-content-item-status">{{ 'creating'|trans({'%contentType%': contentType.name})|desc('Creating - %contentType%') }}</h4>
+        <h1>
+            <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+            </svg>
+            {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
+        </h1>
 
-    <div class="small">
-        {{ contentType.name }} / {{ 'group_id'|trans({'%groupId%': parentGroup.id})|desc('Group ID: %groupId%') }}
+        <div class="small">
+            {{ contentType.name }} / {{ 'group_id'|trans({'%groupId%': parentGroup.id})|desc('Group ID: %groupId%') }}
+        </div>
+        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
+        {% if contentType.descriptions is not empty %}
+            <div class="small text-muted">{{ contentType.description }}</div>
+        {% endif %}
     </div>
-    {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-    {% if contentType.descriptions is not empty %}
-        <div class="small text-muted">{{ contentType.description }}</div>
-    {% endif %}
 {% endblock %}
 
 {% block form_fields %}
-    {{ parent() }}
-    {{ form_widget(form.create, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+    <section class="container mt-4 px-5">
+        <div class="card ez-card">
+            <div class="card-body">
+                {{ parent() }}
+                {{ form_widget(form.create, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+            </div>
+        </div>
+    </section>
 {% endblock %}
 
 {% block right_sidebar %}

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -3,27 +3,35 @@
 {% trans_default_domain 'user_edit' %}
 
 {% block details %}
-    <h4 class="text-muted">{{ 'editing'|trans({'%contentType%': contentType.name})|desc('Editing - %contentType%') }}</h4>
-    <h1>
-        <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
-        </svg>
-        {{ user.name }}
-    </h1>
+    <div class="container mt-5 px-5">
+        <h4 class="ez-content-item-status">{{ 'editing'|trans({'%contentType%': contentType.name})|desc('Editing - %contentType%') }}</h4>
+        <h1>
+            <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+            </svg>
+            {{ user.name }}
+        </h1>
 
-    <div class="small">
-        {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ user.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': user.id})|desc('Content ID: %contentId%') }}{% if user.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': user.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
+        <div class="small">
+            {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ user.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': user.id})|desc('Content ID: %contentId%') }}{% if user.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': user.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
+        </div>
+        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
+        {% if contentType.descriptions is not empty %}
+            <div class="small text-muted">{{ contentType.description }}</div>
+        {% endif %}
     </div>
-    {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-    {% if contentType.descriptions is not empty %}
-        <div class="small text-muted">{{ contentType.description }}</div>
-    {% endif %}
 {% endblock %}
 
 {% block form_fields %}
-    {{ parent() }}
-    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
-    {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+    <section class="container mt-4 px-5">
+        <div class="card ez-card">
+            <div class="card-body">
+                {{ parent() }}
+                {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
+                {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
+            </div>
+        </div>
+    </section>
 {% endblock %}
 
 {% block right_sidebar %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28386](https://jira.ez.no/browse/EZP-28386)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Updated Create and Design layouts based on UI Guidelines design;
- Close button placed on left side, in order to avoid usability issues due to the closeness of Close and Discard buttons when the first one is on the right side;
- Form fields contained within `ez-card` following consistency with Editing view in Admin section.
- Added offset margins to Creating/Editing language name, Content item title, Content Type name and Content Type descriptions;
- Updated color for Creating/Editing language name according to color contrast standards defined in UI Guidelines;
- Added offset margins to `content_edit_component_preview_unavailable`.

![ez platform 31](https://user-images.githubusercontent.com/9256718/37351630-e4c760ae-26b1-11e8-8ffb-71654e096747.png)
![ez platform 30](https://user-images.githubusercontent.com/9256718/37351640-e7754c12-26b1-11e8-95e8-24c90055a0f7.png)
![ez platform 29](https://user-images.githubusercontent.com/9256718/37351645-e9d55754-26b1-11e8-9d49-d838dfa9bc3a.png)
![ez platform 28](https://user-images.githubusercontent.com/9256718/37351649-edc81054-26b1-11e8-9c16-e1b4b8b9b737.png)
![ez platform 27](https://user-images.githubusercontent.com/9256718/37351654-f023fb06-26b1-11e8-80c4-372f89437df6.png)

Next steps:
- Flex Workflow notifications in EZEE should be adapted to this new layout too.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
