### PR TITLE
EZP-29124: Cover basic scenarios of testing fields in content managing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,16 @@ matrix:
         - php: 7.1
           env: PHPUNIT_CONFIG='phpunit.xml'
         - php: 7.1
-          env: COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml" BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction" SYMFONY_ENV=behat
+          env:
+          - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+          - BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction"
+          - SYMFONY_ENV=behat
         - php: 7.1
-          env: WEB_HOST="varnish" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml" BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction" SYMFONY_ENV=behat
+          env:
+          - WEB_HOST="varnish"
+          - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+          - BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction --tags=~@EZP-29291-excluded"
+          - SYMFONY_ENV=behat
 
 cache:
     directories:

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -28,3 +28,5 @@ adminui:
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\SectionsContext
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\ObjectStatesContext
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\DashboardContext
+                - EzSystems\RepositoryForms\Features\Context\ContentType
+                - EzSystems\RepositoryForms\Features\Context\FieldTypeFormContext

--- a/features/ContentTypeFields.feature
+++ b/features/ContentTypeFields.feature
@@ -1,0 +1,45 @@
+Feature: Content fields setting and editing
+  As an administrator
+  In order to manage content on my site
+  I want to set, edit, copy and move content items.
+
+  @javascript @common @EZP-29291-excluded
+  Scenario Outline: Create content item with given field
+    Given a Content Type "<fieldName> CT" with an "<fieldInternalName>" field definition
+      And I am logged as "admin"
+      And I go to "Content structure" in "Content" tab
+    When I start creating a new content "<fieldName> CT"
+      And I set content fields
+        | label    | <label1> | <label2> | <label3> |
+        | Field    | <value1> | <value2> | <value3> |
+      And I click on the edit action bar button "Publish"
+    Then I should be on content item page "<ctName>" of type "<fieldName> CT" in "eZ Platform"
+      And success notification that "Content published." appears
+      And content attributes equal
+        | label    | <label1> | <label2> | <label3> |
+        | Field    | <value1> | <value2> | <value3> |
+
+    Examples:
+      | fieldInternalName    | fieldName                    | label1    | value1                | label2     | value2                | label3  | value3   | ctName                  |
+      | ezselection          | Selection                    | value     | Test-value            |            |                       |         |          | Test-value              |
+      | ezgmaplocation       | Map location                 | latitude  | 32                    | longitude  | 132                   | address | Acapulco | Acapulco                |
+      | ezauthor             | Authors                      | name      | Test Name             | email      | email@example.com     |         |          | Test Name               |
+      | ezboolean            | Checkbox                     | value     | true                  |            |                       |         |          | 1                       |
+      | ezobjectrelation     | Content relation (single)    | value     | Media/Images          |            |                       |         |          | Images                  |
+      | ezobjectrelationlist | Content relations (multiple) | firstItem | Media/Images          | secondItem | Media/Files           |         |          | Images Files            |
+      | ezcountry            | Country                      | value     | Poland                |            |                       |         |          | Poland                  |
+      | ezdate               | Date                         | value     | 12/30/2019            |            |                       |         |          | Monday 30 December 2019 |
+      | ezdatetime           | Date and time                | date      | 12/30/2019            | time       | 13:15                 |         |          | Mon 2019-30-12 13:15:00 |
+      | ezemail              | E-mail address               | value     | email@example.com     |            |                       |         |          | email@example.com       |
+      | ezfloat              | Float                        | value     | 11.11                 |            |                       |         |          | 11.11                   |
+      | ezisbn               | ISBN                         | value     | 978-3-16-148410-0     |            |                       |         |          | 978-3-16-148410-0       |
+      | ezinteger            | Integer                      | value     | 1111                  |            |                       |         |          | 1111                    |
+      | ezkeyword            | Keywords                     | value     | first keyword, second |            |                       |         |          | first keyword, second   |
+      | ezrichtext           | Rich text                    | value     | Lorem ipsum dolor sit |            |                       |         |          | Lorem ipsum dolor sit   |
+      | eztext               | Text block                   | value     | Lorem ipsum dolor sit |            |                       |         |          | Lorem ipsum dolor sit   |
+      | ezstring             | Text line                    | value     | Lorem ipsum dolor sit |            |                       |         |          | Lorem ipsum dolor sit   |
+      | eztime               | Time                         | value     | 13:15                 |            |                       |         |          | 1:15:00 pm              |
+      | ezurl                | URL                          | text      | Test URL              | url        | http://www.google.com |         |          | Test URL                |
+#      | ezmedia              | Media                        | value   | value         |        |                   |        |                   |
+#      | ezimage              | Image                        | value   | value         |        |                   |        |                   |
+#      | ezbinaryfile         | File                         | value   | value         |        |                   |        |                   |

--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -132,7 +132,7 @@ class ContentViewContext extends BusinessContext
         $hash = $parameters->getHash();
         $contentItemPage = PageObjectFactory::createPage($this->utilityContext, ContentItemPage::PAGE_NAME, '');
         foreach ($hash as $field) {
-            $contentItemPage->contentField->verifyFieldHasValue($field['label'], $field['value']);
+            $contentItemPage->contentField->verifyFieldHasValue($field['label'], $field);
         }
     }
 

--- a/src/lib/Behat/PageElement/AdminUpdateForm.php
+++ b/src/lib/Behat/PageElement/AdminUpdateForm.php
@@ -9,6 +9,7 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 use Behat\Mink\Element\NodeElement;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\DefaultFieldElement;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement;
 use PHPUnit\Framework\Assert;
 
 /** Element that describes structures in all update forms */
@@ -18,35 +19,6 @@ class AdminUpdateForm extends Element
     public const ELEMENT_NAME = 'Admin Update Form';
 
     private const NEW_FIELD_TITLE_PATTERN = 'New FieldDefinition (%s)';
