### PR TITLE
EZP-29316: Only show add/remove buttons for urls if policy allows

### DIFF
--- a/src/bundle/Resources/translations/role.en.xliff
+++ b/src/bundle/Resources/translations/role.en.xliff
@@ -82,8 +82,8 @@
         <note>key: policy.update.success</note>
       </trans-unit>
       <trans-unit id="1ac24fa007363b4280663fba53f7a3b436ed4c8f" resname="policy.view.add.title">
-        <source>policy.view.add.title</source>
-        <target state="new">policy.view.add.title</target>
+        <source>Adding a new Policy</source>
+        <target state="new">Adding a new Policy</target>
         <note>key: policy.view.add.title</note>
       </trans-unit>
       <trans-unit id="aefaf3a17b8493e63c82678611eb6eacbcc45d19" resname="policy.view.edit.title">

--- a/src/bundle/Resources/views/admin/policy/add.html.twig
+++ b/src/bundle/Resources/views/admin/policy/add.html.twig
@@ -15,7 +15,7 @@
 
 {% block page_title_admin %}
     {% include '@ezdesign/parts/page_title.html.twig' with {
-        title: 'policy.view.add.title'|trans|trans|desc('Adding a new Policy'),
+        title: 'policy.view.add.title'|trans|desc('Adding a new Policy'),
         iconName: 'roles'
     } %}
 {% endblock %}

--- a/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
@@ -17,10 +17,18 @@
     <tbody>
     {% for custom_url in custom_urls_pager.currentPageResults %}
         <tr>
-            <td class="ez-checkbox-cell">{{ form_widget(form_custom_url_remove.url_aliases[custom_url.id]) }}</td>
+            <td class="ez-checkbox-cell">
+                {% if can_edit_custom_url %}
+                    {{ form_widget(form_custom_url_remove.url_aliases[custom_url.id]) }}
+                {% else %}
+                    {% do form_custom_url_remove.url_aliases.setRendered %}
+                {% endif %}
+            </td>
             <td>{{ custom_url.path }}</td>
             <td>
-                {% for languageCode in custom_url.languageCodes %}{{ admin_ui_config.languages.mappings[languageCode].name }}<br>{% endfor %}
+                {% for languageCode in custom_url.languageCodes %}
+                    {{ admin_ui_config.languages.mappings[languageCode].name }}<br>
+                {% endfor %}
             </td>
             <td>
                 {% if custom_url.forward %}

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -57,25 +57,25 @@
 
 {% macro table_header_tools(form_custom_url_remove) %}
     {% if can_edit_custom_url %}
-    <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
-        <svg class="ez-icon ez-icon-create">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
-        </svg>
-    </button>
+        <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
+            <svg class="ez-icon ez-icon-create">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
+            </svg>
+        </button>
 
-    {% set modal_data_target = 'delete-custom-url-modal' %}
-    <button id="delete-custom-urls" type="button" class="btn btn-danger" disabled data-toggle="modal"
-            data-target="#{{ modal_data_target }}" title="{{ 'tab.urls.action.delete'|trans|desc('Delete Custom URL') }}">
-        <svg class="ez-icon ez-icon-trash">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink"
-                 xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-        </svg>
-    </button>
-    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
-        'id': modal_data_target,
-        'message': 'tab.urls.modal.message'|trans|desc('Do you want to delete selected Custom URLs?'),
-        'data_click': '#' ~ form_custom_url_remove.remove.vars.id,
-    }%}
+        {% set modal_data_target = 'delete-custom-url-modal' %}
+        <button id="delete-custom-urls" type="button" class="btn btn-danger" disabled data-toggle="modal"
+                data-target="#{{ modal_data_target }}" title="{{ 'tab.urls.action.delete'|trans|desc('Delete Custom URL') }}">
+            <svg class="ez-icon ez-icon-trash">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                     xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+            </svg>
+        </button>
+        {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
+            'id': modal_data_target,
+            'message': 'tab.urls.modal.message'|trans|desc('Do you want to delete selected Custom URLs?'),
+            'data_click': '#' ~ form_custom_url_remove.remove.vars.id,
+        }%}
     {% endif %}
 {% endmacro %}
 

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -9,6 +9,7 @@
     {{  include('@ezdesign/content/tab/url/custom_urls_table.html.twig', {
             'custom_urls_pager': custom_urls_pager,
             'form_custom_url_remove': form_custom_url_remove,
+            'can_edit_custom_url': can_edit_custom_url,
     }) }}
 {% else %}
     <p class="ez-table-no-content">

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -56,6 +56,7 @@
 {% include '@ezdesign/content/tab/url/modal_add_custom_url.html.twig' with {'form': form_custom_url_add, 'parent_name': parent_name} only %}
 
 {% macro table_header_tools(form_custom_url_remove) %}
