### PR TITLE
EZP-28965: Modals Close button harmonization in AdminUI

### DIFF
--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -50,14 +50,16 @@
 
 .ez-side-menu,
 .ez-context-menu {
-    .ez-icon {
-        width: 1.875rem;
-        height: 1.875rem;
-        margin-bottom: .1875rem;
+    .ez-sticky-container {
+        .ez-icon {
+            width: 1.875rem;
+            height: 1.875rem;
+            margin-bottom: .1875rem;
+        }
     }
 }
 
-.ez-icon-search-button{
+.ez-icon-search-button {
     fill: $ez-white;
     height: 1rem;
     width: 1rem;
@@ -201,5 +203,13 @@
 .ez-alert--info {
     .ez-icon-warning {
         fill: $ez-secondary-ground-medium;
+    }
+}
+
+.ez-modal {
+    .modal-header {
+        .ez-icon {
+            fill: $ez-black;
+        }
     }
 }

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -59,6 +59,10 @@
 
     .modal-header {
         background: $ez-color-base-pale;
+
+        .close {
+            padding-top: 1.25rem;
+        }
     }
 
     .modal-body {

--- a/src/bundle/Resources/views/admin/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/bulk_delete_confirmation_modal.html.twig
@@ -3,7 +3,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
@@ -6,7 +6,9 @@
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'content_type.modal.title'|trans|desc('Please confirm') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/admin/language/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/language/delete_confirmation_modal.html.twig
@@ -5,7 +5,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
@@ -5,7 +5,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
@@ -6,7 +6,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
@@ -4,7 +4,9 @@
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'modal.title'|trans|desc('Please confirm') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
@@ -8,7 +8,9 @@
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'draft.conflict.header'|trans|desc('Draft conflict when editing') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -5,7 +5,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/content/modal_user_delete.html.twig
+++ b/src/bundle/Resources/views/content/modal_user_delete.html.twig
@@ -7,7 +7,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/content/modal_version_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_version_conflict.html.twig
@@ -6,7 +6,9 @@
             <div class="modal-header">
                 <h5>{{ 'version.conflict.header'|trans|desc('Version conflict when editing') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">

--- a/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
@@ -1,14 +1,16 @@
 {% trans_default_domain 'locationview' %}
 {% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' '@EzPlatformAdminUi/content/tab/translations/translation_add_form_fields.html.twig' %}
 
-<div class="modal fade ez-translation" id="add-translation-modal" tabindex="-1" role="dialog">
+<div class="modal fade ez-modal ez-translation" id="add-translation-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         {{ form_start(form, {'action': path('ezplatform.translation.add')}) }}
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'tab.translations.add.title'|trans|desc('Create new translation') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'translation.modal_close'|trans|desc('Close') }}">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28965](https://jira.ez.no/browse/EZP-28965)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspect:
- Updated Close button style for Modals.

![trash 1](https://user-images.githubusercontent.com/9256718/37433410-36dfcc36-27b2-11e8-8b16-e870c8813a00.png)
![ez platform 35](https://user-images.githubusercontent.com/9256718/37433412-3a60bc9e-27b2-11e8-972e-2e5884a87e68.png)
![ez platform 34](https://user-images.githubusercontent.com/9256718/37433415-3e3407cc-27b2-11e8-9ad8-8a53bc2f9359.png)
![ez platform 33](https://user-images.githubusercontent.com/9256718/37433421-40d563f4-27b2-11e8-8fca-c7961e8d7558.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
