### PR TITLE
EZP-29008: Number and language in the same line on Details tab of CI

### DIFF
--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -32,7 +32,7 @@
             ({{ versionInfo.modificationDate|localizeddate('medium', 'short', app.request.locale) }})
         </td>
         <td>{{ versionInfo.versionNo }}</td>
-        <td>{{ translations|length }}
+        <td>
             {% for translation in translations %}
                 {{ translation.name }}<br>
             {% endfor %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29008
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | yes
| Tests pass?   |yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Number and language in the same line on Details tab of CI


<img width="1178" alt="screen shot 2018-03-23 at 10 18 57 am" src="https://user-images.githubusercontent.com/1654712/37821351-a56aa478-2e83-11e8-9876-1466e046eca3.png">



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
