### PR TITLE
EZP-29023: Setting limitations while creating policies

### DIFF
--- a/features/Roles.feature
+++ b/features/Roles.feature
@@ -78,7 +78,7 @@ Feature: Roles management
       And I click on the edit action bar button "Save"
     Then I should be on "Role" "Test Role edited" page
       And "Policies" list in "Role" "Test Role edited" is empty
-      And There are assignments on the "Test Role edited" assignments list
+      And there are assignments on the "Test Role edited" assignments list
       | user/group          | limitation                         |
       | Administrator User  | Subtree of Location: /Media/Images |
       | Anonymous User      | Subtree of Location: /Media/Images |
@@ -93,7 +93,7 @@ Feature: Roles management
       And I click on the edit action bar button "Save"
     Then I should be on "Role" "Test Role edited" page
       And "Policies" list in "Role" "Test Role edited" is empty
-      And There are assignments on the "Test Role edited" assignments list
+      And there are assignments on the "Test Role edited" assignments list
       | user/group          | limitation                         |
       | Administrator User  | Subtree of Location: /Media/Images |
       | Editors             | Subtree of Location: /Media/Images |
@@ -111,7 +111,7 @@ Feature: Roles management
       | Users	            |
     Then I should be on "Role" "Test Role edited" page
       And "Policies" list in "Role" "Test Role edited" is empty
-      And There's an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
 
   @javascript @common
   Scenario: Adding policy can be discarded
@@ -122,7 +122,7 @@ Feature: Roles management
       And I click on the edit action bar button "Discard changes"
     Then I should be on "Role" "Test Role edited" page
       And "Policies" list in "Role" "Test Role edited" is empty
-      And There's an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
 
   @javascript @common
   Scenario: Policies can be added to role
@@ -131,9 +131,24 @@ Feature: Roles management
     When I start creating new "Policy" in "Test Role edited"
       And I select policy "Content / Read"
       And I click on the edit action bar button "Create"
+      And I select options from "Class"
+        | option  |
+        | File |
+      And I click on the edit action bar button "Update"
     Then I should be on "Role" "Test Role edited" page
-      And There's a policy "Content/Read" with "None" limitation on the "Test Role edited" policies list
-      And There's an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+      And there is a policy "Content/Read" with "Content Type: File" limitation on the "Test Role edited" policies list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+
+  @javascript @common
+  Scenario: Policies without limitations can be added to role
+    Given there's "Test Role edited" on "Roles" list
+      And I go to "Test Role edited" "Role" page
+    When I start creating new "Policy" in "Test Role edited"
+      And I select policy "User / Password"
+      And I click on the edit action bar button "Create"
+    Then I should be on "Role" "Test Role edited" page
+      And there is a policy "User/Password" with "None" limitation on the "Test Role edited" policies list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
 
   @javascript @common
   Scenario: Policies can be edited
@@ -148,12 +163,12 @@ Feature: Roles management
       And I select "Lock:Locked" from "State"
       And I click on the edit action bar button "Update"
     Then I should be on "Role" "Test Role edited" page
-      And There are policies on the "Test Role edited" policies list
+      And there are policies on the "Test Role edited" policies list
       | policy       | limitation                                  |
       | Content/Read | Content Type: Article, Folder               |
       | Content/Read | Subtree of Location: /Users/Anonymous Users |
       | Content/Read | State: Lock:Locked                          |
-      And There's an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
 
   @javascript @common
   Scenario: Policy can be deleted
@@ -163,8 +178,8 @@ Feature: Roles management
       | item     |
       | Content  |
     Then notification that "Policies in role" "Test Role edited" is removed appears
-      And "Policies" list in "Role" "Test Role edited" is empty
-      And There's an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
+      And there is no policy "Content/Read" with "Content Type: File" limitation on the "Test Role edited" policies list
+      And there is an assignment "Subtree of Location: /Media/Images" for "Anonymous User" on the "Test Role edited" assignments list
 
   @javascript @common
   Scenario: Role can be deleted

