### PR TITLE
EZP-28868: Integrated admin design of eZ Design Engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ezsystems/repository-forms": "^2.1@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.1@dev",
         "ezsystems/ez-support-tools": "^0.2@dev",
+        "ezsystems/ezplatform-design-engine": "^2.0@dev",
         "white-october/pagerfanta-bundle": "^1.1",
         "knplabs/knp-menu-bundle": "^2.1"
     },

--- a/src/bundle/Controller/BookmarkController.php
+++ b/src/bundle/Controller/BookmarkController.php
@@ -93,7 +93,7 @@ class BookmarkController extends Controller
         );
 
         return $this->render(
-            'EzPlatformAdminUiBundle:admin/bookmark:list.html.twig',
+            '@ezdesign/admin/bookmark/list.html.twig',
             $viewParameters = [
                 'pager' => $pagerfanta,
                 'form_edit' => $editForm->createView(),

--- a/src/bundle/Controller/Content/VersionDraftConflictController.php
+++ b/src/bundle/Controller/Content/VersionDraftConflictController.php
@@ -65,7 +65,7 @@ class VersionDraftConflictController extends Controller
             $versionsDataset->load($contentInfo);
             $conflictedDrafts = $versionsDataset->getConflictedDraftVersions($contentInfo->currentVersionNo);
 
-            $modalContent = $this->renderView('@EzPlatformAdminUi/content/modal_draft_conflict.html.twig', [
+            $modalContent = $this->renderView('@ezdesign/content/modal_draft_conflict.html.twig', [
                 'conflicted_drafts' => $conflictedDrafts,
                 'location' => $location,
             ]);

--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -291,7 +291,7 @@ class ContentController extends Controller
             );
         }
 
-        return $this->render('@EzPlatformAdminUi/content/content_preview.html.twig', [
+        return $this->render('@ezdesign/content/content_preview.html.twig', [
             'location' => $location,
             'content' => $content,
             'language_code' => $languageCode,

--- a/src/bundle/Controller/ContentOnTheFlyController.php
+++ b/src/bundle/Controller/ContentOnTheFlyController.php
@@ -90,7 +90,7 @@ class ContentOnTheFlyController extends Controller
             }
         }
 
-        return new ContentCreateOnTheFlyView('@EzPlatformAdminUi/content/content_on_the_fly/content_create_on_the_fly.html.twig', [
+        return new ContentCreateOnTheFlyView('@ezdesign/content/content_on_the_fly/content_create_on_the_fly.html.twig', [
             'form' => $form->createView(),
             'language' => $language,
             'contentType' => $contentType,

--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -131,7 +131,7 @@ class ContentTypeController extends Controller
             $deletableTypes[$type->id] = !$this->contentTypeService->isContentTypeUsed($type);
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type/list.html.twig', [
+        return $this->render('@ezdesign/admin/content_type/list.html.twig', [
             'content_type_group' => $group,
             'pager' => $pagerfanta,
             'deletable' => $deletableTypes,
@@ -162,7 +162,7 @@ class ContentTypeController extends Controller
 
         $form = $this->createUpdateForm($group, $contentTypeDraft);
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type/create.html.twig', [
+        return $this->render('@ezdesign/admin/content_type/create.html.twig', [
             'content_type_group' => $group,
             'content_type' => $contentTypeDraft,
             'form' => $form->createView(),
@@ -273,7 +273,7 @@ class ContentTypeController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type/edit.html.twig', [
+        return $this->render('@ezdesign/admin/content_type/edit.html.twig', [
             'content_type_group' => $group,
             'content_type' => $contentTypeDraft,
             'form' => $form->createView(),
@@ -382,7 +382,7 @@ class ContentTypeController extends Controller
             $fieldDefinitionsByGroup[$fieldDefinition->fieldGroup ?: 'content'][] = $fieldDefinition;
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type/view.html.twig', [
+        return $this->render('@ezdesign/admin/content_type/view.html.twig', [
             'content_type_group' => $group,
             'content_type' => $contentType,
             'field_definitions_by_group' => $fieldDefinitionsByGroup,

--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -113,7 +113,7 @@ class ContentTypeGroupController extends Controller
             $count[$contentTypeGroup->id] = $contentTypesCount;
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type_group/list.html.twig', [
+        return $this->render('@ezdesign/admin/content_type_group/list.html.twig', [
             'pager' => $pagerfanta,
             'form_content_type_groups_delete' => $deleteContentTypeGroupsForm->createView(),
             'deletable' => $deletableContentTypeGroup,
@@ -154,7 +154,7 @@ class ContentTypeGroupController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type_group/create.html.twig', [
+        return $this->render('@ezdesign/admin/content_type_group/create.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -193,7 +193,7 @@ class ContentTypeGroupController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/content_type_group/edit.html.twig', [
+        return $this->render('@ezdesign/admin/content_type_group/edit.html.twig', [
             'content_type_group' => $group,
             'form' => $form->createView(),
         ]);
@@ -284,7 +284,7 @@ class ContentTypeGroupController extends Controller
      */
     public function viewAction(Request $request, ContentTypeGroup $group, int $page = 1): Response
     {
-        return $this->render('@EzPlatformAdminUi/admin/content_type_group/view.html.twig', [
+        return $this->render('@ezdesign/admin/content_type_group/view.html.twig', [
             'content_type_group' => $group,
             'page' => $page,
             'route_name' => $request->get('_route'),

--- a/src/bundle/Controller/DashboardController.php
+++ b/src/bundle/Controller/DashboardController.php
@@ -26,7 +26,7 @@ class DashboardController extends Controller
             new ContentEditData()
         );
 
-        return $this->render('@EzPlatformAdminUi/dashboard/dashboard.html.twig', [
+        return $this->render('@ezdesign/dashboard/dashboard.html.twig', [
             'form_edit' => $editForm->createView(),
         ]);
     }

--- a/src/bundle/Controller/LanguageController.php
+++ b/src/bundle/Controller/LanguageController.php
@@ -104,7 +104,7 @@ class LanguageController extends Controller
             new LanguagesDeleteData($this->getLanguagesNumbers($languageList))
         );
 
-        return $this->render('@EzPlatformAdminUi/admin/language/list.html.twig', [
+        return $this->render('@ezdesign/admin/language/list.html.twig', [
             'pager' => $pagerfanta,
             'form_languages_delete' => $deleteLanguagesForm->createView(),
             /* @deprecated since version 2.2, to be removed in 3.0. Use 'can_administrate' instead. */
@@ -128,7 +128,7 @@ class LanguageController extends Controller
             new LanguageDeleteData($language)
         );
 
-        return $this->render('@EzPlatformAdminUi/admin/language/view.html.twig', [
+        return $this->render('@ezdesign/admin/language/view.html.twig', [
             'language' => $language,
             'deleteForm' => $deleteForm->createView(),
             /* @deprecated since version 2.2, to be removed in 3.0. Use 'can_administrate' instead. */
@@ -252,7 +252,7 @@ class LanguageController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/language/create.html.twig', [
+        return $this->render('@ezdesign/admin/language/create.html.twig', [
             'form' => $form->createView(),
             'actionUrl' => $this->generateUrl('ezplatform.language.create'),
         ]);
@@ -292,7 +292,7 @@ class LanguageController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/language/edit.html.twig', [
+        return $this->render('@ezdesign/admin/language/edit.html.twig', [
             'form' => $form->createView(),
             'actionUrl' => $this->generateUrl('ezplatform.language.edit', ['languageId' => $language->id]),
             'language' => $language,

--- a/src/bundle/Controller/LinkManagerController.php
+++ b/src/bundle/Controller/LinkManagerController.php
@@ -96,7 +96,7 @@ class LinkManagerController extends Controller
         $urls->setCurrentPage($data->page);
         $urls->setMaxPerPage($data->limit ? $data->limit : self::DEFAULT_MAX_PER_PAGE);
 
-        return $this->render('@EzPlatformAdminUi/link_manager/list.html.twig', [
+        return $this->render('@ezdesign/link_manager/list.html.twig', [
             'form' => $form->createView(),
             'can_edit' => $this->isGranted(new Attribute('url', 'update')),
             'urls' => $urls,
@@ -135,7 +135,7 @@ class LinkManagerController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/link_manager/edit.html.twig', [
+        return $this->render('@ezdesign/link_manager/edit.html.twig', [
             'form' => $form->createView(),
             'url' => $url,
         ]);
@@ -161,7 +161,7 @@ class LinkManagerController extends Controller
             new ContentEditData()
         );
 
-        return $this->render('@EzPlatformAdminUi/link_manager/view.html.twig', [
+        return $this->render('@ezdesign/link_manager/view.html.twig', [
             'url' => $url,
             'can_edit' => $this->isGranted(new Attribute('url', 'update')),
             'usages' => $usages,

--- a/src/bundle/Controller/ObjectStateController.php
+++ b/src/bundle/Controller/ObjectStateController.php
@@ -96,7 +96,7 @@ class ObjectStateController extends Controller
             $unusedObjectStates[$state->id] = empty($this->objectStateService->getContentCount($state));
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state:list.html.twig', [
+        return $this->render('@ezdesign/admin/object_state/list.html.twig', [
             'can_administrate' => $this->isGranted(new Attribute('state', 'administrate')),
             'object_state_group' => $objectStateGroup,
             'object_states' => $objectStates,
@@ -116,7 +116,7 @@ class ObjectStateController extends Controller
             new ObjectStateDeleteData($objectState)
         )->createView();
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state:view.html.twig', [
+        return $this->render('@ezdesign/admin/object_state/view.html.twig', [
             'can_administrate' => $this->isGranted(new Attribute('state', 'administrate')),
             'object_state_group' => $objectState->getObjectStateGroup(),
             'object_state' => $objectState,
@@ -168,7 +168,7 @@ class ObjectStateController extends Controller
             }
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state:add.html.twig', [
+        return $this->render('@ezdesign/admin/object_state/add.html.twig', [
             'object_state_group' => $objectStateGroup,
             'form' => $form->createView(),
         ]);
@@ -298,7 +298,7 @@ class ObjectStateController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/object_state/edit.html.twig', [
+        return $this->render('@ezdesign/admin/object_state/edit.html.twig', [
             'object_state_group' => $objectState->getObjectStateGroup(),
             'object_state' => $objectState,
             'form' => $form->createView(),

--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -83,7 +83,7 @@ class ObjectStateGroupController extends Controller
             new ObjectStateGroupsDeleteData($this->getObjectStateGroupsIds($objectStateGroups))
         );
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state_group:list.html.twig', [
+        return $this->render('@ezdesign/admin/object_state_group/list.html.twig', [
             'can_administrate' => $this->isGranted(new Attribute('state', 'administrate')),
             'object_state_groups' => $objectStateGroups,
             'empty_object_state_groups' => $emptyObjectStateGroups,
@@ -102,7 +102,7 @@ class ObjectStateGroupController extends Controller
             new ObjectStateGroupDeleteData($objectStateGroup)
         )->createView();
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state_group:view.html.twig', [
+        return $this->render('@ezdesign/admin/object_state_group/view.html.twig', [
             'can_administrate' => $this->isGranted(new Attribute('state', 'administrate')),
             'object_state_group' => $objectStateGroup,
             'delete_form' => $deleteForm,
@@ -153,7 +153,7 @@ class ObjectStateGroupController extends Controller
             }
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/object_state_group:add.html.twig', [
+        return $this->render('@ezdesign/admin/object_state_group/add.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -277,7 +277,7 @@ class ObjectStateGroupController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/object_state_group/edit.html.twig', [
+        return $this->render('@ezdesign/admin/object_state_group/edit.html.twig', [
             'object_state_group' => $group,
             'form' => $form->createView(),
         ]);

--- a/src/bundle/Controller/PolicyController.php
+++ b/src/bundle/Controller/PolicyController.php
@@ -125,7 +125,7 @@ class PolicyController extends Controller
             new PoliciesDeleteData($role, $this->getPoliciesNumbers($policies))
         );
 
-        return $this->render('@EzPlatformAdminUi/admin/policy/list.html.twig', [
+        return $this->render('@ezdesign/admin/policy/list.html.twig', [
             'form_policies_delete' => $deletePoliciesForm->createView(),
             'is_editable' => $isEditable,
             'role' => $role,
@@ -207,7 +207,7 @@ class PolicyController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/policy/add.html.twig', [
+        return $this->render('@ezdesign/admin/policy/add.html.twig', [
             'role' => $role,
             'form' => $form->createView(),
         ]);
@@ -286,7 +286,7 @@ class PolicyController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/policy/edit.html.twig', [
+        return $this->render('@ezdesign/admin/policy/edit.html.twig', [
             'role' => $role,
             'policy' => $policy,
             'form' => $form->createView(),
@@ -338,7 +338,7 @@ class PolicyController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/policy/create_with_limitation.html.twig', [
+        return $this->render('@ezdesign/admin/policy/create_with_limitation.html.twig', [
             'role' => $role,
             'form' => $form->createView(),
         ]);

--- a/src/bundle/Controller/RoleAssignmentController.php
+++ b/src/bundle/Controller/RoleAssignmentController.php
@@ -102,7 +102,7 @@ class RoleAssignmentController extends Controller
             new RoleAssignmentsDeleteData($role, $this->getRoleAssignmentsNumbers($assignments))
         );
 
-        return $this->render('@EzPlatformAdminUi/admin/role_assignment/list.html.twig', [
+        return $this->render('@ezdesign/admin/role_assignment/list.html.twig', [
             'role' => $role,
             'form_role_assignments_delete' => $deleteRoleAssignmentsForm->createView(),
             'pager' => $pagerfanta,
@@ -153,7 +153,7 @@ class RoleAssignmentController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/role_assignment/create.html.twig', [
+        return $this->render('@ezdesign/admin/role_assignment/create.html.twig', [
             'role' => $role,
             'form' => $form->createView(),
         ]);

--- a/src/bundle/Controller/RoleController.php
+++ b/src/bundle/Controller/RoleController.php
@@ -115,7 +115,7 @@ class RoleController extends Controller
 
         $rolesDeleteForm = $this->formFactory->deleteRoles($rolesDeleteData);
 
-        return $this->render('@EzPlatformAdminUi/admin/role/list.html.twig', [
+        return $this->render('@ezdesign/admin/role/list.html.twig', [
             'form_roles_delete' => $rolesDeleteForm->createView(),
             'pager' => $pagerfanta,
             'can_create' => $this->isGranted(new Attribute('role', 'create')),
@@ -146,7 +146,7 @@ class RoleController extends Controller
             $assignments = [];
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/role/view.html.twig', [
+        return $this->render('@ezdesign/admin/role/view.html.twig', [
             'role' => $role,
             'assignments' => $assignments,
             'delete_form' => $deleteForm->createView(),
@@ -192,7 +192,7 @@ class RoleController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/role/add.html.twig', [
+        return $this->render('@ezdesign/admin/role/add.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -240,7 +240,7 @@ class RoleController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/role/edit.html.twig', [
+        return $this->render('@ezdesign/admin/role/edit.html.twig', [
             'role' => $role,
             'form' => $form->createView(),
         ]);

--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -189,7 +189,7 @@ class SearchController extends Controller
                     new ContentEditData()
                 );
 
-                return $this->render('@EzPlatformAdminUi/admin/search/search.html.twig', [
+                return $this->render('@ezdesign/admin/search/search.html.twig', [
                     'results' => $this->pagerContentToDataMapper->map($pagerfanta),
                     'form' => $form->createView(),
                     'pager' => $pagerfanta,
@@ -204,7 +204,7 @@ class SearchController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/admin/search/search.html.twig', [
+        return $this->render('@ezdesign/admin/search/search.html.twig', [
             'form' => $form->createView(),
             'filters_expanded' => false,
             'user_content_type_identifier' => $this->userContentTypeIdentifier,

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -163,7 +163,7 @@ class SectionController extends Controller
             $assignableSections[$section->id] = $this->canUserAssignSectionToAnyContent($section);
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/section:list.html.twig', [
+        return $this->render('@ezdesign/admin/section/list.html.twig', [
             'can_edit' => $this->isGranted(new Attribute('section', 'edit')),
             'can_assign' => $this->isGranted(new Attribute('section', 'assign')),
             'pager' => $pagerfanta,
@@ -186,7 +186,7 @@ class SectionController extends Controller
             new SectionDeleteData($section)
         )->createView();
 
-        return $this->render('EzPlatformAdminUiBundle:admin/section:view.html.twig', [
+        return $this->render('@ezdesign/admin/section/view.html.twig', [
             'section' => $section,
             'form_section_delete' => $sectionDeleteForm,
             'deletable' => !$this->sectionService->isSectionUsed($section),
@@ -243,7 +243,7 @@ class SectionController extends Controller
 
         $pagination = (new EzPagerfantaView(new EzPagerfantaTemplate($this->translator)))->render($pagerfanta, $routeGenerator);
 
-        return $this->render('EzPlatformAdminUiBundle:admin/section:assigned_content.html.twig', [
+        return $this->render('@ezdesign/admin/section/assigned_content.html.twig', [
             'section' => $section,
             'form_section_content_assign' => $sectionContentAssignForm,
             'assigned_content' => $assignedContent,
@@ -424,7 +424,7 @@ class SectionController extends Controller
             }
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/section:create.html.twig', [
+        return $this->render('@ezdesign/admin/section/create.html.twig', [
             'form_section_create' => $form->createView(),
         ]);
     }
@@ -466,7 +466,7 @@ class SectionController extends Controller
             }
         }
 
-        return $this->render('EzPlatformAdminUiBundle:admin/section:update.html.twig', [
+        return $this->render('@ezdesign/admin/section/update.html.twig', [
             'section' => $section,
             'form_section_update' => $form->createView(),
         ]);

--- a/src/bundle/Controller/SystemInfoController.php
+++ b/src/bundle/Controller/SystemInfoController.php
@@ -36,7 +36,7 @@ class SystemInfoController extends Controller
      */
     public function infoAction(): Response
     {
-        return $this->render('@EzPlatformAdminUi/admin/systeminfo/info.html.twig', [
+        return $this->render('@ezdesign/admin/systeminfo/info.html.twig', [
             'collector_identifiers' => $this->collectorRegistry->getIdentifiers(),
         ]);
     }

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -157,7 +157,7 @@ class TrashController extends Controller
             new TrashEmptyData(true)
         );
 
-        return $this->render('@EzPlatformAdminUi/admin/trash/list.html.twig', [
+        return $this->render('@ezdesign/admin/trash/list.html.twig', [
             'can_delete' => $this->isGranted(new Attribute('content', 'remove')),
             'can_restore' => $this->isGranted(new Attribute('content', 'restore')),
             'trash_items' => $trashItemsList,

--- a/src/bundle/Controller/User/UserForgotPasswordController.php
+++ b/src/bundle/Controller/User/UserForgotPasswordController.php
@@ -106,10 +106,10 @@ class UserForgotPasswordController extends Controller
                 $this->sendResetPasswordMessage($user->email, $token);
             }
 
-            return $this->render('@EzPlatformAdminUi/Security/forgot_user_password/success.html.twig');
+            return $this->render('@ezdesign/Security/forgot_user_password/success.html.twig');
         }
 
-        return $this->render('@EzPlatformAdminUi/Security/forgot_user_password/index.html.twig', [
+        return $this->render('@ezdesign/Security/forgot_user_password/index.html.twig', [
             'form_forgot_user_password' => $form->createView(),
         ]);
     }
@@ -141,16 +141,16 @@ class UserForgotPasswordController extends Controller
             }
 
             if (!$user || count($this->userService->loadUsersByEmail($user->email)) < 2) {
-                return $this->render('@EzPlatformAdminUi/Security/forgot_user_password/success.html.twig');
+                return $this->render('@ezdesign/Security/forgot_user_password/success.html.twig');
             }
 
             $token = $this->updateUserToken($user);
             $this->sendResetPasswordMessage($user->email, $token);
 
-            return $this->render('@EzPlatformAdminUi/Security/forgot_user_password/success.html.twig');
+            return $this->render('@ezdesign/Security/forgot_user_password/success.html.twig');
         }
 
-        return $this->render('@EzPlatformAdminUi/Security/forgot_user_password/with_login.html.twig', [
+        return $this->render('@ezdesign/Security/forgot_user_password/with_login.html.twig', [
             'form_forgot_user_password_with_login' => $form->createView(),
         ]);
     }
@@ -172,7 +172,7 @@ class UserForgotPasswordController extends Controller
         try {
             $this->userService->loadUserByToken($hashKey);
         } catch (NotFoundException $e) {
-            return $this->render('@EzPlatformAdminUi/Security/reset_user_password/invalid_link.html.twig', [], $response);
+            return $this->render('@ezdesign/Security/reset_user_password/invalid_link.html.twig', [], $response);
         }
 
         $form = $this->formFactory->resetUserPassword();
@@ -184,7 +184,7 @@ class UserForgotPasswordController extends Controller
                 $currentUser = $this->permissionResolver->getCurrentUserReference();
                 $this->permissionResolver->setCurrentUserReference($user);
             } catch (NotFoundException $e) {
-                return $this->render('@EzPlatformAdminUi/Security/reset_user_password/invalid_link.html.twig', [], $response);
+                return $this->render('@ezdesign/Security/reset_user_password/invalid_link.html.twig', [], $response);
             }
 
             $data = $form->getData();
@@ -196,13 +196,13 @@ class UserForgotPasswordController extends Controller
                 $this->userService->expireUserToken($hashKey);
                 $this->permissionResolver->setCurrentUserReference($currentUser);
 
-                return $this->render('@EzPlatformAdminUi/Security/reset_user_password/success.html.twig', [], $response);
+                return $this->render('@ezdesign/Security/reset_user_password/success.html.twig', [], $response);
             } catch (\Exception $e) {
                 $this->notificationHandler->error($e->getMessage());
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/Security/reset_user_password/index.html.twig', [
+        return $this->render('@ezdesign/Security/reset_user_password/index.html.twig', [
             'form_reset_user_password' => $form->createView(),
         ], $response);
     }
@@ -236,7 +236,7 @@ class UserForgotPasswordController extends Controller
      */
     private function sendResetPasswordMessage(string $to, string $hashKey)
     {
-        $template = $this->twig->loadTemplate('@EzPlatformAdminUi/Security/mail/forgot_user_password.html.twig');
+        $template = $this->twig->loadTemplate('@ezdesign/Security/mail/forgot_user_password.html.twig');
 
         $subject = $template->renderBlock('subject', []);
         $from = $template->renderBlock('from', []);

--- a/src/bundle/Controller/UserProfile/UserPasswordChangeController.php
+++ b/src/bundle/Controller/UserProfile/UserPasswordChangeController.php
@@ -103,7 +103,7 @@ class UserPasswordChangeController extends Controller
             }
         }
 
-        return $this->render('@EzPlatformAdminUi/user-profile/change_user_password.html.twig', [
+        return $this->render('@ezdesign/user-profile/change_user_password.html.twig', [
             'form_change_user_password' => $form->createView(),
         ]);
     }

--- a/src/bundle/DependencyInjection/Compiler/AdminThemePathPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AdminThemePathPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass which maps Resources/views directory to admin Theme and Design of eZ Design Engine.
+ */
+class AdminThemePathPass implements CompilerPassInterface
+{
+    /**
+     * Append Resources/views to the list of paths for admin Theme.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $templatesPathMap = $container->hasParameter('ezdesign.templates_path_map')
+            ? $container->getParameter('ezdesign.templates_path_map')
+            : [];
+
+        $templatesPathMap['admin'][] = realpath(__DIR__ . '/../../Resources/views');
+
+        $container->setParameter('ezdesign.templates_path_map', $templatesPathMap);
+    }
+}

--- a/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
@@ -46,6 +46,7 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $this->prependViews($container);
         $this->prependImageVariations($container);
         $this->prependUniversalDiscoveryWidget($container);
+        $this->prependEzDesignConfiguration($container);
     }
 
     /**
@@ -79,5 +80,17 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $config = Yaml::parse(file_get_contents($udwConfigFile));
         $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($udwConfigFile));
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function prependEzDesignConfiguration(ContainerBuilder $container)
+    {
+        $eZDesignConfigFile = __DIR__ . '/../Resources/config/ezdesign.yml';
+        $config = Yaml::parseFile($eZDesignConfigFile);
+        $container->prependExtensionConfig('ezdesign', $config['ezdesign']);
+        $container->prependExtensionConfig('ezpublish', $config['ezpublish']);
+        $container->addResource(new FileResource($eZDesignConfigFile));
     }
 }

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUiBundle;
 
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\AdminThemePathPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ComponentPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SecurityLoginPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SystemInfoTabGroupPass;
@@ -21,6 +22,7 @@ use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\S
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\UserGroupIdentifier;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\UserIdentifier;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -57,6 +59,7 @@ class EzPlatformAdminUiBundle extends Bundle
         $container->addCompilerPass(new ComponentPass());
         $container->addCompilerPass(new SecurityLoginPass());
         $container->addCompilerPass(new ViewBuilderRegistryPass());
+        $container->addCompilerPass(new AdminThemePathPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 
     /**

--- a/src/bundle/Resources/config/default_parameters.yml
+++ b/src/bundle/Resources/config/default_parameters.yml
@@ -1,32 +1,32 @@
 parameters:
-    ezsettings.admin_group.content_edit.templates.create_draft: 'EzPlatformAdminUiBundle:content/content_edit:content_create_draft.html.twig'
-    ezsettings.admin_group.user_edit.templates.update: 'EzPlatformAdminUiBundle:content/content_edit:user_edit.html.twig'
-    ezsettings.admin_group.user_edit.templates.create: 'EzPlatformAdminUiBundle:content/content_edit:user_create.html.twig'
+    ezsettings.admin_group.content_edit.templates.create_draft: '@@ezdesign/content/content_edit/content_create_draft.html.twig'
+    ezsettings.admin_group.user_edit.templates.update: '@@ezdesign/content/content_edit/user_edit.html.twig'
+    ezsettings.admin_group.user_edit.templates.create: '@@ezdesign/content/content_edit/user_create.html.twig'
 
     ezsettings.global.system_info_view:
         pjax_tab:
             composer:
-                template: 'EzPlatformAdminUiBundle:admin/systeminfo:composer.html.twig'
+                template: '@@ezdesign/admin/systeminfo/composer.html.twig'
                 match:
                     SystemInfo\Identifier: 'composer'
             database:
-                template: 'EzPlatformAdminUiBundle:admin/systeminfo:database.html.twig'
+                template: '@@ezdesign/admin/systeminfo/database.html.twig'
                 match:
                     SystemInfo\Identifier: 'database'
             hardware:
-                template: 'EzPlatformAdminUiBundle:admin/systeminfo:hardware.html.twig'
+                template: '@@ezdesign/admin/systeminfo/hardware.html.twig'
                 match:
                     SystemInfo\Identifier: 'hardware'
             php:
-                template: 'EzPlatformAdminUiBundle:admin/systeminfo:php.html.twig'
+                template: '@@ezdesign/admin/systeminfo/php.html.twig'
                 match:
                     SystemInfo\Identifier: 'php'
             symfony_kernel:
-                template: 'EzPlatformAdminUiBundle:admin/systeminfo:symfony_kernel.html.twig'
+                template: '@@ezdesign/admin/systeminfo/symfony_kernel.html.twig'
                 match:
                     SystemInfo\Identifier: 'symfony_kernel'
 
-    ezplatform.content_view.tabs.default_template: 'EzPlatformAdminUiBundle:parts/tab:default.html.twig'
+    ezplatform.content_view.tabs.default_template: '@@ezdesign/parts/tab/default.html.twig'
 
     ezplatform.multifile_upload.location.mappings: []
 

--- a/src/bundle/Resources/config/ezdesign.yml
+++ b/src/bundle/Resources/config/ezdesign.yml
@@ -1,0 +1,8 @@
+ezdesign:
+    design_list:
+        admin: [admin, standard]
+
+ezpublish:
+    system:
+        admin_group:
+            design: admin

--- a/src/bundle/Resources/config/role.yml
+++ b/src/bundle/Resources/config/role.yml
@@ -1,4 +1,4 @@
 parameters:
     # Limitation mappers
-    ezrepoforms.limitation.null.template: "EzPlatformAdminUiBundle:Limitation:null_limitation_values.html.twig"
-    ezrepoforms.limitation.udw.template: "EzPlatformAdminUiBundle:Limitation:udw_limitation_value.html.twig"
+    ezrepoforms.limitation.null.template: "@@ezdesign/Limitation/null_limitation_values.html.twig"
+    ezrepoforms.limitation.udw.template: "@@ezdesign/Limitation/udw_limitation_value.html.twig"

--- a/src/bundle/Resources/config/services/dashboard.yml
+++ b/src/bundle/Resources/config/services/dashboard.yml
@@ -36,13 +36,13 @@ services:
     ezplatform.adminui.dashboard.me:
         parent: EzSystems\EzPlatformAdminUi\Component\TwigComponent
         arguments:
-            $template: 'EzPlatformAdminUiBundle:dashboard/block:me.html.twig'
+            $template: '@@ezdesign/dashboard/block/me.html.twig'
         tags:
             - { name: ezplatform.admin_ui.component, group: 'dashboard-blocks' }
 
     ezplatform.adminui.dashboard.all:
         parent: EzSystems\EzPlatformAdminUi\Component\TwigComponent
         arguments:
-            $template: 'EzPlatformAdminUiBundle:dashboard/block:all.html.twig'
+            $template: '@@ezdesign/dashboard/block/all.html.twig'
         tags:
             - { name: ezplatform.admin_ui.component, group: 'dashboard-blocks' }

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -1,43 +1,43 @@
 system:
     admin_group:
         user:
-            login_template: '@EzPlatformAdminUi/Security/login.html.twig'
+            login_template: '@ezdesign/Security/login.html.twig'
 
         content_view:
             full:
                 default:
                     controller: 'EzPlatformAdminUiBundle:ContentView:locationView'
-                    template: '@EzPlatformAdminUi/content/locationview.html.twig'
+                    template: '@ezdesign/content/locationview.html.twig'
                     match: true
             preview_ezobjectrelationlist_row:
                 default:
                     controller: 'EzPlatformAdminUiBundle:ContentView:locationView'
-                    template: '@EzPlatformAdminUi\fieldtypes\preview\ezobjectrelationlist_row.html.twig'
+                    template: '@ezdesign\fieldtypes\preview\ezobjectrelationlist_row.html.twig'
                     match: true
 
         content_edit_view:
             full:
                 ezplatform_admin_ui:
-                    template: '@EzPlatformAdminUi/content/content_edit/content_edit.html.twig'
+                    template: '@ezdesign/content/content_edit/content_edit.html.twig'
                     match: true
                     params:
-                        viewbaseLayout: '@EzPlatformAdminUi/layout.html.twig'
+                        viewbaseLayout: '@ezdesign/layout.html.twig'
 
         content_create_view:
             full:
                 ezplatform_admin_ui:
-                    template: '@EzPlatformAdminUi/content/content_edit/content_create.html.twig'
+                    template: '@ezdesign/content/content_edit/content_create.html.twig'
                     match: true
                     params:
-                        viewbaseLayout: '@EzPlatformAdminUi/layout.html.twig'
+                        viewbaseLayout: '@ezdesign/layout.html.twig'
 
         content_translate_view:
             full:
                 ezplatform_admin_ui:
-                    template: '@EzPlatformAdminUi/content/content_edit/content_edit.html.twig'
+                    template: '@ezdesign/content/content_edit/content_edit.html.twig'
                     match: true
                     params:
-                        viewbaseLayout: '@EzPlatformAdminUi/layout.html.twig'
+                        viewbaseLayout: '@ezdesign/layout.html.twig'
 
         fielddefinition_edit_templates:
-            - { template: '@EzPlatformAdminUi/admin/content_type/field_types.html.twig', priority: 10 }
+            - { template: '@ezdesign/admin/content_type/field_types.html.twig', priority: 10 }

--- a/src/bundle/Resources/views/Security/forgot_user_password/index.html.twig
+++ b/src/bundle/Resources/views/Security/forgot_user_password/index.html.twig
@@ -1,6 +1,6 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
-{% form_theme form_forgot_user_password '@EzPlatformAdminUi/Security/form_fields.html.twig'  %}
+{% form_theme form_forgot_user_password '@ezdesign/Security/form_fields.html.twig'  %}
 
 {%- block content -%}
     <h2 class="ez-login__header">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>

--- a/src/bundle/Resources/views/Security/forgot_user_password/success.html.twig
+++ b/src/bundle/Resources/views/Security/forgot_user_password/success.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
 {%- block login_wrapper -%}
     ez-login__text-wrapper

--- a/src/bundle/Resources/views/Security/forgot_user_password/with_login.html.twig
+++ b/src/bundle/Resources/views/Security/forgot_user_password/with_login.html.twig
@@ -1,6 +1,6 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
-{% form_theme form_forgot_user_password_with_login '@EzPlatformAdminUi/Security/form_fields.html.twig'  %}
+{% form_theme form_forgot_user_password_with_login '@ezdesign/Security/form_fields.html.twig'  %}
 
 {%- block content -%}
     <h2 class="ez-login__header">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>

--- a/src/bundle/Resources/views/Security/login.html.twig
+++ b/src/bundle/Resources/views/Security/login.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
 {%- block content -%}
     <form action="{{ path( 'login_check' ) }}" method="post" role="form">

--- a/src/bundle/Resources/views/Security/reset_user_password/index.html.twig
+++ b/src/bundle/Resources/views/Security/reset_user_password/index.html.twig
@@ -1,6 +1,6 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
-{% form_theme form_reset_user_password '@EzPlatformAdminUi/Security/form_fields.html.twig'  %}
+{% form_theme form_reset_user_password '@ezdesign/Security/form_fields.html.twig'  %}
 
 {%- block content -%}
     <h2 class="ez-login__header">{{ 'ezplatform.reset_user_password.change_password'|trans|desc('Change password') }}</h2>

--- a/src/bundle/Resources/views/Security/reset_user_password/invalid_link.html.twig
+++ b/src/bundle/Resources/views/Security/reset_user_password/invalid_link.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
 {%- block content -%}
     <h2 class="ez-login__header">{{ 'ezplatform.reset_user_password.change_password'|trans|desc('Change password') }}</h2>

--- a/src/bundle/Resources/views/Security/reset_user_password/success.html.twig
+++ b/src/bundle/Resources/views/Security/reset_user_password/success.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/Security/base.html.twig' %}
+{% extends '@ezdesign/Security/base.html.twig' %}
 
 {%- block content -%}
     <h2 class="ez-login__header">{{ 'ezplatform.reset_user_password.change_password'|trans|desc('Change password') }}</h2>

--- a/src/bundle/Resources/views/admin/base.html.twig
+++ b/src/bundle/Resources/views/admin/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% block content %}
     <div class="row align-items-stretch ez-main-row">

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -1,8 +1,8 @@
-{% extends "EzPlatformAdminUiBundle::layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'bookmark' %}
 
-{% form_theme form_remove '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_remove '@ezdesign/form_fields.html.twig' %}
 
 {% block body_class %}ez-bookmark-list-view{% endblock %}
 
@@ -15,13 +15,13 @@
 
         <div class="col-sm-10 px-0">
             <section class="container mt-5">
-                {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with { title: 'bookmark.headline'|trans|desc('Bookmarks'), iconName: 'bookmark-manager' } %}
+                {% include '@ezdesign/parts/page_title.html.twig' with { title: 'bookmark.headline'|trans|desc('Bookmarks'), iconName: 'bookmark-manager' } %}
                 <div class="px-4">
                     {{ form_start(form_remove, {
                         'action': path('ezplatform.bookmark.remove'),
                         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#bookmark_remove_remove' }
                     }) }}
-                    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with {
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
                          ground: 'mt-3',
                          headerText: 'bookmark.table.header'|trans|desc('Bookmarks') ~ ' (' ~ pager.count ~ ')',
                          tools: form_widget(form_remove.remove, {'attr': {'class': 'btn btn-primary', 'disabled': true}})

--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -1,8 +1,8 @@
-{% extends "@EzPlatformAdminUi/admin/base.html.twig" %}
+{% extends "@ezdesign/admin/base.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
 
-{% form_theme form _self '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form _self '@ezdesign/form_fields.html.twig'  %}
 
 {% block _ezrepoforms_contenttype_update_removeFieldDefinition_widget %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { url: path('ezplatform.content_type_group.view', { contentTypeGroupId: content_type_group.id }), value: 'content_type_group.breadcrumb.view'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%') },
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type.view.create.title'|trans|desc('Creating a new Content Type'),
         iconName: 'content-type'
     } %}
@@ -130,7 +130,7 @@
 
 {% block right_sidebar %}
     {% set content_type_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_create.sidebar_right', [], {'save_id': form.publishContentType.vars.id, 'group': content_type_group}) %}
-    {{ knp_menu_render(content_type_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_type_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -1,10 +1,10 @@
-{% extends "@EzPlatformAdminUi/admin/base.html.twig" %}
+{% extends "@ezdesign/admin/base.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form '@ezdesign/form_fields.html.twig' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { url: path('ezplatform.content_type_group.view', { contentTypeGroupId: content_type_group.id }), value: 'content_type_group.breadcrumb.view'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%') },
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type.view.edit.title'|trans({ '%name%': content_type.name })|desc('Editing Content Type: %name%'),
         iconName: 'content-type'
     } %}
@@ -63,7 +63,7 @@
                         </svg>
                     </button>
 
-                    {% include 'EzPlatformAdminUiBundle:admin/content_type:delete_confirmation_modal.html.twig' with {'form': form} %}
+                    {% include '@ezdesign/admin/content_type/delete_confirmation_modal.html.twig' with {'form': form} %}
                 </div>
             </div>
             <div class="card-body">
@@ -131,7 +131,7 @@
 
 {% block right_sidebar %}
     {% set content_type_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_edit.sidebar_right', [], {'form_view': form, 'content_type': content_type}) %}
-    {{ knp_menu_render(content_type_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_type_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'content_type' %}
 
-{% import "@EzPlatformAdminUi/admin/content_type/macros.html.twig" as macros %}
+{% import "@ezdesign/admin/content_type/macros.html.twig" as macros %}
 
-{% form_theme form_content_types_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_content_types_delete '@ezdesign/form_fields.html.twig'  %}
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
@@ -24,7 +24,7 @@
                          xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                 </svg>
             </button>
-            {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+            {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                 'id': modal_data_target,
                 'message': 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
                 'data_click': '#content_types_delete_delete',

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -1,13 +1,13 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
 
-{% import "@EzPlatformAdminUi/admin/content_type/macros.html.twig" as macros %}
+{% import "@ezdesign/admin/content_type/macros.html.twig" as macros %}
 
 {% block body_class %}ez-content-type-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') , },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { url: path('ezplatform.content_type_group.view', { contentTypeGroupId: content_type_group.id }), value: 'content_type_group.breadcrumb.view'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%') },
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type.view.view.title'|trans({ '%name%': content_type.name })|desc('%name%'),
         iconName: 'content-type'
     } %}

--- a/src/bundle/Resources/views/admin/content_type_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'content_type' %}
 

--- a/src/bundle/Resources/views/admin/content_type_group/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/create.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
+{% extends "@ezdesign/admin/content_type_group/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'content_type' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { value: 'content_type_group.breadcrumb.add'|trans|desc('Creating a new Content Type Group') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type_group.view.add.title'|trans|desc('Creating a new Content Type Group'),
         iconName: 'content-types'
     } %}
@@ -37,5 +37,5 @@
 
 {% block right_sidebar %}
     {% set content_type_group_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_group_create.sidebar_right') %}
-    {{ knp_menu_render(content_type_group_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_type_group_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/content_type_group/base.html.twig" %}
+{% extends "@ezdesign/admin/content_type_group/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'content_type' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { value: 'content_type_group.breadcrumb.edit'|trans({ '%identifier%': content_type_group.identifier })|desc('Editing Content Type Group "%identifier%"') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type_group.view.edit.title'|trans({'%identifier%': content_type_group.identifier})|desc('Editing Content Type Group "%identifier%"'),
         iconName: 'content-types'
     } %}
@@ -37,5 +37,5 @@
 
 {% block right_sidebar %}
     {% set content_type_group_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_type_group_edit.sidebar_right', [], {'save_id': form.update.vars.id}) %}
-    {{ knp_menu_render(content_type_group_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_type_group_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -1,20 +1,20 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
-{% form_theme form_content_type_groups_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_content_type_groups_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'content_type' %}
 
 {% block body_class %}ez-content-type-group-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') }
     ]} %}
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type_group.view.list.title'|trans|desc('Content Type Groups'),
         iconName: 'content-type'
     } %}
@@ -41,7 +41,7 @@
                              xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                     </svg>
                 </button>
-                {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
                     'message': 'content_type_group.modal.message'|trans|desc('Do you want to delete Content Type Group?'),
                     'data_click': '#content_type_groups_delete_delete',

--- a/src/bundle/Resources/views/admin/content_type_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/view.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'content_type' %}
 
 {% block body_class %}ez-content-type-group-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.content_type_group.list'), value: 'content_type_group.breadcrumb.list'|trans|desc('Content Types') },
         { value: 'content_type_group.breadcrumb.view'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type_group.view.view.title'|trans({ '%identifier%': content_type_group.identifier })|desc('%identifier%'),
         iconName: 'content-type'
     } %}

--- a/src/bundle/Resources/views/admin/language/base.html.twig
+++ b/src/bundle/Resources/views/admin/language/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'language' %}
 

--- a/src/bundle/Resources/views/admin/language/create.html.twig
+++ b/src/bundle/Resources/views/admin/language/create.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/language:base.html.twig' %}
+{% extends '@ezdesign/admin/language/base.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'language' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.language.list'), value: 'language.list'|trans|desc('Languages') },
         { value: 'language.new'|trans|desc('Create a new Language') },
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'language.new.title'|trans|desc('Creating a new Language'),
         iconName: 'languages'
     } %}
@@ -41,5 +41,5 @@
 
 {% block right_sidebar %}
     {% set language_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.language_create.sidebar_right') %}
-    {{ knp_menu_render(language_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(language_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/language/edit.html.twig
+++ b/src/bundle/Resources/views/admin/language/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/language:base.html.twig' %}
+{% extends '@ezdesign/admin/language/base.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'language' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.language.list'), value: 'language.list'|trans|desc('Languages') },
         { value: 'language.edit.identifier'|trans({ '%language%': language.name })|desc('Editing Language "%language%"') }
@@ -15,7 +15,7 @@
 {% block title %}{{ 'language.edit.identifier'|trans({ '%language%': language.name })|desc('Editing Language "%language%"') }}{% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'language.edit.identifier'|trans({ '%language%': language.name })|desc('Editing Language "%language%"'),
         iconName: 'languages'
     } %}
@@ -40,5 +40,5 @@
 
 {% block right_sidebar %}
     {% set language_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.language_edit.sidebar_right', [], {'save_id': form.save.vars.id}) %}
-    {{ knp_menu_render(language_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(language_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -1,13 +1,13 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
-{% form_theme form_languages_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_languages_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'language' %}
 
 {% block body_class %}ez-language-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'language.list'|trans|desc('Languages') }
     ]} %}
@@ -16,7 +16,7 @@
 {% block title %}{{ 'language.list'|trans|desc('Languages') }}{% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'language.list'|trans|desc('Languages'),
         iconName: 'languages'
     } %}
@@ -49,7 +49,7 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                         'id': modal_data_target,
                         'message': 'language.modal.message'|trans|desc('Do you want to delete Language?'),
                         'data_click': '#languages_delete_delete',

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -1,13 +1,13 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
-{% form_theme deleteForm '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme deleteForm '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'language' %}
 
 {% block body_class %}ez-language-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.language.list'), value: 'language.list'|trans|desc('Languages') },
         { value: 'language.view.identifier'|trans({ '%language%': language.name })|desc('%language%') }
@@ -17,7 +17,7 @@
 {% block title %}{{ 'language.view.title.identifier'|trans({ '%language%': language.name })|desc('Language "%language%"') }}{% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'language.view.title.identifier'|trans({ '%language%': language.name })|desc('Language "%language%"'),
         iconName: 'languages'
     } %}
@@ -44,7 +44,7 @@
                         </svg>
                     </button>
 
-                    {% include 'EzPlatformAdminUiBundle:admin/language:delete_confirmation_modal.html.twig' with {'deleteForm': deleteForm} %}
+                    {% include '@ezdesign/admin/language/delete_confirmation_modal.html.twig' with {'deleteForm': deleteForm} %}
 
                     {{ form_end(deleteForm) }}
                 {% endif %}

--- a/src/bundle/Resources/views/admin/object_state/add.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/add.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/object_state/base.html.twig" %}
+{% extends "@ezdesign/admin/object_state/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { url: path('ezplatform.object_state.group.view', { 'objectStateGroupId': object_state_group.id }), value: 'object_state_group.breadcrumb.view'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state.view.add.title'|trans|desc('Creating a new Object State'),
         iconName: 'object-state'
     } %}
@@ -39,5 +39,5 @@
 
 {% block right_sidebar %}
     {% set object_state_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.object_state_create.sidebar_right', [], {'group_id': object_state_group.id}) %}
-    {{ knp_menu_render(object_state_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(object_state_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state/base.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'object_state' %}
 

--- a/src/bundle/Resources/views/admin/object_state/edit.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/object_state/base.html.twig" %}
+{% extends "@ezdesign/admin/object_state/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { url: path('ezplatform.object_state.group.view', { 'objectStateGroupId': object_state_group.id }), value: 'object_state_group.breadcrumb.view'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state.view.edit.title'|trans({'%name%': object_state_group.name})|desc('Editing Object State: %name%'),
         iconName: 'object-state'
     } %}
@@ -39,5 +39,5 @@
 
 {% block right_sidebar %}
     {% set object_state_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.object_state_edit.sidebar_right', [], {'group_id': object_state_group.id, 'save_id': form.save.vars.id}) %}
-    {{ knp_menu_render(object_state_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(object_state_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/list.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form_states_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_states_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
@@ -30,7 +30,7 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                         'id': modal_data_target,
                         'message': 'object_state.modal.message'|trans|desc('Do you want to delete Object State?'),
                         'data_click': '#object_states_delete_delete',

--- a/src/bundle/Resources/views/admin/object_state/view.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/view.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block body_class %}ez-object-state-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { url: path('ezplatform.object_state.group.view', { 'objectStateGroupId': object_state_group.id }), value: 'object_state_group.breadcrumb.view'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%') },
@@ -16,7 +16,7 @@
 {% block title %}{{ 'object_state.view.title'|trans({ '%name%': object_state_group.name })|desc('Object State: %name%') }}{% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state.view.title'|trans({ '%name%': object_state.name })|desc('Object State: %name%'),
         iconName: 'object-state'
     } %}

--- a/src/bundle/Resources/views/admin/object_state_group/add.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/add.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/object_state_group/base.html.twig" %}
+{% extends "@ezdesign/admin/object_state_group/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { value: 'object_state_group.breadcrumb.add'|trans|desc('Creating a new Object State Group') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state_group.view.add.title'|trans|desc('Creating a new Object State Group'),
         iconName: 'object-state'
     } %}
@@ -38,5 +38,5 @@
 
 {% block right_sidebar %}
     {% set object_state_group_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.object_state_group_create.sidebar_right') %}
-    {{ knp_menu_render(object_state_group_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(object_state_group_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'object_state' %}
 

--- a/src/bundle/Resources/views/admin/object_state_group/edit.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/object_state_group/base.html.twig" %}
+{% extends "@ezdesign/admin/object_state_group/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { value: 'object_state_group.breadcrumb.edit'|trans({ '%name%': object_state_group.name })|desc('Editing Object State Group: %name%') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state_group.view.edit.title'|trans({'%name%': object_state_group.name})|desc('Editing Object State Group: %name%'),
         iconName: 'object-state'
     } %}
@@ -38,5 +38,5 @@
 
 {% block right_sidebar %}
     {% set object_state_group_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.object_state_group_edit.sidebar_right', [], {'save_id': form.save.vars.id}) %}
-    {{ knp_menu_render(object_state_group_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(object_state_group_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/list.html.twig
@@ -1,13 +1,13 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
-{% form_theme form_state_groups_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_state_groups_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block body_class %}ez-object-state-group-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
     ]} %}
@@ -16,7 +16,7 @@
 {% block title %}{{ 'object_state_group.view.list.title'|trans|desc('Object State Groups') }}{% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state_group.view.list.title'|trans|desc('Object State Groups'),
         iconName: 'object-state'
     } %}
@@ -49,7 +49,7 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                         'id': modal_data_target,
                         'message': 'object_state_group.modal.message'|trans|desc('Do you want to delete Object State Group?'),
                         'data_click': '#object_state_groups_delete_delete',

--- a/src/bundle/Resources/views/admin/object_state_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/view.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'object_state' %}
 
 {% block body_class %}ez-object-state-group-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.object_state.groups.list'), value: 'object_state_group.breadcrumb.list'|trans|desc('Object States') },
         { value: 'object_state_group.breadcrumb.view'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%') },
@@ -15,7 +15,7 @@
 {% block title %}{{ 'object_state_group.view.title'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%') }}{% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'object_state_group.view.title'|trans({ '%name%': object_state_group.name })|desc('Object State Group: %name%'),
         iconName: 'object-state'
     } %}

--- a/src/bundle/Resources/views/admin/policy/add.html.twig
+++ b/src/bundle/Resources/views/admin/policy/add.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
+{% extends "@ezdesign/admin/policy/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { url: path('ezplatform.role.view', {roleId: role.id}), value: 'role.breadcrumb.view'|trans({ '%identifier%': role.identifier })|desc('%identifier%') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'policy.view.add.title'|trans|trans|desc('Adding a new Policy'),
         iconName: 'roles'
     } %}
@@ -38,5 +38,5 @@
 
 {% block right_sidebar %}
     {% set policy_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.policy_create.sidebar_right', [], {'role': role}) %}
-    {{ knp_menu_render(policy_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(policy_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/policy/base.html.twig
+++ b/src/bundle/Resources/views/admin/policy/base.html.twig
@@ -1,4 +1,4 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'role' %}
 

--- a/src/bundle/Resources/views/admin/policy/create_with_limitation.html.twig
+++ b/src/bundle/Resources/views/admin/policy/create_with_limitation.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
+{% extends "@ezdesign/admin/policy/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { url: path('ezplatform.role.view', {roleId: role.id}), value: 'role.breadcrumb.view.identifier'|trans({ '%identifier%': role.identifier })|desc('Role "%identifier%"') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'policy.view.edit.title'|trans()|desc('Edit limitations'),
         iconName: 'roles'
     } %}
@@ -52,7 +52,7 @@
 
 {% block right_sidebar %}
     {% set policy_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.policy_edit.sidebar_right', [], {'role': role, 'save_id': form.save.vars.id}) %}
-    {{ knp_menu_render(policy_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(policy_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/policy/edit.html.twig
+++ b/src/bundle/Resources/views/admin/policy/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/admin/policy/base.html.twig" %}
+{% extends "@ezdesign/admin/policy/base.html.twig" %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { url: path('ezplatform.role.view', {roleId: role.id}), value: 'role.breadcrumb.view.identifier'|trans({ '%identifier%': role.identifier })|desc('Role "%identifier%"') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'policy.view.edit.title'|trans()|desc('Edit limitations'),
         iconName: 'roles'
     } %}
@@ -52,7 +52,7 @@
 
 {% block right_sidebar %}
     {% set policy_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.policy_edit.sidebar_right', [], {'role': role, 'save_id': form.save.vars.id}) %}
-    {{ knp_menu_render(policy_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(policy_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'role' %}
 
-{% form_theme form_policies_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_policies_delete '@ezdesign/form_fields.html.twig'  %}
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
@@ -28,7 +28,7 @@
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                     </svg>
                 </button>
-                {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
                     'message': 'policy.modal.message'|trans|desc('Do you want to delete Policy?'),
                     'data_click': '#policies_delete_delete',

--- a/src/bundle/Resources/views/admin/role/add.html.twig
+++ b/src/bundle/Resources/views/admin/role/add.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/role:base.html.twig' %}
+{% extends '@ezdesign/admin/role/base.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { value: 'role.breadcrumb.add'|trans|desc('Creating a new Role') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'role.view.add.title'|trans|desc('Creating a new Role'),
         iconName: 'roles'
     } %}
@@ -37,5 +37,5 @@
 
 {% block right_sidebar %}
     {% set role_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.role_create.sidebar_right') %}
-    {{ knp_menu_render(role_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(role_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/role/base.html.twig
+++ b/src/bundle/Resources/views/admin/role/base.html.twig
@@ -1,4 +1,4 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'role' %}
 

--- a/src/bundle/Resources/views/admin/role/edit.html.twig
+++ b/src/bundle/Resources/views/admin/role/edit.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/role:base.html.twig' %}
+{% extends '@ezdesign/admin/role/base.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { value: 'role.breadcrumb.edit'|trans({'%identifier%': role.identifier })|desc('Editing Role: %identifier%') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'role.view.edit.title'|trans({'%identifier%': role.identifier})|desc('Editing Role: %identifier%'),
         iconName: 'roles'
     } %}
@@ -37,5 +37,5 @@
 
 {% block right_sidebar %}
     {% set role_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.role_edit.sidebar_right', [], {'role': role}) %}
-    {{ knp_menu_render(role_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(role_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -1,20 +1,20 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'role' %}
 
-{% form_theme form_roles_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_roles_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% block body_class %}ez-role-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'role.breadcrumb.list'|trans|desc('Roles') }
     ]} %}
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'role.breadcrumb.list'|trans|desc('Roles'),
         iconName: 'roles'
     } %}
@@ -53,7 +53,7 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                         'id': modal_data_target,
                         'message': 'role.modal.message'|trans|desc('Do you want to delete Role?'),
                         'data_click': '#delete-roles_delete',

--- a/src/bundle/Resources/views/admin/role/view.html.twig
+++ b/src/bundle/Resources/views/admin/role/view.html.twig
@@ -1,11 +1,11 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'role' %}
 
 {% block body_class %}ez-role-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { value: 'role.breadcrumb.view.identifier'|trans({'%identifier%': role.identifier })|desc('Role "%identifier%"') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'role.view.view.title'|trans({'%identifier%': role.identifier})|desc('Role "%identifier%"'),
         iconName: 'roles'
     } %}

--- a/src/bundle/Resources/views/admin/role_assignment/base.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/base.html.twig
@@ -1,4 +1,4 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'role' %}
 

--- a/src/bundle/Resources/views/admin/role_assignment/create.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/create.html.twig
@@ -1,11 +1,11 @@
-{% extends '@EzPlatformAdminUi/admin/role_assignment/base.html.twig' %}
+{% extends '@ezdesign/admin/role_assignment/base.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
 {% block breadcrumbs_admin %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.role.list'), value: 'role.breadcrumb.list'|trans|desc('Roles') },
         { url: path('ezplatform.role.view', {roleId: role.id}), value: 'role.breadcrumb.view.identifier'|trans({ '%identifier%': role.identifier })|desc('Role "%identifier%"') },
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'role_assignment.view.add.title'|trans|desc('Assigning users and groups'),
         iconName: 'roles'
     } %}
@@ -80,7 +80,7 @@
 
 {% block right_sidebar %}
     {% set role_assignment_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.role_assignment_create.sidebar_right', [], {'role': role}) %}
-    {{ knp_menu_render(role_assignment_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(role_assignment_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form_role_assignments_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_role_assignments_delete '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'role' %}
 
@@ -29,7 +29,7 @@
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                     </svg>
                 </button>
-                {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
                     'message': 'role_assignments.modal.message'|trans|desc('Do you want to delete Role Assignments?'),
                     'data_click': '#role_assignments_delete_delete',

--- a/src/bundle/Resources/views/admin/search/list.html.twig
+++ b/src/bundle/Resources/views/admin/search/list.html.twig
@@ -1,4 +1,4 @@
-{% extends "EzPlatformAdminUiBundle::layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'search' %}
 
@@ -13,9 +13,9 @@
 
         <div class="col-sm-10 px-0">
             <section class="container mt-5">
-                {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), iconName: 'search' } %}
+                {% include '@ezdesign/parts/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), iconName: 'search' } %}
 
-                {% include '@EzPlatformAdminUi/admin/search/search_form.html.twig' with { form: form } %}
+                {% include '@ezdesign/admin/search/search_form.html.twig' with { form: form } %}
 
                 <div class="ez-table-header mt-3">
                     <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</div>
@@ -50,7 +50,7 @@
                         </thead>
                         <tbody>
                         {% for row in results %}
-                            {% include '@EzPlatformAdminUi/admin/search/search_table_row.html.twig' with { row: row } %}
+                            {% include '@ezdesign/admin/search/search_table_row.html.twig' with { row: row } %}
                         {% endfor %}
                         </tbody>
                     </table>

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -1,4 +1,4 @@
-{% extends "EzPlatformAdminUiBundle::layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'search' %}
 
@@ -17,8 +17,8 @@
 
         <div class="col-sm-10 px-0">
             <section class="container mt-5">
-                {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), iconName: 'search' } %}
-                {% include '@EzPlatformAdminUi/admin/search/search_form.html.twig' with { form: form } %}
+                {% include '@ezdesign/parts/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), iconName: 'search' } %}
+                {% include '@ezdesign/admin/search/search_form.html.twig' with { form: form } %}
 
                 {% if results is defined %}
 
@@ -55,7 +55,7 @@
                             </thead>
                             <tbody>
                             {% for row in results %}
-                                {% include '@EzPlatformAdminUi/admin/search/search_table_row.html.twig' with { row: row } %}
+                                {% include '@ezdesign/admin/search/search_table_row.html.twig' with { row: row } %}
                             {% endfor %}
                             </tbody>
                         </table>
@@ -74,7 +74,7 @@
                         {% endif %}
                     {% endif %}
 
-                    {% form_theme form_edit '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+                    {% form_theme form_edit '@ezdesign/parts/form/flat_widgets.html.twig' %}
 
                     {{ form_start(form_edit, {
                         'action': path('ezplatform.content.edit'),

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'search' %}
 

--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'section' %}
 
-{% form_theme form_section_content_assign '@EzPlatformAdminUi/form_fields.html.twig' '@EzPlatformAdminUi/parts/form/assign_section_widget.html.twig'  %}
+{% form_theme form_section_content_assign '@ezdesign/form_fields.html.twig' '@ezdesign/parts/form/assign_section_widget.html.twig'  %}
 
 <section class="container mt-4 px-5">
     <div class="ez-table-header">

--- a/src/bundle/Resources/views/admin/section/base.html.twig
+++ b/src/bundle/Resources/views/admin/section/base.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'section' %}
 

--- a/src/bundle/Resources/views/admin/section/create.html.twig
+++ b/src/bundle/Resources/views/admin/section/create.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/section:base.html.twig' %}
+{% extends '@ezdesign/admin/section/base.html.twig' %}
 
-{% form_theme form_section_create '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_section_create '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'section' %}
 
 {% block breadcrumbs_admin %}
-    {% include 'EzPlatformAdminUiBundle:parts:breadcrumbs.html.twig' with { 'items': [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { 'items': [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.section.list'), value: 'section.list'|trans|desc('Sections') },
         { value: 'section.new.title'|trans|desc('Creating a new Section') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'section.new.title'|trans|desc('Creating a new Section'),
         iconName: 'sections'
     } %}
@@ -38,5 +38,5 @@
 
 {% block right_sidebar %}
     {% set section_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.section_create.sidebar_right') %}
-    {{ knp_menu_render(section_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(section_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/section/delete_confirmation_modal.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="delete-section-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -1,21 +1,21 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
-{% form_theme form_sections_delete '@EzPlatformAdminUi/form_fields.html.twig'  %}
-{% form_theme form_section_content_assign '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_sections_delete '@ezdesign/form_fields.html.twig'  %}
+{% form_theme form_section_content_assign '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'section' %}
 
 {% block body_class %}ez-section-list-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'section.list.title'|trans|desc('Sections') }
     ]} %}
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'section.list.title'|trans|desc('Sections'),
         iconName: 'sections'
     } %}
@@ -48,7 +48,7 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                         'id': modal_data_target,
                         'message': 'section.modal.message'|trans|desc('Do you want to delete Section?'),
                         'data_click': '#sections_delete_delete',

--- a/src/bundle/Resources/views/admin/section/update.html.twig
+++ b/src/bundle/Resources/views/admin/section/update.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle:admin/section:base.html.twig' %}
+{% extends '@ezdesign/admin/section/base.html.twig' %}
 
-{% form_theme form_section_update '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form_section_update '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain 'section' %}
 
 {% block breadcrumbs_admin %}
-    {% include 'EzPlatformAdminUiBundle:parts:breadcrumbs.html.twig' with { 'items': [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { 'items': [
         { 'value': 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { 'url': path('ezplatform.section.list'), 'value': 'section.list'|trans|desc('Sections') },
         { 'value': 'section.update.title'|trans({ '%identifier%': section.name })|desc('Editing Section "%identifier%"') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'section.update.title'|trans({ '%identifier%': section.name })|desc('Editing Section "%identifier%"'),
         iconName: 'sections'
     } %}
@@ -38,5 +38,5 @@
 
 {% block right_sidebar %}
     {% set section_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.section_edit.sidebar_right', [], {'section': section}) %}
-    {{ knp_menu_render(section_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(section_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -1,11 +1,11 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'section' %}
 
 {% block body_class %}ez-section-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { url: path('ezplatform.section.list'), value: 'section.list'|trans|desc('Sections') },
         { value: 'section.view.title.identifier'|trans({ '%identifier%': section.name })|desc('Section: %identifier%') }
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'section.view.title.identifier'|trans({ '%identifier%': section.name })|desc('Section: %identifier%'),
         iconName: 'sections'
     } %}
@@ -37,7 +37,7 @@
                         </svg>
                     </button>
                     {% if deletable %}
-                        {% include 'EzPlatformAdminUiBundle:admin/section:delete_confirmation_modal.html.twig' with {'form': form_section_delete} %}
+                        {% include '@ezdesign/admin/section/delete_confirmation_modal.html.twig' with {'form': form_section_delete} %}
                     {% endif %}
                 {% endif %}
             </div>

--- a/src/bundle/Resources/views/admin/systeminfo/info.html.twig
+++ b/src/bundle/Resources/views/admin/systeminfo/info.html.twig
@@ -1,23 +1,23 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'systeminfo' %}
 
 {% block body_class %}ez-info-view{% endblock %}
 
 {% block breadcrumbs %}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'systeminfo'|trans|desc('System Information') }
     ]} %}
 {% endblock %}
 
 {% block page_title %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'systeminfo'|trans|desc('System Information'),
         iconName: 'information'
     } %}
 {% endblock %}
 
 {% block content %}
-    {{ ez_platform_tabs('systeminfo', {}, 'EzPlatformAdminUiBundle:parts/tab:system_info.html.twig') }}
+    {{ ez_platform_tabs('systeminfo', {}, '@ezdesign/parts/tab/system_info.html.twig') }}
 {% endblock %}

--- a/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="confirmEmptyTrash" tabindex="-1" role="dialog" aria-labelledby="confirmEmptyTrash"
      aria-hidden="true">

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -1,11 +1,11 @@
-{% extends "EzPlatformAdminUiBundle::layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'trash' %}
 
 {% block page_title %}{% endblock %}
 
-{% form_theme form_trash_item_restore '@EzPlatformAdminUi/form_fields.html.twig' %}
-{% form_theme form_trash_item_delete '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_trash_item_restore '@ezdesign/form_fields.html.twig' %}
+{% form_theme form_trash_item_delete '@ezdesign/form_fields.html.twig' %}
 
 {% block body_class %}ez-trash-list-view{% endblock %}
 
@@ -18,7 +18,7 @@
 
         <div class="col-sm-10 px-0">
             <section class="container mt-5">
-                {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with { title: 'trash.headline'|trans|desc('Trash'), iconName: 'trash' } %}
+                {% include '@ezdesign/parts/page_title.html.twig' with { title: 'trash.headline'|trans|desc('Trash'), iconName: 'trash' } %}
                 {{ form_start(form_trash_item_restore, {'action': path('ezplatform.trash.restore')}) }}
                 <div class="px-4">
                     <div class="ez-table-header mt-3">
@@ -48,7 +48,7 @@
                                          xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                                 </svg>
                             </button>
-                            {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                            {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                                 'id': modal_data_target,
                                 'message': 'trash.modal.message'|trans|desc('Do you want to delete selected item(s) from Trash?'),
                                 'data_click': '#trash_item_delete_delete',
@@ -85,7 +85,7 @@
                                     <td>{{ trash_item.contentType.name }}</td>
                                     <td>
                                         {% if not is_parent_in_trash %}
-                                            {% include 'EzPlatformAdminUiBundle:parts:path.html.twig' with {'locations': trash_item.ancestors, 'link_last_element': true} %}
+                                            {% include '@ezdesign/parts/path.html.twig' with {'locations': trash_item.ancestors, 'link_last_element': true} %}
                                         {% else %}
                                             <em>{{ 'trash.item.ancesor_in_trash'|trans|desc('Ancestor is in the Trash') }}</em>
                                         {% endif %}
@@ -122,13 +122,13 @@
                         {{ pagerfanta(pager, 'ez') }}
                     </div>
                 {% endif %}
-                {% include 'EzPlatformAdminUiBundle:admin/trash:empty_trash_confirmation_modal.html.twig' with {'form': form_trash_empty, 'trash_items_count': pager.nbResults} %}
+                {% include '@ezdesign/admin/trash/empty_trash_confirmation_modal.html.twig' with {'form': form_trash_empty, 'trash_items_count': pager.nbResults} %}
             </section>
         </div>
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
             <div class="ez-sticky-container">
                 {% set sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.trash.sidebar_right', []) %}
-                {{ knp_menu_render(sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+                {{ knp_menu_render(sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
             </div>
         </div>
     </div>

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:content/content_edit:content_edit_base.html.twig' %}
+{% extends '@ezdesign/content/content_edit/content_edit_base.html.twig' %}
 
 {% trans_default_domain 'content_create' %}
 
@@ -41,7 +41,7 @@
 
 {% block right_sidebar %}
     {% set content_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_create.sidebar_right', [], {'parentLocation': parentLocation, 'content_type': contentType, 'language': language}) %}
-    {{ knp_menu_render(content_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block close_button %}

--- a/src/bundle/Resources/views/content/content_edit/content_create_draft.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create_draft.html.twig
@@ -1,7 +1,7 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'content_create_draft' %}
-{% form_theme form with 'EzPlatformAdminUiBundle:content:form_fields.html.twig' %}
+{% form_theme form with '@ezdesign/content/form_fields.html.twig' %}
 
 {% block content %}
     <div class="row align-items-stretch ez-main-row">

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:content/content_edit:content_edit_base.html.twig' %}
+{% extends '@ezdesign/content/content_edit/content_edit_base.html.twig' %}
 
 {% trans_default_domain 'content_edit' %}
 
@@ -59,7 +59,7 @@
         'parent_location': parentLocation,
         'language': language
     }) %}
-    {{ knp_menu_render(content_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(content_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block close_button %}

--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -1,6 +1,6 @@
-{% extends viewbaseLayout is defined ? viewbaseLayout : 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends viewbaseLayout is defined ? viewbaseLayout : '@ezdesign/layout.html.twig' %}
 
-{% set default_form_templates = ['@EzPlatformAdminUi/content/form_fields.html.twig'] %}
+{% set default_form_templates = ['@ezdesign/content/form_fields.html.twig'] %}
 {% set form_templates = form_templates is defined ? form_templates|merge(default_form_templates) : default_form_templates %}
 
 {% trans_default_domain 'content_edit' %}
@@ -54,9 +54,9 @@
 {% endblock %}
 
 {% block javascripts %}
-    {% include 'EzPlatformAdminUiBundle:content/content_edit/parts:javascripts.html.twig' %}
+    {% include '@ezdesign/content/content_edit/parts/javascripts.html.twig' %}
 {% endblock %}
 
 {% block stylesheets %}
-    {% include 'EzPlatformAdminUiBundle:content/content_edit/parts:stylesheets.html.twig' %}
+    {% include '@ezdesign/content/content_edit/parts/stylesheets.html.twig' %}
 {% endblock %}

--- a/src/bundle/Resources/views/content/content_edit/user_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_create.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:content/content_edit:content_edit_base.html.twig' %}
+{% extends '@ezdesign/content/content_edit/content_edit_base.html.twig' %}
 
 {% trans_default_domain 'user_create' %}
 
@@ -36,7 +36,7 @@
 
 {% block right_sidebar %}
     {% set user_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.user_create.sidebar_right', [], {'parent_group': parentGroup, 'content_type': contentType}) %}
-    {{ knp_menu_render(user_create_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(user_create_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block close_button %}

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:content/content_edit:content_edit_base.html.twig' %}
+{% extends '@ezdesign/content/content_edit/content_edit_base.html.twig' %}
 
 {% trans_default_domain 'user_edit' %}
 
@@ -39,7 +39,7 @@
 
 {% block right_sidebar %}
     {% set user_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.user_edit.sidebar_right', [], {'user': user, 'content_type': contentType}) %}
-    {{ knp_menu_render(user_edit_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(user_edit_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block close_button %}

--- a/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:content/content_edit:content_edit_base.html.twig' %}
+{% extends '@ezdesign/content/content_edit/content_edit_base.html.twig' %}
 
 {% trans_default_domain 'content_create' %}
 

--- a/src/bundle/Resources/views/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/content/content_preview.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'content_preview' %}
 

--- a/src/bundle/Resources/views/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/content/content_view_fields.html.twig
@@ -19,7 +19,7 @@
                                     <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
                                 {% else %}
                                     {{ ez_render_field(content, fieldDefinition.identifier, {
-                                        'template': '@EzPlatformAdminUi/fieldtypes/preview/content_fields.html.twig'
+                                        'template': '@ezdesign/fieldtypes/preview/content_fields.html.twig'
                                     }) }}
                                 {% endif %}
                             </div>

--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -1,21 +1,21 @@
 {% use 'bootstrap_4_layout.html.twig' %}
 
 {# specific fieldtypes theming #}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezauthor.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezboolean.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezdatetime.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezrichtext.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezselection.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:eztime.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezdate.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezmedia.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezimage.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezbinaryfile.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezkeyword.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezgmaplocation.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezobjectrelationlist.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezobjectrelation.html.twig' %}
-{% use 'EzPlatformAdminUiBundle:fieldtypes/edit:ezuser.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezauthor.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezboolean.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezdatetime.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezrichtext.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezselection.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/eztime.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezdate.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezmedia.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezimage.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezbinaryfile.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezkeyword.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezgmaplocation.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezobjectrelationlist.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezobjectrelation.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/ezuser.html.twig' %}
 
 {% trans_default_domain 'content_edit' %}
 

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -1,10 +1,10 @@
-{% extends "@EzPlatformAdminUi/layout.html.twig" %}
+{% extends "@ezdesign/layout.html.twig" %}
 
 {% trans_default_domain 'locationview' %}
-{% form_theme form_location_copy '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_location_move '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_content_edit '@EzPlatformAdminUi/form_fields.html.twig' %}
-{% form_theme form_content_create '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_location_copy '@ezdesign/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_location_move '@ezdesign/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_content_edit '@ezdesign/form_fields.html.twig' %}
+{% form_theme form_content_create '@ezdesign/form_fields.html.twig' %}
 
 {% block body_class %}ez-content-view{% endblock %}
 
@@ -33,14 +33,14 @@
                         {% endif %}
                     {% endfor %}
                     {% set items = items|merge([{ 'value': content.name }]) %}
-                    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: items } %}
+                    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: items } %}
 
-                    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+                    {% include '@ezdesign/parts/page_title.html.twig' with {
                         title: content.name,
                         iconName: contentType.identifier,
                         contentTypeName: contentType.name
                     } %}
-                    {% include '@EzPlatformAdminUi/parts/form/location_bookmark.html.twig' with {
+                    {% include '@ezdesign/parts/form/location_bookmark.html.twig' with {
                         form: form_location_bookmark
                     } %}
                 </div>
@@ -56,7 +56,7 @@
                         'system_urls_pagination_params': system_urls_pagination_params,
                         'roles_pagination_params': roles_pagination_params,
                         'policies_pagination_params': policies_pagination_params
-                    }, 'EzPlatformAdminUiBundle:parts/tab:locationview.html.twig') }}
+                    }, '@ezdesign/parts/tab/locationview.html.twig') }}
 
                     {% if contentType.isContainer %}
                     {{ form_start(form_subitems_content_edit, { 'action': path('ezplatform.content.edit'), 'attr': { 'hidden': 'hidden' }}) }}
@@ -74,18 +74,18 @@
         <div class="col-sm-1 pt-4 bg-secondary ez-context-menu">
             <div class="ez-sticky-container">
                 {% set content_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content.sidebar_right', [], {'location': location, 'content': content, 'content_type': contentType}) %}
-                {{ knp_menu_render(content_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+                {{ knp_menu_render(content_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 
                 <div class="ez-extra-actions-container">
-                    {% include '@EzPlatformAdminUi/content/widgets/content_create.html.twig' with {'form': form_content_create} only %}
-                    {% include '@EzPlatformAdminUi/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
+                    {% include '@ezdesign/content/widgets/content_create.html.twig' with {'form': form_content_create} only %}
+                    {% include '@ezdesign/content/widgets/content_edit.html.twig' with {'form': form_content_edit} only %}
                 </div>
             </div>
             {%  if form_location_trash is defined %}
-                {% include '@EzPlatformAdminUi/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
+                {% include '@ezdesign/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
             {% endif %}
             {%  if form_user_delete is defined %}
-                {% include '@EzPlatformAdminUi/content/modal_user_delete.html.twig' with {'form': form_user_delete} only %}
+                {% include '@ezdesign/content/modal_user_delete.html.twig' with {'form': form_user_delete} only %}
             {% endif %}
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}

--- a/src/bundle/Resources/views/content/modal_add_translation.html.twig
+++ b/src/bundle/Resources/views/content/modal_add_translation.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'locationview' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' '@EzPlatformAdminUi/content/translation_add_form_fields.html.twig' %}
+{% form_theme form '@ezdesign/form_fields.html.twig' '@ezdesign/content/translation_add_form_fields.html.twig' %}
 
 <div class="modal fade ez-modal ez-translation" id="add-translation-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
+++ b/src/bundle/Resources/views/content/modal_draft_conflict.html.twig
@@ -25,9 +25,9 @@
                         {{ 'draft.conflict.choice'|trans({})|desc('You can either edit any of your existing draft(s) or add a new one.') }}
                     </p>
                 </div>
-                {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: null, tools: version_modal_draft_conflict.table_header_tools() } %}
+                {% include '@ezdesign/parts/table_header.html.twig' with { headerText: null, tools: version_modal_draft_conflict.table_header_tools() } %}
                 <div class="ez-scrollable-wrapper">
-                    {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
+                    {{ include('@ezdesign/content/tab/versions/table.html.twig', {
                         'versions': conflicted_drafts,
                         'location': location,
                         'is_draft': true,

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form '@ezdesign/form_fields.html.twig' %}
 
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="trash-location-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/content/modal_user_delete.html.twig
+++ b/src/bundle/Resources/views/content/modal_user_delete.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'user_delete' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form '@ezdesign/form_fields.html.twig' %}
 
 <div class="modal fade ez-modal ez-modal--send-to-trash" id="delete-user-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/content/tab/content.html.twig
+++ b/src/bundle/Resources/views/content/tab/content.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/content/content_view_fields.html.twig' %}
+{% extends '@ezdesign/content/content_view_fields.html.twig' %}
 
 {% block extras %}
     {% set current_language = app.request.get('languageCode') ?: content.prioritizedFieldLanguageCode %}

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -1,8 +1,8 @@
 {% trans_default_domain 'locationview' %}
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.content_details'|trans()|desc('Content details') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.details.content_details'|trans()|desc('Content details') } %}
 
-{% form_theme form_location_update '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_location_update '@ezdesign/form_fields.html.twig' %}
 
 <table class="table">
     <thead>
@@ -41,7 +41,7 @@
     </tbody>
 </table>
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.technical_details'|trans()|desc('Technical details') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.details.technical_details'|trans()|desc('Technical details') } %}
 
 <table class="table">
     <thead>
@@ -62,7 +62,7 @@
     </tbody>
 </table>
 {% if can_see_section %}
-    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.section_details'|trans()|desc('Section details') } %}
+    {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.details.section_details'|trans()|desc('Section details') } %}
 
     <table class="table">
         <thead>
@@ -82,7 +82,7 @@
     </table>
 {% endif %}
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.details.state_details'|trans()|desc('State details') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.details.state_details'|trans()|desc('State details') } %}
 
 <table class="table">
     <thead>
@@ -98,7 +98,7 @@
     </thead>
     <tbody>
     {% for objectState in objectStates %}
-        {% form_theme form_state_update[objectState.objectStateGroup.id] '@EzPlatformAdminUi/form_fields.html.twig' %}
+        {% form_theme form_state_update[objectState.objectStateGroup.id] '@ezdesign/form_fields.html.twig' %}
         <tr>
             <td>{{ objectState.objectStateGroup.name }}</td>
             <td>{{ objectState.objectStateGroup.identifier }}</td>
@@ -128,7 +128,7 @@
     </tbody>
 </table>
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with {
+{% include '@ezdesign/parts/table_header.html.twig' with {
     headerText: 'tab.details.sub_items_sorting_order'|trans|desc('Sub-items sorting order'),
     ground: 'ground-base'
 } %}

--- a/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
@@ -1,6 +1,6 @@
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form '@ezdesign/form_fields.html.twig' %}
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with {
+{% include '@ezdesign/parts/table_header.html.twig' with {
     headerText: 'tab.locations.location_content_swap'|trans()|desc('Location Content Swap'),
     ground: 'ground-base'
 } %}

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -1,11 +1,11 @@
 {% trans_default_domain 'locationview' %}
 {% import _self as tab %}
-{% form_theme form_content_location_add 'EzPlatformAdminUiBundle:parts/form:flat_widgets.html.twig' %}
-{% form_theme form_content_location_remove 'EzPlatformAdminUiBundle:parts/form:flat_widgets.html.twig' %}
+{% form_theme form_content_location_add '@ezdesign/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_content_location_remove '@ezdesign/parts/form/flat_widgets.html.twig' %}
 
 <section>
     {{ form(form_content_location_add, {'action': path('ezplatform.location.add')}) }}
-    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.locations.content_locations'|trans()|desc('Content locations'), tools: tab.table_header_tools(form_content_location_add, form_content_location_remove) } %}
+    {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.locations.content_locations'|trans()|desc('Content locations'), tools: tab.table_header_tools(form_content_location_add, form_content_location_remove) } %}
     {{ form_start(form_content_location_remove, {
         'action': path('ezplatform.location.remove'),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-locations' }
@@ -28,7 +28,7 @@
                         {{ form_widget(form_content_location_remove.locations[location.id], {'attr': {'disabled': not location.canDelete}}) }}
                     </td>
                     <td class="align-middle">
-                        {% include 'EzPlatformAdminUiBundle:parts:path.html.twig' with {'locations': location.pathLocations} %}
+                        {% include '@ezdesign/parts/path.html.twig' with {'locations': location.pathLocations} %}
                     </td>
                     <td class="align-middle">{{ location.childCount }}</td>
                     <td>
@@ -62,7 +62,7 @@
 
 </section>
 
-{% include 'EzPlatformAdminUiBundle:content/tab/locations:panel_swap.html.twig' with {'form': form_content_location_swap} %}
+{% include '@ezdesign/content/tab/locations/panel_swap.html.twig' with {'form': form_content_location_swap} %}
 
 {% macro table_header_tools(form_add, form_remove) %}
     <button data-udw-config="{{ ez_udw_config('single', {}) }}" class="btn btn-primary btn--udw-add" title="{{ 'tab.locations.action.add'|trans|desc('Add Location') }}">
@@ -80,7 +80,7 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
-    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
         'id': modal_data_target,
         'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Location?'),
         'data_click': '#' ~ form_remove.remove.vars.id,

--- a/src/bundle/Resources/views/content/tab/policies/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/policies/tab.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'policy' %}
 {% import _self as tab %}
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.policies.policies'|trans|desc('Policies') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.policies.policies'|trans|desc('Policies') } %}
 
 {% if policies_pager.currentPageResults is not empty %}
-    {{  include('@EzPlatformAdminUi/content/tab/policies/table.html.twig', {
+    {{  include('@ezdesign/content/tab/policies/table.html.twig', {
             'policies_pager': policies_pager,
     }) }}
 {% else %}
@@ -13,7 +13,7 @@
 {% endif %}
 
 {% if policies_pager.haveToPaginate %}
-    {{  include('@EzPlatformAdminUi/content/tab/pagination.html.twig', {
+    {{  include('@ezdesign/content/tab/pagination.html.twig', {
             'pager': policies_pager,
             'paginatonParams': {
                 'routeName': policies_pagination_params.route_name,

--- a/src/bundle/Resources/views/content/tab/policies/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/policies/table.html.twig
@@ -39,7 +39,7 @@
                                 <span class="font-weight-bold" title="{{ 'policy.limitation.identifier_tooltip'|trans({'%identifier%': limitation.identifier})|desc('"%identifier%" Limitation') }}">
                                     {{ ('policy.limitation.identifier.' ~ limitation.identifier|lower)|trans({'%identifier%': limitation.identifier}, 'ezrepoforms_policies')|desc('%identifier%') }}:
                                 </span>
-                                {{ ez_render_limitation_value(limitation, {'template': '@EzPlatformAdminUi/content/tab/policies/limitation_values.html.twig'}) }}
+                                {{ ez_render_limitation_value(limitation, {'template': '@ezdesign/content/tab/policies/limitation_values.html.twig'}) }}
                             </li>
                         {%- endfor -%}
                     </ul>

--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -1,10 +1,10 @@
 {% trans_default_domain 'locationview' %}
 
 <section>
-    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.related_content'|trans({'%contentName%' : ez_content_name(content)})|desc('Related content (content items used by %contentName%)') } %}
+    {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.relations.related_content'|trans({'%contentName%' : ez_content_name(content)})|desc('Related content (content items used by %contentName%)') } %}
 
     {% if relations is not empty %}
-        {{ include('@EzPlatformAdminUi/content/tab/relations/table_relations.html.twig', {'relations': relations}) }}
+        {{ include('@ezdesign/content/tab/relations/table_relations.html.twig', {'relations': relations}) }}
     {% else %}
         <p class="ez-table-no-content">
             {{ 'tab.relations.no_relations'|trans()|desc('This content item has no related content.') }}
@@ -12,9 +12,9 @@
     {% endif %}
 
     {% if reverse_relations is defined %}
-        {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.relations.reverse_relations'|trans({'%contentName%' : ez_content_name(content)})|desc('Reverse relations (content items using %contentName%)') } %}
+        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.relations.reverse_relations'|trans({'%contentName%' : ez_content_name(content)})|desc('Reverse relations (content items using %contentName%)') } %}
         {% if reverse_relations is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/relations/table_relations_reverse.html.twig', {'relations': reverse_relations}) }}
+            {{ include('@ezdesign/content/tab/relations/table_relations_reverse.html.twig', {'relations': reverse_relations}) }}
         {% else %}
             <p class="ez-table-no-content">
                 {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}

--- a/src/bundle/Resources/views/content/tab/roles/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/roles/tab.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'role' %}
 {% import _self as tab %}
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.roles.roles'|trans|desc('Roles') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.roles.roles'|trans|desc('Roles') } %}
 
 {% if roles_pager.currentPageResults is not empty %}
-    {{  include('@EzPlatformAdminUi/content/tab/roles/table.html.twig', {
+    {{  include('@ezdesign/content/tab/roles/table.html.twig', {
             'roles_pager': roles_pager,
     }) }}
 {% else %}
@@ -13,7 +13,7 @@
 {% endif %}
 
 {% if roles_pager.haveToPaginate %}
-    {{  include('@EzPlatformAdminUi/content/tab/pagination.html.twig', {
+    {{  include('@ezdesign/content/tab/pagination.html.twig', {
             'pager': roles_pager,
             'paginatonParams': {
                 'routeName': roles_pagination_params.route_name,

--- a/src/bundle/Resources/views/content/tab/roles/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/roles/table.html.twig
@@ -18,7 +18,7 @@
             <td>
                 {%- set limitation = role_assignment.rolelimitation -%}
                 {%- if limitation -%}
-                    {{ ez_render_limitation_value(limitation, {'template': '@EzPlatformAdminUi/content/tab/roles/limitation_values.html.twig'}) }}
+                    {{ ez_render_limitation_value(limitation, {'template': '@ezdesign/content/tab/roles/limitation_values.html.twig'}) }}
                     <span title="{{ 'policy.limitation.identifier_tooltip' | trans({'%identifier%': limitation.identifier})|desc('"%identifier%" Limitation') }}">
                         ({{ ('policy.limitation.identifier.' ~ limitation.identifier|lower)|trans({'%identifier%': limitation.identifier}, 'ezrepoforms_policies')|desc('%identifier%') }})
                     </span>

--- a/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/modal_add_translation.html.twig
@@ -1,2 +1,2 @@
 {# This template is deprecated since 2.2 and will be removed in 3.0. Please use below template as a replacement. #}
-{% include '@EzPlatformAdminUi/content/modal_add_translation.html.twig' %}
+{% include '@ezdesign/content/modal_add_translation.html.twig' %}

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'locationview' %}
 
-{% form_theme form_translation_remove '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_translation_remove '@ezdesign/parts/form/flat_widgets.html.twig' %}
 
 {% import _self as tab %}
 <section>
@@ -8,7 +8,7 @@
         'action': path('ezplatform.translation.remove'),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations' }
     }) }}
-    {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.translations.translation_manger'|trans|desc('Translation manager'), tools: tab.table_header_tools(form_translation_remove) } %}
+    {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.translations.translation_manger'|trans|desc('Translation manager'), tools: tab.table_header_tools(form_translation_remove) } %}
     <table class="table">
         <thead>
         <tr>
@@ -29,7 +29,7 @@
     </table>
     {{ form_end(form_translation_remove) }}
 
-    {% include '@EzPlatformAdminUi/content/tab/translations/modal_add_translation.html.twig' with {'form': form_translation_add} only %}
+    {% include '@ezdesign/content/tab/translations/modal_add_translation.html.twig' with {'form': form_translation_add} only %}
 </section>
 
 {% macro table_header_tools(form_translation_remove) %}
@@ -49,7 +49,7 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
-    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
         'id': modal_data_target,
         'message': 'tab.translations.modal.message'|trans|desc('Do you want to delete Translation?'),
         'data_click': '#' ~ form_translation_remove.remove.vars.id,

--- a/src/bundle/Resources/views/content/tab/translations/translation_add_form_fields.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/translation_add_form_fields.html.twig
@@ -1,2 +1,2 @@
 {# This template is deprecated since 2.2 and will be removed in 3.0. Please use below template as a replacement. #}
-{% include '@EzPlatformAdminUi/content/translation_add_form_fields.html.twig' %}
+{% include '@ezdesign/content/translation_add_form_fields.html.twig' %}

--- a/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain 'content_url' %}
-{% form_theme form_custom_url_remove '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_custom_url_remove '@ezdesign/parts/form/flat_widgets.html.twig' %}
 
 {{ form_start(form_custom_url_remove, {
     'action': path('ezplatform.custom_url.remove'),

--- a/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain 'content_url' %}
-{% form_theme form 'EzPlatformAdminUiBundle:content:form_fields.html.twig' '@EzPlatformAdminUi/content/tab/url/checkbox.html.twig' %}
+{% form_theme form '@ezdesign/content/form_fields.html.twig' '@ezdesign/content/tab/url/checkbox.html.twig' %}
 
 <div class="modal fade ez-modal ez-modal--custom-url-alias" id="ez-modal--custom-url-alias" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'content_url' %}
 {% import _self as tab %}
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.urls.custom_url_aliases'|trans({'%contentName%' : ez_content_name(content)})|desc('Custom URL aliases for %contentName%'), tools: tab.table_header_tools(form_custom_url_remove) } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.urls.custom_url_aliases'|trans({'%contentName%' : ez_content_name(content)})|desc('Custom URL aliases for %contentName%'), tools: tab.table_header_tools(form_custom_url_remove) } %}
 
 {% if custom_urls_pager.currentPageResults is not empty %}
-    {{  include('@EzPlatformAdminUi/content/tab/url/custom_urls_table.html.twig', {
+    {{  include('@ezdesign/content/tab/url/custom_urls_table.html.twig', {
             'custom_urls_pager': custom_urls_pager,
             'form_custom_url_remove': form_custom_url_remove,
     }) }}
@@ -14,7 +14,7 @@
 {% endif %}
 
 {% if custom_urls_pager.haveToPaginate %}
-    {{  include('@EzPlatformAdminUi/content/tab/pagination.html.twig', {
+    {{  include('@ezdesign/content/tab/pagination.html.twig', {
             'pager': custom_urls_pager,
             'paginatonParams': {
                 'routeName': custom_urls_pagination_params.route_name,
@@ -27,10 +27,10 @@
     }) }}
 {% endif %}
 
-{% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.urls.system.title'|trans|desc('System URL') } %}
+{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.urls.system.title'|trans|desc('System URL') } %}
 
 {% if system_urls_pager.currentPageResults is not empty %}
-    {{  include('@EzPlatformAdminUi/content/tab/url/system_urls_table.html.twig', {
+    {{  include('@ezdesign/content/tab/url/system_urls_table.html.twig', {
             'system_urls_pager': system_urls_pager,
     }) }}
 {% else %}
@@ -40,7 +40,7 @@
 {% endif %}
 
 {% if system_urls_pager.haveToPaginate %}
-    {{  include('@EzPlatformAdminUi/content/tab/pagination.html.twig', {
+    {{  include('@ezdesign/content/tab/pagination.html.twig', {
         'pager': system_urls_pager,
         'paginatonParams': {
             'routeName': system_urls_pagination_params.route_name,
@@ -53,7 +53,7 @@
     }) }}
 {% endif %}
 
-{% include '@EzPlatformAdminUi/content/tab/url/modal_add_custom_url.html.twig' with {'form': form_custom_url_add, 'parent_name': parent_name} only %}
+{% include '@ezdesign/content/tab/url/modal_add_custom_url.html.twig' with {'form': form_custom_url_add, 'parent_name': parent_name} only %}
 
 {% macro table_header_tools(form_custom_url_remove) %}
     <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
@@ -70,7 +70,7 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
-    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
         'id': modal_data_target,
         'message': 'tab.urls.modal.message'|trans|desc('Do you want to delete selected Custom URLs?'),
         'data_click': '#' ~ form_custom_url_remove.remove.vars.id,

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'locationview' %}
 
 {% import _self as tab %}
-{% form_theme form_archived_version_restore '@EzPlatformAdminUi/parts/form/flat_widgets.html.twig' %}
-{% form_theme form_version_remove_draft '@EzPlatformAdminUi/form_fields.html.twig' %}
-{% form_theme form_version_remove_archived '@EzPlatformAdminUi/form_fields.html.twig' %}
+{% form_theme form_archived_version_restore '@ezdesign/parts/form/flat_widgets.html.twig' %}
+{% form_theme form_version_remove_draft '@ezdesign/form_fields.html.twig' %}
+{% form_theme form_version_remove_archived '@ezdesign/form_fields.html.twig' %}
 
 {% if draft_pager.currentPageResults is not empty %}
     <section>
@@ -11,8 +11,8 @@
             'action': path('ezplatform.version.remove'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_draft.remove.vars.id }
         }) }}
-        {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
-        {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', {
+        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
+        {{ include('@ezdesign/content/tab/versions/table.html.twig', {
             'versions': draft_pager.currentPageResults,
             'is_draft': true,
             'form': form_version_remove_draft,
@@ -39,14 +39,14 @@
             </div>
         {% endif %}
     </section>
-    {% include '@EzPlatformAdminUi/content/modal_version_conflict.html.twig' %}
+    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
 {% endif %}
 
 {% if published_versions is not empty %}
     <section>
-        {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.published_version'|trans()|desc('Published version') } %}
+        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.published_version'|trans()|desc('Published version') } %}
         {% if published_versions is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', { 'versions': published_versions }) }}
+            {{ include('@ezdesign/content/tab/versions/table.html.twig', { 'versions': published_versions }) }}
         {% else %}
             <p>
                 {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
@@ -61,9 +61,9 @@
             'action': path('ezplatform.version.remove'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_archived.remove.vars.id }
         }) }}
-        {% include '@EzPlatformAdminUi/parts/table_header.html.twig' with { headerText: 'tab.versions.archived_versions'|trans()|desc('Archived versions'), tools: tab.table_header_tools(form_version_remove_archived) } %}
+        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.archived_versions'|trans()|desc('Archived versions'), tools: tab.table_header_tools(form_version_remove_archived) } %}
         {% if archived_versions is not empty %}
-            {{ include('@EzPlatformAdminUi/content/tab/versions/table.html.twig', { 'versions': archived_versions, 'form': form_version_remove_archived, 'is_archived': true, 'form_archived_version_restore': form_archived_version_restore }) }}
+            {{ include('@ezdesign/content/tab/versions/table.html.twig', { 'versions': archived_versions, 'form': form_version_remove_archived, 'is_archived': true, 'form_archived_version_restore': form_archived_version_restore }) }}
         {% else %}
             <p>
                 {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
@@ -89,7 +89,7 @@
                  xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
-    {% include '@EzPlatformAdminUi/bulk_delete_confirmation_modal.html.twig' with {
+    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
     'id': modal_data_target,
     'message': 'tab.versions.modal.message'|trans|desc('Do you want to delete Versions?'),
     'data_click': '#' ~ form.remove.vars.id,

--- a/src/bundle/Resources/views/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard/dashboard.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain 'dashboard' %}
 

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -42,7 +42,7 @@
         {% endfor %}
         </tbody>
     </table>
-    {% include '@EzPlatformAdminUi/content/modal_version_conflict.html.twig' %}
+    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
 {% else %}
     <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
 {% endif %}

--- a/src/bundle/Resources/views/errors/403.html.twig
+++ b/src/bundle/Resources/views/errors/403.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% block content %}
 <div class="row align-items-stretch ez-main-row">

--- a/src/bundle/Resources/views/errors/404.html.twig
+++ b/src/bundle/Resources/views/errors/404.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% block navigation %}
     {% if admin_ui_config.user.user is not empty %}

--- a/src/bundle/Resources/views/errors/error.html.twig
+++ b/src/bundle/Resources/views/errors/error.html.twig
@@ -1,4 +1,4 @@
-{% extends '@EzPlatformAdminUi/layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% block navigation %}{% endblock %}
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezbinaryfile.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
-{% use '@EzPlatformAdminUi/fieldtypes/edit/binary_base.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/binary_base.html.twig' %}
 
 {%- block ezplatform_fieldtype_ezbinaryfile_row -%}
     {% set preview_block_name = 'ezbinaryfile_preview' %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
-{% use '@EzPlatformAdminUi/fieldtypes/edit/binary_base.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/binary_base.html.twig' %}
 
 {%- block ezplatform_fieldtype_ezimage_row -%}
     {% set preview_block_name = 'ezimage_preview' %}
@@ -10,7 +10,7 @@
 {%- endblock -%}
 
 {% block ezimage_preview %}
-    {% form_theme form '@EzPlatformAdminUi/fieldtypes/edit/binary_base_fields.html.twig' %}
+    {% form_theme form '@ezdesign/fieldtypes/edit/binary_base_fields.html.twig' %}
 
     <div class="ez-field-edit-preview">
         <div class="ez-field-edit-preview__visual">

--- a/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
-{% use '@EzPlatformAdminUi/fieldtypes/edit/binary_base.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/binary_base.html.twig' %}
 
 {%- block ezplatform_fieldtype_ezmedia_row -%}
     {% set preview_block_name = 'ezmedia_preview' %}
@@ -10,7 +10,7 @@
 {%- endblock -%}
 
 {% block ezmedia_preview %}
-    {% form_theme form '@EzPlatformAdminUi/fieldtypes/edit/binary_base_fields.html.twig' %}
+    {% form_theme form '@ezdesign/fieldtypes/edit/binary_base_fields.html.twig' %}
 
     <div class="ez-field-edit-preview">
         <div class="ez-field-edit-preview__visual">

--- a/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelation.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelation.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
-{% use '@EzPlatformAdminUi/fieldtypes/edit/relation_base.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/relation_base.html.twig' %}
 
 {% block ezplatform_fieldtype_ezobjectrelation_widget %}
     {% set limit = 1 %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelationlist.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelationlist.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'ezrepoforms_content' %}
 
-{% use '@EzPlatformAdminUi/fieldtypes/edit/relation_base.html.twig' %}
+{% use '@ezdesign/fieldtypes/edit/relation_base.html.twig' %}
 
 {% block ezplatform_fieldtype_ezobjectrelationlist_widget %}
     {% set limit = form.parent.vars.value.fieldDefinition.validatorConfiguration.RelationListValueValidator.selectionLimit %}

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -57,7 +57,7 @@
         <div id="react-udw"></div>
 
         {% block navigation %}
-            {% include 'EzPlatformAdminUiBundle:parts:navigation.html.twig' %}
+            {% include '@ezdesign/parts/navigation.html.twig' %}
         {% endblock %}
         <div class="container-fluid ez-header">
             <div class="container">
@@ -71,7 +71,7 @@
                 {% block left_sidebar %}
                     <div class="col-sm-1 bg-dark pt-4 ez-side-menu">
                         <div class="ez-sticky-container">
-                            {{ knp_menu_render('ezplatform_admin_ui.menu.content.sidebar_left', {'template': '@EzPlatformAdminUi/parts/menu/sidebar_left.html.twig'}) }}
+                            {{ knp_menu_render('ezplatform_admin_ui.menu.content.sidebar_left', {'template': '@ezdesign/parts/menu/sidebar_left.html.twig'}) }}
                         </div>
                     </div>
                 {% endblock left_sidebar %}
@@ -81,7 +81,7 @@
         <div
             class="ez-notifications-container"
             data-notifications="{{ app.flashes|json_encode() }}"
-            data-template="{{ include('EzPlatformAdminUiBundle:parts:notification.html.twig', {
+            data-template="{{ include('@ezdesign/parts/notification.html.twig', {
                 label: '{{ label }}',
                 message: '{{ message }}'
             })|e('html_attr')  }}"></div>

--- a/src/bundle/Resources/views/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/link_manager/edit.html.twig
@@ -1,6 +1,6 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain "linkmanager" %}
 
@@ -9,12 +9,12 @@
         <div class="col-sm-11 px-0 pb-4">
             <div class="ez-header pt-4">
                 <div class="container">
-                    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+                    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
                         { value: 'url.list'|trans, url: path('ezplatform.link_manager.list') },
                         { value: 'url.edit'|trans }
                     ]} %}
 
-                    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+                    {% include '@ezdesign/parts/page_title.html.twig' with {
                         title: 'url.editing'|trans({'%url%': url.url|truncate(50) }),
                         iconName: 'link'
                     } %}
@@ -40,7 +40,7 @@
             {% set url_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.url_edit.sidebar_right', [], {'url': url}) %}
 
             {{ knp_menu_render(url_create_sidebar_right, {
-                'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'
+                'template': '@ezdesign/parts/menu/sidebar_right.html.twig'
             }) }}
         </div>
     </div>

--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -1,19 +1,19 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
-{% form_theme form '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form '@ezdesign/form_fields.html.twig'  %}
 
 {% trans_default_domain "linkmanager" %}
 
 {% block title %}{{ 'url.list'|trans }}{% endblock %}
 
 {%- block breadcrumbs -%}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'url.list'|trans|desc('Link manager') }
     ]} %}
 {%- endblock -%}
 
 {%- block page_title -%}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'url.list'|trans|desc('Link manager'),
         iconName: 'link'
     } %}

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -1,16 +1,16 @@
-{% extends 'EzPlatformAdminUiBundle::layout.html.twig' %}
+{% extends '@ezdesign/layout.html.twig' %}
 
 {% trans_default_domain "linkmanager" %}
 
 {%- block breadcrumbs -%}
-    {% include '@EzPlatformAdminUi/parts/breadcrumbs.html.twig' with { items: [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
         { value: 'url.list'|trans, url: path('ezplatform.link_manager.list') },
         { value: 'url.detail'|trans|desc('Link detail')}
     ]} %}
 {%- endblock -%}
 
 {%- block page_title -%}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
         title: url.url|truncate(60),
         iconName: 'link'
     } %}

--- a/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
+++ b/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain 'locationview' %}
-{% form_theme form _self '@EzPlatformAdminUi/form_fields.html.twig'  %}
+{% form_theme form _self '@ezdesign/form_fields.html.twig'  %}
 
 <div class="ez-add-to-bookmarks {{ form.vars.data.bookmarked ? 'ez-add-to-bookmarks--checked'}}">
     {{ form_start(form, {'action': path('ezplatform.location.update_bookmark')}) }}

--- a/src/bundle/Resources/views/parts/menu/sidebar_left.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_left.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:parts/menu:sidebar_base.html.twig' %}
+{% extends '@ezdesign/parts/menu/sidebar_base.html.twig' %}
 
 {% block item -%}
     {%- set default_classes = 'btn btn-dark btn-block' -%}

--- a/src/bundle/Resources/views/parts/menu/sidebar_right.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_right.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:parts/menu:sidebar_base.html.twig' %}
+{% extends '@ezdesign/parts/menu/sidebar_base.html.twig' %}
 
 {% block item -%}
     {%- set default_classes = 'btn btn-secondary btn-block' -%}

--- a/src/bundle/Resources/views/parts/menu/top_menu.html.twig
+++ b/src/bundle/Resources/views/parts/menu/top_menu.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:parts/menu:top_menu_base.html.twig' %}
+{% extends '@ezdesign/parts/menu/top_menu_base.html.twig' %}
 
 {% block root %}
     {% set listAttributes = item.childrenAttributes %}

--- a/src/bundle/Resources/views/parts/menu/top_menu_2nd_level.html.twig
+++ b/src/bundle/Resources/views/parts/menu/top_menu_2nd_level.html.twig
@@ -1,4 +1,4 @@
-{% extends 'EzPlatformAdminUiBundle:parts/menu:top_menu_base.html.twig' %}
+{% extends '@ezdesign/parts/menu/top_menu_base.html.twig' %}
 
 {% block root %}
     {% set listAttributes = item.childrenAttributes %}

--- a/src/bundle/Resources/views/parts/navigation.html.twig
+++ b/src/bundle/Resources/views/parts/navigation.html.twig
@@ -15,7 +15,7 @@
             <ul class="nav nav-tabs" role="tablist">
                 {{ knp_menu_render(main_menu, {
                     'depth': 1,
-                    'template': '@EzPlatformAdminUi/parts/menu/top_menu.html.twig',
+                    'template': '@ezdesign/parts/menu/top_menu.html.twig',
                     'currentClass': 'active',
                     'ancestorClass': 'active'
                 }) }}
@@ -35,7 +35,7 @@
                 </div>
                 {{ knp_menu_render('ezplatform_admin_ui.menu.user', {
                     'depth': 1,
-                    'template': '@EzPlatformAdminUi/parts/menu/user_menu.html.twig'
+                    'template': '@ezdesign/parts/menu/user_menu.html.twig'
                 }) }}
             </div>
         </div>
@@ -44,7 +44,7 @@
 <nav class="navbar navbar-expand-sm navbar-light ez-main-sub-nav" style="flex-wrap:wrap;">
     {{ knp_menu_render(main_menu, {
         'depth': 2,
-        'template': '@EzPlatformAdminUi/parts/menu/top_menu_2nd_level.html.twig',
+        'template': '@ezdesign/parts/menu/top_menu_2nd_level.html.twig',
         'currentClass': 'active',
         'ancestorClass': 'active'
     }) }}

--- a/src/bundle/Resources/views/user-profile/change_user_password.html.twig
+++ b/src/bundle/Resources/views/user-profile/change_user_password.html.twig
@@ -1,18 +1,18 @@
-{% extends '@EzPlatformAdminUi/admin/base.html.twig' %}
+{% extends '@ezdesign/admin/base.html.twig' %}
 
-{% form_theme form_change_user_password '@EzPlatformAdminUi/user-profile/form_fields.html.twig'  %}
+{% form_theme form_change_user_password '@ezdesign/user-profile/form_fields.html.twig'  %}
 
 {% trans_default_domain 'user_change_password' %}
 
 {% block breadcrumbs_admin %}
-    {% include 'EzPlatformAdminUiBundle:parts:breadcrumbs.html.twig' with { 'items': [
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { 'items': [
     { value: 'breadcrumb.user_preferences'|trans(domain='messages')|desc('User Preferences') },
     { value: 'user_change_password.change_password'|trans|desc('Change Password') }
     ]} %}
 {% endblock %}
 
 {% block page_title_admin %}
-    {% include '@EzPlatformAdminUi/parts/page_title.html.twig' with {
+    {% include '@ezdesign/parts/page_title.html.twig' with {
     title: 'user_change_password.title'|trans|desc('Change my password'),
     iconName: 'edit'
     } %}
@@ -37,7 +37,7 @@
 
 {% block right_sidebar %}
     {% set user_password_change_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.user_password_change.sidebar_right') %}
-    {{ knp_menu_render(user_password_change_sidebar_right, {'template': '@EzPlatformAdminUi/parts/menu/sidebar_right.html.twig'}) }}
+    {{ knp_menu_render(user_password_change_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/lib/Component/Content/PreviewUnavailableTwigComponent.php
+++ b/src/lib/Component/Content/PreviewUnavailableTwigComponent.php
@@ -72,7 +72,7 @@ class PreviewUnavailableTwigComponent implements Renderable
 
         if (empty($siteaccesses)) {
             return $this->twig->render(
-                'EzPlatformAdminUiBundle:content/content_edit/component:preview_unavailable.html.twig'
+                '@ezdesign/content/content_edit/component/preview_unavailable.html.twig'
             );
         }
 

--- a/src/lib/Component/LinkComponent.php
+++ b/src/lib/Component/LinkComponent.php
@@ -61,7 +61,7 @@ class LinkComponent implements Renderable
      */
     public function render(array $parameters = []): string
     {
-        return $this->twig->render('EzPlatformAdminUiBundle:component:link.html.twig', [
+        return $this->twig->render('@ezdesign/component/link.html.twig', [
             'href' => $this->href,
             'type' => $this->type,
             'rel' => $this->rel,

--- a/src/lib/Component/ScriptComponent.php
+++ b/src/lib/Component/ScriptComponent.php
@@ -67,7 +67,7 @@ class ScriptComponent implements Renderable
      */
     public function render(array $parameters = []): string
     {
-        return $this->twig->render('EzPlatformAdminUiBundle:component:script.html.twig', [
+        return $this->twig->render('@ezdesign/component/script.html.twig', [
             'src' => $this->src,
             'type' => $this->type,
             'async' => $this->async,

--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -86,13 +86,13 @@ class AdminExceptionListener
 
         switch ($code) {
             case 404:
-                $content = $this->twig->render('@EzPlatformAdminUi/errors/404.html.twig');
+                $content = $this->twig->render('@ezdesign/errors/404.html.twig');
                 break;
             case 403:
-                $content = $this->twig->render('@EzPlatformAdminUi/errors/403.html.twig');
+                $content = $this->twig->render('@ezdesign/errors/403.html.twig');
                 break;
             default:
-                $content = $this->twig->render('@EzPlatformAdminUi/errors/error.html.twig');
+                $content = $this->twig->render('@ezdesign/errors/error.html.twig');
                 break;
         }
 

--- a/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
@@ -78,7 +78,7 @@ class ContentOnTheFlyProcessor implements EventSubscriberInterface
 
         $event->setResponse(
             new Response(
-                $this->twig->render('@EzPlatformAdminUi/content/content_on_the_fly/content_create_response.html.twig', [
+                $this->twig->render('@ezdesign/content/content_on_the_fly/content_create_response.html.twig', [
                     'locationId' => $content->contentInfo->mainLocationId,
                 ])
             )

--- a/src/lib/Tab/Dashboard/EveryoneContentTab.php
+++ b/src/lib/Tab/Dashboard/EveryoneContentTab.php
@@ -74,7 +74,7 @@ class EveryoneContentTab extends AbstractTab implements OrderedTabInterface
         $pager->setMaxPerPage($limit);
         $pager->setCurrentPage($page);
 
-        return $this->twig->render('EzPlatformAdminUiBundle:dashboard/tab:all_content.html.twig', [
+        return $this->twig->render('@ezdesign/dashboard/tab/all_content.html.twig', [
             'data' => $this->pagerContentToDataMapper->map($pager),
         ]);
     }

--- a/src/lib/Tab/Dashboard/EveryoneMediaTab.php
+++ b/src/lib/Tab/Dashboard/EveryoneMediaTab.php
@@ -74,7 +74,7 @@ class EveryoneMediaTab extends AbstractTab implements OrderedTabInterface
         $pager->setMaxPerPage($limit);
         $pager->setCurrentPage($page);
 
-        return $this->twig->render('EzPlatformAdminUiBundle:dashboard/tab:all_media.html.twig', [
+        return $this->twig->render('@ezdesign/dashboard/tab/all_media.html.twig', [
             'data' => $this->pagerContentToDataMapper->map($pager),
         ]);
     }

--- a/src/lib/Tab/Dashboard/MyContentTab.php
+++ b/src/lib/Tab/Dashboard/MyContentTab.php
@@ -80,7 +80,7 @@ class MyContentTab extends AbstractTab implements OrderedTabInterface
         $pager->setMaxPerPage($limit);
         $pager->setCurrentPage($page);
 
-        return $this->twig->render('EzPlatformAdminUiBundle:dashboard/tab:my_content.html.twig', [
+        return $this->twig->render('@ezdesign/dashboard/tab/my_content.html.twig', [
             'data' => $this->pagerContentToDataMapper->map($pager),
         ]);
     }

--- a/src/lib/Tab/Dashboard/MyDraftsTab.php
+++ b/src/lib/Tab/Dashboard/MyDraftsTab.php
@@ -151,7 +151,7 @@ class MyDraftsTab extends AbstractTab implements OrderedTabInterface, Conditiona
             ];
         }
 
-        return $this->twig->render('EzPlatformAdminUiBundle:dashboard/tab:my_drafts.html.twig', [
+        return $this->twig->render('@ezdesign/dashboard/tab/my_drafts.html.twig', [
             'data' => $data,
         ]);
     }

--- a/src/lib/Tab/Dashboard/MyMediaTab.php
+++ b/src/lib/Tab/Dashboard/MyMediaTab.php
@@ -83,7 +83,7 @@ class MyMediaTab extends AbstractTab implements OrderedTabInterface
         $pager->setMaxPerPage($limit);
         $pager->setCurrentPage($page);
 
-        return $this->twig->render('EzPlatformAdminUiBundle:dashboard/tab:my_media.html.twig', [
+        return $this->twig->render('@ezdesign/dashboard/tab/my_media.html.twig', [
             'data' => $this->pagerContentToDataMapper->map($pager),
         ]);
     }

--- a/src/lib/Tab/LocationView/ContentTab.php
+++ b/src/lib/Tab/LocationView/ContentTab.php
@@ -78,7 +78,7 @@ class ContentTab extends AbstractTab implements OrderedTabInterface
         $languages = $this->loadContentLanguages($content);
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab:content.html.twig',
+            '@ezdesign/content/tab/content.html.twig',
             [
                 'content' => $content,
                 /* @deprecated since version 2.2, to be removed in 3.0 */

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -155,7 +155,7 @@ class DetailsTab extends AbstractTab implements OrderedTabInterface
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab:details.html.twig',
+            '@ezdesign/content/tab/details.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/LocationsTab.php
+++ b/src/lib/Tab/LocationView/LocationsTab.php
@@ -109,7 +109,7 @@ class LocationsTab extends AbstractTab implements OrderedTabInterface
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/locations:tab.html.twig',
+            '@ezdesign/content/tab/locations/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/PoliciesTab.php
+++ b/src/lib/Tab/LocationView/PoliciesTab.php
@@ -150,7 +150,7 @@ class PoliciesTab extends AbstractTab implements OrderedTabInterface, Conditiona
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/policies:tab.html.twig',
+            '@ezdesign/content/tab/policies/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/RelationsTab.php
+++ b/src/lib/Tab/LocationView/RelationsTab.php
@@ -143,7 +143,7 @@ class RelationsTab extends AbstractTab implements OrderedTabInterface, Condition
         $viewParameters['contentTypes'] = $contentTypes;
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/relations:tab.html.twig',
+            '@ezdesign/content/tab/relations/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/RolesTab.php
+++ b/src/lib/Tab/LocationView/RolesTab.php
@@ -150,7 +150,7 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/roles:tab.html.twig',
+            '@ezdesign/content/tab/roles/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -96,7 +96,7 @@ class TranslationsTab extends AbstractTab implements OrderedTabInterface
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/translations:tab.html.twig',
+            '@ezdesign/content/tab/translations/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/UrlsTab.php
+++ b/src/lib/Tab/LocationView/UrlsTab.php
@@ -136,7 +136,7 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab:urls.html.twig',
+            '@ezdesign/content/tab/urls.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/Tab/LocationView/VersionsTab.php
+++ b/src/lib/Tab/LocationView/VersionsTab.php
@@ -167,7 +167,7 @@ class VersionsTab extends AbstractTab implements OrderedTabInterface, Conditiona
         ];
 
         return $this->twig->render(
-            'EzPlatformAdminUiBundle:content/tab/versions:tab.html.twig',
+            '@ezdesign/content/tab/versions/tab.html.twig',
             array_merge($viewParameters, $parameters)
         );
     }

--- a/src/lib/View/ContentTranslateSuccessView.php
+++ b/src/lib/View/ContentTranslateSuccessView.php
@@ -21,7 +21,7 @@ class ContentTranslateSuccessView extends BaseView
      */
     public function __construct(Response $response)
     {
-        parent::__construct('@EzPlatformAdminUi/http/no_content.html.twig');
+        parent::__construct('@ezdesign/http/no_content.html.twig');
 
         $this->setResponse($response);
         $this->setControllerReference(new ControllerReference('EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translationSuccessAction'));


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA issue  | [EZP-28868](https://jira.ez.no/browse/EZP-28868)
| Required PRs | <ul><li>ezsystems/ezplatform#286</li><li>ezsystems/ezplatform-standard-design#2</li></ul>
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | TBD
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR defines admin Design and Theme for the entire eZ Platform Admin UI.
It means that any given template can be easily overridden by just dropping that template in `app/Resources/views/themes/admin`.

Templates are not moved due to BC, `src/bundle/Resources/views` directory is mapped as a directory of `admin` theme.

PR contains several commits that can be reviewed separately.

**TODO**:
- [x] **Before Merging Remove TMP commit and rebase**.
- [x] Prepend eZ Design configuration and set admin Design for `admin_group`.
- [x] Update namespace of AdminUI Twig templates to use eZ Design.
- [x] Update namespace of inner templates (being referenced inside Twig template).
- [x] Wait for result tests with enabled Standard Design package ([successful build](https://travis-ci.org/ezsystems/ezplatform-admin-ui/builds/380616179?utm_source=github_status&utm_medium=notification)).
- [x] Ask for code review.
- [x] **QA: Test extensively**
