### PR TITLE
EZP-29172 - Updated error color in editing view based on usability standards

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -16,7 +16,7 @@
     &.is-invalid {
         .ez-field-edit__label-wrapper,
         .ez-field-edit__label {
-            color: $ez-color-danger;
+            color: $ez-color-warning-dark;
         }
 
         .ez-field-edit__data {
@@ -42,7 +42,7 @@
     &__error {
         display: inline-block;
         margin-left: 8px;
-        color: $ez-color-danger;
+        color: $ez-color-warning-dark;
     }
 
     .ez-data-source__input {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29172](https://jira.ez.no/browse/EZP-29172)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Updated error color in editing view based on usability (color contrast) standards.
- Justification: `$ez-color-warning-dark` is the color that passes all color contrast requirements for legibility of text in that specific view for people with certain visual conditions, as well as improving the reading experience for the rest of users. We are aiming to cover these standards given our users/customers base.

![ez platform 2](https://user-images.githubusercontent.com/9256718/41919473-94933b76-792c-11e8-99f3-761f1d8871ac.png)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
