### PR TITLE
EZP-29348: Edit buttons in tables are not aligned with delete button in table header

### DIFF
--- a/src/bundle/Resources/public/js/scripts/button.state.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.toggle.js
@@ -2,7 +2,7 @@
     const toggleForms = [...doc.querySelectorAll('.ez-toggle-btn-state')];
 
     toggleForms.forEach(toggleForm => {
-        const checkboxes = [...toggleForm.querySelectorAll('.ez-checkbox-cell input[type="checkbox"]')];
+        const checkboxes = [...toggleForm.querySelectorAll('.ez-table__cell.ez-table__cell--has-checkbox input[type="checkbox"]')];
         const toggleButtonState = () => {
             const methodName = checkboxes.some(el => el.checked) ? 'removeAttribute' : 'setAttribute';
             const buttonRemove = doc.querySelector(toggleForm.dataset.toggleButtonId);

--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -20,6 +20,26 @@
         &--field-definitions-head {
             width: calc(100% / 3);
         }
+
+        .table &--has-action-btns {
+            padding-right: 1.25rem;
+        }
+
+        &--has-checkbox {
+            width: 5%;
+        }
+
+        &--no-content {
+            margin-bottom: 3rem;
+            padding: 0.75rem 1rem;
+            background-color: $ez-white;
+            font-style: italic;
+            color: $ez-color-base-dark;
+        }
+
+        &--limitation {
+            width: 70%;
+        }
     }
 }
 

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -26,7 +26,7 @@
                          headerText: 'bookmark.table.header'|trans|desc('Bookmarks') ~ ' (' ~ pager.count ~ ')',
                          tools: form_widget(form_remove.remove, {'attr': {'class': 'btn btn-danger', 'disabled': true}})
                      } %}
-                    <table class="table">
+                    <table class="ez-table table">
                         <thead>
                         <tr>
                             <th></th>
@@ -39,17 +39,17 @@
                         <tbody>
                         {% if pager.count is same as(0) %}
                         <tr>
-                            <td colspan="4">
-                                <span class="ez-table-no-content mb-0 py-1 pl-0">{{ 'bookmark.list.empty'|trans|desc('The bookmark list is empty. Any Content item you bookmark will end up here.') }}</span>
+                            <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                                <span class="mb-0 py-1 pl-0">{{ 'bookmark.list.empty'|trans|desc('The bookmark list is empty. Any Content item you bookmark will end up here.') }}</span>
                             </td>
                         </tr>
                         {% else %}
                         {% for bookmark in pager.currentPageResults %}
                             <tr>
-                                <td class="ez-checkbox-cell">{{ form_widget(form_remove.bookmarks[bookmark.id]) }}</td>
-                                <td><a href="{{ path('_ezpublishLocation', { 'locationId': bookmark.id }) }}">{{ ez_content_name(bookmark.contentInfo) }}</a></td>
-                                <td>{{ bookmark.contentType.name }}</td>
-                                <td>
+                                <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form_remove.bookmarks[bookmark.id]) }}</td>
+                                <td class="ez-table__cell"><a href="{{ path('_ezpublishLocation', { 'locationId': bookmark.id }) }}">{{ ez_content_name(bookmark.contentInfo) }}</a></td>
+                                <td class="ez-table__cell">{{ bookmark.contentType.name }}</td>
+                                <td class="ez-table__cell">
                                     {% if bookmark.pathLocations|length > 1 %}
                                         {% for location in bookmark.pathLocations %}
                                             {% if loop.revindex > 1 %}
@@ -63,10 +63,10 @@
                                         -
                                     {% endif %}
                                 </td>
-                                <td class="text-right">
+                                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                                     {% if bookmark.userCanEdit %}
                                     <button
-                                        class="btn btn-icon mx-3 ez-btn--content-edit"
+                                        class="btn btn-icon mx-2 ez-btn--content-edit"
                                         title="{{ 'bookmark.list.content.edit'|trans|desc('Edit Content') }}"
                                         data-content-id="{{ bookmark.contentInfo.id }}"
                                         data-version-no="{{ bookmark.contentInfo.currentVersionNo }}"

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -45,7 +45,7 @@
         'action': path('ezplatform.content_type.bulk_delete', {"contentTypeGroupId": group.id} ),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-content-types' }
     }) }}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
             <tr>
                 <th></th>
@@ -59,14 +59,14 @@
         <tbody>
         {% for content_type in pager.currentPageResults %}
             <tr>
-                <td class="ez-checkbox-cell">
+                <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_delete %}
                         {{ form_widget(form_content_types_delete.content_types[content_type.id], {"disabled": not deletable[content_type.id]}) }}
                     {% else %}
                         {% do form_content_types_delete.content_types.setRendered %}
                     {% endif %}
                 </td>
