### PR TITLE
EZP-29290: As an Editor, I want to have preconfigured "Author" section while creating the content

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -8,6 +8,12 @@
 
 {# @var data \EzSystems\RepositoryForms\Data\FieldDefinitionData #}
 {# @var form \Symfony\Component\Form\FormView #}
+{% block ezauthor_field_definition_edit %}
+    <div class="ezauthor-settings default-type{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_row(form.defaultAuthor, {'label_attr': {'class': 'radio-inline'}}) -}}
+    </div>
+{% endblock %}
+
 {% block ezbinaryfile_field_definition_edit %}
     <div class="ezbinaryfile-validator max-file-size{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_row(form.maxSize) -}}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29290](https://jira.ez.no/browse/EZP-29290)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

JIRA excerpt:

>Currently, in v2 there is no preconfigured author section (fields filled in with the name and e-mail of the currently logged user). It would be more convenient for the editors to have this fields set automatically while creating a new content. Also, prefilling section with the default data should be configurable at the Author FieldType level.

**Depends on:**
- ezsystems/ezpublish-kernel#2392
- ezsystems/ezpublish-kernel#2417
- ezsystems/repository-forms/pull/251

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
