### PR TITLE
EZP-29131: Improvements to disabling/hiding elements

### DIFF
--- a/src/bundle/Resources/translations/object_state.en.xliff
+++ b/src/bundle/Resources/translations/object_state.en.xliff
@@ -31,6 +31,11 @@
         <target state="new">Delete Object State </target>
         <note>key: object_state.bulk_delete.delete</note>
       </trans-unit>
+      <trans-unit id="3f83af98ac201931eaf0055972d467c386ab72ef" resname="object_state.button.set">
+        <source>Set</source>
+        <target state="new">Set</target>
+        <note>key: object_state.button.set</note>
+      </trans-unit>
       <trans-unit id="ba36d98066b4d157d8c91e3d642a2b54442f4846" resname="object_state.create.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -72,14 +72,16 @@
                             {% endif %}>
                     </td>
                     <td class="text-center">
-                        <a href="{{ path('ezplatform.language.edit', {'languageId': language.id}) }}"
-                           class="btn btn-icon"
-                           title="{{ 'language.edit'|trans|desc('Edit') }}"
-                           {% if not canEdit %} data-disabled{% endif %}>
-                            <svg class="ez-icon ez-icon-edit">
-                                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                            </svg>
-                        </a>
+                        {% if canEdit %}
+                            <a
+                                href="{{ path('ezplatform.language.edit', {'languageId': language.id}) }}"
+                                class="btn btn-icon"
+                                title="{{ 'language.edit'|trans|desc('Edit') }}">
+                                <svg class="ez-icon ez-icon-edit">
+                                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                                </svg>
+                            </a>
+                        {% endif %}
                     </td>
                 </tr>
             </tbody>

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -26,14 +26,16 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'section.list.title'|trans|desc('Sections') }}</div>
             <div>
-                <a title="{{ 'section.new'|trans|desc('Create a new Section') }}"
-                   href="{{ path('ezplatform.section.create') }}"
-                   class="btn btn-primary" {% if not can_edit %} data-disabled{% endif %}>
-                    <svg class="ez-icon ez-icon-create">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
-                    </svg>
-                </a>
+                {% if can_edit %}
+                    <a title="{{ 'section.new'|trans|desc('Create a new Section') }}"
+                       href="{{ path('ezplatform.section.create') }}"
+                    class="btn btn-primary">
+                        <svg class="ez-icon ez-icon-create">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+                        </svg>
+                    </a>
+                {% endif %}
                 {% set modal_data_target = 'delete-sections-modal' %}
                 <button id="delete-sections" type="button" class="btn btn-danger" disabled data-toggle="modal"
                         data-target="#{{ modal_data_target }}" title="{{ 'section.delete'|trans|desc('Delete Section') }}">

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -27,12 +27,12 @@
             <div class="ez-table-header__headline">{{ 'section.list.title'|trans|desc('Sections') }}</div>
             <div>
                 {% if can_edit %}
-                    <a title="{{ 'section.new'|trans|desc('Create a new Section') }}"
-                       href="{{ path('ezplatform.section.create') }}"
-                    class="btn btn-primary">
+                    <a
+                        title="{{ 'section.new'|trans|desc('Create a new Section') }}"
+                        href="{{ path('ezplatform.section.create') }}"
+                        class="btn btn-primary">
                         <svg class="ez-icon ez-icon-create">
-                            <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
                         </svg>
                     </a>
                 {% endif %}