-                <td>
+                <td class="ez-table__cell">
                 {% set view_url = path('ezplatform.content_type.view', {
                         'contentTypeGroupId': content_type_group.id,
                         'contentTypeId': content_type.id
@@ -74,12 +74,12 @@
 
                     <a href="{{ view_url }}">{{ content_type.name }}</a>
                 </td>
-                <td>{{ content_type.identifier }}</td>
-                <td>{{ content_type.id }}</td>
-                <td>{{ content_type.modificationDate|localizeddate('medium', 'short') }}</td>
-                <td class="text-right">
+                <td class="ez-table__cell">{{ content_type.identifier }}</td>
+                <td class="ez-table__cell">{{ content_type.id }}</td>
+                <td class="ez-table__cell">{{ content_type.modificationDate|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                     {% if can_update %}
-                        {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-3') }}
+                        {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
                     {% endif %}
                 </td>
             </tr>

--- a/src/bundle/Resources/views/admin/content_type/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/view.html.twig
@@ -35,7 +35,7 @@
             <div class="ez-table__headline">{{ "content_type.content_type"|trans|desc("Content Type") }}</div>
         </header>
 
-        <table class="table mb-3">
+        <table class="ez-table table mb-3">
             <thead>
             <tr>
                 <th>{{ "content_type.name"|trans|desc("Name") }}</th>
@@ -46,52 +46,52 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>{{ content_type.name }}</td>
-                    <td>{{ content_type.identifier }}</td>
-                    <td>{{ content_type.descriptions[language_code]|default('') }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell">{{ content_type.name }}</td>
+                    <td class="ez-table__cell">{{ content_type.identifier }}</td>
+                    <td class="ez-table__cell">{{ content_type.descriptions[language_code]|default('') }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_update %}
-                            {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-3') }}
+                            {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
                         {% endif %}
                     </td>
                 </tr>
             </tbody>
         </table>
 
-        <table class="table ez-table--list">
+        <table class="ez-table table ez-table--list">
             <tbody>
                 <tr>
-                    <td>{{ "content_type.name_schema"|trans|desc("Content name pattern") }}</td>
-                    <td>{{ content_type.nameSchema }}</td>
+                    <td class="ez-table__cell">{{ "content_type.name_schema"|trans|desc("Content name pattern") }}</td>
+                    <td class="ez-table__cell">{{ content_type.nameSchema }}</td>
                 </tr>
                 <tr>
-                    <td>{{ "content_type.url_alias_schema"|trans|desc("URL alias name pattern") }}</td>
-                    <td>{{ content_type.urlAliasSchema }}</td>
+                    <td class="ez-table__cell">{{ "content_type.url_alias_schema"|trans|desc("URL alias name pattern") }}</td>
+                    <td class="ez-table__cell">{{ content_type.urlAliasSchema }}</td>
                 </tr>
                 <tr>
-                    <td>{{ "content_type.container"|trans|desc("Container") }}</td>
-                    <td>{{ 'yes_no'|transchoice(content_type.isContainer)|desc("{0}No|{1}Yes") }}</td>
+                    <td class="ez-table__cell">{{ "content_type.container"|trans|desc("Container") }}</td>
+                    <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer)|desc("{0}No|{1}Yes") }}</td>
                 </tr>
                 <tr>
-                    <td>{{ "content_type.default_children_sorting"|trans|desc("Default field for sorting children") }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ "content_type.default_children_sorting"|trans|desc("Default field for sorting children") }}</td>
+                    <td class="ez-table__cell">
                         {{ ("content_type.sort_field." ~ content_type.defaultSortField)|trans(domain="ezrepoforms_content_type") }} / {{ ("content_type.sort_order." ~ content_type.defaultSortOrder)|trans(domain="ezrepoforms_content_type") }}
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ "content_type.default_sort"|trans|desc("Default sort order") }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ "content_type.default_sort"|trans|desc("Default sort order") }}</td>
+                    <td class="ez-table__cell">
                         {{ ("content_type.sort_order." ~ content_type.defaultSortOrder)|trans(domain="ezrepoforms_content_type") }}
                     </td>
                 </tr>
                 <tr>
-                    <td>
+                    <td class="ez-table__cell">
                         {{ "content_type.default_availability"|trans|desc('Default content availability') }}
                         <p class="text-secondary small">
                             {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                         </p>
                     </td>
-                    <td>{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable)|desc("{0} Not available|{1} Available") }}</td>
+                    <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable)|desc("{0} Not available|{1} Available") }}</td>
                 </tr>
             </tbody>
         </table>

--- a/src/bundle/Resources/views/admin/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/list.html.twig
@@ -62,7 +62,7 @@
             'action': path('ezplatform.content_type_group.bulk_delete'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-content-type-groups' }
         }) }}
-        <table class="table">
+        <table class="ez-table table">
             <thead>
                 <tr>
                     <th></th>
@@ -75,23 +75,23 @@
             <tbody>
             {% for content_type_group in pager.currentPageResults %}
                 <tr>
-                    <td class="ez-checkbox-cell">
+                    <td class="ez-table__cell ez-table__cell--has-checkbox">
                         {% if can_delete %}
                             {{ form_widget(form_content_type_groups_delete.content_type_groups[content_type_group.id], {"disabled": not deletable[content_type_group.id]}) }}
                         {% else %}
                             {% do form_content_type_groups_delete.content_type_groups.setRendered %}
                         {% endif %}
                     </td>
-                    <td>
+                    <td class="ez-table__cell">
                         {% set view_url = path('ezplatform.content_type_group.view', {
                             contentTypeGroupId: content_type_group.id
                         }) %}
 
                         <a href="{{ view_url }}">{{ content_type_group.identifier }}</a>
                     </td>
-                    <td>{{ content_type_group.id }}</td>
-                    <td>{{ content_types_count[content_type_group.id] }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell">{{ content_type_group.id }}</td>
+                    <td class="ez-table__cell">{{ content_types_count[content_type_group.id] }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_update %}
                             {% set edit_url = path('ezplatform.content_type_group.update', {
                                 contentTypeGroupId: content_type_group.id
@@ -99,7 +99,7 @@
                             <a
                                 title="{{ 'content_type_group.view.list.action.edit'|trans|desc('Edit') }}"
                                 href="{{ edit_url }}"
-                                class="btn btn-icon mx-3">
+                                class="btn btn-icon mx-2">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/admin/language/list.html.twig
@@ -62,7 +62,7 @@
             'action': path('ezplatform.language.bulk_delete'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-languages' }
         }) }}
-        <table class="table mb-3">
+        <table class="ez-table table mb-3">
             <thead>
             <tr>
                 <th></th>
@@ -76,29 +76,29 @@
             <tbody>
             {% for language in pager.currentPageResults %}
                 <tr>
-                    <td class="ez-checkbox-cell">
+                    <td class="ez-table__cell ez-table__cell--has-checkbox">
                         {% if can_administrate %}
                             {{ form_widget(form_languages_delete.languages[language.id]) }}
                         {% else %}
                             {% do form_languages_delete.languages.setRendered %}
                         {% endif %}
                     </td>
-                    <td><a href="{{ path( 'ezplatform.language.view', {'languageId': language.id} ) }}">{{ language.name }}</a></td>
-                    <td>{{ language.languageCode }}</td>
-                    <td>{{ language.id }}</td>
-                    <td>
+                    <td class="ez-table__cell"><a href="{{ path( 'ezplatform.language.view', {'languageId': language.id} ) }}">{{ language.name }}</a></td>
+                    <td class="ez-table__cell">{{ language.languageCode }}</td>
+                    <td class="ez-table__cell">{{ language.id }}</td>
+                    <td class="ez-table__cell">
                         <input
                             type="checkbox"
                             title="{{ language.enabled ? 'language.enabled'|trans|desc('Enabled')  : 'language.disabled'|trans|desc('Disabled')  }}"
                             disabled
                             {% if language.enabled %}checked{% endif %}>
                     </td>
-                    <td class="text-right">
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_administrate %}
                             <a
                                 title="{{ 'language.edit'|trans|desc('Edit') }}"
                                 href="{{ path('ezplatform.language.edit', {'languageId': language.id}) }}"
-                                class="btn btn-icon mx-3">
+                                class="btn btn-icon mx-2">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -51,7 +51,7 @@
             </div>
         </header>
 
-        <table class="table">
+        <table class="ez-table table">
             <thead>
                 <tr>
                     <th>{{ 'language.name.label'|trans|desc('Name') }}</th>
@@ -63,21 +63,21 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>{{ language.name }}</td>
-                    <td>{{ language.languageCode }}</td>
-                    <td>{{ language.id }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ language.name }}</td>
+                    <td class="ez-table__cell">{{ language.languageCode }}</td>
+                    <td class="ez-table__cell">{{ language.id }}</td>
+                    <td class="ez-table__cell">
                         <input
                             type="checkbox"
                             title="{{ language.enabled ? 'language.enabled'|trans|desc('Enabled') : 'language.enabled'|trans|desc('Enabled') }}"
                             disabled
                             {% if language.enabled %}checked{% endif %}>
                     </td>
