### PR TITLE
EZP-29161: Hide Section table in Details if the user does not have "Section/View"

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -36,7 +36,11 @@
             checkbox.removeAttribute('checked');
             checkbox.checked = false;
         });
-        sectionSelect[0].selected = true;
+
+        if (sectionSelect) {
+            sectionSelect[0].selected = true;
+        }
+
         lastModifiedSelect[0].selected = true;
         lastCreatedSelect[0].selected = true;
         lastModifiedSelect.querySelector('option').selected = true;
@@ -52,7 +56,7 @@
     const toggleDisabledStateOnApplyBtn = () => {
         const contentTypeOption = contentTypeSelect.querySelector('option');
         const isContentTypeSelected = contentTypeOption.innerHTML !== contentTypeOption.dataset.default;
-        const isSectionSelected = !!sectionSelect.value;
+        const isSectionSelected = sectionSelect ? !!sectionSelect.value : false;
         const isModifiedSelected = !!lastModifiedSelect.value;
         const isCreatedSelected = !!lastCreatedSelect.value;
         const isCreatorSelected = !!searchCreatorInput.value;
@@ -259,7 +263,11 @@
     clearBtn.addEventListener('click', clearFilters, false);
     filterBtn.addEventListener('click', toggleFiltersVisibility, false);
     contentTypeSelect.addEventListener('click', toggleContentTypeSelectorVisibility, false);
-    sectionSelect.addEventListener('change', toggleDisabledStateOnApplyBtn, false);
+
+    if (sectionSelect) {
+        sectionSelect.addEventListener('change', toggleDisabledStateOnApplyBtn, false);
+    }
+
     lastModifiedSelect.addEventListener('change', toggleModalVisibility, false);
     lastCreatedSelect.addEventListener('change', toggleModalVisibility, false);
     creatorInput.addEventListener('keyup', handleTyping, false);

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -27,10 +27,12 @@
         </select>
         {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
     </div>
-    <div class="ez-filters__item ez-filters__item--section">
-        <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
-        {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
-    </div>
+    {% if form.section is defined %}
+        <div class="ez-filters__item ez-filters__item--section">
+            <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
+            {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
+        </div>
+    {% endif %}
     <div class="ez-filters__item ez-filters__item--modified">
         <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
         {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-modified-range'}}) }}

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -61,25 +61,26 @@
     </tr>
     </tbody>
 </table>
+{% if can_see_section %}
+    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.section_details'|trans()|desc('Section details') } %}
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.section_details'|trans()|desc('Section details') } %}
-
-<table class="table">
-    <thead>
-    <tr>
-        <th>{{ 'tab.details.section_name'|trans()|desc('Section name') }}</th>
-        <th>{{ 'tab.details.section_identifier'|trans()|desc('Section identifier') }}</th>
-        <th>{{ 'tab.details.section_id'|trans()|desc('Section ID') }}</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-        <td>{{ section.name }}</td>
-        <td>{{ section.identifier }}</td>
-        <td>{{ section.id }}</td>
-    </tr>
-    </tbody>
-</table>
+    <table class="table">
+        <thead>
+        <tr>
+            <th>{{ 'tab.details.section_name'|trans()|desc('Section name') }}</th>
+            <th>{{ 'tab.details.section_identifier'|trans()|desc('Section identifier') }}</th>
+            <th>{{ 'tab.details.section_id'|trans()|desc('Section ID') }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>{{ section.name }}</td>
+            <td>{{ section.identifier }}</td>
+            <td>{{ section.id }}</td>
+        </tr>
+        </tbody>
+    </table>
+{% endif %}
 
 {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.state_details'|trans()|desc('State details') } %}
 

--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -17,19 +17,27 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use eZ\Publish\API\Repository\PermissionResolver;
 
 class SearchType extends AbstractType
 {
     /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
+    public function __construct(TranslatorInterface $translator, PermissionResolver $permissionResolver)
     {
         $this->translator = $translator;
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
-     * {@inheritdoc}
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array $options
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -37,11 +45,6 @@ class SearchType extends AbstractType
             ->add('query', CoreSearchType::class, ['required' => false])
             ->add('page', HiddenType::class)
             ->add('limit', HiddenType::class)
-            ->add('section', SectionChoiceType::class, [
-                'required' => false,
-                'multiple' => false,
-                'placeholder' => /** @Desc("Any section") */ 'search.section.any',
-            ])
             ->add('content_types', ContentTypeChoiceType::class, [
                 'multiple' => true,
                 'expanded' => true,
@@ -62,6 +65,14 @@ class SearchType extends AbstractType
                 'mapped' => false,
             ])
         ;
+
+        if ($this->permissionResolver->hasAccess('section', 'view')) {
+            $builder->add('section', SectionChoiceType::class, [
+                'required' => false,
+                'multiple' => false,
+                'placeholder' => /** @Desc("Any section") */ 'search.section.any',
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29161
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2018-05-10 at 3 10 54 pm](https://user-images.githubusercontent.com/1654712/39871701-fc9ac932-5465-11e8-922c-3f4bf2f2116d.png)

![screen shot 2018-05-10 at 3 10 26 pm](https://user-images.githubusercontent.com/1654712/39871702-fcbe5776-5465-11e8-922a-b3985bf6edf2.png)



#### Checklist:
- [x] Hide Section table in Details
- [x] Hide Section dropdown in Search
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
