### PR TITLE
EZP-29022: If user has logged out in edit mode of CT nobody can edit this CT

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -61,6 +61,11 @@
         <target state="new">Description</target>
         <note>key: content_type.description</note>
       </trans-unit>
+      <trans-unit id="2f9cb676bb073af7a8e4b52b374384dfc0aa9551" resname="content_type.edit.error.already_exists">
+        <source>Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'</source>
+        <target state="new">Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'</target>
+        <note>key: content_type.edit.error.already_exists</note>
+      </trans-unit>
       <trans-unit id="9eb89a2f51954babc5ff51f9060cbcda91dcf408" resname="content_type.field_definitions.modal.message">
         <source>Do you want to delete selected field definitions?</source>
         <target state="new">Do you want to delete selected field definitions?</target>
@@ -155,6 +160,11 @@
         <source>URL alias name pattern</source>
         <target state="new">URL alias name pattern</target>
         <note>key: content_type.url_alias_schema</note>
+      </trans-unit>
+      <trans-unit id="30f5ddb258e0ab8c31381ec10d9a90f7071bbf6f" resname="content_type.user_name.can_not_be_fetched">
+        <source>another user</source>
+        <target state="new">another user</target>
+        <note>key: content_type.user_name.can_not_be_fetched</note>
       </trans-unit>
       <trans-unit id="56a9f26e930ab0493fc9cb9609318ea699cf8b76" resname="content_type.view.create.content_field_definitions">
         <source>Content field definitions</source>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29022
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR adds notification with information that Content Type Draft cannot be edited.


<img width="1429" alt="screen shot 2018-04-27 at 11 05 58 am" src="https://user-images.githubusercontent.com/1654712/39354520-083cff7c-4a0b-11e8-879f-ad6345ed7f05.png">



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