-
-    private $fieldTypeMapping = [
-        'Authors' => 'ezauthor',
-        'Checkbox' => 'ezboolean',
-        'Content relation (single)' => 'ezobjectrelation',
-        'Content relations (multiple)' => 'ezobjectrelationlist',
-        'Country' => 'ezcountry',
-        'Date' => 'ezdate',
-        'Date and time' => 'ezdatetime',
-        'E-mail address' => 'ezemail',
-        'File' => 'ezbinaryfile',
-        'Float' => 'ezfloat',
-        'ISBN' => 'ezisbn',
-        'Image' => 'ezimage',
-        'Integer' => 'ezinteger',
-        'Keywords' => 'ezkeyword',
-        'Landing Page' => 'ezlandingpage',
-        'Layout' => 'ezpage',
-        'Map location' => 'ezgmaplocation',
-        'Media' => 'ezmedia',
-        'Rating' => 'ezsrrating',
-        'Rich text' => 'ezrichtext',
-        'Selection' => 'ezselection',
-        'Text block' => 'eztext',
-        'Text line' => 'ezstring',
-        'Time' => 'eztime',
-        'URL' => 'ezurl',
-        'User account' => 'ezuser',
-    ];
 
     public function __construct(UtilityContext $context)
     {
@@ -83,7 +55,7 @@ class AdminUpdateForm extends Element
      */
     public function fillFieldWithValue(string $fieldName, $value, ?string $containerName = null): void
     {
-        $newContainerName = (!$containerName) ? $containerName : sprintf($this::NEW_FIELD_TITLE_PATTERN, $this->fieldTypeMapping[$containerName]);
+        $newContainerName = (!$containerName) ? $containerName : sprintf($this::NEW_FIELD_TITLE_PATTERN, EzFieldElement::getFieldInternalNameByName($containerName));
         $fieldElement = $this->getField($fieldName, $newContainerName);
         $fieldElement->setValue($value);
     }
@@ -142,7 +114,7 @@ class AdminUpdateForm extends Element
      */
     public function verifyNewFieldDefinitionFormExists(string $fieldName): void
     {
-        $form = $this->context->getElementByText(sprintf($this::NEW_FIELD_TITLE_PATTERN, $this->fieldTypeMapping[$fieldName]), $this->fields['fieldDefinitionName']);
+        $form = $this->context->getElementByText(sprintf($this::NEW_FIELD_TITLE_PATTERN, EzFieldElement::getFieldInternalNameByName($fieldName)), $this->fields['fieldDefinitionName']);
         if ($form === null) {
             throw new \Exception('Field definition not added to the form.');
         }
@@ -169,7 +141,7 @@ class AdminUpdateForm extends Element
      */
     public function expandFieldDefinition(string $fieldName): void
     {
-        $container = $this->context->findElement($this->getFieldDefinitionContainerLocator(sprintf($this::NEW_FIELD_TITLE_PATTERN, $this->fieldTypeMapping[$fieldName])));
+        $container = $this->context->findElement($this->getFieldDefinitionContainerLocator(sprintf($this::NEW_FIELD_TITLE_PATTERN, EzFieldElement::getFieldInternalNameByName($fieldName))));
         Assert::assertNotNull($container, sprintf('Definition for field %s not found', $fieldName));
 
         if (strpos($container->getAttribute('class'), $this->fields['fieldCollapsed']) !== false) {

--- a/src/lib/Behat/PageElement/ContentField.php
+++ b/src/lib/Behat/PageElement/ContentField.php
@@ -7,12 +7,14 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
-use PHPUnit\Framework\Assert;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement;
 
 class ContentField extends Element
 {
     /** @var string Name by which Element is recognised */
     public const ELEMENT_NAME = 'ContentField';
+
+    public const FIELD_TYPE_CLASS_REGEX = '/ez[a-z]*-field/';
 
     public function __construct(UtilityContext $context)
     {
@@ -21,10 +23,11 @@ class ContentField extends Element
             'nthFieldContainer' => '.ez-content-field:nth-child(%s)',
             'fieldName' => '.ez-content-field-name',
             'fieldValue' => '.ez-content-field-value',
+            'fieldValueContainer' => ':first-child',
         ];
     }
 
-    public function verifyFieldHasValue(string $label, string $value): void
+    public function verifyFieldHasValue(string $label, array $value): void
     {
         $fieldIndex = $this->context->getElementPositionByText(sprintf('%s:', $label), $this->fields['fieldName']);
         $fieldLocator = sprintf(
@@ -33,15 +36,14 @@ class ContentField extends Element
             $this->fields['fieldValue']
         );
 
-        if ($this->context->checkVisibilityByClass($fieldLocator)) {
-            $fieldDataContainer = $this->context->findElement($fieldLocator);
-            Assert::assertEquals(
-                $value,
-                $fieldDataContainer->getText(),
-                sprintf('Wrong %s value', $label)
-            );
-        } else {
-            Assert::fail(sprintf('Field %s not found', $label));
-        }
+        $fieldClass = $this->context->findElement(sprintf('%s %s', $fieldLocator, $this->fields['fieldValueContainer']))->getAttribute('class');
+
+        preg_match($this::FIELD_TYPE_CLASS_REGEX, $fieldClass, $matches);
+
+        $fieldType = explode('-', $matches[0])[0];
+
+        $fieldElement = ElementFactory::createElement($this->context, EzFieldElement::getFieldNameByInternalName($fieldType), $fieldLocator, $label);
+
+        $fieldElement->verifyValueInItemView($value);
     }
 }

--- a/src/lib/Behat/PageElement/ContentUpdateForm.php
+++ b/src/lib/Behat/PageElement/ContentUpdateForm.php
@@ -17,35 +17,6 @@ class ContentUpdateForm extends Element
 
     public const FIELD_TYPE_CLASS_REGEX = '/ez-field-edit--ez[a-z]*/';
 
-    private $fieldTypeMapping = [
-        'ezauthor' => 'Authors',
-        'ezboolean' => 'Checkbox',
-        'ezobjectrelation' => 'Content relation (single)',
-        'ezobjectrelationlist' => 'Content relations (multiple)',
-        'ezcountry' => 'Country',
-        'ezdate' => 'Date',
-        'ezdatetime' => 'Date and time',
-        'ezemail' => 'E-mail address',
-        'ezbinaryfile' => 'File',
-        'ezfloat' => 'Float',
-        'ezisbn' => 'ISBN',
-        'ezimage' => 'Image',
-        'ezinteger' => 'Integer',
-        'ezkeyword' => 'Keywords',
-        'ezlandingpage' => 'Landing Page',
-        'ezpage' => 'Layout',
-        'ezgmaplocation' => 'Map location',
-        'ezmedia' => 'Media',
-        'ezsrrating' => 'Rating',
-        'ezrichtext' => 'Rich text',
-        'ezselection' => 'Selection',
-        'eztext' => 'Text block',
-        'ezstring' => 'Text line',
-        'eztime' => 'Time',
-        'ezurl' => 'URL',
-        'ezuser' => 'User account',
-    ];
-
     public function __construct(UtilityContext $context)
     {
         parent::__construct($context);
@@ -93,7 +64,7 @@ class ContentUpdateForm extends Element
         $fieldType = explode('--', $matches[0])[1];
         $fieldLocator = sprintf($this->fields['nthField'], $fieldPosition);
 
-        return ElementFactory::createElement($this->context, $this->fieldTypeMapping[$fieldType], $fieldLocator, $fieldName);
+        return ElementFactory::createElement($this->context, EzFieldElement::getFieldNameByInternalName($fieldType), $fieldLocator, $fieldName);
     }
 
     /**

--- a/src/lib/Behat/PageElement/DateAndTimePopup.php
+++ b/src/lib/Behat/PageElement/DateAndTimePopup.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
+
+use DateTime;
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Time;
+
+class DateAndTimePopup extends Element
+{
+    public const ELEMENT_NAME = 'Date and time popup';
+
+    private const DATETIME_FORMAT = 'm/d/Y, g:i:s a';
+
+    public function __construct(UtilityContext $context)
+    {
+        parent::__construct($context);
+        $this->fields = [
+            'openedCalendar' => '.flatpickr-calendar.open',
+            'pickerDaySelector' => '.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)',
+            'pickerDayValue' => 'aria-label',
+            'hourSelector' => '.flatpickr-hour',
+            'minuteSelector' => '.flatpickr-minute',
+            'nextMonthSelector' => '.flatpickr-next-month',
+            'currentDaySelector' => '.flatpickr-day.today',
+        ];
+    }
+
+    /**
+     * @param DateTime $date Date to set
+     */
+    public function setDate(DateTime $date, string $dateFormat = self::DATETIME_FORMAT): void
+    {
+        $convertedDate = $date->format('Y-m-d');
+
+        $currentDateElement = $this->context->findElement(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['currentDaySelector']));
+        $currentDate = DateTime::createFromFormat($dateFormat, $currentDateElement->getAttribute($this->fields['pickerDayValue']));
+        $interval = $date->diff($currentDate);
+        $monthsDiff = 12 * $interval->y + $interval->m;
+
+        for ($i = 0; $i < $monthsDiff; ++$i) {
+            $this->switchToNextMonth();
+        }
+
+        $displayedDays = $this->context->findAllWithWait(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['pickerDaySelector']));
+
+        foreach ($displayedDays as $day) {
+            $currentValue = DateTime::createFromFormat($dateFormat, $day->getAttribute($this->fields['pickerDayValue']));
+            $currentValue = $currentValue->format('Y-m-d');
+
+            if ($currentValue === $convertedDate && $day->isVisible()) {
+                $day->click();
+
+                return;
+            }
+        }
+    }
+
+    public function switchToNextMonth(): void
+    {
+        $this->context->findElement(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['nextMonthSelector']))->click();
+    }
+
+    /**
+     * @param string $hour Hour to set
+     * @param string $minute Minute to set
+     */
+    public function setTime(string $hour, string $minute): void
+    {
+        $this->context->waitUntilElementIsVisible(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['hourSelector']));
+        $visibleHour = $this->context->findElement(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['hourSelector']));
+        $visibleHour->setValue($hour);
+
+        $visibleMinute = $this->context->findElement(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['minuteSelector']));
+        $visibleMinute->setValue($minute);
+    }
+}

