### PR TITLE
EZP-29119: Display proper validation error message when non-image file uploaded in image FieldType

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -1,6 +1,6 @@
 (function (global) {
     const eZ = global.eZ = global.eZ || {};
-    const SELECTOR_FIELD_LABEL = '.ez-field-edit__label-wrapper .col-form-label';
+    const SELECTOR_FIELD_LABEL = '.ez-field-edit__label-wrapper .form-control-label';
 
     class BaseFileFieldValidator extends global.eZ.BaseFieldValidator {
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
@@ -179,6 +179,7 @@
             this.fieldContainer.querySelector(SELECTOR_DATA).removeAttribute('hidden');
             this.fieldContainer.querySelector(SELECTOR_PREVIEW).setAttribute('hidden', true);
             this.fieldContainer.classList.remove('is-invalid');
+            [...this.fieldContainer.querySelectorAll('.ez-field-edit__error')].forEach(element => element.remove());
 
             btnRemove.removeEventListener('click', this.handleRemoveFile);
 

--- a/src/bundle/Resources/views/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/content/form_fields.html.twig
@@ -70,6 +70,14 @@
 
     {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ez-field-edit__data')|trim}) %}
     {% set wrapper_class = 'ez-field-edit ez-field-edit--' ~ fieldtype_identifier %}
+
+    {# BC: to maintain BC we have to map errors which orginated from compound fieldtypes #}
+    {% for error in form.parent.parent.parent.vars.errors %}
+        {% if error.origin == form.vars.errors.form %}
+            {% set errors = errors|default([])|merge([error]) %}
+        {% endif %}
+    {% endfor %}
+
     {% if required %}{% set wrapper_class = (wrapper_class|default('') ~ ' ez-field-edit--required')|trim %}{% endif %}
     {% if errors|length > 0 %}{% set wrapper_class = (wrapper_class|default('') ~ ' is-invalid')|trim %}{% endif %}
     {% if fieldtype_is_not_translatable %}
@@ -89,7 +97,7 @@
 
     <div {% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
         <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
-            {{ block('form_label') }}
+            {% with { 'compound': false } %}{{- block('form_label') }}{% endwith %}
             {{ block('form_errors') }}
         </div>
 
@@ -121,3 +129,5 @@
     {%- set type = type|default('number') -%}
     {{ block('form_widget_simple') }}
 {%- endblock number_widget -%}
+
+{% block form_label_errors %}{% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/binary_base.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/binary_base.html.twig
@@ -6,7 +6,15 @@
     {% set wrapper_attr = wrapper_attr|default({})|merge({'class': (wrapper_attr.class|default('') ~ ' ez-field-edit--with-preview')|trim}) %}
     {% set preview_attr = preview_attr|default({})|merge({'class': (preview_attr.class|default('') ~ ' ez-field-edit__preview')|trim}) %}
     {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ez-field-edit__data')|trim}) %}
-    {% if file_is_empty %}
+
+    {% set has_error = false %}
+    {% for error in form.parent.parent.parent.vars.errors %}
+        {% if error.origin == form.vars.errors.form %}
+            {% set has_error = true %}
+        {% endif %}
+    {% endfor %}
+
+    {% if file_is_empty or has_error %}
         {% set preview_attr = preview_attr|default({})|merge({'hidden': 'hidden'}) %}
     {% else %}
         {% set widget_wrapper_attr = widget_wrapper_attr|merge({'hidden': 'hidden'}) %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29119
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR is also fixing doubled error messages (backend).

<img width="1127" alt="screen shot 2018-06-13 at 3 32 22 pm" src="https://user-images.githubusercontent.com/1654712/41354642-c8e9fa3e-6f1f-11e8-8fd2-a42b9b731c52.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
