### PR TITLE
EZP-29288: Edit button on Bookmarks list is not aligned

### DIFF
--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -63,10 +63,10 @@
                                         -
                                     {% endif %}
                                 </td>
-                                <td class="text-center">
+                                <td class="text-right">
                                     {% if bookmark.userCanEdit %}
                                     <button
-                                        class="btn btn-icon ez-btn--content-edit"
+                                        class="btn btn-icon mx-3 ez-btn--content-edit"
                                         title="{{ 'bookmark.list.content.edit'|trans|desc('Edit Content') }}"
                                         data-content-id="{{ bookmark.contentInfo.id }}"
                                         data-version-no="{{ bookmark.contentInfo.currentVersionNo }}"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29288
| Bug fix?      | -
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixed position of edit button in Bookmark table


#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review

Now:
![screen shot 2018-06-28 at 11 04 59](https://user-images.githubusercontent.com/10233057/42024812-4fe342f8-7ac3-11e8-8b1f-22f13b3be4b1.png)
Previously:
![screen shot 2018-06-28 at 11 05 29](https://user-images.githubusercontent.com/10233057/42024811-4fc774e2-7ac3-11e8-944b-e1aefd524813.png)
