### PR TITLE
[Fix build] Wait until UDW is closed with further actions.

### DIFF
--- a/features/ContentCreation.feature
+++ b/features/ContentCreation.feature
@@ -53,8 +53,8 @@ Scenario: Content draft can be saved
       | Title | Test Article       |
       | Intro | Test article intro |
     And I click on the edit action bar button "Save"
-  Then I should be on "Content Update" "Test Article" page
-    And success notification that "Content draft saved." appears
+  Then success notification that "Content draft saved." appears
+    And I should be on "Content Update" "Test Article" page
     And going to dashboard we see there's draft "Test Article" on list
 
 @javascript @common
@@ -85,8 +85,8 @@ Scenario: Content can be published
       | Title | Test Article       |
       | Intro | Test article intro |
     And I click on the edit action bar button "Publish"
-  Then I should be on content container page "Test Article" of type "Article" in root path
-    And success notification that "Content published." appears
+  Then success notification that "Content published." appears
+    And I should be on content container page "Test Article" of type "Article" in root path
     And content attributes equal
       | label | value              |
       | Title | Test Article       |
@@ -138,8 +138,8 @@ Scenario: Content edit draft can be saved
       | Title | Test Article edited2       |
       | Intro | Test article intro edited2 |
     And I click on the edit action bar button "Save"
-  Then I should be on "Content Update" "Test Article edited2" page
-    And success notification that "Content draft saved." appears
+  Then success notification that "Content draft saved." appears
+    And I should be on "Content Update" "Test Article edited2" page
     And going to dashboard we see there's draft "Test Article edited2" on list
 
 @javascript @common
@@ -151,8 +151,8 @@ Scenario: Content draft can be created and published through draft list modal
       | label | value                      |
       | Title | Test Article edited3       |
     And I click on the edit action bar button "Publish"
-  Then I should be on content container page "Test Article edited3" of type "Article" in root path
-    And success notification that "Content published." appears
+  Then success notification that "Content published." appears
+    And I should be on content container page "Test Article edited3" of type "Article" in root path
     And content attributes equal
       | label | value                |
       | Title | Test Article edited3 |
@@ -182,8 +182,8 @@ Scenario: Content draft from draft list modal can be published
       | label | value                      |
       | Title | Test Article edited4       |
     And I click on the edit action bar button "Publish"
-  Then I should be on content container page "Test Article edited4" of type "Article" in root path
-    And success notification that "Content published." appears
+  Then success notification that "Content published." appears
+    And I should be on content container page "Test Article edited4" of type "Article" in root path
     And content attributes equal
       | label | value                |
       | Title | Test Article edited4 |
@@ -208,8 +208,8 @@ Scenario: Content can be moved
   When I click on the edit action bar button "Move"
     And I select content "Media/Images" through UDW
     And I confirm the selection in UDW
-  Then I should be on content container page "Test Article edited4" of type "Article" in "Media/Images"
-    And success notification that "'Test Article edited4' moved to 'Images'" appears
+  Then success notification that "'Test Article edited4' moved to 'Images'" appears
+    And I should be on content container page "Test Article edited4" of type "Article" in "Media/Images"
     And content attributes equal
       | label | value                |
       | Title | Test Article edited4 |
@@ -236,8 +236,8 @@ Scenario: Content can be copied
   When I click on the edit action bar button "Copy"
     And I select content root node through UDW
     And I confirm the selection in UDW
-  Then I should be on content container page "Test Article edited4" of type "Article" in root path
-    And success notification that "Test Article edited4" has been copied to root node appears
+  Then success notification that "Test Article edited4" has been copied to root node appears
+    And I should be on content container page "Test Article edited4" of type "Article" in root path
     And content attributes equal
       | label | value                |
       | Title | Test Article edited4 |

--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -19,6 +19,7 @@ class UniversalDiscoveryWidget extends Element
         parent::__construct($context);
         $this->fields = [
             'tabSelector' => '.c-tab-nav-item',
+            'mainWindow' => '.m-ud',
             'confirmButton' => '.m-ud__action--confirm',
             'cancelButton' => '.m-ud__action--cancel',
             'selectContentButton' => '.c-meta-preview__btn--select',
@@ -53,11 +54,17 @@ class UniversalDiscoveryWidget extends Element
     public function confirm(): void
     {
         $this->context->getElementByText('Confirm', $this->fields['confirmButton'])->click();
+        $this->context->waitUntil($this->defaultTimeout, function () {
+            return !$this->isVisible();
+        });
     }
 
     public function cancel(): void
     {
         $this->context->getElementByText('Cancel', $this->fields['cancelButton'])->click();
+        $this->context->waitUntil($this->defaultTimeout, function () {
+            return !$this->isVisible();
+        });
     }
 
     public function verifyVisibility(): void
@@ -76,5 +83,10 @@ class UniversalDiscoveryWidget extends Element
         }
 
         Assert::assertArraySubset($expectedTabTitles, $actualTabTitles);
+    }
+
+    protected function isVisible(): bool
+    {
+        return $this->context->isElementVisible($this->fields['mainWindow']);
     }
 }

--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -13,6 +13,7 @@ class UniversalDiscoveryWidget extends Element
 {
     public const ELEMENT_NAME = 'UDW';
     private const UDW_TIMEOUT = 20;
+    private const UDW_DISAPPEAR_TIMEOUT = 2;
 
     public function __construct(UtilityContext $context)
     {
@@ -54,7 +55,7 @@ class UniversalDiscoveryWidget extends Element
     public function confirm(): void
     {
         $this->context->getElementByText('Confirm', $this->fields['confirmButton'])->click();
-        $this->context->waitUntil($this->defaultTimeout, function () {
+        $this->context->waitUntil(self::UDW_DISAPPEAR_TIMEOUT, function () {
             return !$this->isVisible();
         });
     }
@@ -62,7 +63,7 @@ class UniversalDiscoveryWidget extends Element
     public function cancel(): void
     {
         $this->context->getElementByText('Cancel', $this->fields['cancelButton'])->click();
-        $this->context->waitUntil($this->defaultTimeout, function () {
+        $this->context->waitUntil(self::UDW_DISAPPEAR_TIMEOUT, function () {
             return !$this->isVisible();
         });
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | should
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Build https://travis-ci.org/ezsystems/ezplatform-admin-ui/jobs/400311814 failed with:
```
        WebDriver\Exception\UnknownError: unknown error: Element <button class="btn--trigger btn btn-secondary btn-block" data-click="#ezrepoforms_content_edit_publish" id="content_create__sidebar_right__publish-tab">...</button> is not clickable at point (1369, 58). Other element would receive the click: <h1 class="m-ud__title">...</h1
```
It's caused by UDW modal not disappearing fast enough after Confirm is clicked - Publish was still hidden when the action was taken. Adding waiting should do the trick.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

