### PR TITLE
EZP-29114: Fix pagination parameter naming for draft, system and custom url

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -52,7 +52,7 @@ class ContentViewController extends Controller
     private $bookmarkService;
 
     /** @var int */
-    private $defaultPaginationLimit;
+    private $defaultDraftPaginationLimit;
 
     /** @var array */
     private $siteAccessLanguages;
@@ -77,7 +77,7 @@ class ContentViewController extends Controller
      * @param \EzSystems\EzPlatformAdminUi\UI\Module\Subitems\ContentViewParameterSupplier $subitemsContentViewParameterSupplier
      * @param \eZ\Publish\API\Repository\UserService $userService
      * @param \eZ\Publish\API\Repository\BookmarkService $bookmarkService
-     * @param int $defaultPaginationLimit
+     * @param int $defaultDraftPaginationLimit
      * @param array $siteAccessLanguages
      * @param int $defaultRolePaginationLimit
      * @param int $defaultPolicyPaginationLimit
@@ -92,7 +92,7 @@ class ContentViewController extends Controller
         SubitemsContentViewParameterSupplier $subitemsContentViewParameterSupplier,
         UserService $userService,
         BookmarkService $bookmarkService,
-        int $defaultPaginationLimit,
+        int $defaultDraftPaginationLimit,
         array $siteAccessLanguages,
         int $defaultRolePaginationLimit,
         int $defaultPolicyPaginationLimit,
@@ -106,7 +106,7 @@ class ContentViewController extends Controller
         $this->subitemsContentViewParameterSupplier = $subitemsContentViewParameterSupplier;
         $this->userService = $userService;
         $this->bookmarkService = $bookmarkService;
-        $this->defaultPaginationLimit = $defaultPaginationLimit;
+        $this->defaultDraftPaginationLimit = $defaultDraftPaginationLimit;
         $this->siteAccessLanguages = $siteAccessLanguages;
         $this->defaultRolePaginationLimit = $defaultRolePaginationLimit;
         $this->defaultPolicyPaginationLimit = $defaultPolicyPaginationLimit;
@@ -273,7 +273,7 @@ class ContentViewController extends Controller
                 'route_name' => $request->get('_route'),
                 'route_params' => $request->get('_route_params'),
                 'page' => $page['version_draft'] ?? 1,
-                'limit' => $this->defaultPaginationLimit,
+                'limit' => $this->defaultDraftPaginationLimit,
             ],
         ]);
     }

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -64,7 +64,7 @@ services:
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentViewController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
-            $defaultPaginationLimit: '$pagination.version_draft_limit$'
+            $defaultDraftPaginationLimit: '$pagination.version_draft_limit$'
             $siteAccessLanguages: '$languages$'
             $defaultRolePaginationLimit: '$pagination.content_role_limit$'
             $defaultPolicyPaginationLimit: '$pagination.content_policy_limit$'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29114
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Long time ago, there was this idea that there would be only one pagination parameter. Reality has shown something different ;)
As we two times already fall into trap of this defaultPaginationParam name be missguiding, we decided to rename it to be more specific.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
