### PR TITLE
EZP-28945: User will be able to search for content items by just selecting the filters.

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -129,9 +129,11 @@ class SearchController extends Controller
                 $lastModified = $data->getLastModified();
                 $created = $data->getCreated();
                 $query = new Query();
-                $criteria = [
-                    new Criterion\FullText($queryString),
-                ];
+                $criteria = [];
+
+                if (null !== $queryString) {
+                    $criteria[] = new Criterion\FullText($queryString);
+                }
                 if (null !== $section) {
                     $criteria[] = new Criterion\SectionId($section->id);
                 }
@@ -152,7 +154,10 @@ class SearchController extends Controller
                         [$created['start_date'], $created['end_date']]
                     );
                 }
-                $query->filter = new Criterion\LogicalAnd($criteria);
+                if (!empty($criteria)) {
+                    $query->filter = new Criterion\LogicalAnd($criteria);
+                }
+
                 $query->sortClauses[] = new SortClause\DateModified(Query::SORT_ASC);
 
                 $pagerfanta = new Pagerfanta(

--- a/src/lib/Form/Data/Search/SearchData.php
+++ b/src/lib/Form/Data/Search/SearchData.php
@@ -25,11 +25,7 @@ class SearchData
     /** @var int */
     private $page;
 
-    /**
-     * @var string
-     *
-     * @Assert\NotBlank()
-     */
+    /** @var string */
     private $query;
 
     /** @var \eZ\Publish\API\Repository\Values\Content\Section */

--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -33,7 +33,7 @@ class SearchType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('query', CoreSearchType::class)
+            ->add('query', CoreSearchType::class, ['required' => false])
             ->add('page', HiddenType::class)
             ->add('limit', HiddenType::class)
             ->add('section', SectionChoiceType::class, [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28945
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

User should be able to search for content items by just selecting the filters and applying the changes.

<img width="1059" alt="screen shot 2018-03-20 at 10 51 53 am" src="https://user-images.githubusercontent.com/1654712/37649347-c561265c-2c31-11e8-9f71-6a4a9f769596.png">


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
