### PR TITLE
EZP-28362: Display Language name and not language code.

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -30,6 +30,10 @@ services:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'user' }
 
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\Languages:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'languages' }
+
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module\UniversalDiscoveryWidget:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'universalDiscoveryWidget' }

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -23,7 +23,7 @@
                 <td class="ez-checkbox-cell">{{ form_widget(form_custom_url_remove.url_aliases[custom_url.id]) }}</td>
                 <td>{{ custom_url.path }}</td>
                 <td>
-                    {% for languageCode in custom_url.languageCodes %}{{ languageCode }}<br>{% endfor %}
+                    {% for languageCode in custom_url.languageCodes %}{{ admin_ui_config.languages.map[languageCode].name }}<br>{% endfor %}
                 </td>
                 <td>
                     {% if custom_url.forward %}
@@ -59,7 +59,7 @@
             <tr>
                 <td>{{ system_url.path }}</td>
                 <td>
-                    {% for languageCode in system_url.languageCodes %}{{ languageCode }}<br>{% endfor %}
+                    {% for languageCode in system_url.languageCodes %}{{ admin_ui_config.languages.map[languageCode].name }}<br>{% endfor %}
                 </td>
             </tr>
         {% endfor %}

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -17,7 +17,7 @@
             <tr>
                 <td>{{ row.name }}</td>
                 <td>{{ row.type }}</td>
-                <td>{{ row.language }}</td>
+                <td>{{ admin_ui_config.languages.map[row.language].name }}</td>
                 <td>{{ row.version }}</td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Publish\API\Repository\LanguageService;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+/**
+ * Provides information about languages.
+ */
+class Languages implements ProviderInterface
+{
+    /** @var LanguageService */
+    private $languageService;
+
+    /**
+     * @param LanguageService $languageService
+     */
+    public function __construct(LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return [
+            'map' => $this->getLanguagesMap(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getLanguagesMap(): array
+    {
+        $languagesMap = [];
+
+        foreach ($this->languageService->loadLanguages() as $language) {
+            $languagesMap[$language->languageCode] = [
+                'name' => $language->name,
+                'id' => $language->id,
+                'languageCode' => $language->languageCode,
+                'enabled' => $language->enabled,
+            ];
+        }
+
+        return $languagesMap;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28362
| Requires    | https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/59
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Display language name instead of language code.

<img width="988" alt="screen shot 2018-03-21 at 10 42 52 am" src="https://user-images.githubusercontent.com/1654712/37703046-a6237a92-2cf4-11e8-9294-1ab012932eb7.png">
<img width="1038" alt="screen shot 2018-03-21 at 10 42 34 am" src="https://user-images.githubusercontent.com/1654712/37703047-a6476e52-2cf4-11e8-9a3f-db1f663c00aa.png">

#### Checklist:
- [x] Dashboard - Drafts table in the 'Me' widget
- [x] Sub-items table
- [x] Custom URL Alias table and
- [x] System URL table
- [x] UDW - Content Meta Preview
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review (backend part)
