### PR TITLE
EZP-29423: Lazy loading value of the admin_ui_config Twig global variable (CS)

### DIFF
--- a/src/bundle/Templating/Twig/UiConfigExtension.php
+++ b/src/bundle/Templating/Twig/UiConfigExtension.php
@@ -55,9 +55,10 @@ class UiConfigExtension extends Twig_Extension implements Twig_Extension_Globals
     private function createConfigWrapper(): ConfigWrapper
     {
         $factory = new LazyLoadingValueHolderFactory();
-        $initializer = function (& $wrappedObject, LazyLoadingInterface $proxy, $method, array $parameters, & $initializer) {
+        $initializer = function (&$wrappedObject, LazyLoadingInterface $proxy, $method, array $parameters, &$initializer) {
             $initializer = null;
             $wrappedObject = new ConfigWrapper($this->aggregator->getConfig());
+
             return true;
         };
 

--- a/src/lib/UI/Config/ConfigWrapper.php
+++ b/src/lib/UI/Config/ConfigWrapper.php
@@ -16,8 +16,6 @@ class ConfigWrapper implements \ArrayAccess, \JsonSerializable
     private $config;
 
     /**
-     * Config constructor.
-     *
      * @param array $config
      */
     public function __construct(array $config)
@@ -37,12 +35,12 @@ class ConfigWrapper implements \ArrayAccess, \JsonSerializable
 
     public function offsetSet($offset, $value)
     {
-        throw new RuntimeException("Configuration is readonly");
+        throw new RuntimeException('Configuration is readonly');
     }
 
     public function offsetUnset($offset)
     {
-        throw new RuntimeException("Configuration is readonly");
+        throw new RuntimeException('Configuration is readonly');
     }
 
     public function jsonSerialize()


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29423
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
