### PR TITLE
EZP-28957: Cannot open draft conflict modal when two jQuery are loaded

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.tab.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tab.js
@@ -1,11 +1,8 @@
-(function () {
-    var url = document.location.toString();
-    if (url.match('#')) {
-        $('.ez-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
-    }
+(function (global, doc, $) {
+    $('.ez-tabs a[href="#' + global.location.hash.split('#')[1] + '"]').tab('show');
 
     // Change hash for page-reload
     $('.ez-tabs a').on('shown.bs.tab', function (e) {
-        window.location.hash = e.target.hash + '#tab';
+        global.location.hash = e.target.hash + '#tab';
     })
-})();
+})(window, document, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function (global, doc, $) {
     const listContainers = [...doc.querySelectorAll('.ez-sil')];
     const mfuContainer = doc.querySelector('#ez-mfu');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
@@ -91,4 +91,4 @@
             totalCount: subItemsList.ChildrenCount
         }), container);
     });
-})(window, window.document);
+})(window, window.document, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function (global, doc, $) {
     const filterBtn = doc.querySelector('.ez-btn--filter');
     const filters = doc.querySelector('.ez-filters');
     const clearBtn = filters.querySelector('.ez-btn-clear');
@@ -156,4 +156,4 @@
     listGroupsTitle.forEach(group => group.addEventListener('click', toggleGroupState, false));
     contentTypeCheckboxes.forEach(checkbox => checkbox.addEventListener('change', filterByContentType, false));
     selectBtns.forEach(btn => btn.addEventListener('click', setSelectedDateRange, false));
-})(window, document);
+})(window, document, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/admin.version.edit.conflict.js
+++ b/src/bundle/Resources/public/js/scripts/admin.version.edit.conflict.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function (global, doc, $) {
     const editVersion = (event) => {
         const contentDraftEditUrl = event.currentTarget.dataset.contentDraftEditUrl;
         const versionHasConflictUrl = event.currentTarget.dataset.versionHasConflictUrl;
@@ -19,4 +19,4 @@
     };
 
     [...doc.querySelectorAll('.ez-btn--content-draft-edit')].forEach(link => link.addEventListener('click', editVersion, false));
-})(window, document);
+})(window, document, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function (global, doc, $) {
     const FORM_EDIT = 'form.ez-edit-content-form';
     const editVersion = (event) => {
         const versionEditForm = doc.querySelector(FORM_EDIT);
@@ -47,4 +47,4 @@
     };
 
     [...doc.querySelectorAll('.ez-btn--content-edit')].forEach(button => button.addEventListener('click', editVersion, false));
-})(window, document);
+})(window, document, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function (global, doc, $) {
     const editActions = doc.querySelector('.ez-extra-actions--edit');
     const btns = [...editActions.querySelectorAll('.form-check [type="radio"]')];
     const form = editActions.querySelector('form');
@@ -31,4 +31,4 @@
     };
 
     btns.forEach(btn => btn.addEventListener('change', changeHandler, false));
-})(window, document);
+})(window, document, window.jQuery);

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -124,6 +124,8 @@
         'bundles/ezplatformadminui/js/scripts/admin.location.load.map.js'
         'bundles/ezplatformadminui/js/scripts/sidebar/btn/content.edit.js'
         'bundles/ezplatformadminui/js/scripts/admin.location.add.custom_url.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.version.edit.conflict.js'
     %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -97,12 +97,3 @@
     'data_click': '#' ~ form.remove.vars.id,
     } %}
 {% endmacro %}
-
-{% block javascripts %}
-    {% javascripts
-    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
-    '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.version.edit.conflict.js'
-    %}
-    <script type="text/javascript" src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-{% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28957
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Ready for Code Review
