### PR TITLE
EZP-28890: Impl. extractor for *.js files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "ezsystems/ez-support-tools": "^0.2@dev",
         "ezsystems/ezplatform-design-engine": "^2.0@dev",
         "white-october/pagerfanta-bundle": "^1.1",
-        "knplabs/knp-menu-bundle": "^2.1"
+        "knplabs/knp-menu-bundle": "^2.1",
+        "mck89/peast": "^1.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.1",

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -15,6 +15,7 @@ imports:
     - { resource: services/utils.yml }
     - { resource: services/form_ui_action_mappers.yml }
     - { resource: services/views.yml }
+    - { resource: services/translation.yml }
 
 services:
     _defaults:

--- a/src/bundle/Resources/config/services/translation.yml
+++ b/src/bundle/Resources/config/services/translation.yml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformAdminUi\Translation\Extractor\JavaScriptFileVisitor:
+        tags:
+            - { name: jms_translation.file_visitor }

--- a/src/lib/Translation/Extractor/JavaScriptFileVisitor.php
+++ b/src/lib/Translation/Extractor/JavaScriptFileVisitor.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Translation\Extractor;
+
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Annotation\Desc;
+use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use Peast\Peast;
+use Peast\Syntax\Exception;
+use Peast\Syntax\Node;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use SplFileInfo;
+
+class JavaScriptFileVisitor implements FileVisitorInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    const TRANSLATOR_OBJECT = 'Translator';
+    const TRANSLATOR_METHOD = 'trans';
+
+    const ID_ARG = 0;
+    const DOMAIN_ARG = 2;
+
+    /** @var \Doctrine\Common\Annotations\DocParser */
+    private $docParser;
+
+    /** @var string */
+    private $defaultDomain;
+
+    /**
+     * JavaScriptFileVisitor constructor.
+     *
+     * @param string $defaultDomain
+     */
+    public function __construct(string $defaultDomain = 'messages')
+    {
+        $this->logger = new NullLogger();
+        $this->defaultDomain = $defaultDomain;
+
+        $this->docParser = new DocParser();
+        $this->docParser->setIgnoreNotImportedAnnotations(true);
+        $this->docParser->setImports([
+            'desc' => Desc::class,
+        ]);
+    }
+
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
+    {
+        if (!$this->supports($file)) {
+            return;
+        }
+
+        try {
+            $source = file_get_contents($file->getRealPath());
+
+            $parser = Peast::latest($source, [
+                'comments' => true,
+                'jsx' => true,
+                'sourceType' => Peast::SOURCE_TYPE_MODULE,
+            ]);
+
+            $ast = $parser->parse();
+        } catch (Exception $e) {
+            $this->logger->error(sprintf(
+                'Unable to parse file %s: %s in line %d column %d',
+                $file->getRealPath(),
+                $e->getMessage(),
+                $e->getPosition()->getLine(),
+                $e->getPosition()->getColumn()
+            ));
+
+            return;
+        }
+
+        $ast->traverse(function ($node) use ($catalogue, $file) {
+            if ($this->isMethodCall($node, self::TRANSLATOR_OBJECT, self::TRANSLATOR_METHOD)) {
+                $arguments = $node->getArguments();
+
+                $id = $this->extractId($file, $arguments);
+                if ($id !== null) {
+                    $message = new Message($id, $this->extractDomain($file, $arguments) ?? $this->defaultDomain);
+                    $message->setDesc($this->extractDesc($arguments));
+                    $message->addSource(new FileSource((string)$file));
+
+                    $catalogue->add($message);
+                }
+            }
+        });
+    }
+
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    {
+    }
+
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    {
+    }
+
+    /**
+     * Returns true if node is a method call.
+     *
+     * @param \Peast\Syntax\Node\Node $node
+     * @param string $objectName
+     * @param string $methodName
+     *
+     * @return bool
+     */
+    private function isMethodCall(Node\Node $node, string $objectName, string $methodName): bool
+    {
+        if ($node instanceof Node\CallExpression) {
+            $callee = $node->getCallee();
+
+            if ($callee instanceof Node\MemberExpression) {
+                $object = $callee->getObject();
+                $property = $callee->getProperty();
+
+                if ($object instanceof Node\Identifier && $property instanceof Node\Identifier) {
+                    return $object->getName() === $objectName && $property->getName() === $methodName;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extracts a message domain from the translator call.
+     *
+     * @param \SplFileInfo $file
+     * @param \Peast\Syntax\Node\Expression[] $arguments
+     *
+     * @return string|null
+     */
+    private function extractId(SplFileInfo $file, array $arguments): ?string
+    {
+        if (!empty($arguments)) {
+            $idNode = $arguments[self::ID_ARG];
+
+            if (!($idNode instanceof Node\StringLiteral)) {
+                $position = $idNode->getLocation()->getStart();
+
+                $this->logger->error(sprintf(
+                    'Could not extract id, expected string literal but got %s (in %s on line %d column %d).',
+                    $idNode->getType(),
+                    $file->getRealPath(),
+                    $position->getLine(),
+                    $position->getColumn()
+                ));
+            }
+
+            return $idNode->getValue();
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts a message domain from the translator call.
+     *
+     * @param \SplFileInfo $file
+     * @param \Peast\Syntax\Node\Expression[] $arguments
+     *
+     * @return string|null
+     */
+    private function extractDomain(SplFileInfo $file, array $arguments): ?string
+    {
+        if (isset($arguments[self::DOMAIN_ARG])) {
+            $domainNode = $arguments[self::DOMAIN_ARG];
+
+            if (!($domainNode instanceof Node\StringLiteral)) {
+                $position = $domainNode->getLocation()->getStart();
+
+                $this->logger->error(sprintf(
+                    'Could not extract domain, expected string literal but got %s (in %s on line %d column %d).',
+                    $domainNode->getType(),
+                    $file->getRealPath(),
+                    $position->getLine(),
+                    $position->getColumn()
+                ));
+            }
+
+            return $domainNode->getValue();
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts a message description from the translator call.
+     *
+     * @param \Peast\Syntax\Node\Expression[] $arguments
+     *
+     * @return string|null
+     */
+    private function extractDesc(array $arguments): ?string
+    {
+        if (!empty($arguments)) {
+            foreach ($arguments[self::ID_ARG]->getLeadingComments() as $comment) {
+                $annotations = $this->docParser->parse($comment->getText());
+                if (!empty($annotations)) {
+                    return $annotations[0]->text;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true if file is supported by extractor.
+     *
+     * @param \SplFileInfo $file
+     *
+     * @return bool
+     */
+    private function supports(SplFileInfo $file): bool
+    {
+        return '.js' === substr($file->getRealPath(), -3) && '.min.js' !== substr($file->getRealPath(), -7);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28890
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Configuration for `willdurand/js-translation-bundle` will be separate PR. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
