### PR TITLE
EZEE-2040: Expose in config map of content type identifiers to names

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -38,6 +38,10 @@ services:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'contentTypes' }
 
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypeNames:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'contentTypeNames' }
+
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module\UniversalDiscoveryWidget:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'universalDiscoveryWidget' }

--- a/src/lib/UI/Config/Provider/ContentTypeNames.php
+++ b/src/lib/UI/Config/Provider/ContentTypeNames.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+class ContentTypeNames implements ProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     */
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @return mixed Anything that is serializable via json_encode()
+     */
+    public function getConfig()
+    {
+        $contentTypeNames = [];
+
+        foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
+            foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+                $contentTypeNames[$contentType->identifier] = $contentType->getName();
+            }
+        }
+
+        return $contentTypeNames;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | http://jira.ez.no/browse/EZEE-2040
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->

We need to expose additional (flap) map of ContentType identifiers to names, without grouping etc.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