--- a/src/lib/Behat/PageElement/ElementFactory.php
+++ b/src/lib/Behat/PageElement/ElementFactory.php
@@ -6,12 +6,30 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
+use EzSystems\DateBasedPublisher\Behat\PageElement\DateBasedPublisherPopup;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Authors;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Checkbox;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ContentRelationMultiple;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ContentRelationSingle;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Country;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Date;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\DateAndTime;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\DefaultFieldElement;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EmailAddress;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\FloatField;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Integer;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ISBN;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Keywords;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\MapLocation;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\RichText;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Selection;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\TextBlock;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\TextLine;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Time;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\URL;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\UserAccount;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Tables\DashboardTable;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Tables\DoubleHeaderTable;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Tables\LinkedListTable;
@@ -32,7 +50,7 @@ class ElementFactory
      * @param UtilityContext $context
      * @param string $elementName Name of the Element to creator
      *
-     * @return AdminList|Dialog|TrashTable|ContentField|DraftConflictDialog|DashboardTable|EzFieldElement|ContentUpdateForm|DefaultFieldElement|SimpleTable|DoubleHeaderTable|SubItemsTable|SimpleListTable|LinkedListTable|VerticalOrientedTable|PreviewNav|SystemInfoTable|RightMenu|UpperMenu|AdminUpdateForm|Breadcrumb|Notification|NavLinkTabs|UniversalDiscoveryWidget|LanguagePicker|OldSendForReviewForm|ConfirmationPopup Element to interact with
+     * @return AdminList|Dialog|DateBasedPublisherPopup|DateAndTimePopup|TrashTable|ContentField|DraftConflictDialog|DashboardTable|EzFieldElement|ContentUpdateForm|DefaultFieldElement|SimpleTable|DoubleHeaderTable|SubItemsTable|SimpleListTable|LinkedListTable|VerticalOrientedTable|PreviewNav|SystemInfoTable|RightMenu|UpperMenu|AdminUpdateForm|Breadcrumb|Notification|NavLinkTabs|UniversalDiscoveryWidget|LanguagePicker|OldSendForReviewForm|ConfirmationPopup Element to interact with
      */
     public static function createElement(UtilityContext $context, string $elementName, ?string ...$parameters): Element
     {
@@ -91,14 +109,52 @@ class ElementFactory
                 return new RichText($context, $parameters[0], $parameters[1]);
             case TextLine::ELEMENT_NAME:
                 return new TextLine($context, $parameters[0], $parameters[1]);
+            case TextBlock::ELEMENT_NAME:
+                return new TextBlock($context, $parameters[0], $parameters[1]);
             case Authors::ELEMENT_NAME:
                 return new Authors($context, $parameters[0], $parameters[1]);
+            case Checkbox::ELEMENT_NAME:
+                return new Checkbox($context, $parameters[0], $parameters[1]);
+            case Country::ELEMENT_NAME:
+                return new Country($context, $parameters[0], $parameters[1]);
+            case Date::ELEMENT_NAME:
+                return new Date($context, $parameters[0], $parameters[1]);
+            case DateAndTime::ELEMENT_NAME:
+                return new DateAndTime($context, $parameters[0], $parameters[1]);
+            case EmailAddress::ELEMENT_NAME:
+                return new EmailAddress($context, $parameters[0], $parameters[1]);
+            case FloatField::ELEMENT_NAME:
+                return new FloatField($context, $parameters[0], $parameters[1]);
+            case Integer::ELEMENT_NAME:
+                return new Integer($context, $parameters[0], $parameters[1]);
+            case ISBN::ELEMENT_NAME:
+                return new ISBN($context, $parameters[0], $parameters[1]);
+            case Keywords::ELEMENT_NAME:
+                return new Keywords($context, $parameters[0], $parameters[1]);
+            case MapLocation::ELEMENT_NAME:
+                return new MapLocation($context, $parameters[0], $parameters[1]);
+            case Selection::ELEMENT_NAME:
+                return new Selection($context, $parameters[0], $parameters[1]);
+            case Time::ELEMENT_NAME:
+                return new Time($context, $parameters[0], $parameters[1]);
+            case URL::ELEMENT_NAME:
+                return new URL($context, $parameters[0], $parameters[1]);
+            case ContentRelationSingle::ELEMENT_NAME:
+                return new ContentRelationSingle($context, $parameters[0], $parameters[1]);
+            case ContentRelationMultiple::ELEMENT_NAME:
+                return new ContentRelationMultiple($context, $parameters[0], $parameters[1]);
+            case UserAccount::ELEMENT_NAME:
+                return new UserAccount($context, $parameters[0], $parameters[1]);
             case DefaultFieldElement::ELEMENT_NAME:
                 return new DefaultFieldElement($context, $parameters[0], $parameters[1]);
             case LanguagePicker::ELEMENT_NAME:
                 return new LanguagePicker($context);
+            case DateAndTimePopup::ELEMENT_NAME:
+                return new DateAndTimePopup($context);
             case UniversalDiscoveryWidget::ELEMENT_NAME:
                 return new UniversalDiscoveryWidget($context);
+            case DateBasedPublisherPopup::ELEMENT_NAME:
+                return new DateBasedPublisherPopup($context);
             case OldSendForReviewForm::ELEMENT_NAME:
                 return new OldSendForReviewForm($context);
             case ConfirmationPopup::ELEMENT_NAME:

--- a/src/lib/Behat/PageElement/Fields/Authors.php
+++ b/src/lib/Behat/PageElement/Fields/Authors.php
@@ -19,6 +19,7 @@ class Authors extends EzFieldElement
         parent::__construct($context, $locator, $label);
         $this->fields['nameFieldInput'] = '.ez-data-source__field--name input';
         $this->fields['emailFieldInput'] = '.ez-data-source__field--email input';
+        $this->fields['fieldValueInContentItemView'] = '.ez-content-field-value';
     }
 
     public function setValue(array $parameters): void