-                    <td class="text-center">
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_administrate %}
                             <a
                                 href="{{ path('ezplatform.language.edit', {'languageId': language.id}) }}"
-                                class="btn btn-icon"
+                                class="btn btn-icon mx-2"
                                 title="{{ 'language.edit'|trans|desc('Edit') }}">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>

--- a/src/bundle/Resources/views/admin/object_state/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/list.html.twig
@@ -43,7 +43,7 @@
             'action': path('ezplatform.object_state.state.bulk_delete', {'objectStateGroupId': object_state_group.id}),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-object-state' }
         }) }}
-        <table class="table">
+        <table class="ez-table table">
             <thead>
             <tr>
                 <th></th>
@@ -56,29 +56,29 @@
             <tbody>
             {% if object_states is empty %}
             <tr>
-                <td colspan="4">
-                    <span class="ez-table-no-content mb-0 py-1 pl-0">{{ 'object_state.list.empty'|trans|desc('No Object State configured. Object States you\'ll create will appear here.') }}</span>
+                <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                    <span class="mb-0 py-1 pl-0">{{ 'object_state.list.empty'|trans|desc('No Object State configured. Object States you\'ll create will appear here.') }}</span>
                 </td>
             </tr>
             {% else %}
                 {% for object_state in object_states %}
                     <tr>
-                        <td class="ez-checkbox-cell">
+                        <td class="ez-table__cell ez-table__cell--has-checkbox">
                             {% if can_administrate %}
                                 {{ form_widget(form_states_delete.objectStates[object_state.id]) }}
                             {% else %}
                                 {% do form_states_delete.objectStates.setRendered %}
                             {% endif %}
                         </td>
-                        <td><a href="{{ path( 'ezplatform.object_state.state.view', {'objectStateId': object_state.id} ) }}">{{ object_state.name }}</a></td>
-                        <td>{{ object_state.identifier }}</td>
-                        <td>{{ object_state.id }}</td>
-                        <td class="text-right">
+                        <td class="ez-table__cell"><a href="{{ path( 'ezplatform.object_state.state.view', {'objectStateId': object_state.id} ) }}">{{ object_state.name }}</a></td>
+                        <td class="ez-table__cell">{{ object_state.identifier }}</td>
+                        <td class="ez-table__cell">{{ object_state.id }}</td>
+                        <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                             {% if can_administrate %}
                                 <a
                                     title="{{ 'object_state.view.list.action.edit'|trans|desc('Edit') }}"
                                     href="{{ path('ezplatform.object_state.state.update', {'objectStateId': object_state.id}) }}"
-                                    class="btn btn-icon mx-3">
+                                    class="btn btn-icon mx-2">
                                     <svg class="ez-icon ez-icon-edit">
                                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                     </svg>

--- a/src/bundle/Resources/views/admin/object_state/view.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/view.html.twig
@@ -27,7 +27,7 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state.view.information.title'|trans|desc('Object State Information') }}</div>
         </div>
-        <table class="table">
+        <table class="ez-table table">
             <thead>
             <tr>
                 <th>{{ 'object_state.name'|trans|desc('Object state name') }}</th>
@@ -38,14 +38,14 @@
             </thead>
             <tbody>
             <tr>
-                <td>{{ object_state.name }}</td>
-                <td>{{ object_state.identifier }}</td>
-                <td>{{ object_state.id }}</td>
-                <td class="text-right">
+                <td class="ez-table__cell">{{ object_state.name }}</td>
+                <td class="ez-table__cell">{{ object_state.identifier }}</td>
+                <td class="ez-table__cell">{{ object_state.id }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                     {% if can_administrate %}
                         <a title="{{ 'object_state.view.list.action.edit'|trans|desc('Edit') }}"
                            href="{{ path('ezplatform.object_state.state.update', {'objectStateId': object_state.id}) }}"
-                           class="btn btn-icon mx-3">
+                           class="btn btn-icon mx-2">
                             <svg class="ez-icon ez-icon-edit">
                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                             </svg>

--- a/src/bundle/Resources/views/admin/object_state_group/list.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/list.html.twig
@@ -62,7 +62,7 @@
             'action': path('ezplatform.object_state.group.bulk_delete'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-object-state-groups' }
         }) }}
-        <table class="table">
+        <table class="ez-table table">
             <thead>
                 <tr>
                     <th></th>
@@ -75,29 +75,29 @@
             <tbody>
             {% if object_state_groups is empty %}
                 <tr>
-                    <td colspan="4">
-                        <span class="ez-table-no-content mb-0 py-1 pl-0">{{ 'object_state_group.list.empty'|trans|desc('No Object State Group configured. Object State Groups you\'ll create will appear here.') }}</span>
+                    <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                        <span class="mb-0 py-1 pl-0">{{ 'object_state_group.list.empty'|trans|desc('No Object State Group configured. Object State Groups you\'ll create will appear here.') }}</span>
                     </td>
                 </tr>
             {% else %}
                 {% for object_state_group in object_state_groups %}
                     <tr>
-                        <td class="ez-checkbox-cell">
+                        <td class="ez-table__cell ez-table__cell--has-checkbox">
                             {% if can_administrate %}
                                 {{ form_widget(form_state_groups_delete.objectStateGroups[object_state_group.id]) }}
                             {% else %}
                                 {% do form_state_groups_delete.objectStateGroups.setRendered %}
                             {% endif %}
                         </td>
-                        <td><a href="{{ path( 'ezplatform.object_state.group.view', {'objectStateGroupId': object_state_group.id} ) }}">{{ object_state_group.name }}</a></td>
-                        <td>{{ object_state_group.identifier }}</td>
-                        <td>{{ object_state_group.id }}</td>
-                        <td class="text-right">
+                        <td class="ez-table__cell"><a href="{{ path( 'ezplatform.object_state.group.view', {'objectStateGroupId': object_state_group.id} ) }}">{{ object_state_group.name }}</a></td>
+                        <td class="ez-table__cell">{{ object_state_group.identifier }}</td>
+                        <td class="ez-table__cell">{{ object_state_group.id }}</td>
+                        <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                             {% if can_administrate %}
                                 <a
                                     title="{{ 'object_state_group.view.list.action.edit'|trans|desc('Edit') }}"
                                     href="{{ path('ezplatform.object_state.group.update', {'objectStateGroupId': object_state_group.id}) }}"
-                                    class="btn btn-icon mx-3">
+                                    class="btn btn-icon mx-2">
                                     <svg class="ez-icon ez-icon-edit">
                                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                     </svg>

--- a/src/bundle/Resources/views/admin/object_state_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/view.html.twig
@@ -26,7 +26,7 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state_group.view.information.title'|trans|desc('Object State Group Information') }}</div>
         </div>
