### PR TITLE
EZP-28973: Modal close button harmonization review

### DIFF
--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -74,10 +74,14 @@
 }
 
 .ez-card__header {
-    .ez-icon {
-        width: 1.2rem;
-        height: 1.2rem;
-        fill: $white;
+    .form-inline {
+        .btn-danger {
+            .ez-icon {
+                width: 1.2rem;
+                height: 1.2rem;
+                fill: $white;
+            }
+        }
     }
 }
 

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -54,7 +54,9 @@
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'search.date.range'|trans|desc('Select date range') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">
@@ -84,7 +86,9 @@
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'search.date.range'|trans|desc('Select date range') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
                 </button>
             </div>
             <div class="modal-body">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28973](https://jira.ez.no/browse/EZP-28973)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Three more modal close buttons needed to be included for harmonization based on QA feedback, Search filters custom range (`ez-modal--select-modified-range`) and content type editing view delete confirmation modal.

![screen shot 2018-03-20 at 11 05 56 am](https://user-images.githubusercontent.com/9256718/37663690-239b93d0-2c30-11e8-8b9f-e4ac78640986.png)
![screen shot 2018-03-20 at 11 07 01 am](https://user-images.githubusercontent.com/9256718/37663696-270bc67a-2c30-11e8-89d9-99cb424b77ff.png)
![screen shot 2018-03-20 at 11 08 46 am](https://user-images.githubusercontent.com/9256718/37663709-2d05655e-2c30-11e8-89eb-7d66d86cbe1b.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
