### PR TITLE
EZP-29468 Improved style of bookmarks manager's delete button

### DIFF
--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -24,7 +24,7 @@
                     {% include '@ezdesign/parts/table_header.html.twig' with {
                          ground: 'mt-3',
                          headerText: 'bookmark.table.header'|trans|desc('Bookmarks') ~ ' (' ~ pager.count ~ ')',
-                         tools: form_widget(form_remove.remove, {'attr': {'class': 'btn btn-primary', 'disabled': true}})
+                         tools: form_widget(form_remove.remove, {'attr': {'class': 'btn btn-danger', 'disabled': true}})
                      } %}
                     <table class="table">
                         <thead>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29468](https://jira.ez.no/browse/EZP-29468)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
-Improve styling of bookmarks manager's delete button. Current markup for that button should be replaced by `class="btn btn-danger"`

![screen shot 2018-07-27 at 3 59 37 pm](https://user-images.githubusercontent.com/9256718/43344097-978f347c-91b6-11e8-9150-ccc5377c8c01.png)
![screen shot 2018-07-27 at 3 59 54 pm](https://user-images.githubusercontent.com/9256718/43344102-9a4db74c-91b6-11e8-931c-03a8f7289d5f.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
