### PR TITLE
EZEE-2111: Landing Page field is visible while creating new Page with COTF

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/AdminUiForms.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for Admin UI forms settings.
+ *
+ * Example configuration:
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      default: # configuration per SiteAccess or SiteAccess group
+ *          admin_ui_forms:
+ *              content_edit_form_templates: ['template.html.twig']
+ * ```
+ */
+class AdminUiForms extends AbstractParser
+{
+    const FORM_TEMPLATES_PARAM = 'admin_ui_forms.content_edit_form_templates';
+
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('admin_ui_forms')
+                ->info('Admin UI forms configuration settings')
+                ->children()
+                    ->arrayNode('content_edit_form_templates')
+                        ->info('A list of Content Edit (and create) default Twig form templates')
+                        ->scalarPrototype()->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        $contextualizer->setContextualParameter(
+            static::FORM_TEMPLATES_PARAM,
+            $currentScope,
+            $scopeSettings['admin_ui_forms']['content_edit_form_templates'] ?? []
+        );
+    }
+}

--- a/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
@@ -47,6 +47,7 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $this->prependImageVariations($container);
         $this->prependUniversalDiscoveryWidget($container);
         $this->prependEzDesignConfiguration($container);
+        $this->prependAdminUiFormsConfiguration($container);
     }
 
     /**
@@ -92,5 +93,16 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $container->prependExtensionConfig('ezdesign', $config['ezdesign']);
         $container->prependExtensionConfig('ezpublish', $config['ezpublish']);
         $container->addResource(new FileResource($eZDesignConfigFile));
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function prependAdminUiFormsConfiguration(ContainerBuilder $container)
+    {
+        $adminUiFormsConfigFile = __DIR__ . '/../Resources/config/admin_ui_forms.yml';
+        $config = Yaml::parseFile($adminUiFormsConfigFile);
+        $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($adminUiFormsConfigFile));
     }
 }

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -13,6 +13,7 @@ use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SystemInfoTab
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\TabPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UiConfigProviderPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ViewBuilderRegistryPass;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\AdminUiForms;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\ContentTranslateView;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\LocationIds;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Module;
@@ -78,6 +79,7 @@ class EzPlatformAdminUiBundle extends Bundle
             new SubtreeOperations(),
             new Notifications(),
             new ContentTranslateView(),
+            new AdminUiForms(),
         ];
     }
 }

--- a/src/bundle/Resources/config/admin_ui_forms.yml
+++ b/src/bundle/Resources/config/admin_ui_forms.yml
@@ -1,0 +1,5 @@
+system:
+    admin_group:
+        admin_ui_forms:
+            content_edit_form_templates:
+                - { template: '@ezdesign/content/form_fields.html.twig', priority: 0 }

--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -34,6 +34,13 @@ services:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'imageVariations' }
 
+    ezsystems.ezplatform_admin_ui.ui.config.provider.content_edit_form_templates:
+        class: EzSystems\EzPlatformAdminUi\UI\Config\Provider\Value
+        arguments:
+            $value: '$admin_ui_forms.content_edit_form_templates$'
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'contentEditFormTemplates' }
+
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\User:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'user' }

--- a/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit_base.html.twig
@@ -1,6 +1,6 @@
 {% extends viewbaseLayout is defined ? viewbaseLayout : '@ezdesign/layout.html.twig' %}
 
-{% set default_form_templates = ['@ezdesign/content/form_fields.html.twig'] %}
+{% set default_form_templates = admin_ui_config.contentEditFormTemplates %}
 {% set form_templates = form_templates is defined ? form_templates|merge(default_form_templates) : default_form_templates %}
 
 {% trans_default_domain 'content_edit' %}

--- a/src/bundle/Tests/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
+++ b/src/bundle/Tests/DependencyInjection/Configuration/Parser/AdminUiFormsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\AdminUiForms;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test AdminUiForms SiteAccess-aware Configuration Parser.
+ */
+class AdminUiFormsTest extends TestCase
+{
+    /**
+     * @var \EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\AdminUiForms
+     */
+    private $parser;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface
+     */
+    private $contextualizer;
+
+    public function setUp()
+    {
+        $this->parser = new AdminUiForms();
+        $this->contextualizer = $this->createMock(ContextualizerInterface::class);
+    }
+
+    /**
+     * Test given Content edit form templates are sorted according to their priority when mapping.
+     */
+    public function testContentEditFormTemplatesAreMapped()
+    {
+        $scopeSettings = [
+            'admin_ui_forms' => [
+                'content_edit_form_templates' => [
+                    ['template' => 'my_template-01.html.twig', 'priority' => 1],
+                    ['template' => 'my_template-02.html.twig', 'priority' => 0],
+                    ['template' => 'my_template-03.html.twig', 'priority' => 2],
+                ],
+            ],
+        ];
+        $currentScope = 'admin_group';
+
+        $expectedTemplatesList = [
+            'my_template-03.html.twig',
+            'my_template-01.html.twig',
+            'my_template-02.html.twig',
+        ];
+
+        $this->contextualizer
+            ->expects($this->once())
+            ->method('setContextualParameter')
+            ->with(
+                AdminUiForms::FORM_TEMPLATES_PARAM,
+                $currentScope,
+                $expectedTemplatesList
+            );
+
+        $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2111
| Requies | ezsystems/ezplatform-page-builder#98
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR exposes SiteAccess-aware setting to inject custom Twig Form Theme into Admin UI Content edit forms.

Usage:

```yaml
ezpublish:
  system:
     admin_group: # configuration per SiteAccess or SiteAccess group
         admin_ui_forms:
             content_edit_form_templates: 
                 - { template: 'my_template.html.twig', priority: 0 }
```

The higher the priority, the higher the template will be placed on the list.

#### Checklist:
- [x] Create SiteAccess-aware settting
- [x] Create default configuration for the new setting.
- [x] Expose set Form Themes list in the `admin_ui_config.contentEditFormTemplates` Twig global variable.
- [x] Introduce priorities to injected templates.
- [x] Create unit test for mapping prioritized templates.
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
