### PR TITLE
EZP-29330: Long title covers (X) button in message bar

### DIFF
--- a/src/bundle/Resources/public/scss/_notifications.scss
+++ b/src/bundle/Resources/public/scss/_notifications.scss
@@ -10,10 +10,12 @@
         margin-bottom: 0;
         border-radius: 0;
         transition: opacity 0.3s $ez-admin-transition;
+        padding-right: 10rem;
 
         .close {
             opacity: 1;
-            margin-right: 5rem;
+            padding-top: 0.25rem;
+            margin-right: 5.5rem;
             cursor: pointer;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29330
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixed long text in notification covering close button.


#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review
