### PR TITLE
EZP-29019: "Send to trash" action should be disabled when user doesn't have sufficient permission

### DIFF
--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -103,7 +103,13 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         $canDelete = $this->permissionResolver->canUser(
             'content',
             'remove',
-            $options['content']
+            $content
+        );
+        $canTrashLocation = $this->permissionResolver->canUser(
+            'content',
+            'manage_locations',
+            $location->getContentInfo(),
+            [$location]
         );
 
         $createAttributes = [
@@ -116,8 +122,12 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
             'data-actions' => 'edit',
         ];
         $deleteAttributes = [
-                'data-toggle' => 'modal',
-                'data-target' => '#delete-user-modal',
+            'data-toggle' => 'modal',
+            'data-target' => '#delete-user-modal',
+        ];
+        $sendToTrashAttributes = [
+            'data-toggle' => 'modal',
+            'data-target' => '#trash-location-modal',
         ];
 
         $menu->setChildren([
@@ -183,10 +193,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     self::ITEM__SEND_TO_TRASH,
                     [
                         'extras' => ['icon' => 'trash-send'],
-                        'attributes' => [
-                            'data-toggle' => 'modal',
-                            'data-target' => '#trash-location-modal',
-                        ],
+                        'attributes' => $canTrashLocation ?
+                            $sendToTrashAttributes
+                            : array_merge($sendToTrashAttributes, ['disabled' => 'disabled']),
                     ]
                 )
             );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29019
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