--- a/src/bundle/ParamConverter/PolicyDraftParamConverter.php
+++ b/src/bundle/ParamConverter/PolicyDraftParamConverter.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\ParamConverter;
+
+use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\Values\User\PolicyDraft;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class PolicyDraftParamConverter implements ParamConverterInterface
+{
+    const PARAMETER_ROLE_ID = 'roleId';
+    const PARAMETER_POLICY_ID = 'policyId';
+
+    /** @var RoleService */
+    private $roleService;
+
+    /**
+     * RoleParamConverter constructor.
+     *
+     * @param RoleService $roleService
+     */
+    public function __construct(RoleService $roleService)
+    {
+        $this->roleService = $roleService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Request $request, ParamConverter $configuration)
+    {
+        if (!$request->get(self::PARAMETER_ROLE_ID) || !$request->get(self::PARAMETER_POLICY_ID)) {
+            return false;
+        }
+
+        $roleId = (int)$request->get(self::PARAMETER_ROLE_ID);
+
+        $roleDraft = $this->roleService->loadRoleDraftByRoleId($roleId);
+
+        if (!$roleDraft) {
+            throw new NotFoundHttpException("Role $roleId not found!");
+        }
+
+        $policyId = (int)$request->get(self::PARAMETER_POLICY_ID);
+
+        $policyDraft = null;
+        foreach ($roleDraft->getPolicies() as $item) {
+            if ($item->originalId === $policyId) {
+                $policyDraft = $item;
+                break;
+            }
+        }
+
+        if (!$policyDraft) {
+            throw new NotFoundHttpException("Policy draft $policyId not found!");
+        }
+
+        $request->attributes->set($configuration->getName(), $policyDraft);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration)
+    {
+        return PolicyDraft::class === $configuration->getClass();
+    }
+}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -191,6 +191,16 @@ ezplatform.policy.update:
         roleId: \d+
         policyId: \d+
 
+ezplatform.policy.create_with_limitation:
+    path: /role/{roleId}/policy/create/{policyModule}/{policyFunction}
+    methods: ['GET', 'POST']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Policy:createWithLimitation'
+    requirements:
+        roleId: \d+
+        policyModule: \w+
+        policyFunction: \w+
+
 ezplatform.policy.delete:
     path: /role/{roleId}/policy/{policyId}
     methods: ['POST']

--- a/src/bundle/Resources/translations/role.en.xliff
+++ b/src/bundle/Resources/translations/role.en.xliff
@@ -26,6 +26,16 @@
         <target state="new">Select Subtree</target>
         <note>key: locations.select_subtree</note>
       </trans-unit>
+      <trans-unit id="8e8d15bb05038bded496a7dfcdf6374b9449bc51" resname="policy.add.policy.title">
+        <source>Adding - Policy type</source>
+        <target state="new">Adding - Policy type</target>
+        <note>key: policy.add.policy.title</note>
+      </trans-unit>
+      <trans-unit id="df3bafbf431f3c222cebeaec45da0a089cf63736" resname="policy.add.set_limitation">
+        <source>Now you can set limitations for the policy.</source>
+        <target state="new">Now you can set limitations for the policy.</target>
+        <note>key: policy.add.set_limitation</note>
+      </trans-unit>
       <trans-unit id="d92993cb4cb3690f06c599b5f500a29fa23421c9" resname="policy.add.success">
         <source>New policies in role '%role%' created.</source>
         <target state="new">New policies in role '%role%' created.</target>

