### PR TITLE
Fixed EZP-29087: Changed policy which allows to trash a Location

### DIFF
--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -107,7 +107,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         );
         $canTrashLocation = $this->permissionResolver->canUser(
             'content',
-            'manage_locations',
+            'remove',
             $location->getContentInfo(),
             [$location]
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29087](https://jira.ez.no/browse/EZP-29087)
| Depends on | ezsystems/ezpublish-kernel#2314
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This is AdminUI counterpart for ezsystems/ezpublish-kernel#2314. See either that PR or Jira issue description for  more details. 
QA: Kernel PR is targeted to `6.7` so to test this, changes needs to be cherry-picked.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