@@ -61,9 +62,18 @@ class Authors extends EzFieldElement
         );
 
         Assert::assertEquals(
-            $value['name'],
-            $actualFieldValues['name'],
+            $value['email'],
+            $actualFieldValues['email'],
             sprintf('Field %s has wrong value', $value['label'])
+        );
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        Assert::assertEquals(
+            sprintf('%s <%s>', $values['name'], $values['email']),
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
         );
     }
 }

--- a/src/lib/Behat/PageElement/Fields/Checkbox.php
+++ b/src/lib/Behat/PageElement/Fields/Checkbox.php
@@ -9,15 +9,17 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Checkbox extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Checkbox';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = '.ez-data-source__indicator';
+        $this->fields['checkbox'] = '.ez-data-source__label';
+        $this->fields['checked'] = '.is-checked';
     }
 
     public function setValue(array $parameters): void
@@ -28,8 +30,9 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        if ($this->getValue() !== $parameters['value']) {
+            $fieldInput->click();
+        }
     }
 
     public function getValue(): array
@@ -40,14 +43,21 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        return [$fieldInput->getValue()];
+        return [
+            filter_var(
+                $this->context->findElement(
+                    sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['checkbox'])
+                )->hasClass($this->fields['checked']),
+                FILTER_VALIDATE_BOOLEAN
+            ),
+        ];
     }
 
     public function verifyValueInItemView(array $values): void
     {
         Assert::assertEquals(
-            $values['value'],
-            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            filter_var($values['value'], FILTER_VALIDATE_BOOLEAN),
+            filter_var($this->context->findElement($this->fields['fieldContainer'])->getText(), FILTER_VALIDATE_BOOLEAN),
             'Field has wrong value'
         );
     }

