### PR TITLE
EZP-28671: Draft in other language is displayed with eng-GB

### DIFF
--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -17,7 +17,12 @@
             <tr>
                 <td>{{ row.name }}</td>
                 <td>{{ row.type }}</td>
-                <td>{{ admin_ui_config.languages.map[row.language].name }}</td>
+                <td>
+                    {% for languageCode in row.languageList %}
+                        {{ admin_ui_config.languages.map[languageCode].name }}
+                        <br/>
+                    {% endfor %}
+                </td>
                 <td>{{ row.version }}</td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">

--- a/src/lib/Tab/Dashboard/MyDraftsTab.php
+++ b/src/lib/Tab/Dashboard/MyDraftsTab.php
@@ -107,6 +107,7 @@ class MyDraftsTab extends AbstractTab implements OrderedTabInterface
                 'name' => $version->getName(),
                 'type' => $contentType->getName(),
                 'language' => $version->initialLanguageCode,
+                'languageList' => $version->languageCodes,
                 'version' => $version->versionNo,
                 'modified' => $version->modificationDate,
             ];


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28671
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
