### PR TITLE
EZEE-2181: Improve UDW branch switching

### DIFF
--- a/src/lib/Behat/Helper/UtilityContext.php
+++ b/src/lib/Behat/Helper/UtilityContext.php
@@ -260,4 +260,15 @@ class UtilityContext extends MinkContext
             return false;
         }
     }
+
+    public function waitUntilElementDisappears(string $cssSelector, int $timeout): void
+    {
+        try {
+            $this->waitUntil($timeout, function () use ($cssSelector, $timeout) {
+                return !$this->isElementVisible($cssSelector, $timeout);
+            });
+        } catch (Exception $e) {
+            throw new Exception(sprintf('Element with selector: %s did not disappear in %d seconds.', $cssSelector, $timeout));
+        }
+    }
 }

--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -13,7 +13,8 @@ class UniversalDiscoveryWidget extends Element
 {
     public const ELEMENT_NAME = 'UDW';
     private const UDW_TIMEOUT = 20;
-    private const UDW_DISAPPEAR_TIMEOUT = 2;
+    private const UDW_DISAPPEAR_TIMEOUT = 1;
+    private const UDW_BRANCH_LOADING_TIMEOUT = 5;
 
     public function __construct(UtilityContext $context)
     {
@@ -25,6 +26,7 @@ class UniversalDiscoveryWidget extends Element
             'cancelButton' => '.m-ud__action--cancel',
             'selectContentButton' => '.c-meta-preview__btn--select',
             'elementSelector' => '.c-finder-tree-branch:nth-of-type(%d) .c-finder-tree-leaf',
+            'branchLoadingSelector' => '.c-finder-tree-leaf--loading',
             'previewName' => '.c-meta-preview__name',
             'treeBranch' => '.c-finder-tree-branch:nth-child(%d)',
         ];
@@ -40,6 +42,8 @@ class UniversalDiscoveryWidget extends Element
         foreach ($pathParts as $part) {
             $this->context->waitUntilElementIsVisible(sprintf($this->fields['treeBranch'], $depth), self::UDW_TIMEOUT);
             $this->context->getElementByText($part, sprintf($this->fields['elementSelector'], $depth))->click();
+            $this->context->waitUntilElementDisappears($this->fields['branchLoadingSelector'], self::UDW_BRANCH_LOADING_TIMEOUT);
+
             ++$depth;
         }
         $expectedContentName = $pathParts[count($pathParts) - 1];


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2181
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This fix is required for Page Builder, otherwise the tests will be failing soon 😢 
# Problem
What happens:
in Collection Block scenario, the following items are picked (one after another): 'Home,Home/eZ Platform,Media/Images`.

Sometimes it fails when trying to select the last item: I believe it's because we have to switch the parent UDW path (from Home to Media), but for a brief moment before the switch is done the Home items are still displayed. So, in a timeline:
1. Home is selected (Home items are displayed)
2. Media is clicked
3. Before Media items are loaded Home items are still displayed
4. Media items are displayed

(example: http://recordit.co/yPeHbBf4Xl)

If Behat tries to interact with the displayed elements in Phase 3, it won't find the searched element by text and the tests will fail.

# Potential solution
This PR tries to counteract this behaviour by waiting until the loading spinner in UDW disappears. It works locally, I didn't have time to setup this PR as a dependency in Page Builder.

- Other solution: wrap getElementByText with waitUntil and wait until it succeeds.



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review