### PR TITLE
(WIP) Implemented abstract labels based on i18n for custom tags

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -46,3 +46,20 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\FieldType\RichText\CustomTag:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'richTextCustomTags' }
+
+    EzSystems\EzPlatformAdminUi\UI\LabelMaker\RichTextCustomTagLabelMaker:
+        class: EzSystems\EzPlatformAdminUi\UI\LabelMaker\TranlationBasedLabelMaker
+        arguments:
+            $config:
+                domain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
+                patterns:
+                    label: 'ezrichtext.custom_tags.%%s.label'
+                    description: 'ezrichtext.custom_tags.%%s.description'
+
+    EzSystems\EzPlatformAdminUi\UI\LabelMaker\RichTextCustomTagAttributeLabelMaker:
+        class: EzSystems\EzPlatformAdminUi\UI\LabelMaker\TranlationBasedLabelMaker
+        arguments:
+            $config:
+                domain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
+                patterns:
+                    label: 'ezrichtext.custom_tags.%%s.attributes.%%s.label'

--- a/src/bundle/Resources/config/services/ui_config/mappers.yml
+++ b/src/bundle/Resources/config/services/ui_config/mappers.yml
@@ -7,6 +7,7 @@ services:
         autowire: true
         arguments:
             $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
+            $richTextAttributeLabelMaker: '@EzSystems\EzPlatformAdminUi\UI\LabelMaker\RichTextCustomTagAttributeLabelMaker'
         tags:
             - { name: ezplatform.admin_ui.richtext_custom_tag_attribute_mapper, priority: 0 }
 
@@ -22,3 +23,4 @@ services:
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
             $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
             $customTagAttributeMappers: !tagged ezplatform.admin_ui.richtext_custom_tag_attribute_mapper
+            $labelMaker: '@EzSystems\EzPlatformAdminUi\UI\LabelMaker\RichTextCustomTagLabelMaker'

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -25,6 +25,7 @@ class CustomTag
 
     /**
      * @var TranslatorInterface
+     *
      * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
      */
     private $translator;
@@ -40,6 +41,7 @@ class CustomTag
 
     /**
      * @var string
+     *
      * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
      */
     private $translationDomain;

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
 
 use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\AttributeMapper;
+use EzSystems\EzPlatformAdminUi\UI\LabelMaker\LabelMaker;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -22,7 +23,10 @@ class CustomTag
     /** @var array */
     private $customTagsConfiguration;
 
-    /** @var TranslatorInterface */
+    /**
+     * @var TranslatorInterface
+     * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
+     */
     private $translator;
 
     /** @var Packages */
@@ -34,15 +38,22 @@ class CustomTag
     /** @var AttributeMapper[] */
     private $supportedTagAttributeMappersCache;
 
-    /** @var string */
+    /**
+     * @var string
+     * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
+     */
     private $translationDomain;
+
+    /** @var LabelMaker */
+    private $labelMaker;
 
     public function __construct(
         array $customTagsConfiguration,
         TranslatorInterface $translator,
         string $translationDomain,
         Packages $packages,
-        Traversable $customTagAttributeMappers
+        Traversable $customTagAttributeMappers,
+        LabelMaker $labelMaker
     ) {
         $this->customTagsConfiguration = $customTagsConfiguration;
         $this->translator = $translator;
@@ -50,6 +61,7 @@ class CustomTag
         $this->packages = $packages;
         $this->customTagAttributeMappers = $customTagAttributeMappers;
         $this->supportedTagAttributeMappersCache = [];
+        $this->labelMaker = $labelMaker;
     }
 
     /**
@@ -77,19 +89,8 @@ class CustomTag
                 );
             }
 
-            $config[$tagName]['label'] = $this->translator->trans(
-                sprintf('ezrichtext.custom_tags.%s.label', $tagName),
-                [],
-                $this->translationDomain
-            );
-            $config[$tagName]['description'] = $this->translator->trans(
-                sprintf(
-                    'ezrichtext.custom_tags.%s.description',
-                    $tagName
-                ),
-                [],
-                $this->translationDomain
-            );
+            $config[$tagName]['label'] = $this->labelMaker->getLabel('label', $tagName);
+            $config[$tagName]['description'] = $this->labelMaker->getLabel('description', $tagName, false);
 
             foreach ($customTagConfiguration['attributes'] as $attributeName => $properties) {
                 $typeMapper = $this->getAttributeTypeMapper(

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
@@ -18,12 +18,14 @@ class CommonAttributeMapper implements AttributeMapper
 {
     /**
      * @var TranslatorInterface
+     *
      * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
      */
     protected $translator;
 
     /**
      * @var string
+     *
      * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
      */
     protected $translationDomain;
