### PR TITLE
EZP-29079: Cannot edit Content Type after changing the main language of the "admin" siteaccess

### DIFF
--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -404,7 +404,7 @@ class ContentTypeController extends Controller
         $languageCode = reset($this->languages);
 
         foreach ($this->languages as $prioritizedLanguage) {
-            if (isset($contentType->names[$prioritizedLanguage])) {
+            if (isset($contentTypeDraft->names[$prioritizedLanguage])) {
                 $languageCode = $prioritizedLanguage;
                 break;
             }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29079
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
