### PR TITLE
EZP-28774: Fixed misc. deprecation warnings

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -66,6 +66,8 @@ services:
         tags:
             - {name: kernel.event_subscriber}
 
+    EzSystems\EzPlatformAdminUi\Form\SubmitHandler: ~
+
     EzSystems\EzPlatformAdminUi\Form\Type\:
         resource: '../../../lib/Form/Type'
 
@@ -84,6 +86,9 @@ services:
         arguments:
             $userContentTypeIdentifier: '$user_content_type_identifier$'
             $userGroupContentTypeIdentifier: '$user_group_content_type_identifier$'
+
+    EzSystems\EzPlatformAdminUi\UI\Service\:
+        resource: '../../../lib/UI/Service'
 
     EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory:
         lazy: true

--- a/src/bundle/Resources/config/services/form_ui_action_mappers.yml
+++ b/src/bundle/Resources/config/services/form_ui_action_mappers.yml
@@ -7,11 +7,12 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Action\EventDispatcher: ~
     EzSystems\EzPlatformAdminUi\UI\Action\EventDispatcherInterface: '@EzSystems\EzPlatformAdminUi\UI\Action\EventDispatcher'
 
-    EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapper: ~
-    EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapperInterface:
-        alias: '@EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapper'
+    EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapper:
         tags:
             - { name: ezplatform.admin_ui.form_ui_action_mapper }
+
+    EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapperInterface:
+        alias: '@EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapper'
 
     EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMappingDispatcher:
         arguments:

--- a/src/lib/Form/Type/ContentType/SortFieldChoiceType.php
+++ b/src/lib/Form/Type/ContentType/SortFieldChoiceType.php
@@ -32,7 +32,6 @@ class SortFieldChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->getSortFieldChoices(),
-            'choices_as_values' => true,
             'translation_domain' => 'content_type',
         ]);
     }

--- a/src/lib/Form/Type/ContentType/SortOrderChoiceType.php
+++ b/src/lib/Form/Type/ContentType/SortOrderChoiceType.php
@@ -33,7 +33,6 @@ class SortOrderChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->getSortOrderChoices(),
-            'choices_as_values' => true,
             'translation_domain' => 'content_type',
         ]);
     }

--- a/src/lib/Form/Type/Policy/PolicyChoiceType.php
+++ b/src/lib/Form/Type/Policy/PolicyChoiceType.php
@@ -70,7 +70,6 @@ class PolicyChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => $this->policyChoices,
-            'choices_as_values' => true,
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28774
| Bug fix?      | yes| New feature?  | yes/no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed the following deprecation warnings generated by admin ui:

1. ```The configuration key "tags" is unsupported for the service "EzSystems\EzPlatformAdminUi\UI\Action\FormUiActionMapperInterface" which is defined as an alias in "/Users/awojs/Workspace/ezplatform-admin-ui/src/bundle/DependencyInjection/../Resources/config/services/form_ui_action_mappers.yml". Allowed configuration keys for service aliases are "alias" and "public". The YamlFileLoader will raise an exception in Symfony 4.0, instead of silently ignoring unsupported attributes.```
2. ```Relying on service auto-registration for type "EzSystems\EzPlatformAdminUi\Form\SubmitHandler" is deprecated since Symfony 3.4 and won't be supported in 4.0. Create a service named "EzSystems\EzPlatformAdminUi\Form\SubmitHandler" instead.```
3. ```Relying on service auto-registration for type "EzSystems\EzPlatformAdminUi\UI\Service\PathService" is deprecated since Symfony 3.4 and won't be supported in 4.0. Create a service named "EzSystems\EzPlatformAdminUi\UI\Service\PathService" instead.```
4. ```Relying on service auto-registration for type "EzSystems\EzPlatformAdminUi\UI\Service\TabService" is deprecated since Symfony 3.4 and won't be supported in 4.0. Create a service named "EzSystems\EzPlatformAdminUi\UI\Service\TabService" instead.```
5. ```User Deprecated: The "choices_as_values" option is deprecated since Symfony 3.1 and will be removed in 4.0. You should not use it anymore.```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
