### PR TITLE
[EZP-28461] Pagination design consistency

### DIFF
--- a/src/bundle/Resources/public/scss/_custom.scss
+++ b/src/bundle/Resources/public/scss/_custom.scss
@@ -41,7 +41,7 @@ $ez-alloyeditor-color-hover: #65B6F0;
 
 $ez-pagination-bg: transparent;
 $ez-pagination-margin: 0.25rem;
-$ez-pagination-font-size: 0.9rem;
+$ez-pagination-font-size: 1rem;
 $ez-pagination-page-link-radius: 50%;
 $ez-pagination-border-radius: 0.3rem;
 

--- a/src/bundle/Resources/public/scss/_pagination.scss
+++ b/src/bundle/Resources/public/scss/_pagination.scss
@@ -1,5 +1,17 @@
 .ez-pagination {
     font-size: $ez-pagination-font-size;
+
+    &__text {
+        font-size: .75rem;
+    }
+
+    &__btn {
+        font-size: 1rem;
+    }
+
+    &__spacing {
+        margin-top: -2rem;
+    }
 }
 
 .page-item {
@@ -25,8 +37,10 @@
 .page-item.prev, .page-item.next {
     &.disabled .page-link {
         color: $ez-white;
-        background-color: $ez-ground-base-medium;
-        border: $ez-ground-base-medium;
+        background-color: $ez-color-secondary;
+        border: $ez-color-secondary;
+        opacity: .3;
+        cursor: not-allowed;
     }
 }
 

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -86,14 +86,14 @@
 
 
                 {% if pager.haveToPaginate %}
-                    <div class="row justify-content-center align-items-center mb-2">
-                        <span>
+                    <div class="row justify-content-center align-items-center ez-pagination__spacing mb-2">
+                        <span class="ez-pagination__text">
                             {{ 'pagination.viewing'|trans({
                                 '%viewing%': pager.currentPageResults|length,
                                 '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                         </span>
                     </div>
-                    <div class="row justify-content-center align-items-center">
+                    <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                         {{ pagerfanta(pager, 'ez') }}
                     </div>
                 {% endif %}

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -74,14 +74,14 @@
     {{ form_end(form_content_types_delete) }}
 
     {% if pager.haveToPaginate %}
-        <div class="row justify-content-center align-items-center mb-2">
-                <span>
+        <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                <span class="ez-pagination__text">
                     {{ 'pagination.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
         </div>
-        <div class="row justify-content-center align-items-center">
+        <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
             {{ pagerfanta(pager, 'ez', {
                 'routeName': route_name,
                 'routeParams': {'contentTypeGroupId': group.id}

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -98,14 +98,14 @@
         {{ form_end(form_content_type_groups_delete) }}
 
         {% if pager.haveToPaginate %}
-            <div class="row justify-content-center align-items-center mb-2">
-                <span>
+            <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                <span class="ez-pagination__text">
                     {{ 'pagination.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                 {{ pagerfanta(pager, 'ez') }}
             </div>
         {% endif %}

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -113,13 +113,13 @@
 
         {% if pager.haveToPaginate %}
             <div class="row justify-content-center align-items-center mb-2">
-                <span>
+                <span class="ez-pagination__text">
                     {{ 'language.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults})|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                 {{ pagerfanta(pager, 'ez') }}
             </div>
         {% endif %}

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -97,14 +97,14 @@
     {{ form_end(form_policies_delete) }}
 
     {% if pager.haveToPaginate %}
-        <div class="row justify-content-center align-items-center mb-2">
-                <span>
+        <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                <span class="ez-pagination__text">
                     {{ 'pagination.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
         </div>
-        <div class="row justify-content-center align-items-center">
+        <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
             {{ pagerfanta(pager, 'ez',{
                 'routeName': route_name,
                 'routeParams': {'_fragment': 'policies', 'roleId': role.id},

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -117,13 +117,13 @@
 
         {% if pager.haveToPaginate %}
             <div class="row justify-content-center align-items-center mb-2">
-                <span>
+                <span class="ez-pagination__text">
                     {{ 'role.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults})|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                 {{ pagerfanta(pager, 'ez') }}
             </div>
         {% endif %}

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -88,14 +88,14 @@
     {{ form_end(form_role_assignments_delete) }}
 
     {% if pager.haveToPaginate %}
-        <div class="row justify-content-center align-items-center mb-2">
-                <span>
+        <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                <span class="ez-pagination__text">
                     {{ 'pagination.viewing'|trans({
                         '%viewing%': pager.currentPageResults|length,
                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
         </div>
-        <div class="row justify-content-center align-items-center">
+        <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
             {{ pagerfanta(pager, 'ez',{
                 'routeName': route_name,
                 'routeParams': {'_fragment': 'users-and-groups', 'roleId': role.id},

--- a/src/bundle/Resources/views/admin/search/list.html.twig
+++ b/src/bundle/Resources/views/admin/search/list.html.twig
@@ -54,10 +54,10 @@
                         {% endfor %}
                         </tbody>
                     </table>
-                    <div class="row justify-content-center align-items-center">
-                        <h6>{{ 'search.viewing'|trans({'%viewing%': pagerfanta.currentPageResults|length, '%total%': pagerfanta.nbResults})|desc('Viewing %viewing% out of %total% sub-items') }}</h6>
+                    <div class="row justify-content-center align-items-center ez-pagination__spacing">
+                        <h6 class="ez-pagination__text">{{ 'search.viewing'|trans({'%viewing%': pagerfanta.currentPageResults|length, '%total%': pagerfanta.nbResults})|desc('Viewing %viewing% out of %total% sub-items') }}</h6>
                     </div>
-                    <div class="row justify-content-center align-items-center">
+                    <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                         {% if pagerfanta.haveToPaginate %}
                             {{ pagination|raw }}
                         {% endif %}

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -61,14 +61,14 @@
                         </table>
 
                         {% if pager.haveToPaginate %}
-                            <div class="row justify-content-center align-items-center mb-2">
-                                <span>
+                            <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                                <span class="ez-pagination__text">
                                     {{ 'pagination.viewing'|trans({
                                         '%viewing%': pager.currentPageResults|length,
                                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                                 </span>
                             </div>
-                            <div class="row justify-content-center align-items-center">
+                            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                                 {{ pagerfanta(pager, 'ez', {'pageParameter': '[search][page]'}) }}
                             </div>
                         {% endif %}

--- a/src/bundle/Resources/views/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/admin/section/assigned_content.html.twig
@@ -63,7 +63,7 @@
         </tbody>
     </table>
 
-    <div class="row justify-content-center align-items-center">
+    <div class="row justify-content-center align-items-center ez-pagination__spacing mb-5">
         {% if pagerfanta.haveToPaginate %}
             {{ pagination|raw }}
         {% endif %}

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -118,13 +118,13 @@
 
         {% if pager.haveToPaginate %}
             <div class="row justify-content-center align-items-center mb-2">
-                <span>
+                <span class="ez-pagination__text">
                     {{ 'section.viewing'|trans({
                     '%viewing%': pager.currentPageResults|length,
                     '%total%': pager.nbResults})|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                 {{ pagerfanta(pager, 'ez') }}
             </div>
         {% endif %}

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -111,14 +111,14 @@
                 {{ form_end(form_trash_item_delete, { 'render_rest': false }) }}
 
                 {% if pager.haveToPaginate %}
-                    <div class="row justify-content-center align-items-center mb-2">
-                        <span>
+                    <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                        <span class="ez-pagination__text">
                             {{ 'pagination.viewing'|trans({
                                 '%viewing%': pager.currentPageResults|length,
                                 '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                         </span>
                     </div>
-                    <div class="row justify-content-center align-items-center">
+                    <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
                         {{ pagerfanta(pager, 'ez') }}
                     </div>
                 {% endif %}

--- a/src/bundle/Resources/views/content/tab/pagination.html.twig
+++ b/src/bundle/Resources/views/content/tab/pagination.html.twig
@@ -1,10 +1,10 @@
-<div class="row justify-content-center align-items-center mb-2">
-    <span>
+<div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+    <span class="ez-pagination__text">
         {{ 'pagination.viewing'|trans({
             '%viewing%': pager.currentPageResults|length,
             '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
     </span>
 </div>
-<div class="row justify-content-center align-items-center mb-3">
+<div class="row justify-content-center align-items-center mb-3 ez-pagination__btn mb-4">
     {{ pagerfanta(pager, 'ez', paginatonParams) }}
 </div>

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -22,13 +22,13 @@
 
         {% if draft_pager.haveToPaginate %}
             <div class="row justify-content-center align-items-center mb-2">
-                <span>
+                <span class="ez-pagination__text">
                     {{ 'pagination.viewing'|trans({
                         '%viewing%': draft_pager.currentPageResults|length,
                         '%total%': draft_pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                 </span>
             </div>
-            <div class="row justify-content-center align-items-center mb-3">
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-4">
                 {{ pagerfanta(draft_pager, 'ez',{
                     'routeName': draft_pagination_params.route_name,
                     'routeParams': draft_pagination_params.route_params|merge({

--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -101,7 +101,7 @@
         </table>
 
         {% if urls.haveToPaginate %}
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__spacing mb-5">
                 {{ pagerfanta(urls, 'ez', {'pageParameter': '[search_data][page]'}) }}
             </div>
         {% endif %}

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -118,7 +118,7 @@
         </table>
 
         {% if usages.haveToPaginate %}
-            <div class="row justify-content-center align-items-center">
+            <div class="row justify-content-center align-items-center ez-pagination__spacing mb-5">
                 {{ pagerfanta(usages, 'ez') }}
             </div>
         {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-28461](https://jira.ez.no/browse/EZP-28461)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspects:
- Design goals:
    - Customer request -> When a Notification message shows up it blocks pagination buttons.
    - Harmonize Pagination and Load more features.

- Design specifications:
    - Pagination text that specifies viewed items and items in total should have the same font-size as in Load more feature;
    - Pagination buttons should have the same font-size as regular buttons in the application (= 1rem)
    - Add extra space below pagination feature, in order to avoid that notification bars block this feature.

![bookmarks](https://user-images.githubusercontent.com/9256718/41696576-c33223f0-74e2-11e8-86d4-32338364a3bb.png)
![content_tab_drafts](https://user-images.githubusercontent.com/9256718/41696581-c5fa08d2-74e2-11e8-9067-8ab7b5c09f12.png)
![content_tab_policies](https://user-images.githubusercontent.com/9256718/41696583-c8993a68-74e2-11e8-9266-24433636e41d.png)
![content_tab_roles](https://user-images.githubusercontent.com/9256718/41696584-caf7881e-74e2-11e8-9991-4a863f0169f7.png)
![content_tab_urls](https://user-images.githubusercontent.com/9256718/41696585-cd49599e-74e2-11e8-9256-a76e153cfa80.png)
![content_types_list](https://user-images.githubusercontent.com/9256718/41696587-cfb3ad42-74e2-11e8-8e9c-ff4639ecff8e.png)
![languages](https://user-images.githubusercontent.com/9256718/41696590-d38080c6-74e2-11e8-9c8b-b9138409ab18.png)
![link http___caniuse com](https://user-images.githubusercontent.com/9256718/41696592-d621bb88-74e2-11e8-812c-8e7177dbe088.png)
![link manager](https://user-images.githubusercontent.com/9256718/41696595-d866f5d4-74e2-11e8-931c-8855dd10c427.png)
![role_list](https://user-images.githubusercontent.com/9256718/41696599-db57194a-74e2-11e8-9afb-a1fb7aa0bbe8.png)
![roles_assignments](https://user-images.githubusercontent.com/9256718/41696603-ddc45012-74e2-11e8-9e9f-68d2981ac7a3.png)
![roles_policies](https://user-images.githubusercontent.com/9256718/41696605-e04b5100-74e2-11e8-815a-decd5dbe5956.png)
![search](https://user-images.githubusercontent.com/9256718/41696608-e3c5b3fc-74e2-11e8-9a56-d14a1c9630c6.png)
![section_assigned](https://user-images.githubusercontent.com/9256718/41696610-e6cefa7c-74e2-11e8-9ded-7518be1cbb28.png)
![sections_list](https://user-images.githubusercontent.com/9256718/41696614-e996b420-74e2-11e8-8829-ba4bcea0080a.png)
![trash](https://user-images.githubusercontent.com/9256718/41696615-ebf09aa6-74e2-11e8-919f-f91b4a2e1fa3.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
