### PR TITLE
EZP-29010: Move Content on the Fly common configuration to root namespace od AdminUI config

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -34,6 +34,10 @@ services:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'languages' }
 
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypes:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'contentTypes' }
+
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module\UniversalDiscoveryWidget:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'universalDiscoveryWidget' }

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -23,7 +23,7 @@
                 <td class="ez-checkbox-cell">{{ form_widget(form_custom_url_remove.url_aliases[custom_url.id]) }}</td>
                 <td>{{ custom_url.path }}</td>
                 <td>
-                    {% for languageCode in custom_url.languageCodes %}{{ admin_ui_config.languages.map[languageCode].name }}<br>{% endfor %}
+                    {% for languageCode in custom_url.languageCodes %}{{ admin_ui_config.languages.mappings[languageCode].name }}<br>{% endfor %}
                 </td>
                 <td>
                     {% if custom_url.forward %}
@@ -59,7 +59,7 @@
             <tr>
                 <td>{{ system_url.path }}</td>
                 <td>
-                    {% for languageCode in system_url.languageCodes %}{{ admin_ui_config.languages.map[languageCode].name }}<br>{% endfor %}
+                    {% for languageCode in system_url.languageCodes %}{{ admin_ui_config.languages.mappings[languageCode].name }}<br>{% endfor %}
                 </td>
             </tr>
         {% endfor %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -32,7 +32,7 @@
                 {{ version.versionNo }}
             </td>
             <td>
-                {{ admin_ui_config.languages.map[version.initialLanguageCode].name }}
+                {{ admin_ui_config.languages.mappings[version.initialLanguageCode].name }}
             </td>
             <td>
                 {% if version.author is not empty %}

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -17,7 +17,7 @@
             <tr>
                 <td>{{ row.name }}</td>
                 <td>{{ row.type }}</td>
-                <td>{{ admin_ui_config.languages.map[row.language].name }}</td>
+                <td>{{ admin_ui_config.languages.mappings[row.language].name }}</td>
                 <td>{{ row.version }}</td>
                 <td>{{ row.modified|date('M d, Y h:iA') }}</td>
                 <td class="text-center">

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+class ContentTypes implements ProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     */
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @return mixed Anything that is serializable via json_encode()
+     */
+    public function getConfig()
+    {
+        $contentTypeGroups = [];
+
+        foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
+            foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+                $contentTypeGroups[$contentTypeGroup->identifier][] = [
+                    'identifier' => $contentType->identifier,
+                    'name' => $contentType->getName(),
+                ];
+            }
+        }
+
+        return $contentTypeGroups;
+    }
+}

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
 
 use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 
 /**
@@ -16,15 +17,22 @@ use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
  */
 class Languages implements ProviderInterface
 {
-    /** @var LanguageService */
+    /** @var \eZ\Publish\API\Repository\LanguageService */
     private $languageService;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
     /**
-     * @param LanguageService $languageService
+     * @param \eZ\Publish\API\Repository\LanguageService $languageService
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      */
-    public function __construct(LanguageService $languageService)
-    {
+    public function __construct(
+        LanguageService $languageService,
+        ConfigResolverInterface $configResolver
+    ) {
         $this->languageService = $languageService;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -33,7 +41,8 @@ class Languages implements ProviderInterface
     public function getConfig(): array
     {
         return [
-            'map' => $this->getLanguagesMap(),
+            'mappings' => $this->getLanguagesMap(),
+            'priority' => $this->getLanguagesPriority(),
         ];
     }
 
@@ -54,5 +63,41 @@ class Languages implements ProviderInterface
         }
 
         return $languagesMap;
+    }
+
+    /**
+     * Returns list of languages in a prioritized form.
+     *
+     * First: languages that are main of siteaccesses are displayed first.
+     * Next: fallback languages of siteaccesses.
+     * Last: languages defined but not used in siteaccesses.
+     *
+     * @return array
+     */
+    protected function getLanguagesPriority(): array
+    {
+        $priority = [];
+        $fallback = [];
+        $siteAccesses = $this->configResolver->getParameter('list', 'ezpublish', 'siteaccess');
+
+        foreach ($siteAccesses as $siteAccess) {
+            $siteAccessLanguages = $this->configResolver->getParameter('languages', null, $siteAccess);
+            $priority[] = array_shift($siteAccessLanguages);
+            $fallback = array_merge($fallback, $siteAccessLanguages);
+        }
+
+        // Append fallback languages at the end of priority language list
+        $languageCodes = array_unique(array_merge($priority, $fallback));
+        $languagesMap = $this->getLanguagesMap();
+
+        $languages = array_filter(array_values($languageCodes), function ($languageCode) use ($languagesMap) {
+            // Get only Languages defined and enabled in Admin
+            return isset($languagesMap[$languageCode]) && $languagesMap[$languageCode]['enabled'];
+        });
+
+        // Languages that are not configured in any of SiteAccess but user is still able to create content
+        $unused = array_diff(array_keys($languagesMap), $languages);
+
+        return array_merge($languages, $unused);
     }
 }

--- a/src/lib/UI/Config/Provider/Module/UniversalDiscoveryWidget.php
+++ b/src/lib/UI/Config/Provider/Module/UniversalDiscoveryWidget.php
@@ -48,7 +48,6 @@ class UniversalDiscoveryWidget implements ProviderInterface
         /* config structure has to reflect UDW module's config structure */
         return [
             'startingLocationId' => $this->getStartingLocationId(),
-            'contentOnTheFly' => $this->getContentOnTheFlyConfiguration(),
         ];
     }
 
@@ -60,35 +59,5 @@ class UniversalDiscoveryWidget implements ProviderInterface
         return $this->configResolver->getParameter(
             'universal_discovery_widget_module.default_location_id'
         );
-    }
-
-    /**
-     * @return array
-     */
-    protected function getContentOnTheFlyConfiguration(): array
-    {
-        $languages = [];
-        foreach ($this->languageService->loadLanguages() as $language) {
-            $languages[] = [
-                'languageCode' => $language->languageCode,
-                'name' => $language->name,
-            ];
-        }
-
-        $contentTypeGroups = [];
-
-        foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
-            foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
-                $contentTypeGroups[$contentTypeGroup->identifier][] = [
-                    'identifier' => $contentType->identifier,
-                    'name' => $contentType->getName(),
-                ];
-            }
-        }
-
-        return [
-            'languages' => $languages,
-            'contentTypes' => $contentTypeGroups,
-        ];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29010
| Requires/QA    | https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/61
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review