### PR TITLE
EZP-29423: Lazy loading value of the admin_ui_config Twig global variable

### DIFF
--- a/src/lib/UI/Config/ConfigWrapper.php
+++ b/src/lib/UI/Config/ConfigWrapper.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config;
+
+use RuntimeException;
+
+class ConfigWrapper implements \ArrayAccess, \JsonSerializable
+{
+    /** @var array */
+    private $config;
+
+    /**
+     * Config constructor.
+     *
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->config[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->config[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new RuntimeException("Configuration is readonly");
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new RuntimeException("Configuration is readonly");
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->config;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29423
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`bazinga:js-translation:dump` internally use Twig to generate JS translations files. Some implementations of the `Config\ProviderInterface` (used to compute value of the `admin_ui_config` Twig global variable ) depends indirect on database connection which cause this command to fail when database connection isn't properly setup. For instance when the `bazinga:js-translation:dump` is executed as part of `composer install` on the newly created projects. Ref. https://github.com/ezsystems/ezplatform/blob/master/composer.json#L78

Moreover value of this variable is computed also in case of rendering non administration panel related templates, where is useless. 

This PR makes the value of `admin_ui_config` variable lazy loaded using the [Proxy Pattern](https://ocramius.github.io/ProxyManager/docs/lazy-loading-value-holder.html). 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