@@ -69,6 +71,7 @@ class CommonAttributeMapper implements AttributeMapper
     /**
      * @param string $tagName
      * @param string $attributeName
+     *
      * @return string
      */
     private function getLabel(string $tagName, string $attributeName): string

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag;
 
+use EzSystems\EzPlatformAdminUi\UI\LabelMaker\LabelMaker;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -15,16 +16,30 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class CommonAttributeMapper implements AttributeMapper
 {
-    /** @var TranslatorInterface */
+    /**
+     * @var TranslatorInterface
+     * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
+     */
     protected $translator;
 
-    /** @var string */
+    /**
+     * @var string
+     * @deprecated Deprecated since v1.2.0. Label generation is now covered by a LabelMaker.
+     */
     protected $translationDomain;
+    /**
+     * @var LabelMaker
+     */
+    private $richTextAttributeLabelMaker;
 
-    public function __construct(TranslatorInterface $translator, string $translationDomain)
-    {
+    public function __construct(
+        TranslatorInterface $translator,
+        string $translationDomain,
+        LabelMaker $richTextAttributeLabelMaker = null
+    ) {
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
+        $this->richTextAttributeLabelMaker = $richTextAttributeLabelMaker;
     }
 
     /**
@@ -44,7 +59,23 @@ class CommonAttributeMapper implements AttributeMapper
         array $customTagAttributeProperties
     ): array {
         return [
-            'label' => $this->translator->trans(
+            'label' => $this->getLabel($tagName, $attributeName),
+            'type' => $customTagAttributeProperties['type'],
+            'required' => $customTagAttributeProperties['required'],
+            'defaultValue' => $customTagAttributeProperties['default_value'],
+        ];
+    }
+
+    /**
+     * @param string $tagName
+     * @param string $attributeName
+     * @return string
+     */
+    private function getLabel(string $tagName, string $attributeName): string
+    {
+        /** @deprecated v1.2.0 backward compatibility */
+        if ($this->richTextAttributeLabelMaker === null) {
+            return $this->translator->trans(
                 sprintf(
                     'ezrichtext.custom_tags.%s.attributes.%s.label',
                     $tagName,
@@ -52,10 +83,9 @@ class CommonAttributeMapper implements AttributeMapper
                 ),
                 [],
                 $this->translationDomain
-            ),
-            'type' => $customTagAttributeProperties['type'],
-            'required' => $customTagAttributeProperties['required'],
-            'defaultValue' => $customTagAttributeProperties['default_value'],
-        ];
+            );
+        }
+
+        return $this->richTextAttributeLabelMaker->getLabel('label', [$tagName, $attributeName]);
     }
 }

--- a/src/lib/UI/LabelMaker/LabelMaker.php
+++ b/src/lib/UI/LabelMaker/LabelMaker.php
@@ -1,0 +1,18 @@
+<?php
+namespace EzSystems\EzPlatformAdminUi\UI\LabelMaker;
+
+/**
+ * Makes human readable labels for UI items given an item and a label identifier.
+ */
+interface LabelMaker
+{
+    /**
+     * @param string $identifier Identifier of the label to make. Example: 'description'.
+     * @param string mixed $items Components of the generated item. Example: a custom tag's identifier & attribute.
+     * @param bool $generateDefault Wether or not to generate a default label if none is set.
+     * @return string The label if one exists.
+     *                If none exists, a default is built based on $defaultBase, unless it is set to false.
+     *
+     */
+    public function getLabel(string $identifier, $items, bool $generateDefault = true): string;
+}

