### PR TITLE
EZP-29159: [Copy/Move] Wrong notifications after moving and copying

### DIFF
--- a/features/ContentCreation.feature
+++ b/features/ContentCreation.feature
@@ -209,7 +209,7 @@ Scenario: Content can be moved
     And I select content "Media/Images" through UDW
     And I confirm the selection in UDW
   Then I should be on content container page "Test Article edited4" of type "Article" in "Media/Images"
-    And success notification that "Location 'Test Article edited4' moved to location 'Images'" appears
+    And success notification that "'Test Article edited4' moved to 'Images'" appears
     And content attributes equal
       | label | value                |
       | Title | Test Article edited4 |
@@ -237,7 +237,7 @@ Scenario: Content can be copied
     And I select content "eZ Platform" through UDW
     And I confirm the selection in UDW
   Then I should be on content container page "Test Article edited4" of type "Article" in "eZ Platform"
-    And success notification that "Location 'Test Article edited4' copied to location 'eZ Platform'" appears
+    And success notification that "'Test Article edited4' copied to 'eZ Platform'" appears
     And content attributes equal
       | label | value                |
       | Title | Test Article edited4 |

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -131,7 +131,7 @@ class LocationController extends Controller
 
                 $this->notificationHandler->success(
                     $this->translator->trans(
-                        /** @Desc("Location '%name%' moved to location '%location%'") */
+                        /** @Desc("'%name%' moved to '%location%'") */
                         'location.move.success',
                         ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
                         'location'
@@ -193,7 +193,7 @@ class LocationController extends Controller
 
                 $this->notificationHandler->success(
                     $this->translator->trans(
-                        /** @Desc("Location '%name%' copied to location '%location%'") */
+                        /** @Desc("'%name%' copied to '%location%'") */
                         'location.copy.success',
                         ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
                         'location'

--- a/src/bundle/Resources/translations/location.en.xliff
+++ b/src/bundle/Resources/translations/location.en.xliff
@@ -7,8 +7,8 @@
     </header>
     <body>
       <trans-unit id="7f616359fa64ad9a44aba2d7eeebfde7aac7f16f" resname="location.copy.success">
-        <source>Location '%name%' copied to location '%location%'</source>
-        <target state="new">Location '%name%' copied to location '%location%'</target>
+        <source>'%name%' copied to '%location%'</source>
+        <target state="new">'%name%' copied to '%location%'</target>
         <note>key: location.copy.success</note>
       </trans-unit>
       <trans-unit id="656c4be212bdf722670400927051cb39593938a5" resname="location.copy_subtree.success">
@@ -27,8 +27,8 @@
         <note>key: location.delete.success</note>
       </trans-unit>
       <trans-unit id="9d5d2fb830ae5b1806bcb908c01f115c93de4eda" resname="location.move.success">
-        <source>Location '%name%' moved to location '%location%'</source>
-        <target state="new">Location '%name%' moved to location '%location%'</target>
+        <source>'%name%' moved to '%location%'</source>
+        <target state="new">'%name%' moved to '%location%'</target>
         <note>key: location.move.success</note>
       </trans-unit>
       <trans-unit id="20dae8cf8c7cf8972d802224728554706e2b4699" resname="location.swap.success">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29159
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
