### PR TITLE
EZP-28479: In the content item edit view, the application does not display the help text when I hover over the input field

### DIFF
--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -82,7 +82,12 @@
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-data-source__input')|trim}) %}
     {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ' ~ wrapper_class)|trim}) %}
 
-    <div{% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
+    {% set field_type_descriptions = fieldtype.vars.value.fieldDefinition.descriptions %}
+    {% if field_type_descriptions[fieldtype.vars.languageCode] is defined %}
+        {% set wrapper_attr = wrapper_attr|merge({'title': field_type_descriptions[fieldtype.vars.languageCode]}) %}
+    {% endif %}
+
+    <div {% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
         <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {{ block('form_label') }}
             {{ block('form_errors') }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28479
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
