### PR TITLE
[i18n] updated wrong source message in pagination domain

### DIFF
--- a/src/bundle/Resources/translations/pagination.en.xliff
+++ b/src/bundle/Resources/translations/pagination.en.xliff
@@ -7,7 +7,7 @@
     </header>
     <body>
       <trans-unit id="0173399db18eb7fe3a297f66fac4bf3a98378733" resname="pagination.next_message">
-        <source>Back</source>
+        <source>Next</source>
         <target state="new">Next</target>
         <note>key: pagination.next_message</note>
       </trans-unit>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | none
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Running the extractor did not modify the string, even though it was okay in the template.