### PR TITLE
EZP-28947: Filtered search inconsistencies

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -171,6 +171,7 @@ class SearchController extends Controller
                     'form' => $form->createView(),
                     'pager' => $pagerfanta,
                     'form_edit' => $editForm->createView(),
+                    'filters_expanded' => $data->isFiltered(),
                 ]);
             });
 
@@ -181,6 +182,7 @@ class SearchController extends Controller
 
         return $this->render('@EzPlatformAdminUi/admin/search/search.html.twig', [
             'form' => $form->createView(),
+            'filters_expanded' => false,
         ]);
     }
 }

--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -37,6 +37,8 @@
         lastModifiedEnd.value = '';
         lastCreatedPeriod.value = '';
         lastCreatedEnd.value = '';
+
+        event.target.closest('form').submit();
     };
     const toggleApplyBtnDisabledState = () => {
         const contentTypeOption = contentTypeSelect.querySelector('option');
@@ -54,10 +56,18 @@
 
         filters.classList.toggle('ez-filters--collapsed');
     };
-    const toggleContentTypeSelectorVisibility = (event) => {
-        event.preventDefault();
+    const handleClickOutside = (event) => {
+        if (event.target.closest('.ez-content-type-selector') || event.target.closest('.ez-filters__select--content-type')) {
+            return;
+        }
+
+        toggleContentTypeSelectorVisibility();
+    };
+    const toggleContentTypeSelectorVisibility = () => {
+        const methodName = contentTypeSelector.classList.contains('ez-content-type-selector--collapsed') ? 'addEventListener' : 'removeEventListener';
 
         contentTypeSelector.classList.toggle('ez-content-type-selector--collapsed');
+        doc.querySelector('body')[methodName]('click', handleClickOutside, false);
     };
     const toggleModalVisibility = (event) => {
         const modal = $(event.target.dataset.targetSelector);
@@ -80,7 +90,7 @@
     };
     const filterByContentType = () => {
         const selectedCheckboxes = contentTypeCheckboxes.filter(checkbox => checkbox.checked);
-        const contentTypesText = selectedCheckboxes.map(checkbox => checkbox.value).join();
+        const contentTypesText = selectedCheckboxes.map(checkbox => checkbox.dataset.name).join(', ');
         const option = contentTypeSelect[0];
         const defaultText = option.dataset.default;
 
@@ -146,6 +156,8 @@
     };
 
     dateFields.forEach(initFlatPickr);
+
+    filterByContentType();
 
     clearBtn.addEventListener('click', clearFilters, false);
     filterBtn.addEventListener('click', toggleFiltersVisibility, false);

--- a/src/bundle/Resources/public/scss/_content-type-selector.scss
+++ b/src/bundle/Resources/public/scss/_content-type-selector.scss
@@ -24,8 +24,8 @@
     }
 
     &__item {
-        min-width: 8rem;
-        padding-right: 1rem;
+        flex-basis: 33%;
+        display: flex;
     }
 
     &__group-title {

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -179,80 +179,15 @@
         <target state="new">Delete</target>
         <note>key: modal.delete</note>
       </trans-unit>
-      <trans-unit id="ef88894d37b21eeb205ece403d77ab05ccea52cf" resname="modal.select">
-        <source>Select</source>
-        <target state="new">Select</target>
-        <note>key: modal.select</note>
-      </trans-unit>
       <trans-unit id="08a5f336891a76fbd5fce4f454bb2d71b1df0223" resname="modal.title">
         <source>Please confirm</source>
         <target state="new">Please confirm</target>
         <note>key: modal.title</note>
       </trans-unit>
-      <trans-unit id="2c0d71c1688c1f04ff156bb9dff167ca5ae663b6" resname="search.any.content.type">
-        <source>Any content type</source>
-        <target state="new">Any content type</target>
-        <note>key: search.any.content.type</note>
-      </trans-unit>
       <trans-unit id="08232f4c5c3ca88a7f2fd8e29eda7e20ec346aae" resname="search.any_time">
         <source>Any time</source>
         <target state="new">Any time</target>
         <note>key: search.any_time</note>
-      </trans-unit>
-      <trans-unit id="8605c5030193beebc7097a652f6c9dcb648cccec" resname="search.apply">
-        <source>Apply</source>
-        <target state="new">Apply</target>
-        <note>key: search.apply</note>
-      </trans-unit>
-      <trans-unit id="27f2f932e2b2f60b36b3331b45a3e15b421ee86f" resname="search.clear">
-        <source>Clear</source>
-        <target state="new">Clear</target>
-        <note>key: search.clear</note>
-      </trans-unit>
-      <trans-unit id="52574f2c1d5e0b3ffcd4f105b770e91ae1e519fa" resname="search.content.type">
-        <source>Content type:</source>
-        <target state="new">Content type:</target>
-        <note>key: search.content.type</note>
-      </trans-unit>
-      <trans-unit id="738c66eb92535505455b34b383f8089fb1bc0479" resname="search.created">
-        <source>Created:</source>
-        <target state="new">Created:</target>
-        <note>key: search.created</note>
-      </trans-unit>
-      <trans-unit id="9cef4cf2cb67458460a2a01c0adc1b4238320459" resname="search.date.from">
-        <source>From:</source>
-        <target state="new">From:</target>
-        <note>key: search.date.from</note>
-      </trans-unit>
-      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
-        <source>Select date range</source>
-        <target state="new">Select date range</target>
-        <note>key: search.date.range</note>
-      </trans-unit>
-      <trans-unit id="ec2194ad5a5851c9bb326a091c6985adedcd42b2" resname="search.date.to">
-        <source>To:</source>
-        <target state="new">To:</target>
-        <note>key: search.date.to</note>
-      </trans-unit>
-      <trans-unit id="9db82102d1da5efb63380ca328a83d13732a02ee" resname="search.filter">
-        <source>Filter</source>
-        <target state="new">Filter</target>
-        <note>key: search.filter</note>
-      </trans-unit>
-      <trans-unit id="c2e9df867c114a94918c00f775d3a54d24358dfa" resname="search.last.modified">
-        <source>Last modified:</source>
-        <target state="new">Last modified:</target>
-        <note>key: search.last.modified</note>
-      </trans-unit>
-      <trans-unit id="6fa93ef4dfbce97076a254427bb30bf7c5819c5d" resname="search.perform">
-        <source>Search</source>
-        <target state="new">Search</target>
-        <note>key: search.perform</note>
-      </trans-unit>
-      <trans-unit id="34cd11448c2016e5c0a098947eb3e2aef01a9ac5" resname="search.section">
-        <source>Section:</source>
-        <target state="new">Section:</target>
-        <note>key: search.section</note>
       </trans-unit>
       <trans-unit id="03d6d5922fd2012e155e50306eaf98e2dfeb21c6" resname="search.section.any">
         <source>Any section</source>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -6,15 +6,70 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="7fe072f41348fb097b6bb018eec4f1b1bc9cffc3" resname="modal.cancel">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note>key: modal.cancel</note>
+      </trans-unit>
+      <trans-unit id="ef88894d37b21eeb205ece403d77ab05ccea52cf" resname="modal.select">
+        <source>Select</source>
+        <target state="new">Select</target>
+        <note>key: modal.select</note>
+      </trans-unit>
       <trans-unit id="3559d7accf00360971961ca18989adc0614089c0" resname="search">
         <source>Search</source>
         <target state="new">Search</target>
         <note>key: search</note>
       </trans-unit>
+      <trans-unit id="2c0d71c1688c1f04ff156bb9dff167ca5ae663b6" resname="search.any.content.type">
+        <source>Any content type</source>
+        <target state="new">Any content type</target>
+        <note>key: search.any.content.type</note>
+      </trans-unit>
+      <trans-unit id="8605c5030193beebc7097a652f6c9dcb648cccec" resname="search.apply">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note>key: search.apply</note>
+      </trans-unit>
+      <trans-unit id="27f2f932e2b2f60b36b3331b45a3e15b421ee86f" resname="search.clear">
+        <source>Clear</source>
+        <target state="new">Clear</target>
+        <note>key: search.clear</note>
+      </trans-unit>
+      <trans-unit id="52574f2c1d5e0b3ffcd4f105b770e91ae1e519fa" resname="search.content.type">
+        <source>Content Type:</source>
+        <target state="new">Content Type:</target>
+        <note>key: search.content.type</note>
+      </trans-unit>
+      <trans-unit id="738c66eb92535505455b34b383f8089fb1bc0479" resname="search.created">
+        <source>Created:</source>
+        <target state="new">Created:</target>
+        <note>key: search.created</note>
+      </trans-unit>
       <trans-unit id="a18d7835f5b4a97ac94331f82e729abcb698be41" resname="search.custom_range">
         <source>Custom range</source>
         <target state="new">Custom range</target>
         <note>key: search.custom_range</note>
+      </trans-unit>
+      <trans-unit id="9cef4cf2cb67458460a2a01c0adc1b4238320459" resname="search.date.from">
+        <source>From:</source>
+        <target state="new">From:</target>
+        <note>key: search.date.from</note>
+      </trans-unit>
+      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
+        <source>Select date range</source>
+        <target state="new">Select date range</target>
+        <note>key: search.date.range</note>
+      </trans-unit>
+      <trans-unit id="ec2194ad5a5851c9bb326a091c6985adedcd42b2" resname="search.date.to">
+        <source>To:</source>
+        <target state="new">To:</target>
+        <note>key: search.date.to</note>
+      </trans-unit>
+      <trans-unit id="9db82102d1da5efb63380ca328a83d13732a02ee" resname="search.filter">
+        <source>Filter</source>
+        <target state="new">Filter</target>
+        <note>key: search.filter</note>
       </trans-unit>
       <trans-unit id="0ec8148d681b43e87a6d0751fff188517be1ea26" resname="search.header">
         <source>Search results (%total%)</source>
@@ -25,6 +80,11 @@
         <source>Search</source>
         <target state="new">Search</target>
         <note>key: search.headline</note>
+      </trans-unit>
+      <trans-unit id="c2e9df867c114a94918c00f775d3a54d24358dfa" resname="search.last.modified">
+        <source>Last modified:</source>
+        <target state="new">Last modified:</target>
+        <note>key: search.last.modified</note>
       </trans-unit>
       <trans-unit id="2d007a8d9fc080db790dc5c45c12dd369d144fbe" resname="search.last_month">
         <source>Last month</source>
@@ -60,6 +120,16 @@
         <source>Sorry, no results were found for "%query%".</source>
         <target state="new">Sorry, no results were found for "%query%".</target>
         <note>key: search.no_result</note>
+      </trans-unit>
+      <trans-unit id="6fa93ef4dfbce97076a254427bb30bf7c5819c5d" resname="search.perform">
+        <source>Search</source>
+        <target state="new">Search</target>
+        <note>key: search.perform</note>
+      </trans-unit>
+      <trans-unit id="34cd11448c2016e5c0a098947eb3e2aef01a9ac5" resname="search.section">
+        <source>Section:</source>
+        <target state="new">Section:</target>
+        <note>key: search.section</note>
       </trans-unit>
       <trans-unit id="777cc1ef279096d5a978aa3553e9434d828f8248" resname="search.tips.check_spelling">
         <source>Check spelling of keywords.</source>

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -1,5 +1,7 @@
 {% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
 
+{% trans_default_domain 'search' %}
+
 {{ form_start(form) }}
 <div class="input-group">
     {{ form_widget(form.query) }}
@@ -17,10 +19,10 @@
             {{ 'search.filter'|trans|desc('Filter') }}</button>
     </span>
 </div>
-<div class="ez-filters ez-filters--collapsed mt-4 pt-2">
+<div class="ez-filters mt-4 pt-2{% if not filters_expanded %} ez-filters--collapsed{% endif %}">
     <div class="ez-filters__item ez-filters__item--content-type">
-        <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content type:') }}</label>
-        <select class="form-control ez-filters__select">
+        <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
+        <select class="form-control ez-filters__select ez-filters__select--content-type">
             <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any content type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any content type') }}</option>
         </select>
         {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -56,7 +56,7 @@
 {%- block search_type_choice_widget_options -%}
     {%- for group_label, choice in options -%}
         <li class="ez-content-type-selector__item">
-            {{ form_widget(form[choice.value]) }}
+            {{ form_widget(form[choice.value], {'attr': {'data-name': choice.label}, 'label_attr': {'class': 'checkbox-inline'}}) }}
         </li>
     {%- endfor -%}
 {%- endblock -%}

--- a/src/lib/Form/Data/Search/SearchData.php
+++ b/src/lib/Form/Data/Search/SearchData.php
@@ -200,4 +200,17 @@ class SearchData
     {
         return $this->created;
     }
+
+    /**
+     * @return bool
+     */
+    public function isFiltered(): bool
+    {
+        $contentTypes = $this->getContentTypes();
+        $section = $this->getSection();
+        $lastModified = $this->getLastModified();
+        $created = $this->getCreated();
+
+        return !empty($contentTypes) || null !== $section || !empty($lastModified) || !empty($created);
+    }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28947 https://jira.ez.no/browse/EZP-28946
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
- [x] clear button refresh results
- [x] use content type name instead of content type identifier
- [x] restore content type selection when send form
- [x] fixed `Content type` to `Content Type`
- [x] checkbox alignment
- [x] added space in content type list
- [x] filters are expanded when are selected
- [x] collapsing content type list when clicked outside