### PR TITLE
EZP-29204: RichText link popup on Microsoft Edge has broken styling

### DIFF
--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -241,7 +241,7 @@
 
 .ae-ui IE10-PLUS::-ms-reveal,
 .ae-ui [class^=ae-toolbar] {
-  height: 40px;
+  height: auto;
   box-sizing: content-box;
 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29204
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Change from `height: 40px` to `height: auto` inside `.ae-ui IE10-PLUS::-ms-reveal, .ae-ui [class^=ae-toolbar]` fixes background not stretching for entire toolbar problem on Edge, that shows mostly when new link toolbar is open.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
