### PR TITLE
EZP-29270: Sub-items sorting order not respected by UDW

### DIFF
--- a/src/bundle/Resources/public/js/scripts/udw/browse.js
+++ b/src/bundle/Resources/public/js/scripts/udw/browse.js
@@ -1,30 +1,16 @@
-(function () {
-    const btns = document.querySelectorAll('.btn--udw-browse');
-    const udwContainer = document.getElementById('react-udw');
-    const token = document.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
-
+(function(global, doc) {
+    const btns = doc.querySelectorAll('.btn--udw-browse');
+    const onUdwConfirm = (items) => {
         window.location.href = window.Routing.generate('_ezpublishLocation', { locationId: items[0].id });
     };
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
+    const getUdwConfig = (event) => ({
+        confirmLabel: 'View content',
+        title: 'Browse content',
+        multiple: false,
+        startingLocationId: parseInt(event.currentTarget.dataset.startingLocationId, 10),
+        onConfirm: onUdwConfirm,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
-
-        ReactDOM.render(React.createElement(eZ.modules.UniversalDiscovery, Object.assign({
-            onConfirm,
-            onCancel,
-            confirmLabel: 'View content',
-            title: 'Browse content',
-            multiple: false,
-            startingLocationId: parseInt(event.currentTarget.dataset.startingLocationId, 10),
-            restInfo: {token, siteaccess},
-        }, config)), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})();
+    udwInitializer.initialize(btns, getUdwConfig);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/copy.js
+++ b/src/bundle/Resources/public/js/scripts/udw/copy.js
@@ -1,34 +1,21 @@
-(function () {
-    const btns = document.querySelectorAll('.btn--udw-copy');
-    const form = document.querySelector('form[name="location_copy"]');
+(function(global, doc) {
+    const btns = doc.querySelectorAll('.btn--udw-copy');
+    const form = doc.querySelector('form[name="location_copy"]');
     const input = form.querySelector('#location_copy_new_parent_location');
-    const udwContainer = document.getElementById('react-udw');
-    const token = document.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
 
+    const onUdwConfirm = (items) => {
         input.value = items[0].id;
         form.submit();
     };
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
+    const getUdwConfig = (event) => ({
+        confirmLabel: 'Copy to location',
+        title: 'Select location',
+        multiple: false,
+        startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
+        onConfirm: onUdwConfirm,
+        allowContainersOnly: true,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
-
-        ReactDOM.render(React.createElement(eZ.modules.UniversalDiscovery, Object.assign({
-            onConfirm,
-            onCancel,
-            confirmLabel: 'Copy to location',
-            title: 'Select location',
-            multiple: false,
-            startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
-            restInfo: {token, siteaccess},
-            allowContainersOnly: true
-        }, config)), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})();
+    udwInitializer.initialize(btns, getUdwConfig);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/copy_subtree.js
+++ b/src/bundle/Resources/public/js/scripts/udw/copy_subtree.js
@@ -1,31 +1,21 @@
-(function (global, doc, React, ReactDOM) {
+(function(global, doc) {
     const btns = [...doc.querySelectorAll('.ez-btn--udw-copy-subtree')];
     const form = doc.querySelector('form[name="location_copy_subtree"]');
     const input = form.querySelector('#location_copy_subtree_new_parent_location');
-    const udwContainer = doc.querySelector('#react-udw');
-    const token = doc.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
 
+    const onUdwConfirm = (items) => {
         input.value = items[0].id;
         form.submit();
     };
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
+    const getUdwConfig = (event) => ({
+        allowContainersOnly: true,
+        confirmLabel: 'View content',
+        title: 'Select location',
+        multiple: false,
+        startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
+        onConfirm: onUdwConfirm,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        ReactDOM.render(React.createElement(global.eZ.modules.UniversalDiscovery, {
-            onConfirm,
-            onCancel,
-            title: 'Select location',
-            multiple: false,
-            startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
-            restInfo: {token, siteaccess},
-            allowContainersOnly: true
-        }), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})(window, document, window.React, window.ReactDOM);
+    udwInitializer.initialize(btns, getUdwConfig);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/locations.tab.js
+++ b/src/bundle/Resources/public/js/scripts/udw/locations.tab.js
@@ -1,37 +1,26 @@
-(function () {
-    const btns = document.querySelectorAll('.btn--udw-add');
-    const submitButton = document.querySelector('#content_location_add_add');
-    const form = document.querySelector('form[name="content_location_add"]');
+(function(global, doc) {
+    const btns = doc.querySelectorAll('.btn--udw-add');
+    const submitButton = doc.querySelector('#content_location_add_add');
+    const form = doc.querySelector('form[name="content_location_add"]');
     const input = form.querySelector('#content_location_add_new_locations');
-    const udwContainer = document.getElementById('react-udw');
-    const token = document.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
 
+    const canSelectContent = ({ item }, callback) => callback(item.ContentInfo.Content.ContentTypeInfo.isContainer);
+    const beforeUdwOpen = (event) => {
+        event.stopPropagation();
+    };
+    const onUdwConfirm = (items) => {
         input.value = items[0].id;
         submitButton.click();
     };
-    const canSelectContent = ({ item }, callback) => callback(item.ContentInfo.Content.ContentTypeInfo.isContainer);
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
+    const getUdwConfig = () => ({
+        canSelectContent,
+        confirmLabel: 'Add location',
+        title: 'Select location',
+        multiple: false,
+        startingLocationId: global.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
+        onConfirm: onUdwConfirm,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
-
-        window.ReactDOM.render(window.React.createElement(window.eZ.modules.UniversalDiscovery, Object.assign({
-            onConfirm,
-            onCancel,
-            canSelectContent,
-            confirmLabel: 'Add location',
-            title: 'Select location',
-            multiple: false,
-            startingLocationId: window.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
-            restInfo: {token, siteaccess}
-        }, config)), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})();
+    udwInitializer.initialize(btns, getUdwConfig, beforeUdwOpen);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/move.js
+++ b/src/bundle/Resources/public/js/scripts/udw/move.js
@@ -1,36 +1,23 @@
-(function () {
-    const btns = document.querySelectorAll('.btn--udw-move');
-    const form = document.querySelector('form[name="location_move"]');
+(function(global, doc) {
+    const btns = doc.querySelectorAll('.btn--udw-move');
+    const form = doc.querySelector('form[name="location_move"]');
     const input = form.querySelector('#location_move_new_parent_location');
-    const udwContainer = document.getElementById('react-udw');
-    const token = document.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
 
+    const canSelectContent = ({ item }, callback) => callback(item.ContentInfo.Content.ContentTypeInfo.isContainer);
+    const onUdwConfirm = (items) => {
         input.value = items[0].id;
         form.submit();
     };
-    const canSelectContent = ({item}, callback) => callback(item.ContentInfo.Content.ContentTypeInfo.isContainer);
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
+    const getUdwConfig = (event) => ({
+        confirmLabel: 'Move to location',
+        title: 'Select destination',
+        canSelectContent,
+        multiple: false,
+        startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
+        onConfirm: onUdwConfirm,
+        allowContainersOnly: true,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
-
-        window.ReactDOM.render(window.React.createElement(window.eZ.modules.UniversalDiscovery, Object.assign({
-            onConfirm,
-            onCancel,
-            canSelectContent,
-            confirmLabel: 'Move to location',
-            title: 'Select destination',
-            multiple: false,
-            startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
-            restInfo: {token, siteaccess},
-            allowContainersOnly: true
-        }, config)), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})();
+    udwInitializer.initialize(btns, getUdwConfig);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/swap.js
+++ b/src/bundle/Resources/public/js/scripts/udw/swap.js
@@ -1,33 +1,20 @@
-(function () {
-    const btns = document.querySelectorAll('.btn--udw-swap');
-    const form = document.querySelector('form[name="location_swap"]');
+(function(global, doc) {
+    const btns = doc.querySelectorAll('.btn--udw-swap');
+    const form = doc.querySelector('form[name="location_swap"]');
     const input = form.querySelector('#location_swap_new_location');
-    const udwContainer = document.getElementById('react-udw');
-    const token = document.querySelector('meta[name="CSRF-Token"]').content;
-    const siteaccess = document.querySelector('meta[name="SiteAccess"]').content;
-    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
-    const onConfirm = (items) => {
-        closeUDW();
 
+    const onUdwConfirm = (items) => {
         input.value = items[0].id;
         form.submit();
     };
-    const onCancel = () => closeUDW();
-    const openUDW = (event) => {
-        event.preventDefault();
+    const getUdwConfig = () => ({
+        confirmLabel: 'Swap location',
+        title: 'Select location to be swapped with',
+        multiple: false,
+        startingLocationId: global.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
+        onConfirm: onUdwConfirm,
+    });
+    const udwInitializer = global.eZ.UdwInitializer;
 
-        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
-
-        ReactDOM.render(React.createElement(eZ.modules.UniversalDiscovery, Object.assign({
-            onConfirm,
-            onCancel,
-            confirmLabel: 'Swap location',
-            title: 'Select location to be swapped with',
-            multiple: false,
-            startingLocationId: window.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
-            restInfo: {token, siteaccess}
-        }, config)), udwContainer);
-    };
-
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
-})();
+    udwInitializer.initialize(btns, getUdwConfig);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/udw/udw.initializer.js
+++ b/src/bundle/Resources/public/js/scripts/udw/udw.initializer.js
@@ -62,25 +62,11 @@
             this._setBaseConfig(event);
             this._addEventTargetUdwConfig(event);
             this._wrapOnConfigFunctions();
-            this._setSubItemsSortOrderConfig();
             this._setRestInfoConfig();
         }
 
         _addOpeningButtonsListeners() {
             this.openingButtons.forEach((button) => button.addEventListener('click', this._onOpeningButtonClick, false));
-        }
-
-        _setSubItemsSortOrderConfig() {
-            const sortContainer = doc.querySelector('[data-sort-field][data-sort-order]');
-
-            if (!sortContainer) {
-                return;
-            }
-
-            const sortField = sortContainer.getAttribute('data-sort-field');
-            const sortOrder = sortContainer.getAttribute('data-sort-order');
-
-            this.udwConfig.sortClauses = { [sortField]: sortOrder };
         }
 
         _setRestInfoConfig() {

--- a/src/bundle/Resources/public/js/scripts/udw/udw.initializer.js
+++ b/src/bundle/Resources/public/js/scripts/udw/udw.initializer.js
@@ -1,0 +1,141 @@
+(function(global, doc) {
+    const eZ = (global.eZ = global.eZ || {});
+
+    eZ.UdwInitializer = class UdwInitializer {
+        constructor(openingButtons, getBaseConfig, beforeUdwOpen) {
+            this.openingButtons = openingButtons;
+            this.getBaseConfig = getBaseConfig;
+            this.beforeUdwOpen = !!beforeUdwOpen ? beforeUdwOpen : () => {};
+            this.udwConfig = {};
+
+            this._onOpeningButtonClick = this._onOpeningButtonClick.bind(this);
+
+            this._addOpeningButtonsListeners();
+        }
+
+        /**
+         * Creates UdwInitializer instance which in turn creates opening buttons listeners.
+         * On opening button click UDW is being opened.
+         *
+         * @method initialize
+         * @param {Elements[]} openingButtons
+         * @param {Function} getBaseConfig
+         * @param {Function} beforeUdwOpen
+         * @returns {UdwInitializer}
+         * @memberof UdwInitializer
+         */
+        static initialize(openingButtons, getBaseConfig, beforeUdwOpen) {
+            return new UdwInitializer(openingButtons, getBaseConfig, beforeUdwOpen);
+        }
+
+        _onOpeningButtonClick(event) {
+            event.preventDefault();
+
+            this.beforeUdwOpen(event);
+            this._prepareUdwConfig(event);
+            this._openUdw();
+        }
+
+        _getEventTargetUdwConfig(event) {
+            return JSON.parse(event.currentTarget.dataset.udwConfig);
+        }
+
+        _addEventTargetUdwConfig(event) {
+            const targetUdwConfig = this._getEventTargetUdwConfig(event);
+
+            this.udwConfig = Object.assign(targetUdwConfig, this.udwConfig);
+        }
+
+        _setBaseConfig(event) {
+            const baseUdwConfig = this.getBaseConfig(event);
+
+            this.udwConfig = Object.assign(
+                this.udwConfig,
+                {
+                    onCancel: () => {},
+                },
+                baseUdwConfig
+            );
+        }
+
+        _prepareUdwConfig(event) {
+            this._setBaseConfig(event);
+            this._addEventTargetUdwConfig(event);
+            this._wrapOnConfigFunctions();
+            this._setSubItemsSortOrderConfig();
+            this._setRestInfoConfig();
+        }
+
+        _addOpeningButtonsListeners() {
+            this.openingButtons.forEach((button) => button.addEventListener('click', this._onOpeningButtonClick, false));
+        }
+
+        _setSubItemsSortOrderConfig() {
+            const sortContainer = doc.querySelector('[data-sort-field][data-sort-order]');
+
+            if (!sortContainer) {
+                return;
+            }
+
+            const sortField = sortContainer.getAttribute('data-sort-field');
+            const sortOrder = sortContainer.getAttribute('data-sort-order');
+
+            this.udwConfig.sortClauses = { [sortField]: sortOrder };
+        }
+
+        _setRestInfoConfig() {
+            const token = doc.querySelector('meta[name="CSRF-Token"]').content;
+            const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
+
+            this.udwConfig.restInfo = { token, siteaccess };
+        }
+
+        _getUdwReactElement() {
+            const React = global.React;
+            const udwModule = eZ.modules.UniversalDiscovery;
+
+            return React.createElement(udwModule, this.udwConfig);
+        }
+
+        _wrapWithClosing(fn) {
+            if (!fn) {
+                return null;
+            }
+
+            const self = this;
+
+            return function() {
+                self._closeUdw();
+
+                fn.apply(null, arguments);
+            };
+        }
+
+        _wrapOnConfigFunctions() {
+            const onConfirm = this.udwConfig.onConfirm;
+            const onCancel = this.udwConfig.onCancel;
+
+            this.udwConfig.onConfirm = this._wrapWithClosing(onConfirm);
+            this.udwConfig.onCancel = this._wrapWithClosing(onCancel);
+        }
+
+        _getUdwDomContainer() {
+            return doc.getElementById('react-udw');
+        }
+
+        _openUdw() {
+            const ReactDOM = global.ReactDOM;
+            const udwReactElement = this._getUdwReactElement();
+            const container = this._getUdwDomContainer();
+
+            ReactDOM.render(udwReactElement, container);
+        }
+
+        _closeUdw() {
+            const ReactDOM = global.ReactDOM;
+            const container = this._getUdwDomContainer();
+
+            ReactDOM.unmountComponentAtNode(container);
+        }
+    };
+})(window, document);

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -120,6 +120,7 @@
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.update.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.add.translation.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.content.edit.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/udw.initializer.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/move.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/copy.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/swap.js'

--- a/src/bundle/Resources/views/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard/dashboard.html.twig
@@ -39,6 +39,7 @@
 
 {% block javascripts %}
     {%  javascripts
+        'bundles/ezplatformadminui/js/scripts/udw/udw.initializer.js'
         'bundles/ezplatformadminui/js/scripts/udw/browse.js'
         'bundles/ezplatformadminui/js/scripts/cotf/create.js'
         'bundles/ezplatformadminui/js/scripts/button.content.edit.js'

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -104,6 +104,7 @@
             '@EzPlatformAdminUiModulesBundle/Resources/public/js/UniversalDiscovery.module.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.trigger.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.prevent.default.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/udw.initializer.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/browse.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.user.menu.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.prevent.click.js'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29270
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Refactored scripts responsible for opening UDW.

**Info for QA**: You need to check if UDW is woring correctly when used during _move_, _browse_, _copy_, etc. because of scripts refactorization.

#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review