--- a/src/bundle/Resources/views/admin/policy/create_with_limitation.html.twig
+++ b/src/bundle/Resources/views/admin/policy/create_with_limitation.html.twig
@@ -1,0 +1,64 @@
+{% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
+
+{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+
+{% trans_default_domain 'role' %}
+
+{% block breadcrumbs_admin %}
+    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+        { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
+        { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
+        { url: path('ezplatform.role.view', {roleId: role.id}), value: 'role.breadcrumb.view.identifier'|trans({ '%identifier%': role.identifier })|desc('Role "%identifier%"') },
+        { value: 'policy.breadcrumb.edit'|trans()|desc('Edit limitations') }
+    ]} %}
+{% endblock %}
+
+{% block page_title_admin %}
+    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+        title: 'policy.view.edit.title'|trans()|desc('Edit limitations'),
+        iconName: 'roles'
+    } %}
+{% endblock %}
+
+{% block form %}
+    {{ form_start(form) }}
+    <section class="container mt-4 px-5">
+        <div class="card ez-card">
+            <div class="ez-card__header">
+                <h5>{{ 'policy.add.policy.title'|trans|desc('Adding - Policy type') }}</h5>
+            </div>
+            <div class="ez-card__body">
+                {{ form.vars.value.module|capitalize ~ ' / ' ~ form.vars.value.function|capitalize }}
+                {{ form_widget(form.policy, {"attr": {"hidden": "hidden"}}) }}
+            </div>
+        </div>
+
+        <div class="card ez-adminsection-edit mt-4 ez-card">
+            <div class="card-header">
+                <h2>{{ 'policy.view.limitations.title'|trans|desc('Edit limitations') }}</h2>
+            </div>
+            <div class="card-body">
+                {% for limitation_form in form.limitations %}
+                    {{ include(limitation_form.vars.template, {form: limitation_form}, with_context = false) }}
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+
+    {{ form_widget(form.save, {"attr": {"hidden": "hidden"}}) }}
+
+    {{ form_end(form) }}
+{% endblock %}
+
+{% block right_sidebar %}
+    {% set policy_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.policy_edit.sidebar_right', [], {'role': role, 'save_id': form.save.vars.id}) %}
+    {{ knp_menu_render(policy_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+{% endblock %}
+
+{% block javascripts %}
+    {% javascripts
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.limitation.pick.js'
+    %}
+        <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/lib/Behat/BusinessContext/RolesContext.php
+++ b/src/lib/Behat/BusinessContext/RolesContext.php
@@ -89,23 +89,8 @@ class RolesContext extends BusinessContext
     public function thereIsAPolicy(string $moduleAndFunction, string $limitation, string $roleName): void
     {
         $rolePage = PageObjectFactory::createPage($this->utilityContext, RolePage::PAGE_NAME, $roleName);
-        $rolePage->navLinkTabs->goToTab($this->tabMapping['policy']);
-        $adminList = $rolePage->adminLists[$this->tabMapping['policy']];
-        $actualPoliciesList = $adminList->table->getTableHash();
-        $policyExists = false;
-        $expectedModule = explode('/', $moduleAndFunction)[0];
-        $expectedFunction = explode('/', $moduleAndFunction)[1];
-        foreach ($actualPoliciesList as $policy) {
-            if (
-                $policy['Module'] === $expectedModule &&
-                $policy['Function'] === $expectedFunction &&
-                false !== strpos($policy['Limitations'], $limitation)
-            ) {
-                $policyExists = true;
-            }
-        }
 
-        if (!$policyExists) {
+        if (!$rolePage->isRoleWithLimitationPresent($this->tabMapping['policy'], $moduleAndFunction, $limitation)) {
             throw new Exception(sprintf('Policy "%s" with limitation "%s" not found on the "%s" policies list.', $moduleAndFunction, $limitation, $roleName));
         }
     }
@@ -116,23 +101,8 @@ class RolesContext extends BusinessContext
     public function thereIsNoPolicy(string $moduleAndFunction, string $limitation, string $roleName): void
     {
         $rolePage = PageObjectFactory::createPage($this->utilityContext, RolePage::PAGE_NAME, $roleName);
-        $rolePage->navLinkTabs->goToTab($this->tabMapping['policy']);
-        $adminList = $rolePage->adminLists[$this->tabMapping['policy']];
-        $actualPoliciesList = $adminList->table->getTableHash();
-        $policyExists = false;
-        $expectedModule = explode('/', $moduleAndFunction)[0];
-        $expectedFunction = explode('/', $moduleAndFunction)[1];
-        foreach ($actualPoliciesList as $policy) {
-            if (
-                $policy['Module'] === $expectedModule &&
-                $policy['Function'] === $expectedFunction &&
-                false !== strpos($policy['Limitations'], $limitation)
-            ) {
-                $policyExists = true;
-            }
-        }
 
-        if ($policyExists) {
+        if ($rolePage->isRoleWithLimitationPresent($this->tabMapping['policy'], $moduleAndFunction, $limitation)) {
             throw new Exception(sprintf('Policy "%s" with limitation "%s" found on the "%s" policies list.', $moduleAndFunction, $limitation, $roleName));
         }
     }

--- a/src/lib/Behat/BusinessContext/RolesContext.php
+++ b/src/lib/Behat/BusinessContext/RolesContext.php
@@ -84,7 +84,7 @@ class RolesContext extends BusinessContext
     }
 
     /**
-     * @Then There's a policy :moduleAndFunction with :limitation limitation on the :roleName policies list
+     * @Then there is a policy :moduleAndFunction with :limitation limitation on the :roleName policies list
      */
     public function thereIsAPolicy(string $moduleAndFunction, string $limitation, string $roleName): void
     {
@@ -99,19 +99,46 @@ class RolesContext extends BusinessContext
             if (
                 $policy['Module'] === $expectedModule &&
                 $policy['Function'] === $expectedFunction &&
-                strpos($policy['Limitations'], $limitation) !== false
+                false !== strpos($policy['Limitations'], $limitation)
             ) {
                 $policyExists = true;
             }
         }
 
         if (!$policyExists) {
-            throw new Exception(sprintf('Policy "%s" with limitation "%s" not found.', $moduleAndFunction, $limitation));
+            throw new Exception(sprintf('Policy "%s" with limitation "%s" not found on the "%s" policies list.', $moduleAndFunction, $limitation, $roleName));
         }
     }
 
     /**
-     * @Then There's an assignment :limitation for :userOrGroup on the :roleName assignments list
+     * @Then there is no policy :moduleAndFunction with :limitation limitation on the :roleName policies list
+     */
+    public function thereIsNoPolicy(string $moduleAndFunction, string $limitation, string $roleName): void
+    {
+        $rolePage = PageObjectFactory::createPage($this->utilityContext, RolePage::PAGE_NAME, $roleName);
+        $rolePage->navLinkTabs->goToTab($this->tabMapping['policy']);
+        $adminList = $rolePage->adminLists[$this->tabMapping['policy']];
+        $actualPoliciesList = $adminList->table->getTableHash();
+        $policyExists = false;
+        $expectedModule = explode('/', $moduleAndFunction)[0];
+        $expectedFunction = explode('/', $moduleAndFunction)[1];
+        foreach ($actualPoliciesList as $policy) {
+            if (
+                $policy['Module'] === $expectedModule &&
+                $policy['Function'] === $expectedFunction &&
+                false !== strpos($policy['Limitations'], $limitation)
+            ) {
+                $policyExists = true;
+            }
+        }
+
+        if ($policyExists) {
+            throw new Exception(sprintf('Policy "%s" with limitation "%s" found on the "%s" policies list.', $moduleAndFunction, $limitation, $roleName));
+        }
+    }
+
+    /**
+     * @Then there is an assignment :limitation for :userOrGroup on the :roleName assignments list
      */
     public function thereIsAnAssignment(string $limitation, string $userOrGroup, string $roleName): void
     {
@@ -132,7 +159,7 @@ class RolesContext extends BusinessContext
     }
 
     /**
-     * @Then There are policies on the :roleName policies list
+     * @Then there are policies on the :roleName policies list
      */
     public function thereArePolicies(string $roleName, TableNode $settings): void
     {
@@ -143,7 +170,7 @@ class RolesContext extends BusinessContext
     }
 
     /**
-     * @Then There are assignments on the :roleName assignments list
+     * @Then there are assignments on the :roleName assignments list
      */
     public function thereAreAssignments(string $roleName, TableNode $settings): void
     {

--- a/src/lib/Behat/PageObject/RolePage.php
+++ b/src/lib/Behat/PageObject/RolePage.php
@@ -104,4 +104,37 @@ class RolePage extends Page
         $this->navLinkTabs->goToTab('Assignments');
         $this->adminLists['Assignments']->clickAssignButton();
     }
+
+    /**
+     * Verifies if Role with Limitation from given list is present.
+     *
+     * @param string $listName
+     * @param string $moduleAndFunction
+     * @param string $limitation
+     *
+     * @return bool
+     */
+    public function isRoleWithLimitationPresent(string $listName, string $moduleAndFunction, string $limitation): bool
+    {
+        $policyExists = false;
+
+        $this->navLinkTabs->goToTab($listName);
+        $adminList = $this->adminLists[$listName];
+        $actualPoliciesList = $adminList->table->getTableHash();
+
+        $expectedModule = explode('/', $moduleAndFunction)[0];
+        $expectedFunction = explode('/', $moduleAndFunction)[1];
+
+        foreach ($actualPoliciesList as $policy) {
+            if (
+                $policy['Module'] === $expectedModule &&
+                $policy['Function'] === $expectedFunction &&
+                false !== strpos($policy['Limitations'], $limitation)
+            ) {
+                $policyExists = true;
+            }
+        }
+
+        return $policyExists;
+    }
 }

--- a/src/lib/Form/Data/Policy/PolicyCreateData.php
+++ b/src/lib/Form/Data/Policy/PolicyCreateData.php
@@ -16,6 +16,9 @@ class PolicyCreateData
     /** @var string */
     private $function;
 
+    /** @var array */
+    private $limitations = [];
+
     /**
      * @return string
      */
@@ -78,5 +81,21 @@ class PolicyCreateData
             'module' => $this->getModule(),
             'function' => $this->getFunction(),
         ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getLimitations(): ?array
+    {
+        return $this->limitations;
+    }
+
+    /**
+     * @param array $limitations
+     */
+    public function setLimitations(array $limitations)
+    {
+        $this->limitations = $limitations;
     }
 }

--- a/src/lib/Form/DataMapper/PolicyCreateMapper.php
+++ b/src/lib/Form/DataMapper/PolicyCreateMapper.php
@@ -35,6 +35,7 @@ class PolicyCreateMapper implements DataMapperInterface
 
         $data->setModule($value->module);
         $data->setFunction($value->function);
+        $data->setLimitations($value->getLimitations());
 
         return $data;
     }
@@ -54,9 +55,17 @@ class PolicyCreateMapper implements DataMapperInterface
             throw new InvalidArgumentException('data', 'must be an instance of ' . PolicyCreateData::class);
         }
 
