### PR TITLE
EZP-29103: Implement permissions for Object State in Admin Panel

### DIFF
--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -71,7 +71,7 @@ class ObjectStateGroupController extends Controller
      */
     public function listAction(): Response
     {
-        /** @var ObjectStateGroup[] $objectStateGroups */
+        /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[] $objectStateGroups */
         $objectStateGroups = $this->objectStateService->loadObjectStateGroups();
         $emptyObjectStateGroups = [];
 
@@ -116,6 +116,7 @@ class ObjectStateGroupController extends Controller
      */
     public function addAction(Request $request): Response
     {
+        $this->denyAccessUnlessGranted(new Attribute('state', 'administrate'));
         $defaultLanguageCode = reset($this->languages);
 
         $form = $this->formFactory->createObjectStateGroup(
@@ -165,6 +166,7 @@ class ObjectStateGroupController extends Controller
      */
     public function deleteAction(Request $request, ObjectStateGroup $group): Response
     {
+        $this->denyAccessUnlessGranted(new Attribute('state', 'administrate'));
         $form = $this->formFactory->deleteObjectStateGroup(
             new ObjectStateGroupDeleteData($group)
         );
@@ -202,6 +204,7 @@ class ObjectStateGroupController extends Controller
      */
     public function bulkDeleteAction(Request $request): Response
     {
+        $this->denyAccessUnlessGranted(new Attribute('state', 'administrate'));
         $form = $this->formFactory->deleteObjectStateGroups(
             new ObjectStateGroupsDeleteData()
         );
@@ -240,6 +243,7 @@ class ObjectStateGroupController extends Controller
      */
     public function updateAction(Request $request, ObjectStateGroup $group): Response
     {
+        $this->denyAccessUnlessGranted(new Attribute('state', 'administrate'));
         $form = $this->formFactory->updateObjectStateGroup(
             new ObjectStateGroupUpdateData($group)
         );

--- a/src/bundle/Resources/views/admin/object_state/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/list.html.twig
@@ -7,27 +7,35 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state.view.list.title'|trans({'%count%': object_states|length})|desc('Object States (%count%)') }}</div>
             <div>
-                <a title="{{ 'object_state.new'|trans|desc('Create a new Object State ') }}"
-                   href="{{ path('ezplatform.object_state.state.add', {'objectStateGroupId': object_state_group.id}) }}"
-                   class="btn btn-primary" {% if not can_administrate %} disabled="disabled"{% endif %}>
-                    <svg class="ez-icon ez-icon-create">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
-                    </svg>
-                </a>
-                {% set modal_data_target = 'delete-object-state-modal' %}
-                <button id="delete-object-state" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}" title="{{ 'object_state.delete.bulk_delete.submit'|trans|desc('Delete Object State') }}">
-                    <svg class="ez-icon ez-icon-trash">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-                    </svg>
-                </button>
-                {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
-                    'id': modal_data_target,
-                    'message': 'object_state.modal.message'|trans|desc('Do you want to delete Object State?'),
-                    'data_click': '#object_states_delete_delete',
-                }%}
+                {% if can_administrate %}
+                    <a
+                        title="{{ 'object_state.new'|trans|desc('Create a new Object State ') }}"
+                        href="{{ path('ezplatform.object_state.state.add', {'objectStateGroupId': object_state_group.id}) }}"
+                        class="btn btn-primary">
+                        <svg class="ez-icon ez-icon-create">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+                        </svg>
+                    </a>
+
+                    {% set modal_data_target = 'delete-object-state-modal' %}
+                    <button
+                        id="delete-object-state"
+                        type="button"
+                        class="btn btn-danger"
+                        disabled
+                        data-toggle="modal"
+                        data-target="#{{ modal_data_target }}"
+                        title="{{ 'object_state.delete.bulk_delete.submit'|trans|desc('Delete Object State') }}">
+                        <svg class="ez-icon ez-icon-trash">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        </svg>
+                    </button>
+                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                        'id': modal_data_target,
+                        'message': 'object_state.modal.message'|trans|desc('Do you want to delete Object State?'),
+                        'data_click': '#object_states_delete_delete',
+                    }%}
+                {% endif %}
             </div>
         </div>
 
@@ -56,16 +64,21 @@
                 {% for object_state in object_states %}
                     <tr>
                         <td class="ez-checkbox-cell">
-                            {{ form_widget(form_states_delete.objectStates[object_state.id], {"disabled": not can_administrate}) }}
+                            {% if can_administrate %}
+                                {{ form_widget(form_states_delete.objectStates[object_state.id]) }}
+                            {% else %}
+                                {% do form_states_delete.objectStates.setRendered %}
+                            {% endif %}
                         </td>
                         <td><a href="{{ path( 'ezplatform.object_state.state.view', {'objectStateId': object_state.id} ) }}">{{ object_state.name }}</a></td>
                         <td>{{ object_state.identifier }}</td>
                         <td>{{ object_state.id }}</td>
                         <td class="text-right">
                             {% if can_administrate %}
-                                <a title="{{ 'object_state.view.list.action.edit'|trans|desc('Edit') }}"
-                                   href="{{ path('ezplatform.object_state.state.update', {'objectStateId': object_state.id}) }}"
-                                   class="btn btn-icon mx-3">
+                                <a
+                                    title="{{ 'object_state.view.list.action.edit'|trans|desc('Edit') }}"
+                                    href="{{ path('ezplatform.object_state.state.update', {'objectStateId': object_state.id}) }}"
+                                    class="btn btn-icon mx-3">
                                     <svg class="ez-icon ez-icon-edit">
                                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                     </svg>

--- a/src/bundle/Resources/views/admin/object_state_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/list.html.twig
@@ -27,27 +27,34 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state_group.view.list.title'|trans|desc('Object State Groups') }}</div>
             <div>
-                <a title="{{ 'object_state_group.new'|trans|desc('Create a new Object State Group') }}"
-                   href="{{ path('ezplatform.object_state.group.add') }}"
-                   class="btn btn-primary" {% if not can_administrate %} disabled="disabled"{% endif %}>
-                    <svg class="ez-icon ez-icon-create">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
-                    </svg>
-                </a>
-                {% set modal_data_target = 'delete-object-state-groups-modal' %}
-                <button id="delete-object-state-groups" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                        data-target="#{{ modal_data_target }}" title="{{ 'object_state_group.delete.bulk_delete.submit'|trans|desc('Delete Object State Group') }}">
-                    <svg class="ez-icon ez-icon-trash">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                             xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-                    </svg>
-                </button>
-                {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
-                    'id': modal_data_target,
-                    'message': 'object_state_group.modal.message'|trans|desc('Do you want to delete Object State Group?'),
-                    'data_click': '#object_state_groups_delete_delete',
-                }%}
+                {% if can_administrate %}
+                    <a
+                        title="{{ 'object_state_group.new'|trans|desc('Create a new Object State Group') }}"
+                        href="{{ path('ezplatform.object_state.group.add') }}"
+                        class="btn btn-primary">
+                        <svg class="ez-icon ez-icon-create">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+                        </svg>
+                    </a>
+                    {% set modal_data_target = 'delete-object-state-groups-modal' %}
+                    <button
+                        id="delete-object-state-groups"
+                        type="button"
+                        class="btn btn-danger"
+                        disabled
+                        data-toggle="modal"
+                        data-target="#{{ modal_data_target }}"
+                        title="{{ 'object_state_group.delete.bulk_delete.submit'|trans|desc('Delete Object State Group') }}">
+                        <svg class="ez-icon ez-icon-trash">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        </svg>
+                    </button>
+                    {% include '@EzPlatformAdminUi/admin/bulk_delete_confirmation_modal.html.twig' with {
+                        'id': modal_data_target,
+                        'message': 'object_state_group.modal.message'|trans|desc('Do you want to delete Object State Group?'),
+                        'data_click': '#object_state_groups_delete_delete',
+                    }%}
+                {% endif %}
             </div>
         </div>
 
@@ -76,16 +83,21 @@
                 {% for object_state_group in object_state_groups %}
                     <tr>
                         <td class="ez-checkbox-cell">
-                            {{ form_widget(form_state_groups_delete.objectStateGroups[object_state_group.id], {"disabled": not can_administrate}) }}
+                            {% if can_administrate %}
+                                {{ form_widget(form_state_groups_delete.objectStateGroups[object_state_group.id]) }}
+                            {% else %}
+                                {% do form_state_groups_delete.objectStateGroups.setRendered %}
+                            {% endif %}
                         </td>
                         <td><a href="{{ path( 'ezplatform.object_state.group.view', {'objectStateGroupId': object_state_group.id} ) }}">{{ object_state_group.name }}</a></td>
                         <td>{{ object_state_group.identifier }}</td>
                         <td>{{ object_state_group.id }}</td>
                         <td class="text-right">
                             {% if can_administrate %}
-                                <a title="{{ 'object_state_group.view.list.action.edit'|trans|desc('Edit') }}"
-                                   href="{{ path('ezplatform.object_state.group.update', {'objectStateGroupId': object_state_group.id}) }}"
-                                   class="btn btn-icon mx-3">
+                                <a
+                                    title="{{ 'object_state_group.view.list.action.edit'|trans|desc('Edit') }}"
+                                    href="{{ path('ezplatform.object_state.group.update', {'objectStateGroupId': object_state_group.id}) }}"
+                                    class="btn btn-icon mx-3">
                                     <svg class="ez-icon ez-icon-edit">
                                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                     </svg>

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -107,7 +107,7 @@
             <td>{{ objectState.identifier }}</td>
             <td>{{ objectState.id }}</td>
             <td>
-                {% if form_state_update[objectState.objectStateGroup.id].objectState.vars.choices|length != 0 %}
+                {% if can_assign and form_state_update[objectState.objectStateGroup.id].objectState.vars.choices|length != 0 %}
                     {{ form_start(form_state_update[objectState.objectStateGroup.id], {
                         'method': 'POST',
                         'action': path('ezplatform.object_state.contentstate.update', {

--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -65,10 +65,11 @@ class ContentObjectStateUpdateType extends AbstractType
             $form->add('objectState', ObjectStateChoiceType::class, [
                 'label' => false,
                 'choice_loader' => new CallbackChoiceLoader(function () use ($objectStateGroup, $contentInfo) {
+                    $contentState = $this->objectStateService->getContentState($contentInfo, $objectStateGroup);
                     return array_filter(
                         $this->objectStateService->loadObjectStates($objectStateGroup),
-                        function (ObjectState $objectState) use ($contentInfo) {
-                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]);
+                        function (ObjectState $objectState) use ($contentInfo, $contentState) {
+                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]) && $contentState->id !== $objectState->id;
                         }
                     );
                 }),

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -222,20 +222,22 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
             $menuItems[$usersItem->getName()] = $usersItem;
         }
 
-        $menuItems[self::ITEM_ADMIN__OBJECT_STATES] = $this->createMenuItem(
-            self::ITEM_ADMIN__OBJECT_STATES,
-            ['route' => 'ezplatform.object_state.groups.list', 'extras' => [
-                'routes' => [
-                    'group_list' => 'ezplatform.object_state.groups.list',
-                    'group_create' => 'ezplatform.object_state.group.add',
-                    'group_edit' => 'ezplatform.object_state.group.update',
-                    'group_view' => 'ezplatform.object_state.group.view',
-                    'state_create' => 'ezplatform.object_state.state.add',
-                    'state_view' => 'ezplatform.object_state.state.view',
-                    'state_edit' => 'ezplatform.object_state.state.update',
-                ],
-            ]]
-        );
+        if ($this->permissionResolver->hasAccess('state', 'administrate')) {
+            $menuItems[self::ITEM_ADMIN__OBJECT_STATES] = $this->createMenuItem(
+                self::ITEM_ADMIN__OBJECT_STATES,
+                ['route' => 'ezplatform.object_state.groups.list', 'extras' => [
+                    'routes' => [
+                        'group_list' => 'ezplatform.object_state.groups.list',
+                        'group_create' => 'ezplatform.object_state.group.add',
+                        'group_edit' => 'ezplatform.object_state.group.update',
+                        'group_view' => 'ezplatform.object_state.group.view',
+                        'state_create' => 'ezplatform.object_state.state.add',
+                        'state_view' => 'ezplatform.object_state.state.view',
+                        'state_edit' => 'ezplatform.object_state.state.update',
+                    ],
+                ]]
+            );
+        }
 
         return $menuItems;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29103
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


For now state/assign policy is only checked by `$this->permissionResolver->hasAccess('state', 'assign')` method. When user has some limitation, button will be displayed.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
