### PR TITLE
EZP-28915: Hardcoded Administrator in content edit details section

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -21,7 +21,10 @@
         </h1>
 
         <div class="small">
-            {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ content.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
+            {{ contentType.name }} /
+            {% if creator is not null %}{{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }} /{% endif %}
+            {{ content.versionInfo.contentInfo.publishedDate|localizeddate('medium', 'medium', app.request.locale) }} /
+            {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
             {% if isPublished == false %}
                 {{ 'parent_location_id'|trans({'%locationId%': parentLocation.id})|desc('Parent Location ID: %locationId%') }}
             {% else %}

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -13,7 +13,10 @@
         </h1>
 
         <div class="small">
-            {{ contentType.name }} / {{ 'created_by'|trans({'%name%': 'Administrator'})|desc('Created by %name%') }} / {{ user.versionInfo.creationDate|localizeddate('medium', 'medium', app.request.locale) }} / {{ 'content_id'|trans({'%contentId%': user.id})|desc('Content ID: %contentId%') }}{% if user.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': user.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
+            {{ contentType.name }} /
+            {% if creator is not null %}{{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }} /{% endif %}
+            {{ user.versionInfo.contentInfo.publishedDate|localizeddate('medium', 'medium', app.request.locale) }} /
+            {{ 'content_id'|trans({'%contentId%': user.id})|desc('Content ID: %contentId%') }}{% if user.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': user.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
         </div>
         {# @todo remove if statement once getDescription() bug is resolved in kernel #}
         {% if contentType.descriptions is not empty %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28915
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Now Content Item creator name is displayed. It comes from Content Item ownerId field. Displayed date near creator information is changed to contentInfo publishedDate.

<img width="1061" alt="screen shot 2018-03-22 at 4 35 30 pm" src="https://user-images.githubusercontent.com/1654712/37781026-401ecae2-2df0-11e8-892f-3f25a65490fc.png">

<img width="1261" alt="screen shot 2018-03-23 at 9 12 27 am" src="https://user-images.githubusercontent.com/1654712/37818429-653b8e52-2e7a-11e8-87d8-f74c71975fb0.png">

#### Checklist:
- [x] Content edit view
- [x] User edit view
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