-        return new PolicyCreateStruct([
+        $policyCreateStruct = new PolicyCreateStruct([
             'module' => $data->getModule(),
             'function' => $data->getFunction(),
         ]);
+
+        foreach ($data->getLimitations() as $limitation) {
+            if (!empty($limitation->limitationValues)) {
+                $policyCreateStruct->addLimitation($limitation);
+            }
+        }
+
+        return $policyCreateStruct;
     }
 }

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -93,6 +93,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationTrashType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationUpdateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStateGroupsDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStatesDeleteType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyCreateWithLimitationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Trash\TrashItemDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\User\UserPasswordChangeType;
 use EzSystems\EzPlatformAdminUi\Form\Type\User\UserDeleteType;
@@ -791,8 +792,8 @@ class FormFactory
     }
 
     /**
-     * @param PolicyCreateData|null $data
-     * @param null|string $name
+     * @param \EzSystems\EzPlatformAdminUi\Form\Data\Policy\PolicyCreateData|null $data
+     * @param string|null $name
      *
      * @return FormInterface
      */
@@ -803,6 +804,21 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(PolicyCreateType::class);
 
         return $this->formFactory->createNamed($name, PolicyCreateType::class, $data);
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Data\Policy\PolicyCreateData|null $data
+     * @param string|null $name
+     *
+     * @return FormInterface
+     */
+    public function createPolicyWithLimitation(
+        ?PolicyCreateData $data = null,
+        ?string $name = null
+    ): FormInterface {
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(PolicyCreateWithLimitationType::class);
+
+        return $this->formFactory->createNamed($name, PolicyCreateWithLimitationType::class, $data);
     }
 
     /**

--- a/src/lib/Form/Type/Policy/PolicyCreateWithLimitationType.php
+++ b/src/lib/Form/Type/Policy/PolicyCreateWithLimitationType.php
@@ -9,25 +9,23 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Policy;
 
 use eZ\Publish\API\Repository\RoleService;
-use EzSystems\EzPlatformAdminUi\Form\Data\Policy\PolicyUpdateData;
-use EzSystems\RepositoryForms\Form\Type\Role\LimitationType;
+use EzSystems\EzPlatformAdminUi\Form\Data\Policy\PolicyCreateData;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use EzSystems\RepositoryForms\Form\Type\Role\LimitationType;
 
-class PolicyUpdateType extends AbstractType
+class PolicyCreateWithLimitationType extends AbstractType
 {
-    /** @var RoleService */
+    /** @var \eZ\Publish\API\Repository\RoleService */
     private $roleService;
 
     /**
-     * PolicyLimitationsType constructor.
-     *
-     * @param RoleService $roleService
+     * @param \eZ\Publish\API\Repository\RoleService $roleService
      */
     public function __construct(RoleService $roleService)
     {
@@ -51,14 +49,14 @@ class PolicyUpdateType extends AbstractType
             ->add(
                 'save',
                 SubmitType::class,
-                ['label' => /** @Desc("Update") */ 'policy_create.update']
+                ['label' => /** @Desc("Create") */ 'policy_create.save']
             );
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
             $data = $event->getData();
             $form = $event->getForm();
 
-            if ($data instanceof PolicyUpdateData) {
+            if ($data instanceof PolicyCreateData) {
                 $availableLimitationTypes = $this->roleService->getLimitationTypesByModuleFunction(
                     $data->getModule(),
                     $data->getFunction()
@@ -84,7 +82,7 @@ class PolicyUpdateType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'ezrepoforms_role',
-            'data_class' => PolicyUpdateData::class,
+            'data_class' => PolicyCreateData::class,
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29023
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Currently, after creating/adding a new policy to a role it is instantly active with no limitations. They could be added by editing this policy. The idea is to specify limitations while creating a new policy by setting this as next step to follow when policy can have limitations.

<img width="1425" alt="screen shot 2018-04-30 at 1 37 40 pm" src="https://user-images.githubusercontent.com/1654712/39425428-b1decd9a-4c7b-11e8-87e0-92283fcbb6fa.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
