### PR TITLE
[EZP-29327] Updated ez-page-title for bookmark button

### DIFF
--- a/src/bundle/Resources/public/scss/_add-to-bookmarks.scss
+++ b/src/bundle/Resources/public/scss/_add-to-bookmarks.scss
@@ -1,21 +1,21 @@
 .ez-add-to-bookmarks {
-    width: 3rem;
-    position: absolute;
-    top: 50%;
-    right: 5rem;
-    transform: translateY(-50%);
+    width: 2.25rem;
+    transform: translateY(3%);
+    grid-area: bookmark;
+    justify-self: center;
 
     &__label {
-        width: 3rem;
-        height: 3rem;
+        width: 2.25rem;
+        height: 2.25rem;
         display: block;
         position: relative;
+        margin-bottom: 0;
         border-radius: 50%;
         cursor: pointer;
 
         &::after {
             display: block;
-            margin-left: -1px;
+            margin-top: 1px;
             border-radius: 50%;
             content: "";
             animation: background-to-transparent .25s ease-in;
@@ -27,10 +27,15 @@
         &::after,
         .ez-add-to-bookmarks__icon-wrapper {
             position: absolute;
-            width: 3rem;
-            height: 3rem;
-            padding: .4rem;
+            width: 2.25rem;
+            height: 2.25rem;
+            padding: .25rem;
             transition: all .25s ease-in;
+        }
+
+        .ez-icon--secondary {
+            width: 1.75rem;
+            height: 1.75rem;
         }
     }
 

--- a/src/bundle/Resources/public/scss/_page-title.scss
+++ b/src/bundle/Resources/public/scss/_page-title.scss
@@ -1,15 +1,28 @@
 .ez-page-title {
     padding-bottom: 1rem;
+    display: grid;
+    grid-template-columns: 1fr 40px;
+    grid-column-gap: 10px;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "content-item bookmark"
+        "content-type-name .";
 
-    h1 {
+    &__content-item {
         margin-bottom: 0;
+        padding-left: 2.25rem;
+        text-indent: -2.4rem;
+        grid-area: content-item;
+        justify-self: start;
     }
 
-    h4 {
-        padding-left: 2.5rem;
+    &__content-type-name {
+        padding-left: 2.25rem;
         font-size: 1.125rem;
         font-weight: 400;
         color: $ez-color-base-light;
+        grid-area: content-type-name;
+        justify-self: start;
+        align-self: start;
     }
-
 }

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -40,9 +40,6 @@
                         iconName: contentType.identifier,
                         contentTypeName: contentType.name
                     } %}
-                    {% include '@ezdesign/parts/form/location_bookmark.html.twig' with {
-                        form: form_location_bookmark
-                    } %}
                 </div>
             </div>
             <div class="panel panel-primary">

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -59,12 +59,14 @@
         {% block navigation %}
             {% include '@ezdesign/parts/navigation.html.twig' %}
         {% endblock %}
-        <div class="container-fluid ez-header">
-            <div class="container">
-                {% block breadcrumbs %}{% endblock %}
-                {% block page_title %}{% endblock %}
+        {% block header %}
+            <div class="container-fluid ez-header">
+                <div class="container">
+                    {% block breadcrumbs %}{% endblock %}
+                    {% block page_title %}{% endblock %}
+                </div>
             </div>
-        </div>
+        {% endblock %}
         <div class="container-fluid ez-main-container">
             {% block content %}
 

--- a/src/bundle/Resources/views/parts/page_title.html.twig
+++ b/src/bundle/Resources/views/parts/page_title.html.twig
@@ -1,6 +1,6 @@
 {% if title is defined %}
     <div class="ez-page-title pt-3 pb-4 px-4">
-        <h1>
+        <h1 class="ez-page-title__content-item">
         {% if iconName is defined%}
             <svg class="ez-icon ez-icon-{{ iconName }}">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ iconName }}"></use>
@@ -9,7 +9,10 @@
         {{ title }}
         </h1>
         {% if contentTypeName is defined %}
-            <h4>{{ contentTypeName }}</h4>
+            <h4 class="ez-page-title__content-type-name">{{ contentTypeName }}</h4>
         {% endif %}
+        {% include '@ezdesign/parts/form/location_bookmark.html.twig' with {
+            form: form_location_bookmark
+        } %}
     </div>
 {% endif %}

--- a/src/bundle/Resources/views/parts/page_title.html.twig
+++ b/src/bundle/Resources/views/parts/page_title.html.twig
@@ -11,8 +11,10 @@
         {% if contentTypeName is defined %}
             <h4 class="ez-page-title__content-type-name">{{ contentTypeName }}</h4>
         {% endif %}
-        {% include '@ezdesign/parts/form/location_bookmark.html.twig' with {
-            form: form_location_bookmark
-        } %}
+        {% if form_location_bookmark is defined %}
+            {% include '@ezdesign/parts/form/location_bookmark.html.twig' with {
+                form: form_location_bookmark
+            } %}
+        {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29327](https://jira.ez.no/browse/EZP-29327)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Updated `ez-page-title` design due to long content item title was covered by Bookmark button;
- Added `grid` for re-arranging elements;
- Resized bookmark button (according to UI Guidelines);
- Added `text-indent` for wrapping long content item titles.

![ez platform 1](https://user-images.githubusercontent.com/9256718/41761613-f94c6656-75c5-11e8-90d1-4c52a9ea8987.png)
![ez platform 2](https://user-images.githubusercontent.com/9256718/41761616-fbeecb92-75c5-11e8-9b36-46b73af1dca4.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
