### PR TITLE
EZEE-2025: Add extension point in `content_edit_base.html.twig` allowing spoofing form templates

### DIFF
--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -1,7 +1,10 @@
 {% extends viewbaseLayout is defined ? viewbaseLayout : 'EzPlatformAdminUiBundle::layout.html.twig' %}
 
+{% set default_form_templates = ['@EzPlatformAdminUi/content/form_fields.html.twig'] %}
+{% set form_templates = form_templates is defined ? form_templates|merge(default_form_templates) : default_form_templates %}
+
 {% trans_default_domain 'content_edit' %}
-{% form_theme form with 'EzPlatformAdminUiBundle:content:form_fields.html.twig' %}
+{% form_theme form with form_templates %}
 
 {% block body_class %}ez-standalone-page ez-content-edit{% endblock %}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2025
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This is needed to fix https://jira.ez.no/browse/EZEE-2024. My PR adds new variable `form_templates` which can be defined outside when embedding `content_edit_base.html.twig` providing injection point of custom Twig templates for content edit/create form. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
