### PR TITLE
EZP-29046: As an Editor, I want to have "Content field definitions" header sticky to the top

### DIFF
--- a/src/bundle/Resources/public/scss/_card.scss
+++ b/src/bundle/Resources/public/scss/_card.scss
@@ -24,6 +24,12 @@
             color: $ez-secondary-ground-medium;
             font-weight: 400;
         }
+
+        &--sticky-top {
+            position: sticky;
+            top: 0;
+            z-index: 9999;
+        }
     }
 
     &__body {

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -43,7 +43,7 @@
 
     <section class="container mt-4 px-5">
         <div class="card ez-card">
-            <div class="ez-card__header ez-card__header--secondary d-flex justify-content-between">
+            <div class="ez-card__header ez-card__header--sticky-top ez-card__header--secondary d-flex justify-content-between" style="position: sticky; top: 0; z-index: 9999;">
                 <div class="p-2">
                     {{ 'content_type.view.edit.content_field_definitions'|trans|desc('Content field definitions') }}
                 </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29046
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->

<img width="1193" alt="screen shot 2018-03-29 at 2 10 49 pm" src="https://user-images.githubusercontent.com/1654712/38088130-075796d8-335b-11e8-8dae-cc37bd0f78f1.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
