### PR TITLE
EZP-28334: Fix for restoring from trash after removing structure of items.

### DIFF
--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -59,16 +59,17 @@
                         {% else %}
                             {% for key, form in form_trash_item_restore.trash_items %}
                                 {% set trash_item = trash_items[key] %}
+                                {% set is_parent_in_trash = trash_item.parentInTrash %}
                                 <tr>
                                     <td>
                                         {{ form_widget(form, {attr: {
-                                            'data-is-parent-in-trash': trash_item.isParentInTrash() ? '1': '0'
+                                            'data-is-parent-in-trash': is_parent_in_trash ? '1': '0'
                                         }}) }}
                                     </td>
                                     <td>{{ ez_content_name(trash_item.location.contentInfo) }}</td>
                                     <td>{{ trash_item.contentType.name }}</td>
                                     <td>
-                                        {% if not trash_item.parentInTrash %}
+                                        {% if not is_parent_in_trash %}
                                             {% include 'EzPlatformAdminUiBundle:parts:path.html.twig' with {'locations': trash_item.ancestors, 'link_last_element': true} %}
                                         {% else %}
                                             <em>{{ 'trash.item.ancesor_in_trash'|trans|desc('Ancestor is in the Trash') }}</em>

--- a/src/lib/Form/Data/TrashItemData.php
+++ b/src/lib/Form/Data/TrashItemData.php
@@ -91,6 +91,8 @@ class TrashItemData
 
     public function isParentInTrash(): bool
     {
-        return !end($this->ancestors) instanceof Location;
+        $lastAncestor = end($this->ancestors);
+
+        return $this->location->path !== array_merge($lastAncestor->path, [(string)$this->location->id]);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28334
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When a Parent item is sent to Trash - then all the corresponding child items will no longer have a parent location ID and each of these child content item's should display a status/message 'Item's ancestors are in Trash' under the path column.

And whenever a user tries to restore the child item then the option to restore is disabled and only the option to restore under a new parent is enabled.

<img width="1426" alt="screen shot 2018-03-14 at 9 07 19 am" src="https://user-images.githubusercontent.com/1654712/37390307-cdeaed22-2767-11e8-9bb2-7553fc3f08bd.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