-        <table class="table">
+        <table class="ez-table table">
             <thead>
             <tr>
                 <th>{{ 'object_state_group.name'|trans|desc('Object state group name') }}</th>
@@ -37,14 +37,14 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>{{ object_state_group.name }}</td>
-                    <td>{{ object_state_group.identifier }}</td>
-                    <td>{{ object_state_group.id }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell">{{ object_state_group.name }}</td>
+                    <td class="ez-table__cell">{{ object_state_group.identifier }}</td>
+                    <td class="ez-table__cell">{{ object_state_group.id }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_administrate %}
                             <a title="{{ 'object_state_group.view.list.action.edit'|trans|desc('Edit') }}"
                                href="{{ path('ezplatform.object_state.group.update', {'objectStateGroupId': object_state_group.id}) }}"
-                               class="btn btn-icon mx-3">
+                               class="btn btn-icon mx-2">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/admin/policy/list.html.twig
+++ b/src/bundle/Resources/views/admin/policy/list.html.twig
@@ -40,7 +40,7 @@
         'action': path('ezplatform.policy.bulk_delete', {"roleId": role.id} ),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-policies' }
     }) }}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th></th>
@@ -53,16 +53,16 @@
         <tbody>
         {% for policy in pager.currentPageResults %}
             <tr>
-                <td class="ez-checkbox-cell">
+                <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_update %}
                         {{ form_widget(form_policies_delete.policies[policy.id]) }}
                     {% else %}
                         {% do form_policies_delete.policies.setRendered %}
                     {% endif %}
                 </td>
-                <td>{{ policy.module|capitalize }}</td>
-                <td>{{ policy.function|capitalize }}</td>
-                <td>
+                <td class="ez-table__cell">{{ policy.module|capitalize }}</td>
+                <td class="ez-table__cell">{{ policy.function|capitalize }}</td>
+                <td class="ez-table__cell">
                     {%- if policy.limitations is not empty -%}
                         <ul class="list-unstyled">
                             {%- for limitation in policy.limitations -%}
@@ -78,12 +78,12 @@
                         {{- 'policy.limitation.none'|trans|desc('None') -}}
                     {%- endif -%}
                 </td>
-                <td class="text-right">
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                     {% if can_update %}
                         <a
                             title="{{ 'policy.view.list.panel.policies.action.edit'|trans|desc('Edit') }}"
                             href="{{ path('ezplatform.policy.update', { roleId: role.id, policyId: policy.id }) }}"
-                            class="btn btn-icon mx-3{{ not is_editable[policy.id] ? ' disabled' : '' }}">
+                            class="btn btn-icon mx-2{{ not is_editable[policy.id] ? ' disabled' : '' }}">
                             <svg class="ez-icon ez-icon-edit">
                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                             </svg>

--- a/src/bundle/Resources/views/admin/role/list.html.twig
+++ b/src/bundle/Resources/views/admin/role/list.html.twig
@@ -62,7 +62,7 @@
             </div>
         </div>
 
-        <table class="table mb-3">
+        <table class="ez-table table mb-3">
             <thead>
                 <tr>
                     <th></th>
@@ -74,20 +74,20 @@
             <tbody>
             {% for role in pager.currentPageResults %}
                 <tr>
-                    <td class="ez-checkbox-cell">
+                    <td class="ez-table__cell ez-table__cell--has-checkbox">
                         {% if can_delete %}
                             {{ form_widget(form_roles_delete.roles[role.id]) }}
                         {% else %}
                             {% do form_roles_delete.roles.setRendered %}
                         {% endif %}
                     </td>
-                    <td>
+                    <td class="ez-table__cell">
                         <a href="{{ path('ezplatform.role.view', { roleId: role.id }) }}">
                             {{ role.identifier }}
                         </a>
                     </td>
-                    <td>{{ role.id }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell">{{ role.id }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_assign %}
                             <a
                                 title="{{ 'role.view.list.action.assign_to_users_or_groups'|trans|desc('Assign to Users/Groups') }}"
@@ -102,7 +102,7 @@
                             <a
                                 title="{{ 'role.view.list.action.edit'|trans|desc('Edit') }}"
                                 href="{{ path('ezplatform.role.update', { roleId: role.id }) }}"
-                                class="btn btn-icon mx-3">
+                                class="btn btn-icon mx-2">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/admin/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/list.html.twig
@@ -41,7 +41,7 @@
         'action': path('ezplatform.role_assignment.bulk_delete', {"roleId": role.id} ),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-role-assignments' }
     }) }}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th></th>
@@ -52,21 +52,21 @@
         <tbody>
         {% for role_assignment in pager.currentPageResults %}
             <tr>
-                <td class="ez-checkbox-cell">
+                <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_assign %}
                         {{ form_widget(form_role_assignments_delete.role_assignments[role_assignment.id]) }}
                     {% else %}
                         {% do form_role_assignments_delete.role_assignments.setRendered %}
                     {% endif %}
                 </td>
-                <td>
+                <td class="ez-table__cell">
                     {%- if role_assignment.usergroup is defined -%}
                         {{ ez_content_name( role_assignment.usergroup ) }}
                     {%- else -%}
                         {{ ez_content_name( role_assignment.user ) }}
                     {%- endif -%}
                 </td>
-                <td class="ez-limitation-cell">
+                <td class="ez-table__cell ez-table__cell--limitation">
                     {%- set limitation = role_assignment.rolelimitation -%}
                     {%- if limitation -%}
                         <ul class="list-unstyled">

--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -1,11 +1,11 @@
 <tr>
-    <td>
+    <td class="ez-table__cell">
         <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a>
     </td>
-    <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-    <td>{{ row.type }}</td>
-    <td class="text-center">
-        <button class="btn btn-icon ez-btn--content-edit"
+    <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+    <td class="ez-table__cell">{{ row.type }}</td>
+    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+        <button class="btn btn-icon mx-2 ez-btn--content-edit"
                 data-content-id="{{ row.contentId }}"
                 data-version-no="{{ row.version }}"
                 data-language-code="{{ row.initialLanguageCode }}">

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -61,7 +61,7 @@
             'action': path('ezplatform.section.bulk_delete'),
             'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-sections' }
         }) }}
-        <table class="table mb-3">
+        <table class="ez-table table mb-3">
             <thead>
                 <tr>
                     <th></th>
@@ -75,18 +75,18 @@
             <tbody>
             {% for section in pager.currentPageResults %}
                 <tr>
-                    <td class="ez-checkbox-cell">
+                    <td class="ez-table__cell ez-table__cell--has-checkbox">
                         {% if can_edit %}
                             {{ form_widget(form_sections_delete.sections[section.id], {"disabled": not deletable[section.id]}) }}
                         {% else %}
                             {% do form_sections_delete.sections.setRendered %}
                         {% endif %}
                     </td>