@@ -40,8 +40,7 @@
                 <button id="delete-sections" type="button" class="btn btn-danger" disabled data-toggle="modal"
                         data-target="#{{ modal_data_target }}" title="{{ 'section.delete'|trans|desc('Delete Section') }}">
                     <svg class="ez-icon ez-icon-trash">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                     </svg>
                 </button>
                 {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
@@ -78,12 +77,13 @@
                     <td>{{ section.id }}</td>
                     <td>{{ content_count[section.id] }}</td>
                     <td class="text-right">
-                        <a title="{{ 'section.assign_content'|trans|desc('Assign content') }}"
-                           href="#"
-                           data-section-id="{{ section.id }}"
-                           data-form-action="{{ path("ezplatform.section.assign_content", {"sectionId": section.id}) }}"
-                           data-udw-config="{{ ez_udw_config('multiple', {}) }}"
-                           class="btn btn-icon mx-3">
+                        <a
+                            title="{{ 'section.assign_content'|trans|desc('Assign content') }}"
+                            href="#"
+                            data-section-id="{{ section.id }}"
+                            data-form-action="{{ path("ezplatform.section.assign_content", {"sectionId": section.id}) }}"
+                            data-udw-config="{{ ez_udw_config('multiple', {}) }}"
+                            class="btn btn-icon mx-3">
                             <svg class="ez-icon ez-icon-relations ez-icon--secondary btn--open-udw">
                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#assign-section"></use>
                             </svg>

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -57,13 +57,16 @@
             <td>{{ section.identifier }}</td>
             <td>{{ section.id }}</td>
             <td class="text-right">
-                <a href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
-                   title="{{ 'section.edit'|trans|desc('Edit') }}"
-                   class="btn btn-icon mx-3"{% if not can_edit %} data-disabled{% endif %}>
-                    <svg class="ez-icon ez-icon-edit">
-                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                    </svg>
-                </a>
+                {% if can_edit %}
+                    <a
+                        href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
+                        title="{{ 'section.edit'|trans|desc('Edit') }}"
+                        class="btn btn-icon mx-3">
+                        <svg class="ez-icon ez-icon-edit">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                        </svg>
+                    </a>
+                {% endif %}
             </td>
             </tbody>
         </table>

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -106,23 +106,21 @@
             <td>{{ objectState.identifier }}</td>
             <td>{{ objectState.id }}</td>
             <td>
-                {{ form_start(form_state_update[objectState.objectStateGroup.id], {
-                    'method': 'POST',
-                    'action': path('ezplatform.object_state.contentstate.update', {
-                        'contentInfoId': contentInfo.id,
-                        'objectStateGroupId': objectState.objectStateGroup.id
-                    }),
-                    'attr': {'class': 'form-inline ez-form-inline'}
-                }) }}
-                {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
-                {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}
-                {{ form_row(form_state_update[objectState.objectStateGroup.id].objectState) }}
-
-                <button type="submit" class="btn btn-secondary"{% if not state_update_disabled[objectState.objectStateGroup.id] %}data-disabled{% endif %}>
-                    {{ 'tab.details.sub_items_listing_by_set'|trans|desc('Set') }}
-                </button>
-
-                {{ form_end(form_state_update[objectState.objectStateGroup.id]) }}
+                {% if form_state_update[objectState.objectStateGroup.id].objectState.vars.choices|length != 0 %}
+                    {{ form_start(form_state_update[objectState.objectStateGroup.id], {
+                        'method': 'POST',
+                        'action': path('ezplatform.object_state.contentstate.update', {
+                            'contentInfoId': contentInfo.id,
+                            'objectStateGroupId': objectState.objectStateGroup.id
+                        }),
+                        'attr': {'class': 'form-inline ez-form-inline'}
+                    }) }}
+                        {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
+                        {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}
+                        {{ form_row(form_state_update[objectState.objectStateGroup.id].objectState) }}
+                        {{ form_row(form_state_update[objectState.objectStateGroup.id].set) }}
+                    {{ form_end(form_state_update[objectState.objectStateGroup.id]) }}
+                {% endif %}
             </td>
         </tr>
     {% endfor %}

--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\ObjectState;
 
 use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use EzSystems\EzPlatformAdminUi\Form\Data\ObjectState\ContentObjectStateUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -20,15 +23,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentObjectStateUpdateType extends AbstractType
 {
-    /** @var ObjectStateService */
+    /** @var \eZ\Publish\API\Repository\ObjectStateService */
     protected $objectStateService;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
     /**
-     * @param ObjectStateService $objectStateService
+     * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
-    public function __construct(ObjectStateService $objectStateService)
+    public function __construct(ObjectStateService $objectStateService, PermissionResolver $permissionResolver)
     {
         $this->objectStateService = $objectStateService;
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -42,18 +50,27 @@ class ContentObjectStateUpdateType extends AbstractType
             ])
             ->add('objectStateGroup', ObjectStateGroupType::class, [
                 'label' => false,
+            ])
+            ->add('set', SubmitType::class, [
+                'label' => /** @Desc("Set") */ 'object_state.button.set',
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             /** @var ContentObjectStateUpdateData $contentObjectStateUpdateData */
             $contentObjectStateUpdateData = $event->getData();
             $objectStateGroup = $contentObjectStateUpdateData->getObjectStateGroup();
+            $contentInfo = $contentObjectStateUpdateData->getContentInfo();
             $form = $event->getForm();
 
             $form->add('objectState', ObjectStateChoiceType::class, [
                 'label' => false,
-                'choice_loader' => new CallbackChoiceLoader(function () use ($objectStateGroup) {
-                    return $this->objectStateService->loadObjectStates($objectStateGroup);
+                'choice_loader' => new CallbackChoiceLoader(function () use ($objectStateGroup, $contentInfo) {
+                    return array_filter(
+                        $this->objectStateService->loadObjectStates($objectStateGroup),
+                        function (ObjectState $objectState) use ($contentInfo) {
+                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]);
+                        }
+                    );
                 }),
             ]);
         });

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -98,13 +98,12 @@ class DetailsTab extends AbstractTab implements OrderedTabInterface
         );
         $objectStatesDataset = $this->datasetFactory->objectStates();
         $objectStatesDataset->load($contentInfo);
+
         $contentObjectStateUpdateTypeByGroupId = [];
-        $contentObjectStateUpdateCanAssignGroupId = [];
         foreach ($objectStatesDataset->getObjectStates() as $objectState) {
             $contentObjectStateUpdateTypeByGroupId[$objectState->objectStateGroup->id] = $this->formFactory->updateContentObjectState(
                 new ContentObjectStateUpdateData($contentInfo, $objectState->objectStateGroup, $objectState)
             )->createView();
-            $contentObjectStateUpdateCanAssignGroupId[$objectState->objectStateGroup->id] = $objectState->userCanAssign;
         }
 
         $creator = (new UserExists($this->userService))->isSatisfiedBy($contentInfo->ownerId)
@@ -124,7 +123,6 @@ class DetailsTab extends AbstractTab implements OrderedTabInterface
             'objectStates' => $objectStatesDataset->getObjectStates(),
             'sort_field_clause_map' => $this->getSortFieldClauseMap(),
             'form_state_update' => $contentObjectStateUpdateTypeByGroupId,
-            'state_update_disabled' => $contentObjectStateUpdateCanAssignGroupId,
         ];
 
         return $this->twig->render(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29131
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Basically this removes some leftovers from unused `data-disabled` attribute and improves object state dropdown. (filtering by policies and not displaying when empty).

Previously, for some reason in order to disable button (due to lack of access to functionality, `data-disabled` attribute was added to corresponding element). Because of missing JS (probably) that was not working correctly. That was fixed with removing those attributes and, as guildlines says, hiding the button instead of disabling it.

Second thing, list of available ObjectStates is now filtered according to policies. Till now, there was button that should be disabled, but was not because of the above bug and also, from my point of view, not proper logic. When there are no available policies form is not displayed.

Policies:
![image](https://user-images.githubusercontent.com/19517274/39511200-e2cf0164-4dec-11e8-99bc-06aad04e9b43.png)
Before:
![image](https://user-images.githubusercontent.com/19517274/39511230-ffab19c6-4dec-11e8-97e1-dd94126e2c29.png)
Now:
![image](https://user-images.githubusercontent.com/19517274/39511120-a124fd2c-4dec-11e8-908a-654dd8d0456a.png)



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
