### PR TITLE
EZP-29342: Deleting related object for ezobjectrelations field throws error 500

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -363,6 +363,8 @@ class ContentViewController extends Controller
      */
     private function supplyIsLocationBookmarked(ContentView $view): void
     {
-        $view->addParameters(['location_is_bookmarked' => $this->bookmarkService->isBookmarked($view->getLocation())]);
+        $locationIsBookmarked = $view->getLocation() ? $this->bookmarkService->isBookmarked($view->getLocation()) : false;
+
+        $view->addParameters(['location_is_bookmarked' => $locationIsBookmarked]);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29342
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Now if `$view->getLocation()` returns null (because of sending related location to trash) `location_is_bookmarked` parameter will be set to false.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