+    {% if can_edit_custom_url %}
     <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
         <svg class="ez-icon ez-icon-create">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
@@ -75,6 +76,7 @@
         'message': 'tab.urls.modal.message'|trans|desc('Do you want to delete selected Custom URLs?'),
         'data_click': '#' ~ form_custom_url_remove.remove.vars.id,
     }%}
+    {% endif %}
 {% endmacro %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -1,6 +1,9 @@
 {% trans_default_domain 'content_url' %}
 {% import _self as tab %}
-{% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.urls.custom_url_aliases'|trans({'%contentName%' : ez_content_name(content)})|desc('Custom URL aliases for %contentName%'), tools: tab.table_header_tools(form_custom_url_remove) } %}
+{% include '@ezdesign/parts/table_header.html.twig' with {
+    headerText: 'tab.urls.custom_url_aliases'|trans({'%contentName%' : ez_content_name(content)})|desc('Custom URL aliases for %contentName%'),
+    tools: tab.table_header_tools(form_custom_url_remove, can_edit_custom_url)
+} %}
 
 {% if custom_urls_pager.currentPageResults is not empty %}
     {{  include('@ezdesign/content/tab/url/custom_urls_table.html.twig', {
@@ -55,7 +58,7 @@
 
 {% include '@ezdesign/content/tab/url/modal_add_custom_url.html.twig' with {'form': form_custom_url_add, 'parent_name': parent_name} only %}
 
-{% macro table_header_tools(form_custom_url_remove) %}
+{% macro table_header_tools(form_custom_url_remove, can_edit_custom_url) %}
     {% if can_edit_custom_url %}
         <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
             <svg class="ez-icon ez-icon-create">

--- a/src/lib/Tab/LocationView/UrlsTab.php
+++ b/src/lib/Tab/LocationView/UrlsTab.php
@@ -142,7 +142,7 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
             'custom_urls_pagination_params' => $customUrlsPaginationParams,
             'system_urls_pager' => $systemUrlPagerfanta,
             'system_urls_pagination_params' => $systemUrlsPaginationParams,
-            'can_edit_custom_url' => $canEditCustomUrl
+            'can_edit_custom_url' => $canEditCustomUrl,
         ];
 
         return $this->twig->render(

--- a/src/lib/Tab/LocationView/UrlsTab.php
+++ b/src/lib/Tab/LocationView/UrlsTab.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\Tab\LocationView;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\PermissionResolver;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\CustomUrl\CustomUrlAddData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\CustomUrl\CustomUrlRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
@@ -39,6 +40,9 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
     /** @var \eZ\Publish\API\Repository\LocationService */
     protected $locationService;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    protected $permissionResolver;
+
     /**
      * @param \Twig\Environment $twig
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
@@ -46,6 +50,7 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
      * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
     public function __construct(
         Environment $twig,
@@ -53,7 +58,8 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
         URLAliasService $urlAliasService,
         FormFactory $formFactory,
         DatasetFactory $datasetFactory,
-        LocationService $locationService
+        LocationService $locationService,
+        PermissionResolver $permissionResolver
     ) {
         parent::__construct($twig, $translator);
 
@@ -61,6 +67,7 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
         $this->formFactory = $formFactory;
         $this->datasetFactory = $datasetFactory;
         $this->locationService = $locationService;
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -125,6 +132,8 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
         $customUrlRemoveForm = $this->createCustomUrlRemoveForm($location, $customUrlPagerfanta->getCurrentPageResults());
         $parentLocation = $this->locationService->loadLocation($location->parentLocationId);
 
+        $canEditCustomUrl = $this->permissionResolver->hasAccess('content', 'urltranslator');
+
         $viewParameters = [
             'form_custom_url_add' => $customUrlAddForm->createView(),
             'form_custom_url_remove' => $customUrlRemoveForm->createView(),
@@ -133,6 +142,7 @@ class UrlsTab extends AbstractTab implements OrderedTabInterface
             'custom_urls_pagination_params' => $customUrlsPaginationParams,
             'system_urls_pager' => $systemUrlPagerfanta,
             'system_urls_pagination_params' => $systemUrlsPaginationParams,
+            'can_edit_custom_url' => $canEditCustomUrl
         ];
 
         return $this->twig->render(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29316](https://jira.ez.no/browse/EZP-29316)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Urls should only allow add/remove urls if policy allows

![screen shot 2018-06-20 at 3 27 00 pm](https://user-images.githubusercontent.com/1654712/41661303-b0e6c5e6-749e-11e8-9ec7-314382ff02dd.png)


![screen shot 2018-06-21 at 8 50 43 am](https://user-images.githubusercontent.com/1654712/41702436-71550a22-7530-11e8-8232-9c6ff0ef1fc3.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
