### PR TITLE
EZP-29213: Error 500 when user doesn't have Content/reverserelatedlist policy

### DIFF
--- a/src/lib/Tab/LocationView/RelationsTab.php
+++ b/src/lib/Tab/LocationView/RelationsTab.php
@@ -12,27 +12,29 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformAdminUi\Tab\AbstractTab;
+use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
 use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 
-class RelationsTab extends AbstractTab implements OrderedTabInterface
+class RelationsTab extends AbstractTab implements OrderedTabInterface, ConditionalTabInterface
 {
-    /** @var PermissionResolver */
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
     protected $permissionResolver;
 
-    /** @var DatasetFactory */
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory */
     protected $datasetFactory;
 
-    /** @var ContentTypeService */
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
     protected $contentTypeService;
 
     /**
-     * @param Environment $twig
-     * @param TranslatorInterface $translator
-     * @param PermissionResolver $permissionResolver
-     * @param DatasetFactory $datasetFactory
+     * @param \Twig\Environment $twig
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      */
     public function __construct(
         Environment $twig,
@@ -48,22 +50,58 @@ class RelationsTab extends AbstractTab implements OrderedTabInterface
         $this->contentTypeService = $contentTypeService;
     }
 
+    /**
+     * @return string
+     */
     public function getIdentifier(): string
     {
         return 'relations';
     }
 
+    /**
+     * @return string
+     */
     public function getName(): string
     {
         /** @Desc("Relations") */
         return $this->translator->trans('tab.name.relations', [], 'locationview');
     }
 
+    /**
+     * @return int
+     */
     public function getOrder(): int
     {
         return 500;
     }
 
+    /**
+     * Get information about tab presence.
+     *
+     * @param array $parameters
+     *
+     * @return bool
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function evaluate(array $parameters): bool
+    {
+        return $this->permissionResolver->canUser('content', 'reverserelatedlist', $parameters['content']);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string
+     *
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
     public function renderView(array $parameters): string
     {
         /** @var Content $content */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29213
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2018-05-21 at 10 29 38 am](https://user-images.githubusercontent.com/1654712/40300757-7832e958-5cea-11e8-87d1-e54afb27780e.png)
![screen shot 2018-05-21 at 10 29 19 am](https://user-images.githubusercontent.com/1654712/40300758-78512b70-5cea-11e8-83e0-5edd41b8235e.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
