### PR TITLE
EZP-29449: Cannot read property 'innerHTML' of null on upload in ezimage, ezmedia & ezbinaryfile

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -1,6 +1,6 @@
 (function (global) {
     const eZ = global.eZ = global.eZ || {};
-    const SELECTOR_FIELD_LABEL = '.ez-field-edit__label-wrapper .form-control-label';
+    const SELECTOR_FIELD_LABEL = '.ez-field-edit__label-wrapper .ez-field-edit__label';
 
     class BaseFileFieldValidator extends global.eZ.BaseFieldValidator {
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -45,7 +45,7 @@
             const isEmpty = isNaN(value);
             const isInteger = Number.isInteger(value);
             const isError = (isEmpty && isRequired) || (!isEmpty && !isInteger);
-            const label = input.closest(SELECTOR_INFO_WRAPPER).querySelector('.form-control-label').innerHTML;
+            const label = input.closest(SELECTOR_INFO_WRAPPER).querySelector('.ez-field-edit-preview__label').innerHTML;
             const result = { isError };
 
             if (isEmpty) {

--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -1,5 +1,5 @@
 form:not(.form-inline) {
-    .form-control-label {
+    .ez-field-edit__label {
         font-weight: 700;
         font-size: 14px;
         color: $ez-color-base-dark;
@@ -46,7 +46,7 @@ form:not(.form-inline) {
 
     .col-form-label,
     .form-control,
-    .form-control-label {
+    .ez-field-edit__label {
         margin-right: .5rem;
     }
 }

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezimage.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezimage.scss
@@ -39,7 +39,7 @@
     .ez-data-source__field--alternativeText {
         &.is-invalid {
             .ez-data-source__label-wrapper,
-            .ez-data-source__label-wrapper .form-control-label {
+            .ez-data-source__label-wrapper .ez-field-edit__label {
                 color: $ez-color-danger;
             }
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
@@ -37,8 +37,8 @@
                     {{ form_row(form.loop, {'label_attr': {'class': 'checkbox-inline'}}) }}
                 </div>
                 <div class="ez-field-edit-preview__dimensions">
-                    {{ form_row(form.width) }}
-                    {{ form_row(form.height) }}
+                    {{ form_row(form.width, {'label_attr': {'class': 'ez-field-edit-preview__label'}}) }}
+                    {{ form_row(form.height, {'label_attr': {'class': 'ez-field-edit-preview__label'}}) }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29449
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