--- a/src/lib/Behat/PageElement/Fields/ContentRelationMultiple.php
+++ b/src/lib/Behat/PageElement/Fields/ContentRelationMultiple.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\UniversalDiscoveryWidget;
+use PHPUnit\Framework\Assert;
+
+class ContentRelationMultiple extends EzFieldElement
+{
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'Content relations (multiple)';
+
+    public const VIEW_PATTERN = '/Multiple relations:[\w\/,: ]* %s [\w \/,:]*/';
+
+    public function __construct(UtilityContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['selectContent'] = '.ez-relations__cta-btn-label';
+    }
+
+    public function setValue(array $parameters): void
+    {
+        $selectContent = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectContent'])
+        );
+
+        Assert::assertNotNull($selectContent, sprintf('Select content button for field %s not found.', $this->label));
+
+        $selectContent->click();
+
+        $UDW = ElementFactory::createElement($this->context, UniversalDiscoveryWidget::ELEMENT_NAME);
+        $UDW->selectContent($parameters['firstItem']);
+        $UDW->selectContent($parameters['secondItem']);
+        $UDW->confirm();
+    }
+
+    public function getValue(): array
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectContent'])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
+
+        return [$fieldInput->getText()];
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        $explodedValue = explode('/', $values['firstItem']);
+        $firstValue = $explodedValue[count($explodedValue) - 1];
+        $explodedValue = explode('/', $values['secondItem']);
+        $secondValue = $explodedValue[count($explodedValue) - 1];
+
+        Assert::assertRegExp(
+            sprintf(self::VIEW_PATTERN, $firstValue),
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+        Assert::assertRegExp(
+            sprintf(self::VIEW_PATTERN, $secondValue),
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+    }
+}

--- a/src/lib/Behat/PageElement/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/PageElement/Fields/ContentRelationSingle.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\UniversalDiscoveryWidget;
+use PHPUnit\Framework\Assert;
+
+class ContentRelationSingle extends EzFieldElement
+{
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'Content relation (single)';
+
+    public const VIEW_PATTERN = '/Single relation:[\w\/,: ]* %s [\w \/,:]*/';
+
+    public function __construct(UtilityContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['selectContent'] = '.ez-relations__cta-btn-label';
+    }
+
+    public function setValue(array $parameters): void
+    {
+        $selectContent = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectContent'])
+        );
+
+        Assert::assertNotNull($selectContent, sprintf('Select content button for field %s not found.', $this->label));
+
+        $selectContent->click();
+
+        $UDW = ElementFactory::createElement($this->context, UniversalDiscoveryWidget::ELEMENT_NAME);
+        $UDW->selectContent($parameters['value']);
+        $UDW->confirm();
+    }
+
+    public function getValue(): array
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectContent'])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
+
+        return [$fieldInput->getText()];
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        $explodedValue = explode('/', $values['value']);
+        $value = $explodedValue[count($explodedValue) - 1];
+
+        Assert::assertRegExp(
+            sprintf(self::VIEW_PATTERN, $value),
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+    }
+}

--- a/src/lib/Behat/PageElement/Fields/Country.php
+++ b/src/lib/Behat/PageElement/Fields/Country.php
@@ -9,15 +9,15 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Country extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Country';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = 'select';
     }
 
     public function setValue(array $parameters): void
@@ -28,8 +28,7 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        $fieldInput->selectOption($parameters['value']);
     }
 
     public function getValue(): array

--- a/src/lib/Behat/PageElement/Fields/Date.php
+++ b/src/lib/Behat/PageElement/Fields/Date.php
@@ -7,17 +7,22 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\DateAndTimePopup;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Date extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Date';
+
+    private const DATE_FORMAT = 'm/d/Y';
+    private const VIEW_DATE_FORMAT = 'd/m/Y';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = 'input.flatpickr-input.ez-data-source__input';
     }
 
     public function setValue(array $parameters): void
@@ -28,8 +33,10 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        $fieldInput->click();
+
+        $dateAndTimePopup = ElementFactory::createElement($this->context, DateAndTimePopup::ELEMENT_NAME);
+        $dateAndTimePopup->setDate(\DateTime::createFromFormat(self::DATE_FORMAT, $parameters['value']), self::DATE_FORMAT);
     }
 
     public function getValue(): array
@@ -40,14 +47,16 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        return [$fieldInput->getValue()];
+        return [$fieldInput->getText()];
     }
 
     public function verifyValueInItemView(array $values): void
     {
+        $expectedDateTime = date_format(\DateTime::createFromFormat(self::DATE_FORMAT, $values['value']), self::DATE_FORMAT);
+        $actualDateTime = date_format(\DateTime::createFromFormat(self::VIEW_DATE_FORMAT, $this->context->findElement($this->fields['fieldContainer'])->getText()), self::DATE_FORMAT);
         Assert::assertEquals(
-            $values['value'],
-            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            $expectedDateTime,
+            $actualDateTime,
             'Field has wrong value'
         );
     }

--- a/src/lib/Behat/PageElement/Fields/DateAndTime.php
+++ b/src/lib/Behat/PageElement/Fields/DateAndTime.php
@@ -7,17 +7,22 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\DateAndTimePopup;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class DateAndTime extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Date and time';
+
+    private const DATE_FORMAT = 'm/d/Y';
+    private const VIEW_DATE_FORMAT = 'd/m/Y';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = '.flatpickr-input.ez-data-source__input';
     }
 
     public function setValue(array $parameters): void