-                    <td><a href="{{ path( 'ezplatform.section.view', {'sectionId': section.id} ) }}">{{ section.name }}</a></td>
-                    <td>{{ section.identifier }}</td>
-                    <td>{{ section.id }}</td>
-                    <td>{{ content_count[section.id] }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell"><a href="{{ path( 'ezplatform.section.view', {'sectionId': section.id} ) }}">{{ section.name }}</a></td>
+                    <td class="ez-table__cell">{{ section.identifier }}</td>
+                    <td class="ez-table__cell">{{ section.id }}</td>
+                    <td class="ez-table__cell">{{ content_count[section.id] }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if assignable[section.id] %}
                             <a
                                 title="{{ 'section.assign_content'|trans|desc('Assign content') }}"
@@ -103,7 +103,7 @@
                         {% if can_edit %}
                             <a title="{{ 'section.edit'|trans|desc('Edit') }}"
                                href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
-                               class="btn btn-icon mx-3">
+                               class="btn btn-icon mx-2">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>

--- a/src/bundle/Resources/views/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/admin/section/view.html.twig
@@ -43,7 +43,7 @@
             </div>
         </header>
 
-        <table class="table">
+        <table class="ez-table table">
             <thead>
             <tr>
                 <th>{{ 'section.name'|trans|desc('Name') }}</th>
@@ -53,15 +53,15 @@
             </tr>
             </thead>
             <tbody>
-            <td>{{ section.name }}</td>
-            <td>{{ section.identifier }}</td>
-            <td>{{ section.id }}</td>
-            <td class="text-right">
+            <td class="ez-table__cell">{{ section.name }}</td>
+            <td class="ez-table__cell">{{ section.identifier }}</td>
+            <td class="ez-table__cell">{{ section.id }}</td>
+            <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                 {% if can_edit %}
                     <a
                         href="{{ path('ezplatform.section.update', {'sectionId': section.id}) }}"
                         title="{{ 'section.edit'|trans|desc('Edit') }}"
-                        class="btn btn-icon mx-3">
+                        class="btn btn-icon mx-2">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                         </svg>

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -62,7 +62,7 @@
                             {% endif %}
                         </div>
                     </div>
-                    <table class="table">
+                    <table class="ez-table table">
                         <thead>
                         <tr>
                             <th></th>
@@ -74,8 +74,8 @@
                         <tbody>
                         {% if trash_items is empty %}
                             <tr>
-                                <td colspan="4">
-                                    <span class="ez-table-no-content mb-0 py-1 pl-0">
+                                <td class="ez-table__cell ez-table__cell--no-content" colspan="4">
+                                    <span class="mb-0 py-1 pl-0">
                                         {{ 'trash.empty'|trans|desc('Trash is empty. Any content item you send to trash will end up here.') }}
                                     </span>
                                 </td>
@@ -85,14 +85,14 @@
                                 {% set trash_item = trash_items[key] %}
                                 {% set is_parent_in_trash = trash_item.parentInTrash %}
                                 <tr>
-                                    <td>
+                                    <td class="ez-table__cell">
                                         {{ form_widget(form, {attr: {
                                             'data-is-parent-in-trash': is_parent_in_trash ? '1': '0'
                                         }}) }}
                                     </td>
-                                    <td>{{ ez_content_name(trash_item.location.contentInfo) }}</td>
-                                    <td>{{ trash_item.contentType.name }}</td>
-                                    <td>
+                                    <td class="ez-table__cell">{{ ez_content_name(trash_item.location.contentInfo) }}</td>
+                                    <td class="ez-table__cell">{{ trash_item.contentType.name }}</td>
+                                    <td class="ez-table__cell">
                                         {% if not is_parent_in_trash %}
                                             {% include '@ezdesign/parts/path.html.twig' with {'locations': trash_item.ancestors, 'link_last_element': true} %}
                                         {% else %}

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -13,7 +13,7 @@
         'action': path('ezplatform.location.remove'),
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-locations' }
     }) }}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th></th>
@@ -27,14 +27,14 @@
         {% if locations is not empty %}
             {% for location in locations %}
                 <tr>
-                    <td class="align-middle ez-checkbox-cell">
+                    <td class="ez-table__cell ez-table__cell--has-checkbox align-middle">
                         {{ form_widget(form_content_location_remove.locations[location.id], {'attr': {'disabled': not location.canDelete}}) }}
                     </td>
-                    <td class="align-middle">
+                    <td class="ez-table__cell align-middle">
                         {% include '@ezdesign/parts/path.html.twig' with {'locations': location.pathLocations} %}
                     </td>
-                    <td class="align-middle">{{ location.childCount }}</td>
-                    <td>
+                    <td class="ez-table__cell align-middle">{{ location.childCount }}</td>
+                    <td class="ez-table__cell">
                         {% if location.invisible and not location.hidden %}
                             {{ 'tab.locations.hidden_by_superior'|trans()|desc('Hidden by superior') }}
                         {% elseif not can_hide[location.id] %}
@@ -56,8 +56,8 @@
                             </label>
                         {% endif %}
                     </td>
-                    <td class="align-middle"></td>
-                    <td class="align-middle">
+                    <td class="ez-table__cell align-middle"></td>
+                    <td class="ez-table__cell align-middle">
                         <input
                             type="radio"
                             {{ location.main ? 'checked' }}

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -9,7 +9,7 @@
         'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations' }
     }) }}
     {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.translations.translation_manger'|trans|desc('Translation manager'), tools: tab.table_header_tools(form_translation_remove) } %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th></th>
@@ -20,9 +20,9 @@
         <tbody>
         {% for translation in translations %}
             <tr>
-                <td class="ez-checkbox-cell">{{ form_widget(form_translation_remove.language_codes[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
-                <td>{{ translation.name }}</td>
-                <td>{{ translation.languageCode }}</td>
+                <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form_translation_remove.language_codes[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
+                <td class="ez-table__cell">{{ translation.name }}</td>
+                <td class="ez-table__cell">{{ translation.languageCode }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/custom_urls_table.html.twig
@@ -5,7 +5,7 @@
     'action': path('ezplatform.custom_url.remove'),
     'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-custom-urls' }
 }) }}
-<table class="table">
+<table class="ez-table table">
     <thead>
     <tr>
         <th></th>
@@ -17,20 +17,20 @@
     <tbody>
     {% for custom_url in custom_urls_pager.currentPageResults %}
         <tr>
-            <td class="ez-checkbox-cell">
+            <td class="ez-table__cell ez-table__cell--has-checkbox">
                 {% if can_edit_custom_url %}
                     {{ form_widget(form_custom_url_remove.url_aliases[custom_url.id]) }}
                 {% else %}
                     {% do form_custom_url_remove.url_aliases.setRendered %}
                 {% endif %}
             </td>
-            <td>{{ custom_url.path }}</td>
-            <td>
+            <td class="ez-table__cell">{{ custom_url.path }}</td>
+            <td class="ez-table__cell">
                 {% for languageCode in custom_url.languageCodes %}
                     {{ admin_ui_config.languages.mappings[languageCode].name }}<br>
                 {% endfor %}
             </td>
-            <td>
+            <td class="ez-table__cell">
                 {% if custom_url.forward %}
                     {{ 'tab.urls.type.redirect'|trans|desc('Redirect') }}
                 {% else %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -4,7 +4,7 @@
 {% set is_archived = is_archived is defined and is_archived %}
 {% set is_draft_conflict = is_draft_conflict is defined and is_draft_conflict %}
 
-<table class="table {% if is_draft and haveToPaginate %} mb-3 {% endif %} {% if is_draft_conflict %} ez-table__draft-conflict {% endif %}">
+<table class="ez-table table {% if is_draft and haveToPaginate %} mb-3 {% endif %} {% if is_draft_conflict %} ez-table__draft-conflict {% endif %}">
     <thead>
     <tr>
         {% if form is defined %}
@@ -26,15 +26,15 @@
     {% for version in versions %}
         <tr>
             {% if form is defined %}
-                <td class="ez-checkbox-cell">{{ form_widget(form.versions[version.versionNo], {'attr': {'disabled': not version.canDelete}}) }}</td>
+                <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form.versions[version.versionNo], {'attr': {'disabled': not version.canDelete}}) }}</td>
             {% endif %}
