### PR TITLE
EZP-29160: Hide Roles and Policies tab if the user does not have "Role/Read" permission

### DIFF
--- a/src/lib/Tab/LocationView/PoliciesTab.php
+++ b/src/lib/Tab/LocationView/PoliciesTab.php
@@ -19,6 +19,7 @@ use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
+use eZ\Publish\API\Repository\PermissionResolver;
 
 class PoliciesTab extends AbstractTab implements OrderedTabInterface, ConditionalTabInterface
 {
@@ -33,25 +34,31 @@ class PoliciesTab extends AbstractTab implements OrderedTabInterface, Conditiona
     /** @var array */
     private $userGroupContentTypeIdentifier;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    protected $permissionResolver;
+
     /**
      * @param \Twig\Environment $twig
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
      * @param array $userContentTypeIdentifier
      * @param array $userGroupContentTypeIdentifier
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
     public function __construct(
         Environment $twig,
         TranslatorInterface $translator,
         DatasetFactory $datasetFactory,
         array $userContentTypeIdentifier,
-        array $userGroupContentTypeIdentifier
+        array $userGroupContentTypeIdentifier,
+        PermissionResolver $permissionResolver
     ) {
         parent::__construct($twig, $translator);
 
         $this->datasetFactory = $datasetFactory;
         $this->userContentTypeIdentifier = $userContentTypeIdentifier;
         $this->userGroupContentTypeIdentifier = $userGroupContentTypeIdentifier;
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -87,9 +94,16 @@ class PoliciesTab extends AbstractTab implements OrderedTabInterface, Conditiona
      * @param array $parameters
      *
      * @return bool
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function evaluate(array $parameters): bool
     {
+        if (false === $this->permissionResolver->canUser('role', 'read', $parameters['content'])) {
+            return false;
+        }
+
         /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
         $contentType = $parameters['contentType'];
 

--- a/src/lib/Tab/LocationView/RolesTab.php
+++ b/src/lib/Tab/LocationView/RolesTab.php
@@ -19,6 +19,7 @@ use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
+use eZ\Publish\API\Repository\PermissionResolver;
 
 class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTabInterface
 {
@@ -33,25 +34,31 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
     /** @var array */
     private $userGroupContentTypeIdentifier;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    protected $permissionResolver;
+
     /**
      * @param \Twig\Environment $twig
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
      * @param array $userContentTypeIdentifier
      * @param array $userGroupContentTypeIdentifier
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
     public function __construct(
         Environment $twig,
         TranslatorInterface $translator,
         DatasetFactory $datasetFactory,
         array $userContentTypeIdentifier,
-        array $userGroupContentTypeIdentifier
+        array $userGroupContentTypeIdentifier,
+        PermissionResolver $permissionResolver
     ) {
         parent::__construct($twig, $translator);
 
         $this->datasetFactory = $datasetFactory;
         $this->userContentTypeIdentifier = $userContentTypeIdentifier;
         $this->userGroupContentTypeIdentifier = $userGroupContentTypeIdentifier;
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -87,9 +94,16 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
      * @param array $parameters
      *
      * @return bool
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function evaluate(array $parameters): bool
     {
+        if (false === $this->permissionResolver->canUser('role', 'read', $parameters['content'])) {
+            return false;
+        }
+
         /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
         $contentType = $parameters['contentType'];
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29160
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR hide Roles and Policies tab if the user does not have "Role/Read" permission. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
