### PR TITLE
EZP-29270: Sub-items sorting order not respected by UDW

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -19,6 +19,14 @@ services:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'multiFileUpload' }
 
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\SortFieldMappings:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'sortFieldMappings' }
+
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\SortOrderMappings:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'sortOrderMappings' }
+
     ezsystems.ezplatform_admin_ui.ui.config.provider.image_variations:
         class: EzSystems\EzPlatformAdminUi\UI\Config\Provider\Value
         arguments:

--- a/src/lib/UI/Config/Provider/SortFieldMappings.php
+++ b/src/lib/UI/Config/Provider/SortFieldMappings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+/**
+ * Provides information about mapping between serialized sort field and the value accepted by sort clause.
+ *
+ * @see \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor::serializeSortField
+ */
+class SortFieldMappings implements ProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return [
+           'PATH' => 'LocationPath',
+           'PUBLISHED' => 'DatePublished',
+           'MODIFIED' => 'DateModified',
+           'SECTION' => 'SectionIdentifier',
+           'DEPTH' => 'LocationDepth',
+           'PRIORITY' => 'LocationPriority',
+           'NAME' => 'ContentName',
+           'NODE_ID' => 'LocationId',
+           'CONTENTOBJECT_ID' => 'ContentId',
+        ];
+    }
+}

--- a/src/lib/UI/Config/Provider/SortOrderMappings.php
+++ b/src/lib/UI/Config/Provider/SortOrderMappings.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+/**
+ * Provides information about mapping between serialized sort order and the value accepted by sort clause.
+ *
+ * @see \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor::serializeSortOrder
+ */
+class SortOrderMappings implements ProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return [
+            'ASC' => Query::SORT_ASC,
+            'DESC' => Query::SORT_DESC,
+        ];
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29270
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Unfortunately serialized values of `\eZ\Publish\API\Repository\Values\Content\Location::$sortField` and `\eZ\Publish\API\Repository\Values\Content\Location::$sortOrder` are hardcoded in REST API.  


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
