### PR TITLE
EZP-28279: User cannot set max file size in Image field type

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
@@ -4,7 +4,7 @@
 
 {%- block ezplatform_fieldtype_ezimage_row -%}
     {% set preview_block_name = 'ezimage_preview' %}
-    {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize, max_upload_size) %}
+    {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size|round) %}
     {% set attr = attr|merge({'accept': 'image/*'}) %}
     {{ block('binary_base_row') }}
 {%- endblock -%}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28279
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fix display and frontend js validation.
related to:
https://github.com/ezsystems/ezpublish-kernel/pull/2280
https://github.com/ezsystems/repository-forms/pull/226


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
