### PR TITLE
EZP-28803: Edit button in sections is not aligned to the right

### DIFF
--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -56,10 +56,10 @@
             <td>{{ section.name }}</td>
             <td>{{ section.identifier }}</td>
             <td>{{ section.id }}</td>
-            <td class="text-center">
+            <td class="text-right">
                 <a href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
                    title="{{ 'section.edit'|trans|desc('Edit') }}"
-                   class="btn btn-icon"{% if not can_edit %} data-disabled{% endif %}>
+                   class="btn btn-icon mx-3"{% if not can_edit %} data-disabled{% endif %}>
                     <svg class="ez-icon ez-icon-edit">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                     </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28803
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Edit button in sections is aligned to the right


<img width="1037" alt="screen shot 2018-03-26 at 11 08 01 am" src="https://user-images.githubusercontent.com/1654712/37897676-019c5c36-30e7-11e8-8592-d15d37fed2e6.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
