### PR TITLE
EZP-29266: Content item seems to be always bookmarked

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
@@ -3,7 +3,6 @@
     const SELECTOR_BOOKMARK_CHECKBOX = '#location_update_bookmark_bookmarked';
     const SELECTOR_BOOKMARK_LOCATION_INPUT = '#location_update_bookmark_location';
     const SELECTOR_BOOKMARK_WRAPPER = '.ez-add-to-bookmarks';
-
     const CLASS_BOOKMARK_CHECKED = 'ez-add-to-bookmarks--checked';
 
     const updateBookmarkLocationInput = doc.querySelector(SELECTOR_BOOKMARK_LOCATION_INPUT);

--- a/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
@@ -2,6 +2,7 @@
     const SELECTOR_FORM = 'form[name="location_update_bookmark"]';
     const SELECTOR_BOOKMARK_CHECKBOX = '#location_update_bookmark_bookmarked';
     const SELECTOR_BOOKMARK_LOCATION_INPUT = '#location_update_bookmark_location';
+    const SELECTOR_BOOKMARK_WRAPPER = '.ez-add-to-bookmarks';
 
     const updateBookmarkLocationInput = doc.querySelector(SELECTOR_BOOKMARK_LOCATION_INPUT);
     const currentLocationId = parseInt(updateBookmarkLocationInput.value, 10);
@@ -15,14 +16,31 @@
     const isCurrentLocation = (locationId) => {
         return parseInt(locationId, 10) === currentLocationId;
     };
+    const setBookmarkWrapperCheckedClass = (bookmarked) => {
+        const wrapperClassList = document.querySelector(SELECTOR_BOOKMARK_WRAPPER).classList;
+        const bookmarkCheckedClass = 'ez-add-to-bookmarks--checked';
+
+        if (bookmarked) {
+            wrapperClassList.add(bookmarkCheckedClass);
+        } else {
+            wrapperClassList.remove(bookmarkCheckedClass);
+        }
+    };
     const updateBookmarkForm = (event) => {
         const { bookmarked, locationId } = event.detail;
 
         if (isCurrentLocation(locationId)) {
             updateBookmarkCheckbox(bookmarked);
+            setBookmarkWrapperCheckedClass(bookmarked);
         }
+    };
+    const updateBookmarkWrapperClass = (event) => {
+        const checked = event.target.checked;
+
+        setBookmarkWrapperCheckedClass(checked);
     };
 
     doc.body.addEventListener('ez-bookmark-change', updateBookmarkForm, false);
     doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', submitBookmarkForm, false);
+    doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', updateBookmarkWrapperClass, false);
 })(window, document);

--- a/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.bookmark.js
@@ -4,6 +4,8 @@
     const SELECTOR_BOOKMARK_LOCATION_INPUT = '#location_update_bookmark_location';
     const SELECTOR_BOOKMARK_WRAPPER = '.ez-add-to-bookmarks';
 
+    const CLASS_BOOKMARK_CHECKED = 'ez-add-to-bookmarks--checked';
+
     const updateBookmarkLocationInput = doc.querySelector(SELECTOR_BOOKMARK_LOCATION_INPUT);
     const currentLocationId = parseInt(updateBookmarkLocationInput.value, 10);
 
@@ -16,31 +18,26 @@
     const isCurrentLocation = (locationId) => {
         return parseInt(locationId, 10) === currentLocationId;
     };
-    const setBookmarkWrapperCheckedClass = (bookmarked) => {
-        const wrapperClassList = document.querySelector(SELECTOR_BOOKMARK_WRAPPER).classList;
-        const bookmarkCheckedClass = 'ez-add-to-bookmarks--checked';
+    const toggleBookmarkIconState = (isBookmarked) => {
+        const wrapper = doc.querySelector(SELECTOR_BOOKMARK_WRAPPER);
 
-        if (bookmarked) {
-            wrapperClassList.add(bookmarkCheckedClass);
-        } else {
-            wrapperClassList.remove(bookmarkCheckedClass);
-        }
+        wrapper.classList.toggle(CLASS_BOOKMARK_CHECKED, isBookmarked);
     };
     const updateBookmarkForm = (event) => {
         const { bookmarked, locationId } = event.detail;
 
         if (isCurrentLocation(locationId)) {
             updateBookmarkCheckbox(bookmarked);
-            setBookmarkWrapperCheckedClass(bookmarked);
+            toggleBookmarkIconState(bookmarked);
         }
     };
-    const updateBookmarkWrapperClass = (event) => {
+    const updateBookmarkIconState = (event) => {
         const checked = event.target.checked;
 
-        setBookmarkWrapperCheckedClass(checked);
+        toggleBookmarkIconState(checked);
     };
 
     doc.body.addEventListener('ez-bookmark-change', updateBookmarkForm, false);
     doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', submitBookmarkForm, false);
-    doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', updateBookmarkWrapperClass, false);
+    doc.querySelector(SELECTOR_BOOKMARK_CHECKBOX).addEventListener('change', updateBookmarkIconState, false);
 })(window, document);

--- a/src/bundle/Resources/public/scss/_add-to-bookmarks.scss
+++ b/src/bundle/Resources/public/scss/_add-to-bookmarks.scss
@@ -34,7 +34,7 @@
         }
     }
 
-    &__checkbox:checked + &__label {
+    &--checked &__label {
         &::after {
             background-color: #fff;
             animation: background-to-white .25s ease-in;
@@ -49,8 +49,8 @@
         z-index: 2;
     }
 
-    &__checkbox:checked + &__label &__icon-wrapper--add,
-    &__checkbox:not(:checked) + &__label &__icon-wrapper--remove {
+    &--checked &__label &__icon-wrapper--add,
+    &:not(.ez-add-to-bookmarks--checked) &__label &__icon-wrapper--remove {
         opacity: 0;
         transform: scale(0);
     }

--- a/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
+++ b/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
@@ -1,4 +1,5 @@
 {% trans_default_domain 'locationview' %}
+{% form_theme form _self '@EzPlatformAdminUi/form_fields.html.twig'  %}
 
 <div class="ez-add-to-bookmarks {{ form.vars.data.bookmarked ? 'ez-add-to-bookmarks--checked'}}">
     {{ form_start(form, {'action': path('ezplatform.location.update_bookmark')}) }}

--- a/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
+++ b/src/bundle/Resources/views/parts/form/location_bookmark.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'locationview' %}
 
-<div class="ez-add-to-bookmarks">
+<div class="ez-add-to-bookmarks {{ form.vars.data.bookmarked ? 'ez-add-to-bookmarks--checked'}}">
     {{ form_start(form, {'action': path('ezplatform.location.update_bookmark')}) }}
         {{ form_widget(form.bookmarked, {'attr': {'class': 'ez-add-to-bookmarks__checkbox'}}) }}
         <label class="ez-add-to-bookmarks__label" for="{{ form.bookmarked.vars.id}}">


### PR DESCRIPTION
Fixes the bug concerning a bookmark star on a location page. The content was always bookmarked, even if it wasn't.

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29266
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
