### PR TITLE
EZP-28181: Inconsistence with labels in content type specific view

### DIFF
--- a/features/ContentType.feature
+++ b/features/ContentType.feature
@@ -35,7 +35,7 @@ Feature: Content types management
       | label                | value    |
       | Name                 | Test CT  |
       | Identifier           | iTestCT  |
-      | Content name schema  | <name>   |
+      | Content name pattern | <name>   |
       And Content Type "Test CT" has field "CountryField" of type "ezcountry"
       And notification that "Content type" "Test CT" is updated appears
 
@@ -68,7 +68,7 @@ Feature: Content types management
       | label                | value           |
       | Name                 | Test CT edited  |
       | Identifier           | iTestCT         |
-      | Content name schema  | <name>          |
+      | Content name pattern | <name>          |
       And Content Type "Test CT" has proper fields
       | fieldName      | fieldType |
       | CountryField   | ezcountry |

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -27,8 +27,8 @@
         <note>key: content_type.container</note>
       </trans-unit>
       <trans-unit id="693f9ade0c2bb6a7c19b6f9b818d96aa23f1e013" resname="content_type.default_availability">
-        <source>Default availability</source>
-        <target state="new">Default availability</target>
+        <source>Default content availability</source>
+        <target state="new">Default content availability</target>
         <note>key: content_type.default_availability</note>
       </trans-unit>
       <trans-unit id="3b3fc626a669a5462ec9fa7c94280a3573d8b106" resname="content_type.default_availability.help">
@@ -87,8 +87,8 @@
         <note>key: content_type.name</note>
       </trans-unit>
       <trans-unit id="9e9628fc59643f3167ebe81dfed3e40eecd281c9" resname="content_type.name_schema">
-        <source>Content name schema</source>
-        <target state="new">Content name schema</target>
+        <source>Content name pattern</source>
+        <target state="new">Content name pattern</target>
         <note>key: content_type.name_schema</note>
       </trans-unit>
       <trans-unit id="da59e6ae77cae375a30d7285970b1b2d9690049e" resname="content_type.sort_field.ascending">

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -48,7 +48,7 @@
                 <td>{{ content_type.descriptions[language_code]|default('') }}</td>
             </tr>
             <tr>
-                <th>{{ "content_type.name_schema"|trans|desc("Content name schema") }}</th>
+                <th>{{ "content_type.name_schema"|trans|desc("Content name pattern") }}</th>
                 <td>{{ content_type.nameSchema }}</td>
             </tr>
             <tr>
@@ -71,7 +71,7 @@
             </tr>
             <tr>
                 <th>
-                    {{ "content_type.default_availability"|trans|desc('Default availability') }}
+                    {{ "content_type.default_availability"|trans|desc('Default content availability') }}
                     <p class="text-secondary small">
                         {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                     </p>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28181
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Labels changes in the Content Type View. 'Content name schema' to 'Content name pattern'
and 'Default availability' to 'Default content availability'

<img width="1004" alt="screen shot 2018-03-23 at 11 33 50 am" src="https://user-images.githubusercontent.com/1654712/37828409-67cfd328-2e9b-11e8-9c16-7a0046a75431.png">



#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
