### PR TITLE
Fix EZP-29433. Unauthorized exception user has no permission to read the parent location

### DIFF
--- a/src/bundle/Resources/translations/content_url.en.xliff
+++ b/src/bundle/Resources/translations/content_url.en.xliff
@@ -121,6 +121,11 @@
         <target state="new">URL</target>
         <note>key: tab.urls.url</note>
       </trans-unit>
+      <trans-unit id="8cbd9ea97c79240d3a2f41a84328c79908cd8265" resname="tabs.urls.add.site_root.helper.no_parent_name">
+        <source>Unchecked will create the new alias under the parent of the location</source>
+        <target state="new">Unchecked will create the new alias under the parent of the location</target>
+        <note>key: tabs.urls.add.site_root.helper.no_parent_name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
@@ -28,7 +28,13 @@
                 <span class="ez-modal--custom-url-alias__label">{{ 'tab.urls.add.site_root'|trans|desc('Place alias at the site root') }}</span>
                 {{ form_widget(form.site_root) }}
                 <div class="ez-modal--custom-url-alias__info-text">{{ 'tab.urls.add.site_root.helper.checked'|trans|desc('Checked will create the alias at the site root.') }}</div>
-                <div class="ez-modal--custom-url-alias__info-text">{{ 'tab.urls.add.site_root.helper.unchecked'|trans({'%parent_name%': parent_name})|desc('Unchecked will create the new alias under %parent_name%') }}</div>
+                <div class="ez-modal--custom-url-alias__info-text">
+                    {% if parent_name is not null %}
+                        {{ 'tab.urls.add.site_root.helper.unchecked'|trans({'%parent_name%': parent_name})|desc('Unchecked will create the new alias under %parent_name%') }}
+                    {% else %}
+                        {{ 'tab.urls.add.site_root.helper.no_parent_name'|trans|desc('Unchecked will create the new alias under the parent of this location') }}
+                    {% endif %}
+                </div>
             </div>
             <div class="modal-footer justify-content-center">
                 <button type="button" class="btn btn-dark" data-dismiss="modal">


### PR DESCRIPTION
…the parent location

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29433
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When the situation explained in the ticket, the user has read permissions limited to '/1/2/' and '/1/43/' 

When viewing the location 2 in the admin, it tries to render the tabs with the info about related urls. The tab related code is trying to load the parent Location at some point and hence the error. 

This is not only a problem with the root node. if you have a role with content / read and limitations `/1/2/100/200` `/1/2/100/300`, you will have the same error if trying to view the location 200 or 300 in the admin interface. 

So, i suggest to hardcode the parent_name to something in case you can't read the parent location. the only use of this var later is to indicate you that you will be creating an url alias under `{{ parent_name }}`

Take this as a proof of concept. Maybe we can move that test to a constant and make it translatable too...

ping @andrerom @alongosz 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
