### PR TITLE
EZP-29268: Change bookmark status in Location page when bookmark changed elsewhere on the site

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
@@ -1,6 +1,28 @@
-(function (global, doc) {
+(function(global, doc) {
     const SELECTOR_FORM = 'form[name="location_update_bookmark"]';
-    const updateBookmark = () => doc.querySelector(SELECTOR_FORM).submit();
+    const SELECTOR_BOOKMARK_CHECKBOX = '#location_update_bookmark_bookmarked';
+    const SELECTOR_BOOKMARK_LOCATION_INPUT = '#location_update_bookmark_location';
 
-    doc.querySelector('#location_update_bookmark_bookmarked').addEventListener('change', updateBookmark, false);
+    const updateBookmarkLocationInput = doc.querySelector(SELECTOR_BOOKMARK_LOCATION_INPUT);
+    const currentLocationId = parseInt(updateBookmarkLocationInput.value, 10);
+
+    const submitBookmarkForm = () => doc.querySelector(SELECTOR_FORM).submit();
+    const updateBookmarkCheckbox = (bookmarked) => {
+        const checkbox = doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX);
+
+        checkbox.checked = bookmarked;
+    };
+    const isCurrentLocation = (locationId) => {
+        return parseInt(locationId, 10) === currentLocationId;
+    };
+    const updateBookmarkForm = (event) => {
+        const { bookmarked, locationId } = event.detail;
+
+        if (isCurrentLocation(locationId)) {
+            updateBookmarkCheckbox(bookmarked);
+        }
+    };
+
+    doc.body.addEventListener('ez-bookmark-change', updateBookmarkForm, false);
+    doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', submitBookmarkForm, false);
 })(window, document);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29268
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | ?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Status of a bookmark from Location page should be changed when this location is being bookmarked or unbookmarked elsewhere on the page. 
E.g. when I bookmark Location 2 in Content Meta Preview in UDW, while being on the page of Location 2, the bookmark from the page should change.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