-            <td>
+            <td class="ez-table__cell">
                 {{ version.versionNo }}
             </td>
-            <td>
+            <td class="ez-table__cell">
                 {{ admin_ui_config.languages.mappings[version.initialLanguageCode].name }}
             </td>
-            <td>
+            <td class="ez-table__cell">
                 {% if version.author is not empty %}
                     {{ ez_content_name(version.author) }}
                 {% else %}
@@ -42,18 +42,18 @@
                 {% endif %}
             </td>
             {% if not is_draft_conflict %}
-            <td>
+            <td class="ez-table__cell">
                 {{ version.creationDate|localizeddate('medium', 'short', app.request.locale) }}
             </td>
             {% endif %}
-            <td>
+            <td class="ez-table__cell">
                 {{ version.modificationDate|localizeddate('medium', 'short', app.request.locale) }}
             </td>
             {% if is_draft_conflict %}
-                <td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                     {% set edit_draft_disabled = version.author.id != admin_ui_config.user.user.id %}
                     <a href="{{ path('ez_content_draft_edit', { 'contentId': version.contentInfo.id, 'versionNo': version.versionNo, 'language': version.translations[0].languageCode, 'locationId': location.id }) }}"
-                       class="btn btn-icon {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
+                       class="btn btn-icon mx-2 {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
                        title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}"
                        {% if edit_draft_disabled %}disabled{% endif %}>
                         <svg class="ez-icon ez-icon-edit">
@@ -62,7 +62,7 @@
                     </a>
                 </td>
             {% elseif is_draft %}
-                <td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                     <button
                         data-content-draft-edit-url="{{ path('ez_content_draft_edit', {
                             'contentId': version.contentInfo.id,
@@ -75,7 +75,7 @@
                             'versionNo': version.versionNo,
                             'languageCode': version.translations[0].languageCode
                         }) }}"
-                        class="btn btn-icon ez-btn--content-draft-edit"
+                        class="btn btn-icon mx-2 ez-btn--content-draft-edit"
                         title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}">
                         <svg class="ez-icon ez-icon-edit">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
@@ -84,8 +84,8 @@
                 </td>
             {% endif %}
             {% if is_archived %}
-                <td>
-                    <button class="btn btn-icon ez-btn--content-edit"
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-edit"
                             title="{{ 'tab.versions.table.action.archived.edit'|trans|desc('Restore Archived Version') }}"
                             data-content-id="{{ version.contentInfo.id }}"
                             data-version-no="{{ version.versionNo }}"

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
@@ -14,18 +14,18 @@
         <tbody>
         {% for row in data %}
             <tr>
-                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
-                <td>{{ row.type }}</td>
-                <td>
+                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell">
                     {% if row.contributor is not null %}
                         {{ row.contributor.name }}
                     {% else %}
                         {{ 'dashboard.table.contributor.not_found'|trans|desc('Can’t fetch contributor') }}
                     {% endif %}
                 </td>
-                <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-                <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-edit"
+                <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-edit"
                             title="{{ 'dashboard.table.all.content.edit'|trans|desc('Edit Content') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
@@ -14,18 +14,18 @@
         <tbody>
         {% for row in data %}
             <tr>
-                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
-                <td>{{ row.type }}</td>
-                <td>
+                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell">
                     {% if row.contributor is not null %}
                         {{ row.contributor.name }}
                     {% else %}
                         {{ 'dashboard.table.contributor.not_found'|trans|desc('Can’t fetch contributor') }}
                     {% endif %}
                 </td>
-                <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-                <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-edit"
+                <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-edit"
                             title="{{ 'dashboard.table.all.media.edit'|trans|desc('Edit Media') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"

--- a/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
@@ -13,11 +13,11 @@
         <tbody>
         {% for row in data %}
             <tr>
-                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
-                <td>{{ row.type }}</td>
-                <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-                <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-edit"
+                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-edit"
                             title="{{ 'dashboard.table.content.edit'|trans|desc('Edit Content') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
@@ -15,13 +15,13 @@
         <tbody>
         {% for row in data %}
             <tr>
-                <td>{{ row.name }}</td>
-                <td>{{ row.type }}</td>
-                <td>{{ admin_ui_config.languages.mappings[row.language].name }}</td>
-                <td>{{ row.version }}</td>
-                <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-                <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-draft-edit"
+                <td class="ez-table__cell">{{ row.name }}</td>
+                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
+                <td class="ez-table__cell">{{ row.version }}</td>
+                <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-draft-edit"
                             title="{{ 'dashboard.table.draft.edit'|trans|desc('Edit Draft') }}"
                             data-content-draft-edit-url="{{ path('ez_content_draft_edit', {
                                 'contentId': row.contentId,

--- a/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}
-    <table class="table">
+    <table class="ez-table table">
         <thead>
         <tr>
             <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
@@ -13,11 +13,11 @@
         <tbody>
         {% for row in data %}
             <tr>
-                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
-                <td>{{ row.type }}</td>
-                <td>{{ row.modified|localizeddate('medium', 'short') }}</td>
-                <td class="text-center">
-                    <button class="btn btn-icon ez-btn--content-edit"
+                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short') }}</td>
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <button class="btn btn-icon mx-2 ez-btn--content-edit"
                             title="{{ 'dashboard.table.media.edit'|trans|desc('Edit Media') }}"
                             data-content-id="{{ row.contentId }}"
                             data-version-no="{{ row.version }}"

