### PR TITLE
EZP-28439: Related content is still displayed after it is moved to trash

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -85,12 +85,15 @@ class ContentViewController extends Controller
         // JIRA ref: https://jira.ez.no/browse/EZP-28190
         $view->setCacheEnabled(false);
 
-        $this->supplyPathLocations($view);
+        if (!$view->getContent()->contentInfo->isTrashed()) {
+            $this->supplyPathLocations($view);
+            $this->subitemsContentViewParameterSupplier->supply($view);
+        }
+
         $this->supplyContentType($view);
         $this->supplyContentActionForms($view);
 
         $this->supplyDraftPagination($view, $request);
-        $this->subitemsContentViewParameterSupplier->supply($view);
 
         return $view;
     }

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -41,6 +41,11 @@
         <target state="new">User Preferences</target>
         <note>key: breadcrumb.user_preferences</note>
       </trans-unit>
+      <trans-unit id="fb19ae886e63bac3aa3b851ac00aae8a3b777992" resname="content.in_trash">
+        <source>In Trash</source>
+        <target state="new">In Trash</target>
+        <note>key: content.in_trash</note>
+      </trans-unit>
       <trans-unit id="fe1c876b1a9bcde155f03227bce4ae4fbd54c24f" resname="custom_url_alias_add_form.add">
         <source>Create</source>
         <target state="new">Create</target>

--- a/src/bundle/Resources/views/fieldtypes/preview/ezobjectrelationlist_row.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/ezobjectrelationlist_row.html.twig
@@ -1,5 +1,12 @@
 <td>
-    <a href="{{ path('_ezpublishLocation', { 'locationId': locationId } ) }}">{{ content.getName() }}</a>
+    <a {% if not content.contentInfo.trashed %}
+        href="{{ path('_ezpublishLocation', { 'locationId': locationId } ) }}"
+    {% endif %}>
+        {{ content.getName() }}
+        {% if content.contentInfo.trashed %}
+            <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
+        {% endif %}
+    </a>
 </td>
 <td>
     {{ contentType.getName() }}


### PR DESCRIPTION
### **Depends on:** https://github.com/ezsystems/ezpublish-kernel/pull/2287 


| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28439](https://jira.ez.no/browse/EZP-28439), (with Kernel it also solves [EZP-28781](https://jira.ez.no/browse/EZP-28781) and [EZP-28865](https://jira.ez.no/browse/EZP-28865))
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review