### PR TITLE
EZP-28999: Object state set button style update

### DIFF
--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -40,10 +40,22 @@ form:not(.form-inline) {
 }
 
 .ez-form-inline {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-end;
+
     .col-form-label,
     .form-control,
     .form-control-label {
         margin-right: .5rem;
+    }
+}
+
+.ez-table--no-border {
+    .ez-form-inline {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: flex-start;
     }
 }
 

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -112,13 +112,13 @@
                         'contentInfoId': contentInfo.id,
                         'objectStateGroupId': objectState.objectStateGroup.id
                     }),
-                    'attr': {'class': 'form-inline'}
+                    'attr': {'class': 'form-inline ez-form-inline'}
                 }) }}
                 {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
                 {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}
                 {{ form_row(form_state_update[objectState.objectStateGroup.id].objectState) }}
 
-                <button type="submit" class="btn btn-primary ml-1"{% if not state_update_disabled[objectState.objectStateGroup.id] %}data-disabled{% endif %}>
+                <button type="submit" class="btn btn-secondary"{% if not state_update_disabled[objectState.objectStateGroup.id] %}data-disabled{% endif %}>
                     {{ 'tab.details.sub_items_listing_by_set'|trans|desc('Set') }}
                 </button>
 
@@ -150,7 +150,7 @@
                 {{ form_label(form_location_update.sort_order, 'tab.details.sub_items_listing_by.in'|trans|desc('in')) }}
                 {{ form_widget(form_location_update.sort_order) }}
 
-                {{ form_widget(form_location_update.update, { 'label': 'tab.details.sub_items_listing_by_set'|trans|desc('Set'), 'translation_domain': false, 'attr': {'class': 'btn-secondary ml-1'} }) }}
+                {{ form_widget(form_location_update.update, { 'label': 'tab.details.sub_items_listing_by_set'|trans|desc('Set'), 'translation_domain': false, 'attr': {'class': 'btn-secondary'} }) }}
 
             {{ form_end(form_location_update) }}
         </td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28999](https://jira.ez.no/browse/EZP-28999)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Update Object state set button style update to `btn-secondary` in order to align with the rest of UI

![screen shot 2018-03-22 at 2 35 19 pm](https://user-images.githubusercontent.com/9256718/37791508-c9ae2020-2ddf-11e8-8883-8613364e7fcd.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
