### PR TITLE
EZP-28982: Modal Send to trash content update

### DIFF
--- a/src/bundle/Resources/public/scss/_card.scss
+++ b/src/bundle/Resources/public/scss/_card.scss
@@ -17,7 +17,6 @@
     &__header {
         background-color: $ez-color-base-pale;
         color: $ez-black;
-        font-weight: 700;
         border-radius: .25rem .25rem 0 0;
         padding: .75rem 1.25rem .5rem 1.25rem;
 

--- a/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
@@ -4,7 +4,6 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">{{ 'content_type.modal.title'|trans|desc('Please confirm') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <svg class="ez-icon ez-icon--medium" aria-hidden="true">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
@@ -12,11 +11,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <p>{{ 'content_type.field_definitions.modal.message'|trans|desc('Do you want to delete selected field definitions?') }}</p>
+                <p class="ez-modal-body__main">{{ 'content_type.field_definitions.modal.message'|trans|desc('Do you want to delete selected field definitions?') }}</p>
             </div>
             <div class="modal-footer">
-                {{ form_widget(form.removeFieldDefinition, { attr: { class: 'btn btn-danger'}, label: 'modal.delete'|trans|desc('Delete')}) }}
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">{{ 'modal.cancel'|trans|desc('Cancel') }}</button>
+                {{ form_widget(form.removeFieldDefinition, { attr: { class: 'btn btn-danger'}, label: 'modal.delete'|trans|desc('Delete')}) }}
             </div>
         </div>
     </div>

--- a/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
@@ -2,7 +2,6 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">{{ 'modal.title'|trans|desc('Please confirm') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <svg class="ez-icon ez-icon--medium" aria-hidden="true">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
@@ -10,7 +9,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <p>{{ message }}</p>
+                <p class="ez-modal-body__main">{{ message }}</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28982](https://jira.ez.no/browse/EZP-28982)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspects:
- Update content from Send to trash URL for consistency purposes;
- Update content  and color from Send to trash field type when in Content type editing view.

![screen shot 2018-03-20 at 1 57 33 pm](https://user-images.githubusercontent.com/9256718/37673920-e1ac3926-2c47-11e8-8126-1ab2f986d325.png)
![screen shot 2018-03-20 at 2 01 52 pm](https://user-images.githubusercontent.com/9256718/37673925-e54f5de2-2c47-11e8-9cb1-abf74768cb06.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
