### PR TITLE
EZP-29491: Harmonized item status color in COTF

### DIFF
--- a/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block details %}
-    <h2 class="text-muted">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
+    <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
     <h1>
         <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29491](https://jira.ez.no/browse/EZP-29491)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Harmonized color of content item status in Content On The Fly, Create view, as defined in Content section - Edit/Create views.

![ez platform 9](https://user-images.githubusercontent.com/9256718/43542860-316434ec-959c-11e8-8459-9f6d1ab1ddda.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
