### PR TITLE
Fixed 2 parameters types passed to SubItems & MultiFileUpload

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -13,7 +13,7 @@
         }),
         parentInfo: {
             contentTypeIdentifier: mfuContainer.dataset.parentContentTypeIdentifier,
-            contentTypeId: mfuContainer.dataset.parentContentTypeId,
+            contentTypeId: parseInt(mfuContainer.dataset.parentContentTypeId, 10),
             locationPath: mfuContainer.dataset.parentLocationPath,
             language: mfuContainer.dataset.parentContentLanguage
         },
@@ -70,7 +70,7 @@
         global.ReactDOM.render(global.React.createElement(global.eZ.modules.SubItems, {
             handleEditItem,
             generateLink,
-            parentLocationId: container.dataset.location,
+            parentLocationId: parseInt(container.dataset.location, 10),
             sortClauses: {[sortField]: sortOrder},
             restInfo: {token, siteaccess},
             extraActions: [{


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Instead of sending to _SubItems_ & _MultiFileUpload_ paramaters as string, they are sent as numbers. Parameters are: `parentLocationId` & `contentTypeId` respectively.

Connected with:
https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/74

#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review
