### PR TITLE
EZP-28932: Broken empty option design after selecting it from ezselection fieldtype

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
@@ -16,6 +16,9 @@
             position: relative;
             min-height: 2.8rem;
             background-color: $ez-white;
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
 
             &:after {
                 content: '';
@@ -52,6 +55,7 @@
                 border-radius: .25rem;
                 position: relative;
                 color: $ez-white;
+                min-height: 34px;
 
                 .remove-selection {
                     width: 1rem;
@@ -114,6 +118,11 @@
 
                 &.option-selected {
                     background-color: $ez-ground-primary;
+                }
+
+                &:not(.option-selected):hover,
+                &:not(.option-selected):focus {
+                    background: $ez-secondary-ground-pale;
                 }
             }
         }

--- a/src/bundle/Resources/public/scss/fieldType/preview/_ezselection.scss
+++ b/src/bundle/Resources/public/scss/fieldType/preview/_ezselection.scss
@@ -2,6 +2,9 @@
     list-style: none;
     padding-left: 0;
     margin-bottom: 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
 
     .ez-selection__item {
         display: inline-block;
@@ -9,6 +12,7 @@
         background: $ez-ground-primary;
         border-radius: 5px;
         margin: .25rem;
+        min-height: 40px;
     }
 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28932
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->