### PR TITLE
 EZP-29209: Front-end Notification System (from JS) API

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Notifications.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for subtree related operations.
+ *
+ * Example configuration:
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      admin_group: # configuration per siteaccess or siteaccess group
+ *          notifications:
+ *              warning: # type of notification
+ *                  timeout: 5000 # in milliseconds
+ * ```
+ */
+class Notifications extends AbstractParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (empty($scopeSettings['notifications'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['notifications'];
+        $nodes = ['timeout'];
+
+        foreach ($settings as $type => $config) {
+            foreach ($nodes as $key) {
+                if (!isset($config[$key]) || empty($config[$key])) {
+                    continue;
+                }
+
+                $contextualizer->setContextualParameter(
+                    sprintf('notifications.%s.%s', $type, $key),
+                    $currentScope,
+                    $config[$key]
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('notifications')
+                ->useAttributeAsKey('type')
+                ->info('AdminUI notifications configuration.')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('timeout')
+                            ->info('Time in milliseconds notifications should disappear after.')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+}

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -14,6 +14,7 @@ use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\TabPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UiConfigProviderPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\LocationIds;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Module;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Notifications;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Pagination;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Security;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations;
@@ -38,6 +39,7 @@ class EzPlatformAdminUiBundle extends Bundle
         $core->addConfigParser(new UserIdentifier());
         $core->addConfigParser(new UserGroupIdentifier());
         $core->addConfigParser(new SubtreeOperations());
+        $core->addConfigParser(new Notifications());
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['ezplatform_default_settings.yml']);
 
         $this->addCompilerPasses($container);

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -36,3 +36,9 @@ parameters:
 
     # Subtree Operations
     ezsettings.default.subtree_operations.copy_subtree.limit: 100
+
+    # Notifications
+    ezsettings.default.notifications.error.timeout: 0
+    ezsettings.default.notifications.warning.timeout: 0
+    ezsettings.default.notifications.success.timeout: 5000
+    ezsettings.default.notifications.info.timeout: 0

--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -46,3 +46,8 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\FieldType\RichText\CustomTag:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'richTextCustomTags' }
+
+    # Notifications
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\Notifications:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'notifications' }

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.js
@@ -1,0 +1,29 @@
+(function (global, doc, eZ, $) {
+    const notificationsContainer = doc.querySelector('.ez-notifications-container');
+    const notifications = JSON.parse(notificationsContainer.dataset.notifications);
+    const template = notificationsContainer.dataset.template;
+    const addNotification = ({ detail }) => {
+        // @TODO: Unify 'error' and 'danger' label in 3.0.
+        const configKey = detail.label === 'danger' ? 'error' : detail.label;
+        const config = eZ.adminUiConfig.notifications[configKey];
+        const timeout = config ? config.timeout : 0;
+        const container = doc.createElement('div');
+        const notification = template.replace('{{ label }}', detail.label).replace('{{ message }}', detail.message);
+
+        container.insertAdjacentHTML('beforeend', notification);
+
+        const notificationNode = container.querySelector('.alert');
+
+        notificationsContainer.append(notificationNode);
+
+        if (timeout) {
+            global.setTimeout(() => $(notificationNode).alert('close'), timeout);
+        }
+    };
+
+    Object.entries(notifications).forEach(([ label, messages ]) => {
+        messages.forEach(message => addNotification({ detail: { label, message }}));
+    });
+
+    doc.body.addEventListener('ez-notify', addNotification, false);
+})(window, window.document, window.eZ, window.jQuery);

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="bb7c5bc498a649c6ec116abc12e7b8be1d4f7b92" resname="alert.close">
+        <source>Close</source>
+        <target state="new">Close</target>
+        <note>key: alert.close</note>
+      </trans-unit>
       <trans-unit id="d2293b387ecddbc6173fd579abd37873fcbc5e97" resname="authentication.forgot_password">
         <source>Forgot password?</source>
         <target state="new">Forgot password?</target>

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -71,48 +71,42 @@
 
             {% endblock content %}
         </div>
-        <div class="ez-notifications-container">
-            {% for label, messages in app.flashes %}
-                {% for message in messages %}
-                    <div class="alert alert-{{ label }} alert-dismissible fade show" role="alert">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <svg class="ez-icon ez-icon--light ez-icon-small">
-                                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#circle-close"></use>
-                            </svg>
-                        </button>
-                        {{ message|trans }}
-                    </div>
-                {% endfor %}
-            {% endfor %}
-        </div>
+        <div
+            class="ez-notifications-container"
+            data-notifications="{{ app.flashes|json_encode() }}"
+            data-template="{{ include('EzPlatformAdminUiBundle:parts:notification.html.twig', {
+                label: '{{ label }}',
+                message: '{{ message }}'
+            })|e('html_attr')  }}"></div>
         <div class="ez-modal-wrapper"></div>
         {%  javascripts
-            'bundles/ezplatformadminuiassets/vendors/react/umd/react.production.min.js'
-            'bundles/ezplatformadminuiassets/vendors/react-dom/umd/react-dom.production.min.js'
-            'bundles/ezplatformadminuiassets/vendors/jquery/dist/jquery.min.js'
-            'bundles/ezplatformadminuiassets/vendors/popper.js/dist/umd/popper.min.js'
-            'bundles/ezplatformadminuiassets/vendors/bootstrap/dist/js/bootstrap.min.js'
-            'bundles/ezplatformadminuiassets/vendors/create-react-class/create-react-class.min.js'
-            'bundles/ezplatformadminuiassets/vendors/prop-types/prop-types.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/react/umd/react.production.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/react-dom/umd/react-dom.production.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/jquery/dist/jquery.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/popper.js/dist/umd/popper.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/bootstrap/dist/js/bootstrap.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/create-react-class/create-react-class.min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/prop-types/prop-types.min.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}
         {{ ezplatform_admin_ui_component_group('custom-admin-ui-modules') }}
         {{ ezplatform_admin_ui_component_group('custom-admin-ui-config') }}
         {%  javascripts
-            'bundles/ezplatformadminuimodules/js/UniversalDiscovery.module.js'
-            'bundles/ezplatformadminui/js/scripts/button.trigger.js'
-            'bundles/ezplatformadminui/js/scripts/button.prevent.default.js'
-            'bundles/ezplatformadminui/js/scripts/udw/browse.js'
-            'bundles/ezplatformadminui/js/scripts/admin.user.menu.js'
-            'bundles/ezplatformadminui/js/scripts/admin.prevent.click.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.notifications.js'
+            '@EzPlatformAdminUiModulesBundle/Resources/public/js/UniversalDiscovery.module.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.trigger.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.prevent.default.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/browse.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.user.menu.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.prevent.click.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}
         {# CKEditor is not compatible with 'use strict' mode, React 16 force 'use strict' on the entire file.
            CKEditor and React 16 cannot be compiled into one file by assetic #}
         {%  javascripts
-            'bundles/ezplatformadminuiassets/vendors/alloyeditor/dist/alloy-editor/alloy-editor-no-react-min.js'
+            '@EzPlatformAdminUiAssetsBundle/Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-no-react-min.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}

--- a/src/bundle/Resources/views/parts/notification.html.twig
+++ b/src/bundle/Resources/views/parts/notification.html.twig
@@ -1,0 +1,8 @@
+<div class="alert alert-{{ label }} alert-dismissible fade show">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close" title="{{ 'alert.close'|trans|desc('Close') }}">
+        <svg class="ez-icon ez-icon--light ez-icon-small">
+            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
+        </svg>
+    </button>
+    {{ message }}
+</div>

--- a/src/lib/UI/Config/Provider/Notifications.php
+++ b/src/lib/UI/Config/Provider/Notifications.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+/**
+ * Provides information about notifications.
+ */
+class Notifications implements ProviderInterface
+{
+    public const NOTIFICATION_TYPES = ['error', 'warning', 'info', 'success'];
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     */
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        $config = [];
+        foreach (self::NOTIFICATION_TYPES as $type) {
+            $config[$type] = [
+                'timeout' => $this->configResolver->getParameter(sprintf('notifications.%s.timeout', $type)),
+            ];
+        }
+
+        return $config;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29209
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

**Screenshot**
![notifications](https://user-images.githubusercontent.com/12594013/40364229-1352d82a-5dd2-11e8-9b59-4fc54c35f0f0.png)

**Usage**
```js
const eventInfo = new CustomEvent('ez-notify', {
    detail: {
        label: 'info',
        message: 'this is info message'
    }
});
const eventSuccess = new CustomEvent('ez-notify', {
    detail: {
        label: 'success',
        message: 'this is success message'
    }
});
const eventWarning = new CustomEvent('ez-notify', {
    detail: {
        label: 'warning',
        message: 'this is warning message'
    }
});
const eventError = new CustomEvent('ez-notify', {
    detail: {
        label: 'danger',
        message: 'this is error message'
    }
});

document.body.dispatchEvent(eventInfo);
document.body.dispatchEvent(eventSuccess);
document.body.dispatchEvent(eventWarning);
document.body.dispatchEvent(eventError);
```

Notifications on backend side are still the same.

**Doc/QA**
We have new settings: `notifications timeout`. Timeout when the notification should hide (in ms).

Defaults:
```
error: 0
warning: 0
success: 5000
info: 0
```

How to override:
```yml
# Notifications
ezpublish:
    system:
        admin: # configuration per siteaccess or siteaccess group
            notifications:
                error:
                    timeout: 0
                warning:
                    timeout: 0
                success:
                    timeout: 5000
                info:
                    timeout: 0
```
#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
