### PR TITLE
EZEE-1610: Ignore Language Picker for Content with one Language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
         - php: 7.1
           env: BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction" SYMFONY_ENV=behat
 
+cache:
+    directories:
+      - $HOME/.composer/cache
+
 env:
   global:
     # For acceptance tests

--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -13,6 +13,7 @@ use EzSystems\EzPlatformAdminUi\Behat\PageElement\RightMenu;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\UniversalDiscoveryWidget;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\ContentStructurePage;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\PageObjectFactory;
+use EzSystems\EzPlatformAdminUi\UI\Value\Content\Language;
 use PHPUnit\Framework\Assert;
 
 class ContentViewContext extends BusinessContext
@@ -50,9 +51,12 @@ class ContentViewContext extends BusinessContext
         $rightMenu = new RightMenu($this->utilityContext);
         $rightMenu->clickButton('Edit');
 
-        $languagePicker = new LanguagePicker($this->utilityContext);
+        $languagePicker = ElementFactory::createElement($this->utilityContext, LanguagePicker::ELEMENT_NAME);
 
         if ($languagePicker->isVisible()) {
+            $availableLanguages = $languagePicker->getLanguages();
+            Assert::assertGreaterThan(1, count($availableLanguages));
+            Assert::assertContains($language, $availableLanguages);
             $languagePicker->chooseLanguage($language);
         }
     }

--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -42,15 +42,19 @@ class ContentViewContext extends BusinessContext
     }
 
     /**
+     * @given I start editing the content
      * @Given I start editing the content in :language language
      */
-    public function startEditingContent(string $language): void
+    public function startEditingContent(string $language = null): void
     {
         $rightMenu = new RightMenu($this->utilityContext);
         $rightMenu->clickButton('Edit');
 
         $languagePicker = new LanguagePicker($this->utilityContext);
-        $languagePicker->chooseLanguage($language);
+
+        if ($languagePicker->isVisible()) {
+            $languagePicker->chooseLanguage($language);
+        }
     }
 
     /**

--- a/src/lib/Behat/Helper/UtilityContext.php
+++ b/src/lib/Behat/Helper/UtilityContext.php
@@ -23,7 +23,7 @@ class UtilityContext extends MinkContext
      * @param string $cssSelector
      * @param int $timeout
      *
-     * @throws Exception when element not found
+     * @throws Exception when element not found or is not visible
      */
     public function waitUntilElementIsVisible(string $cssSelector, int $timeout = 5): void
     {

--- a/src/lib/Behat/PageElement/ElementFactory.php
+++ b/src/lib/Behat/PageElement/ElementFactory.php
@@ -7,6 +7,8 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\FlexWorkflow\Behat\PageElement\OldSendForReviewForm;
+use EzSystems\StudioUIBundle\Tests\Behat\PageElement\ConfirmationPopup;
 
 class ElementFactory
 {
@@ -16,7 +18,7 @@ class ElementFactory
      * @param UtilityContext $context
      * @param string $elementName Name of the Element to creator
      *
-     * @return AdminList|Dialog|RightMenu|UpperMenu|UpdateForm|Breadcrumb|Notification|NavLinkTabs|UniversalDiscoveryWidget Element to interact with
+     * @return AdminList|Dialog|RightMenu|UpperMenu|UpdateForm|Breadcrumb|Notification|NavLinkTabs|UniversalDiscoveryWidget|LanguagePicker|OldSendForReviewForm|ConfirmationPopup Element to interact with
      */
     public static function createElement(UtilityContext $context, string $elementName, ?string ...$parameters): Element
     {
@@ -51,8 +53,14 @@ class ElementFactory
                 return new DoubleHeaderTable($context, $parameters[0]);
             case NavLinkTabs::ELEMENT_NAME:
                 return new NavLinkTabs($context);
+            case LanguagePicker::ELEMENT_NAME:
+                return new LanguagePicker($context);
             case UniversalDiscoveryWidget::ELEMENT_NAME:
                 return new UniversalDiscoveryWidget($context);
+            case OldSendForReviewForm::ELEMENT_NAME:
+                return new OldSendForReviewForm($context);
+            case ConfirmationPopup::ELEMENT_NAME:
+                return new ConfirmationPopup($context);
             default:
                 throw new \InvalidArgumentException(sprintf('Unrecognized element name: %s', $elementName));
         }

--- a/src/lib/Behat/PageElement/LanguagePicker.php
+++ b/src/lib/Behat/PageElement/LanguagePicker.php
@@ -6,11 +6,15 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
+use Behat\Mink\Element\NodeElement;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use WebDriver\Exception\ElementNotVisible;
 
 class LanguagePicker extends Element
 {
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'LanguagePicker';
+
     private $loadingTimeout;
 
     public function __construct(UtilityContext $context)
@@ -23,12 +27,19 @@ class LanguagePicker extends Element
         $this->loadingTimeout = 5;
     }
 
-    public function chooseLanguage($language)
+    public function chooseLanguage($language): void
     {
         $this->context->getElementByText($language, $this->fields['languageSelector'])->click();
     }
 
-    public function isVisible()
+    public function getLanguages(): array
+    {
+        return array_map(function (NodeElement $element) {
+            return $element->getText();
+        }, $this->context->findAllWithWait($this->fields['languageSelector']));
+    }
+
+    public function isVisible(): bool
     {
         try {
             $this->context->waitUntilElementIsVisible($this->fields['languagePickerSelector'], $this->loadingTimeout);

--- a/src/lib/Behat/PageElement/LanguagePicker.php
+++ b/src/lib/Behat/PageElement/LanguagePicker.php
@@ -7,19 +7,35 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use WebDriver\Exception\ElementNotVisible;
 
 class LanguagePicker extends Element
 {
+    private $loadingTimeout;
+
     public function __construct(UtilityContext $context)
     {
         parent::__construct($context);
         $this->fields = [
+            'languagePickerSelector' => '#content_edit_language',
             'languageSelector' => '#content_edit_language .form-check-label',
         ];
+        $this->loadingTimeout = 5;
     }
 
     public function chooseLanguage($language)
     {
         $this->context->getElementByText($language, $this->fields['languageSelector'])->click();
+    }
+
+    public function isVisible()
+    {
+        try {
+            $this->context->waitUntilElementIsVisible($this->fields['languagePickerSelector'], $this->loadingTimeout);
+
+            return true;
+        } catch (ElementNotVisible $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-1610
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This change is for 1.1 - since 2.1 release, the Language Picker is not visible if Content has only one language.

This is required by: https://github.com/ezsystems/flex-workflow/pull/97/files

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