--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -52,7 +52,7 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'url.list.title'|trans({ '%count%': urls.count })|desc('Links (%count%)') }}</div>
         </div>
-        <table class="table">
+        <table class="ez-table table">
             <thead>
                 <tr>
                     <th>{{ 'url.label.address'|trans }}</th>
@@ -67,22 +67,22 @@
                 {% set edit_url = path('ezplatform.link_manager.edit', {urlId: url.id}) %}
                 {% set view_url = path('ezplatform.link_manager.view', {urlId: url.id}) %}
                 <tr>
-                    <td>
+                    <td class="ez-table__cell">
                         <a href="{{ view_url }}">{{ url.url|truncate(50) }}</a>
                         (<a href="{{ url.url }}" target="_blank">{{ 'url.open'|trans }}</a>)
                     </td>
-                    <td>{{ url.isValid ? 'url.status.valid'|trans : 'url.status.invalid'|trans }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ url.isValid ? 'url.status.valid'|trans : 'url.status.invalid'|trans }}</td>
+                    <td class="ez-table__cell">
                         {% if url.lastChecked %}
                             {{ url.lastChecked|localizeddate('medium', 'short') }}
                         {% else %}
                             Never
                         {% endif %}
                     </td>
-                    <td>{{ url.modified|localizeddate('medium', 'short') }}</td>
-                    <td class="text-right">
+                    <td class="ez-table__cell">{{ url.modified|localizeddate('medium', 'short') }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_edit %}
-                            <a href="{{ edit_url }}" class="btn btn-icon" title="{{ 'url.action.edit'|trans|desc('Edit URL') }}">
+                            <a href="{{ edit_url }}" class="btn btn-icon mx-2" title="{{ 'url.action.edit'|trans|desc('Edit URL') }}">
                                 <svg class="ez-icon ez-icon-edit">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>
@@ -92,8 +92,8 @@
                 </tr>
             {% else %}
                 <tr>
-                    <td colspan="5">
-                        <p><i>{{ 'url.list.no_urls'|trans }}</i></p>
+                    <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                        <span class="mb-0 py-1 pl-0">{{ 'url.list.no_urls'|trans }}</span>
                     </td>
                 </tr>
             {% endfor %}

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -31,7 +31,7 @@
             <tbody>
                 <tr>
                     <td class="ez-table__cell">{{ 'url.label.address'|trans }}</td>
-                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    <td class="ez-table__cell ez-table__cell--has-action-btns">
                         <a href="{{ url.url }}" target="_blank">{{ url.url }}</a>
                         <a href="{{ path('ezplatform.link_manager.edit', { urlId: url.id }) }}"
                            class="btn btn-icon mx-2 float-right"

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -20,7 +20,7 @@
 
 {%- block content -%}
     <section class="container mt-5">
-        <table class="table ez-table--list">
+        <table class="ez-table table ez-table--list">
             <thead>
                 <tr>
                    <th colspan="2">
@@ -30,11 +30,11 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>{{ 'url.label.address'|trans }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ 'url.label.address'|trans }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         <a href="{{ url.url }}" target="_blank">{{ url.url }}</a>
                         <a href="{{ path('ezplatform.link_manager.edit', { urlId: url.id }) }}"
-                           class="btn btn-icon float-right "
+                           class="btn btn-icon mx-2 float-right"
                            title="{{ 'url.action.edit'|trans|desc('Edit URL') }}">
                             <svg class="ez-icon ez-icon-edit">
                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
@@ -43,12 +43,12 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'url.label.status'|trans }}</td>
-                    <td>{{ url.isValid ? 'url.status.valid'|trans : 'url.status.invalid'|trans }}</td>
+                    <td class="ez-table__cell">{{ 'url.label.status'|trans }}</td>
+                    <td class="ez-table__cell">{{ url.isValid ? 'url.status.valid'|trans : 'url.status.invalid'|trans }}</td>
                 </tr>
                 <tr>
-                    <td>{{ 'url.label.last_checked'|trans }}</td>
-                    <td>
+                    <td class="ez-table__cell">{{ 'url.label.last_checked'|trans }}</td>
+                    <td class="ez-table__cell">
                         {% if url.lastChecked %}
                             {{ url.lastChecked|localizeddate('medium', 'short') }}
                         {% else %}
@@ -57,12 +57,12 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'url.label.created'|trans }}</td>
-                    <td>{{ url.created|localizeddate('medium', 'short') }}</td>
+                    <td class="ez-table__cell">{{ 'url.label.created'|trans }}</td>
+                    <td class="ez-table__cell">{{ url.created|localizeddate('medium', 'short') }}</td>
                 </tr>
                 <tr>
-                    <td>{{ 'url.label.modified'|trans }}</td>
-                    <td>{{ url.modified|localizeddate('medium', 'short') }}</td>
+                    <td class="ez-table__cell">{{ 'url.label.modified'|trans }}</td>
+                    <td class="ez-table__cell">{{ url.modified|localizeddate('medium', 'short') }}</td>
                 </tr>
             </tbody>
         </table>
@@ -74,7 +74,7 @@
                 {{ 'url.tab.usages'|trans({'%count%': usages.nbResults })|desc('Content item(s) using this URL') }}
             </div>
         </div>
-        <table class="table">
+        <table class="ez-table table">
             <thead>
                 <tr>
                     <th>{{ 'url.usages.column.name'|trans|desc('Name') }}</th>
@@ -87,21 +87,21 @@
                     {% set view_url = path('_ez_content_view', { contentId: content.id }) %}
 
                     <tr>
-                        <td>
+                        <td class="ez-table__cell">
                             <a href="{{ view_url }}">
                                 {{ ez_content_name(content) }}
                             </a>
                         </td>
-                        <td>
+                        <td class="ez-table__cell">
                             {% if content.published %}
                                 {{ 'url.usages.content_status.published'|trans|desc('Published') }}
                             {% else %}
                                 {{ 'url.usages.content_status.draft'|trans|desc('Draft') }}
                             {% endif %}
                         </td>
-                        <td class="text-right">
+                        <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                             {% if can_edit %}
-                                <button class="btn btn-icon btn-link ez-btn--content-edit"
+                                <button class="btn btn-icon btn-link mx-2 ez-btn--content-edit"
                                         title="{{ 'url.action.item.edit'|trans|desc('Edit Item') }}"
                                         data-content-id="{{ content.id }}"
                                         data-version-no="{{ content.currentVersionNo }}"

