### PR TITLE
EZP-28929: User is unable to add translation to Content item

### DIFF
--- a/src/bundle/Controller/ContentEditController.php
+++ b/src/bundle/Controller/ContentEditController.php
@@ -65,6 +65,10 @@ class ContentEditController extends Controller
      * @param int|null $locationId
      *
      * @return ContentEditView|Response
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function translateAction(
         Content $content,
@@ -111,7 +115,7 @@ class ContentEditController extends Controller
             }
         }
 
-        return new ContentEditView(null, [
+        return new ContentEditView('@EzPlatformAdminUi/content/content_edit/content_edit.html.twig', [
             'form' => $form->createView(),
             'location' => $location,
             'language' => $toLanguage,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28929](https://jira.ez.no/browse/EZP-28929)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | TBD
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes inability to add new Translation to a Content item by providing missing Content edit template.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
