### PR TITLE
[CS][1.1] Aligned missed CS fixes and adjusted php-cs-fixer conf

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,6 +26,7 @@ return PhpCsFixer\Config::create()
         ],
         'yoda_style' => false,
         'no_break_comment' => false,
+        'self_accessor' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/lib/Tests/Form/DataTransformer/LanguageTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/LanguageTransformerTest.php
@@ -79,7 +79,7 @@ class LanguageTransformerTest extends TestCase
 
         $result = $transformer->reverseTransform(null);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testReverseTransformWithNotFoundException()

--- a/src/lib/Tests/Form/DataTransformer/LocationTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/LocationTransformerTest.php
@@ -75,7 +75,7 @@ class LocationTransformerTest extends TestCase
 
         $result = $transformer->reverseTransform(null);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testReverseTransformWithNotFoundException()

--- a/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
@@ -75,7 +75,7 @@ class RoleAssignmentTransformerTest extends TestCase
 
         $result = $transformer->reverseTransform(null);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testReverseTransformWithNotFoundException()

--- a/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
@@ -75,7 +75,7 @@ class RoleTransformerTest extends TestCase
 
         $result = $transformer->reverseTransform(null);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testReverseTransformWithNotFoundException()

--- a/src/lib/Tests/Form/DataTransformer/SectionTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/SectionTransformerTest.php
@@ -74,7 +74,7 @@ class SectionTransformerTest extends TestCase
 
         $result = $transformer->reverseTransform(null);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testReverseTransformWithNotFoundException()

--- a/src/lib/Tests/Form/DataTransformer/SectionsTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/SectionsTransformerTest.php
@@ -62,7 +62,7 @@ class SectionsTransformerTest extends TestCase
         $transformer = new SectionsTransformer($service);
         $result = $transformer->reverseTransform($value);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     /**


### PR DESCRIPTION
This PR aligns code with missing CS rules on 1.1 (one more remaining for master).

I planned to push this directly, however there's one debatable change.

The php-cs-fixer, according to `self_accessor` rule, tries to fix:
[src/lib/Specification/SpecificationInterface.php](https://github.com/ezsystems/ezplatform-admin-ui/blob/v1.1.1/src/lib/Specification/SpecificationInterface.php) in the following way:
```php
    /**
     * @param SpecificationInterface $other
     *
     * @return SpecificationInterface
     */
    public function and(self $other): self;
```

While this seems like a good direction, it looks like PhpStorm (2018.1.4) is completely unable to understand that (in terms of classes implementing that interface and also param type hinting). This is really annoying and leads to bad dev experience.

We've decided with @Nattfarinn that for now we should disable that rule, especially that it belongs to `@Symfony:risky` group.

WDYT?

**TODO**:
- [x] Wait for php-cs-fixer to confirm.
- [x] Align code with `php_unit_construct rule` of php-cs-fixer
- [x] Disable `self_accessor` rule due to some issues.