### PR TITLE
Fix rendering custom fieldgroup names

### DIFF
--- a/src/lib/Tab/LocationView/ContentTab.php
+++ b/src/lib/Tab/LocationView/ContentTab.php
@@ -110,6 +110,7 @@ class ContentTab extends AbstractTab implements OrderedTabInterface
             }
 
             $fieldDefinitionsByGroup[$groupId]['fieldDefinitions'][] = $fieldDefinition;
+            $fieldDefinitionsByGroup[$groupId]['name'] = $fieldDefinitionsByGroup[$groupId]['name'] ?? $groupId;
         }
 
         return $fieldDefinitionsByGroup;

--- a/src/lib/Tests/Tab/ContentTabTest.php
+++ b/src/lib/Tests/Tab/ContentTabTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Tests\Tab;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
+use eZ\Publish\Core\REST\Client\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformAdminUi\Tab\LocationView\ContentTab;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
+
+class ContentTabTest extends TestCase
+{
+    public function testGroupFieldDefinitions()
+    {
+        $contentTab = $this->createForGroupFieldDefitions();
+
+        $refl = new \ReflectionMethod(ContentTab::class, 'groupFieldDefinitions');
+        $refl->setAccessible(true);
+
+        $fieldDefinitionsByGroup = $refl->invokeArgs($contentTab, [[
+            new FieldDefinition([
+                'fieldGroup' => 'random', // this is a new fieldGroup which is not defined originally for the tab
+            ]),
+            new FieldDefinition(), // should go to the default group (content)
+        ]]);
+
+        $this->assertCount(2, $fieldDefinitionsByGroup);
+
+        $this->assertArrayHasKey('content', $fieldDefinitionsByGroup);
+        $this->assertArrayHasKey('random', $fieldDefinitionsByGroup);
+
+        $this->assertArrayHasKey('name', $fieldDefinitionsByGroup['content']);
+        $this->assertArrayHasKey('name', $fieldDefinitionsByGroup['random']);
+
+        $this->assertSame('Content', $fieldDefinitionsByGroup['content']['name']);
+        $this->assertSame('random', $fieldDefinitionsByGroup['random']['name']);
+
+        $this->assertArrayHasKey('fieldDefinitions', $fieldDefinitionsByGroup['content']);
+        $this->assertArrayHasKey('fieldDefinitions', $fieldDefinitionsByGroup['random']);
+
+        $this->assertCount(1, $fieldDefinitionsByGroup['content']['fieldDefinitions']);
+        $this->assertCount(1, $fieldDefinitionsByGroup['random']['fieldDefinitions']);
+    }
+
+    protected function createForGroupFieldDefitions()
+    {
+        $fieldsGroupList = $this->createMock(FieldsGroupsList::class);
+
+        $fieldsGroupList
+            ->expects(self::once())
+            ->method('getGroups')
+            ->willReturn([
+                'content' => 'Content',
+            ])
+        ;
+        $fieldsGroupList
+            ->expects(self::once())
+            ->method('getDefaultGroup')
+            ->willReturn('content')
+        ;
+
+        return new ContentTab(
+            $this->createMock(Environment::class),
+            $this->createMock(TranslatorInterface::class),
+            $fieldsGroupList,
+            $this->createMock(LanguageService::class),
+            []
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

If I specify a random `fieldGroup` for a content type's field, then the admin can only display the group if I define the group in the symfony config: `ezpublish.repositories.default.fields_groups`.

Otherwise I get a fatal error when viewing a content in the admin:
![ezfatal](https://user-images.githubusercontent.com/543367/40001750-2b31c68e-578f-11e8-8325-9e10ed5c7144.png)

 In 1.x I didn't have to specify the group in the config, so there was a BC break somewhere I think. With my change, the `fieldGroup` string (that I randomly defined at content type creation) is the fallback for the name, if translation or definition is missing (I would call this the old behavior).


#### Checklist:
- [x] Ready for Code Review