@@ -28,8 +33,19 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        $fieldInput->click();
+
+        $time = explode(':', $parameters['time']);
+
+        $dateAndTimePopup = ElementFactory::createElement($this->context, DateAndTimePopup::ELEMENT_NAME);
+        $dateAndTimePopup->setDate(\DateTime::createFromFormat($this::DATE_FORMAT, $parameters['date']));
+        $dateAndTimePopup->setTime($time[0], $time[1]);
+
+        $expectedTimeValue = date_format(date_create(sprintf('%s, %s', $parameters['date'], $parameters['time'])), 'm/d/Y, g:i:s A');
+
+        $this->context->waitUntil($this->defaultTimeout, function () use ($expectedTimeValue) {
+            return $this->context->findElement(sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['fieldInput']))->getValue() === $expectedTimeValue;
+        });
     }
 
     public function getValue(): array
@@ -40,13 +56,14 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        return [$fieldInput->getValue()];
+        return [$fieldInput->getText()];
     }
 
     public function verifyValueInItemView(array $values): void
     {
+        $expectedDate = date_format(\DateTime::createFromFormat(self::DATE_FORMAT, $values['date']), self::VIEW_DATE_FORMAT);
         Assert::assertEquals(
-            $values['value'],
+            sprintf('%s %s', $expectedDate, $values['time']),
             $this->context->findElement($this->fields['fieldContainer'])->getText(),
             'Field has wrong value'
         );

--- a/src/lib/Behat/PageElement/Fields/EmailAddress.php
+++ b/src/lib/Behat/PageElement/Fields/EmailAddress.php
@@ -9,10 +9,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class EmailAddress extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'E-mail address';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {

--- a/src/lib/Behat/PageElement/Fields/EzFieldElement.php
+++ b/src/lib/Behat/PageElement/Fields/EzFieldElement.php
@@ -8,10 +8,50 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Element;
+use PHPUnit\Framework\Assert;
 
 abstract class EzFieldElement extends Element
 {
     protected $label;
+
+    private static $FIELD_TYPE_MAPPING = [
+        'ezauthor' => 'Authors',
+        'ezboolean' => 'Checkbox',
+        'ezobjectrelation' => 'Content relation (single)',
+        'ezobjectrelationlist' => 'Content relations (multiple)',
+        'ezcountry' => 'Country',
+        'ezdate' => 'Date',
+        'ezdatetime' => 'Date and time',
+        'ezemail' => 'E-mail address',
+        'ezbinaryfile' => 'File',
+        'ezfloat' => 'Float',
+        'ezisbn' => 'ISBN',
+        'ezimage' => 'Image',
+        'ezinteger' => 'Integer',
+        'ezkeyword' => 'Keywords',
+        'ezlandingpage' => 'Landing Page',
+        'ezpage' => 'Layout',
+        'ezgmaplocation' => 'Map location',
+        'ezmedia' => 'Media',
+        'ezsrrating' => 'Rating',
+        'ezrichtext' => 'Rich text',
+        'ezselection' => 'Selection',
+        'eztext' => 'Text block',
+        'ezstring' => 'Text line',
+        'eztime' => 'Time',
+        'ezurl' => 'URL',
+        'ezuser' => 'User account',
+    ];
+
+    public static function getFieldNameByInternalName(string $internalFieldName): string
+    {
+        return static::$FIELD_TYPE_MAPPING[$internalFieldName];
+    }
+
+    public static function getFieldInternalNameByName(string $fieldName): string
+    {
+        return array_search($fieldName, static::$FIELD_TYPE_MAPPING);
+    }
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
@@ -28,5 +68,12 @@ abstract class EzFieldElement extends Element
 
     abstract public function getValue(): array;
 
-    abstract public function verifyValue(array $value): void;
+    public function verifyValue(array $value): void
+    {
+        Assert::assertEquals(
+            $value['value'],
+            $this->getValue()[0],
+            sprintf('Field %s has wrong value', $value['label'])
+        );
+    }
 }

--- a/src/lib/Behat/PageElement/Fields/FloatField.php
+++ b/src/lib/Behat/PageElement/Fields/FloatField.php
@@ -9,10 +9,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class FloatField extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Float';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {

--- a/src/lib/Behat/PageElement/Fields/ISBN.php
+++ b/src/lib/Behat/PageElement/Fields/ISBN.php
@@ -9,10 +9,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class ISBN extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'ISBN';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {

--- a/src/lib/Behat/PageElement/Fields/Integer.php
+++ b/src/lib/Behat/PageElement/Fields/Integer.php
@@ -9,10 +9,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Integer extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Integer';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {

--- a/src/lib/Behat/PageElement/Fields/Keywords.php
+++ b/src/lib/Behat/PageElement/Fields/Keywords.php
@@ -9,10 +9,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Keywords extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Keywords';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
@@ -46,7 +46,7 @@ class TextLine extends EzFieldElement
     public function verifyValueInItemView(array $values): void
     {
         Assert::assertEquals(
-            $values['value'],
+            str_replace(', ', '', $values['value']),
             $this->context->findElement($this->fields['fieldContainer'])->getText(),
             'Field has wrong value'
         );

--- a/src/lib/Behat/PageElement/Fields/MapLocation.php
+++ b/src/lib/Behat/PageElement/Fields/MapLocation.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use PHPUnit\Framework\Assert;
+
+class MapLocation extends EzFieldElement
+{
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'Map location';
+
+    public function __construct(UtilityContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['latitude'] = '#ezrepoforms_content_edit_fieldsData_field_value_latitude';
+        $this->fields['longitude'] = '#ezrepoforms_content_edit_fieldsData_field_value_longitude';
+        $this->fields['address'] = '#ezrepoforms_content_edit_fieldsData_field_value_address';
+    }
+
+    public function setValue(array $parameters): void
+    {
+        $this->setSpecificCoordinate('latitude', $parameters['latitude']);
+        $this->setSpecificCoordinate('longitude', $parameters['longitude']);
+        $this->setSpecificCoordinate('address', $parameters['address']);
+    }
+
+    public function setSpecificCoordinate(string $coordinateName, string $value): void
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$coordinateName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input %s for field %s not found.', $coordinateName, $this->label));
+
+        $fieldInput->setValue('');
+        $fieldInput->setValue($value);
+    }
+
+    public function getValue(): array
+    {
+        return [
+            'latitude' => $this->getSpecificCoordinate('latitude'),
+            'longitude' => $this->getSpecificCoordinate('longitude'),
+            'address' => $this->getSpecificCoordinate('address'),
+            ];
+    }
+
+    public function getSpecificCoordinate(string $coordinateName): string
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$coordinateName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
+
+        return $fieldInput->getValue();
+    }
+
+    public function verifyValue(array $value): void
+    {
+        Assert::assertEquals(
+            $value['latitude'],
+            $this->getValue()['latitude'],
+            sprintf('Field %s has wrong latitude value', $value['label'])
+        );
+        Assert::assertEquals(
+            $value['longitude'],
+            $this->getValue()['longitude'],
+            sprintf('Field %s has wrong longitude value', $value['label'])
+        );
+        Assert::assertEquals(
+            $value['address'],
+            $this->getValue()['address'],
+            sprintf('Field %s has wrong address value', $value['label'])
+        );
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        Assert::assertStringEndsWith(
+            sprintf('Address: %s Latitude: %s Longitude: %s', $values['address'], $values['latitude'], $values['longitude']),
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+    }
+}

--- a/src/lib/Behat/PageElement/Fields/RichText.php
+++ b/src/lib/Behat/PageElement/Fields/RichText.php
@@ -44,12 +44,12 @@ class RichText extends EzFieldElement
         return [$fieldInput->getText()];
     }
 
-    public function verifyValue(array $value): void
+    public function verifyValueInItemView(array $values): void
     {
         Assert::assertEquals(
-            $value['value'],
-            $this->getValue()[0],
-            sprintf('Field %s has wrong value', $value['label'])
+            $values['value'],
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
         );
     }
 }

--- a/src/lib/Behat/PageElement/Fields/Selection.php
+++ b/src/lib/Behat/PageElement/Fields/Selection.php
@@ -9,33 +9,32 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Selection extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Selection';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['selectBar'] = '.ez-data-source__selected';
+        $this->fields['selectOption'] = '.ez-data-source__options .option-item';
+        $this->fields['specificOption'] = '[data-value="%s"]';
     }
 
     public function setValue(array $parameters): void
     {
-        $fieldInput = $this->context->findElement(
-            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['fieldInput'])
-        );
+        $this->context->findElement(sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectBar']))->click();
 
-        Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
+        $index = $this->context->getElementPositionByText($parameters['value'], $this->fields['selectOption']) - 2;
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        $this->context->findElement(sprintf($this->fields['specificOption'], $index))->click();
     }
 
     public function getValue(): array
     {
         $fieldInput = $this->context->findElement(
-            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['fieldInput'])
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['selectBar'])
         );
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));

