### PR TITLE
EZP-28980: When restoring a trash item under a new parent, the user should not be able to select multiple location in the UDW

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.trash.list.js
+++ b/src/bundle/Resources/public/js/scripts/admin.trash.list.js
@@ -25,7 +25,8 @@
             title: 'Select a location to restore you content item(s)',
             startingLocationId: window.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
             allowContainersOnly: true,
-            restInfo: {token, siteaccess}
+            restInfo: {token, siteaccess},
+            multiple: false
         }), udwContainer);
     };
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28980
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Ready for Code Review