--- a/src/lib/UI/LabelMaker/LabelMaker.php
+++ b/src/lib/UI/LabelMaker/LabelMaker.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformAdminUi\UI\LabelMaker;
 
 /**
@@ -9,10 +14,10 @@ interface LabelMaker
     /**
      * @param string $identifier Identifier of the label to make. Example: 'description'.
      * @param string mixed $items Components of the generated item. Example: a custom tag's identifier & attribute.
-     * @param bool $generateDefault Wether or not to generate a default label if none is set.
+     * @param bool $generateDefault wether or not to generate a default label if none is set
+     *
      * @return string The label if one exists.
      *                If none exists, a default is built based on $defaultBase, unless it is set to false.
-     *
      */
     public function getLabel(string $identifier, $items, bool $generateDefault = true): string;
 }

--- a/src/lib/UI/LabelMaker/TranlationBasedLabelMaker.php
+++ b/src/lib/UI/LabelMaker/TranlationBasedLabelMaker.php
@@ -1,0 +1,66 @@
+<?php
+namespace EzSystems\EzPlatformAdminUi\UI\LabelMaker;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Makes human readable labels using translations.
+ * The item and label identifier are prefixed with a configured string, and translated in a configured domain.
+ *
+ * Example: $labelMaker->getLabel($myCustomTag, 'description').
+ *
+ * If no translation exists, uses the
+ */
+class TranlationBasedLabelMaker implements LabelMaker
+{
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /** @var string[] */
+    private $patterns;
+
+    /** @var string */
+    private $domain;
+
+    public function __construct(TranslatorInterface $translator, array $config = [])
+    {
+        $this->translator = $translator;
+        $this->patterns = $config['patterns'];
+        $this->domain = $config['domain'];
+    }
+
+    public function getLabel(string $identifier, $items, bool $generateDefault = true): string
+    {
+        if (!is_array($items)) {
+            $items = [$items];
+        }
+
+        $key = $this->makeTranslationKey($items, $identifier);
+        $translation = $this->translator->trans($key, [], $this->domain);
+        if ($translation !== $key) {
+            return $translation;
+        }
+
+        if ($generateDefault === false) {
+            return '';
+        }
+
+        $defaultItem = array_pop($items);
+
+        return ucfirst(str_replace('_', ' ', $defaultItem));
+    }
+
+    /**
+     * @param array $items
+     * @param string $labelIdentifier
+     * @return string
+     */
+    private function makeTranslationKey(array $items, string $labelIdentifier): string
+    {
+        if (!isset($this->patterns[$labelIdentifier])) {
+            throw new \InvalidArgumentException(sprintf("No pattern set for '%s'", $labelIdentifier));
+        }
+
+        return vsprintf($this->patterns[$labelIdentifier], array_merge([$labelIdentifier], $items));
+    }
+}

--- a/src/lib/UI/LabelMaker/TranlationBasedLabelMaker.php
+++ b/src/lib/UI/LabelMaker/TranlationBasedLabelMaker.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformAdminUi\UI\LabelMaker;
 
 use Symfony\Component\Translation\TranslatorInterface;
@@ -53,6 +58,7 @@ class TranlationBasedLabelMaker implements LabelMaker
     /**
      * @param array $items
      * @param string $labelIdentifier
+     *
      * @return string
      */
     private function makeTranslationKey(array $items, string $labelIdentifier): string


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | None yet
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Adds abstraction around the usage of the Translator to generate items labels. The new implement has support for default labels if no translations are defined.

![before](https://user-images.githubusercontent.com/235928/38490102-729d785a-3be8-11e8-88aa-8bbe371a10a8.png)

![after](https://user-images.githubusercontent.com/235928/38490155-95fb3986-3be8-11e8-9650-6f3b11501ec2.png)

### Architecture
A `LabelMaker` interface is introduced. The example below generates the label (name) for the `author` attribute of the `quote`  custom tag.
```
$labelMaker->makeLabel('label', ['quote', 'author']);
```

It comes with a `TranslationBasedLabelMaker` that uses the `Translator`. Configured patterns mapped to label identifiers (ex: `label`, `description`) are used to generate a translation key, passed to the Translator. If no translation is set, it may generate a default label based on the
last item.

The `TranslationBasedLabelMaker` is instantiated as multiple services, one for each label type (ex: `custom tag` (label, description), custom tag attribute label...).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Unit test for `TranslationBasedLabelMaker`
- [ ] Handle BC in `CustomTag` mapper as well
- [ ] Ready for Code Review
