### PR TITLE
EZP-28890: Added crowdin in-context translation JS code

### DIFF
--- a/src/bundle/Resources/views/Security/base.html.twig
+++ b/src/bundle/Resources/views/Security/base.html.twig
@@ -38,5 +38,12 @@
         %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}
+        {% if app.request.locale == 'ach_UG' %}
+            <script type="text/javascript">
+                var _jipt = [];
+                _jipt.push(['project', 'ezplatform']);
+            </script>
+            <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+        {% endif %}
     </body>
 </html>

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -34,6 +34,13 @@
         </script>
         <script src="/bundles/fosjsrouting/js/router.js"></script>
         <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+        {% if app.request.locale == 'ach_UG' %}
+            <script type="text/javascript">
+                var _jipt = [];
+                _jipt.push(['project', 'ezplatform']);
+            </script>
+            <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+        {% endif %}
         <title>{% block title %}eZ Platform{% endblock %}</title>
         {% stylesheets filter='scssphp'
             'bundles/ezplatformadminui/scss/ezplatform-bootstrap.scss'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28890](http://jira.ez.no/browse/EZP-28890)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Adds support for in-context translation, as introduced in https://github.com/ezsystems/PlatformUIBundle/pull/773.

#### Checklist:
- [x] Consider having a variable that sets the crowdin project, instead of hardcoding `ezplatform`. It would allow usage of in-context for any 3rd party bundle.
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
