### PR TITLE
[Composer] Fixed minimum-stability for 2.1-beta related packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "^7.1",
-        "ezsystems/repository-forms": "^2.1",
-        "ezsystems/ezplatform-admin-ui-modules": "^1.1",
+        "ezsystems/ezpublish-kernel": "^7.1@beta",
+        "ezsystems/repository-forms": "^2.1@beta",
+        "ezsystems/ezplatform-admin-ui-modules": "^1.1@beta",
         "ezsystems/ez-support-tools": "^0.2",
         "white-october/pagerfanta-bundle": "^1.1",
         "knplabs/knp-menu-bundle": "^2.1"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | TBD
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes minimum-stability for:
- ezpublish-kernel
- repository-forms
- ezplatform-admin-ui-modules

as the provided versions are beta versions and `composer install` fails.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