--- a/src/lib/Behat/PageElement/Fields/TextBlock.php
+++ b/src/lib/Behat/PageElement/Fields/TextBlock.php
@@ -9,15 +9,15 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class TextBlock extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Text block';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = 'textarea';
     }
 
     public function setValue(array $parameters): void

--- a/src/lib/Behat/PageElement/Fields/Time.php
+++ b/src/lib/Behat/PageElement/Fields/Time.php
@@ -7,17 +7,19 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\DateAndTimePopup;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use PHPUnit\Framework\Assert;
 
-class TextLine extends EzFieldElement
+class Time extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
-    public const ELEMENT_NAME = 'Text line';
+    public const ELEMENT_NAME = 'Time';
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
         parent::__construct($context, $locator, $label);
-        $this->fields['fieldInput'] = 'input';
+        $this->fields['fieldInput'] = '.ez-data-source__input-wrapper input';
     }
 
     public function setValue(array $parameters): void
@@ -28,8 +30,18 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $fieldInput->setValue('');
-        $fieldInput->setValue($parameters['value']);
+        $fieldInput->click();
+
+        $time = explode(':', $parameters['value']);
+
+        $dateAndTimePopup = ElementFactory::createElement($this->context, DateAndTimePopup::ELEMENT_NAME);
+        $dateAndTimePopup->setTime($time[0], $time[1]);
+
+        $expectedTimeValue = $parameters['value'];
+
+        $this->context->waitUntil($this->defaultTimeout, function () use ($expectedTimeValue) {
+            return $this->context->findElement(sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['fieldInput']))->getValue() === $expectedTimeValue;
+        });
     }
 
     public function getValue(): array
@@ -40,7 +52,7 @@ class TextLine extends EzFieldElement
 
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        return [$fieldInput->getValue()];
+        return [$fieldInput->getText()];
     }
 
     public function verifyValueInItemView(array $values): void

--- a/src/lib/Behat/PageElement/Fields/URL.php
+++ b/src/lib/Behat/PageElement/Fields/URL.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use PHPUnit\Framework\Assert;
+
+class URL extends EzFieldElement
+{
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'URL';
+
+    public function __construct(UtilityContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['url'] = '#ezrepoforms_content_edit_fieldsData_field_value_link';
+        $this->fields['text'] = '#ezrepoforms_content_edit_fieldsData_field_value_text';
+    }
+
+    public function setValue(array $parameters): void
+    {
+        $this->setSpecificFieldValue('url', $parameters['url']);
+        $this->setSpecificFieldValue('text', $parameters['text']);
+    }
+
+    public function setSpecificFieldValue(string $coordinateName, string $value): void
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$coordinateName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input %s for field %s not found.', $coordinateName, $this->label));
+
+        $fieldInput->setValue('');
+        $fieldInput->setValue($value);
+    }
+
+    public function getValue(): array
+    {
+        return [
+            'url' => $this->getSpecificFieldValue('url'),
+            'text' => $this->getSpecificFieldValue('text'),
+            ];
+    }
+
+    public function getSpecificFieldValue(string $coordinateName): string
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$coordinateName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input %s for field %s not found.', $coordinateName, $this->label));
+
+        return $fieldInput->getValue();
+    }
+
+    public function verifyValue(array $value): void
+    {
+        Assert::assertEquals(
+            $value['url'],
+            $this->getValue()['url'],
+            sprintf('Field %s has wrong value', $value['label'])
+        );
+        Assert::assertEquals(
+            $value['text'],
+            $this->getValue()['text'],
+            sprintf('Field %s has wrong value', $value['label'])
+        );
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        Assert::assertEquals(
+            $values['text'],
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+        Assert::assertEquals(
+            $values['url'],
+            $this->context->findElement(sprintf('%s %s', $this->fields['fieldContainer'], 'a'))->getAttribute('href'),
+            'Field has wrong value'
+        );
+    }
+}

