### PR TITLE
EZP-29247: Error 500 after trying to enter dashboard with "My drafts" without Content/VersionRead policy

### DIFF
--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -66,6 +66,7 @@ class ContentObjectStateUpdateType extends AbstractType
                 'label' => false,
                 'choice_loader' => new CallbackChoiceLoader(function () use ($objectStateGroup, $contentInfo) {
                     $contentState = $this->objectStateService->getContentState($contentInfo, $objectStateGroup);
+
                     return array_filter(
                         $this->objectStateService->loadObjectStates($objectStateGroup),
                         function (ObjectState $objectState) use ($contentInfo, $contentState) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29218
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Hide tab if user has absolutely no access to content/versionread. If user has no access content/versionread for one of versions, exception is caught and draft array is empty.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