--- a/src/lib/Behat/PageElement/Tables/LinkedListTable.php
+++ b/src/lib/Behat/PageElement/Tables/LinkedListTable.php
@@ -17,7 +17,7 @@ class LinkedListTable extends Table
     {
         parent::__construct($context, $containerLocator);
         $this->fields['horizontalHeaders'] = $this->fields['list'] . ' .ez-table-header + .table thead th, .ez-table-header + form thead th';
-        $this->fields['listElementLink'] = $this->fields['list'] . ' .ez-checkbox-cell+ td a';
+        $this->fields['listElementLink'] = $this->fields['list'] . ' .ez-table__cell--has-checkbox+ td.ez-table__cell a';
         $this->fields['checkboxInput'] = ' .form-check-input';
         $this->fields['assignButton'] = $this->fields['list'] . ' tr:nth-child(%s) a[title*=Assign]';
     }

--- a/src/lib/Behat/PageElement/Tables/SimpleListTable.php
+++ b/src/lib/Behat/PageElement/Tables/SimpleListTable.php
@@ -18,7 +18,7 @@ class SimpleListTable extends Table
     {
         parent::__construct($context, $containerLocator);
         $this->fields['horizontalHeaders'] = $this->fields['list'] . ' .ez-table-header + form thead th';
-        $this->fields['listElement'] = $this->fields['list'] . ' .ez-checkbox-cell+ td';
+        $this->fields['listElement'] = $this->fields['list'] . ' .ez-table__cell--has-checkbox+ td.ez-table__cell';
         $this->fields['checkboxInput'] = ' .form-check-input';
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29348
| Bug fix?      | -
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Edit buttons in tables are not aligned with delete button in table header.

**For QA** : check pages which are rendered using modified twigs. See list in _Files Changed_ on GitHub. 

Effect:
<img width="663" alt="screen shot 2018-06-28 at 13 41 41" src="https://user-images.githubusercontent.com/10233057/42032819-12a5bcd2-7adb-11e8-9e7b-0af85ebc1962.png">

#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review

Edited tables:
![screen shot 2018-08-08 at 11 27 46](https://user-images.githubusercontent.com/10233057/43830073-cc513c2a-9b00-11e8-9c5a-4e205770f228.png)
![screen shot 2018-08-08 at 11 30 07](https://user-images.githubusercontent.com/10233057/43830075-cc6ff50c-9b00-11e8-8f9a-41dc30ec6fc6.png)
![screen shot 2018-08-08 at 11 32 33](https://user-images.githubusercontent.com/10233057/43830076-cc8acdd2-9b00-11e8-856d-c6b86a956315.png)
![screen shot 2018-08-08 at 11 33 13](https://user-images.githubusercontent.com/10233057/43830077-cca7e3f4-9b00-11e8-8874-55642c0f4d7a.png)
![screen shot 2018-08-08 at 11 33 46](https://user-images.githubusercontent.com/10233057/43830078-ccc6d8ea-9b00-11e8-9fd3-50bc393a9aaa.png)
![screen shot 2018-08-08 at 11 34 13](https://user-images.githubusercontent.com/10233057/43830081-cce56f4e-9b00-11e8-9b01-7f4353cb987a.png)
![screen shot 2018-08-08 at 11 34 58](https://user-images.githubusercontent.com/10233057/43830082-ccff1232-9b00-11e8-80b4-bf88241ec514.png)
![screen shot 2018-08-08 at 11 35 42](https://user-images.githubusercontent.com/10233057/43830083-cd1f9a98-9b00-11e8-828c-76327ebd143c.png)
![screen shot 2018-08-08 at 11 36 48](https://user-images.githubusercontent.com/10233057/43830084-cd3bb2fa-9b00-11e8-9943-ab2f7e38d334.png)
![screen shot 2018-08-08 at 11 37 24](https://user-images.githubusercontent.com/10233057/43830085-cd67f2f2-9b00-11e8-8f42-0a023af1fa0e.png)
![screen shot 2018-08-08 at 11 39 09](https://user-images.githubusercontent.com/10233057/43830086-cd83c216-9b00-11e8-937a-fae74ac7be4b.png)
![screen shot 2018-08-08 at 11 39 33](https://user-images.githubusercontent.com/10233057/43830087-cd9ef2ac-9b00-11e8-9304-4de0da4276c6.png)
![screen shot 2018-08-08 at 11 40 06](https://user-images.githubusercontent.com/10233057/43830088-cdb9460c-9b00-11e8-9c3c-6aee3d0ea113.png)
![screen shot 2018-08-08 at 11 40 31](https://user-images.githubusercontent.com/10233057/43830090-cdd572d2-9b00-11e8-926a-6bccae4895c1.png)
![screen shot 2018-08-08 at 11 40 55](https://user-images.githubusercontent.com/10233057/43830092-cdf0426a-9b00-11e8-9e29-421155bd115c.png)
![screen shot 2018-08-08 at 11 41 30](https://user-images.githubusercontent.com/10233057/43830093-ce0c2ec6-9b00-11e8-84ca-c6e4f81ea98a.png)
![screen shot 2018-08-08 at 11 42 28](https://user-images.githubusercontent.com/10233057/43830094-ce26aed6-9b00-11e8-9e68-1c1faf2e0ef3.png)
Dashboard:
![screen shot 2018-08-08 at 11 43 30](https://user-images.githubusercontent.com/10233057/43830095-ce43fa54-9b00-11e8-89fe-bc8286d41b9a.png)
Dashboard:
![screen shot 2018-08-08 at 11 43 53](https://user-images.githubusercontent.com/10233057/43830096-ce5f83e6-9b00-11e8-91f5-45abb717ed3d.png)
![screen shot 2018-08-08 at 11 44 20](https://user-images.githubusercontent.com/10233057/43830097-ce7c55ac-9b00-11e8-82cc-6d669706b7b5.png)
![screen shot 2018-08-08 at 11 44 33](https://user-images.githubusercontent.com/10233057/43830098-ce976022-9b00-11e8-9f0f-402b033861fa.png)
![screen shot 2018-08-08 at 11 44 43](https://user-images.githubusercontent.com/10233057/43830099-ceb950e2-9b00-11e8-9363-353bdf0fdc94.png)
![screen shot 2018-08-08 at 11 45 25](https://user-images.githubusercontent.com/10233057/43830100-ced67b54-9b00-11e8-87d5-ca93ce516571.png)




![screen shot 2018-08-20 at 12 02 10](https://user-images.githubusercontent.com/10233057/44334905-1b3d5a00-a473-11e8-99ea-543de2c7e53a.png)
![screen shot 2018-08-20 at 12 01 33](https://user-images.githubusercontent.com/10233057/44334906-1b3d5a00-a473-11e8-9b13-605cb8143b4b.png)
![screen shot 2018-08-20 at 12 01 12](https://user-images.githubusercontent.com/10233057/44334907-1b3d5a00-a473-11e8-826d-4795d0c11460.png)
![screen shot 2018-08-20 at 11 59 37](https://user-images.githubusercontent.com/10233057/44334909-1bd5f080-a473-11e8-9a4e-2cb5bf78e659.png)