--- a/src/lib/Behat/PageElement/Fields/UserAccount.php
+++ b/src/lib/Behat/PageElement/Fields/UserAccount.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
+use PHPUnit\Framework\Assert;
+
+class UserAccount extends EzFieldElement
+{
+    /** @var string Name by which Element is recognised */
+    public const ELEMENT_NAME = 'User account';
+
+    public function __construct(UtilityContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['username'] = '#ezrepoforms_user_create_fieldsData_field_value_username';
+        $this->fields['password'] = '#ezrepoforms_user_create_fieldsData_field_value_password_first';
+        $this->fields['confirmPassword'] = '#ezrepoforms_user_create_fieldsData_field_value_password_second';
+        $this->fields['email'] = '#ezrepoforms_user_create_fieldsData_field_value_email';
+    }
+
+    public function setValue(array $parameters): void
+    {
+        $this->setSpecificFieldValue('username', $parameters['username']);
+        $this->setSpecificFieldValue('password', $parameters['password']);
+        $this->setSpecificFieldValue('confirmPassword', $parameters['password']);
+        $this->setSpecificFieldValue('email', $parameters['email']);
+    }
+
+    public function setSpecificFieldValue(string $fieldName, string $value): void
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$fieldName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input %s for field %s not found.', $fieldName, $this->label));
+
+        $fieldInput->setValue('');
+        $fieldInput->setValue($value);
+    }
+
+    public function getValue(): array
+    {
+        return [
+            'username' => $this->getSpecificFieldValue('username'),
+            'email' => $this->getSpecificFieldValue('email'),
+        ];
+    }
+
+    public function getSpecificFieldValue(string $fieldName): string
+    {
+        $fieldInput = $this->context->findElement(
+            sprintf('%s %s', $this->fields['fieldContainer'], $this->fields[$fieldName])
+        );
+
+        Assert::assertNotNull($fieldInput, sprintf('Input $s for field %s not found.', $fieldName, $this->label));
+
+        return $fieldInput->getValue();
+    }
+
+    public function verifyValue(array $value): void
+    {
+        Assert::assertEquals(
+            $value['username'],
+            $this->getValue()['username'],
+            sprintf('Field %s has wrong value', $value['label'])
+        );
+        Assert::assertEquals(
+            $value['email'],
+            $this->getValue()['email'],
+            sprintf('Field %s has wrong value', $value['label'])
+        );
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        Assert::assertEquals(
+            $values['value'],
+            $this->context->findElement($this->fields['fieldContainer'])->getText(),
+            'Field has wrong value'
+        );
+    }
+}

--- a/src/lib/Behat/PageElement/Notification.php
+++ b/src/lib/Behat/PageElement/Notification.php
@@ -51,6 +51,7 @@ class Notification extends Element
     public function closeAlert(): void
     {
         $this->context->findElement($this->fields['closeAlert'])->click();
+
         $this->context->waitUntil($this->defaultTimeout, function () {
             return !$this->isVisible();
         });

--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Assert;
 class UniversalDiscoveryWidget extends Element
 {
     public const ELEMENT_NAME = 'UDW';
+    private const UDW_TIMEOUT = 20;
 
     public function __construct(UtilityContext $context)
     {
@@ -22,6 +23,8 @@ class UniversalDiscoveryWidget extends Element
             'cancelButton' => '.m-ud__action--cancel',
             'selectContentButton' => '.c-meta-preview__btn--select',
             'elementSelector' => '.c-finder-tree-branch:nth-of-type(%d) .c-finder-tree-leaf',
+            'previewName' => '.c-meta-preview__name',
+            'treeBranch' => '.c-finder-tree-branch:nth-child(%d)',
         ];
     }
 
@@ -33,9 +36,16 @@ class UniversalDiscoveryWidget extends Element
         $pathParts = explode('/', $itemPath);
         $depth = 1;
         foreach ($pathParts as $part) {
+            $this->context->waitUntilElementIsVisible(sprintf($this->fields['treeBranch'], $depth), self::UDW_TIMEOUT);
             $this->context->getElementByText($part, sprintf($this->fields['elementSelector'], $depth))->click();
             ++$depth;
         }
+        $expectedContentName = $pathParts[count($pathParts) - 1];
+        $this->context->waitUntil(
+            self::UDW_TIMEOUT,
+            function () use ($expectedContentName) {
+                return $this->context->findElement($this->fields['previewName'])->getText() === $expectedContentName;
+            });
 
         $this->context->findElement($this->fields['selectContentButton'])->click();
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR contains one scenario outline for 16 basic field types, excluding
- User that will be covered alongside with Users feature, 
- Rating that is not editable, 
- Media, Image and  BinaryFile that requires file uploading, and will be covered in the next PR

The scenario itself contains the creation of Content Type with given field using API (that saves a lot of time - we already tests the creation of a content type in other feature), and creation of Content Item based on such Content Type.

The date picker exists not only in DateBasedPublisher, but also in the admin-ui, so I moved the class DateBasedPublisherPopup to admin-ui, changed the name to DateAndTimePopup and adjusted it. As soon as i'm done with corresponding changes in other bundles, i'll link the related PRs.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
