### PR TITLE
EZP-29498: showDangerNotification duplicates the functionality of showErrorNotification

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/notification.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/notification.helper.js
@@ -4,13 +4,13 @@
     const NOTIFICATION_INFO_LABEL = 'info';
     const NOTIFICATION_SUCCESS_LABEL = 'success';
     const NOTIFICATION_WARNING_LABEL = 'warning';
-    const NOTIFICATION_DANGER_LABEL = 'danger';
+    const NOTIFICATION_ERROR_LABEL = 'danger';
 
     /**
      * Dispatches notification event
      *
      * @function showNotification
-     * @param {Object} detail
+     * @param {{message: string, label: string}} detail
      */
     const showNotification = (detail) => {
         const event = new CustomEvent('ez-notify', { detail });
@@ -60,22 +60,33 @@
      * @function showDangerNotification
      * @param {String} message
      */
-    const showDangerNotification = (message) =>
-        showNotification({
-            message,
-            label: NOTIFICATION_DANGER_LABEL,
-        });
+    const showDangerNotification = (message) => {
+        console.warn('[DEPRECATED] showDangerNotification is deprecated');
+        console.warn('[DEPRECATED] it will be removed from ezplatform-admin-ui 2.0');
+        console.warn('[DEPRECATED] use showErrorNotification instead');
+
+        showErrorNotification(message);
+    };
 
     /**
-     * Dispatches danger notification event
+     * Dispatches error notification event
      *
      * @function showErrorNotification
-     * @param {Error} error
+     * @param {(string | Error)} error
      */
-    const showErrorNotification = (error) => showDangerNotification(error.message);
+    const showErrorNotification = (error) => {
+        const isErrorObj = error instanceof Error;
+        const message = isErrorObj ? error.message : error;
+
+        showNotification({
+            message,
+            label: NOTIFICATION_ERROR_LABEL,
+        });
+    };
 
     eZ.helpers = eZ.helpers || {};
     eZ.helpers.notification = {
+        showNotification,
         showInfoNotification,
         showSuccessNotification,
         showWarningNotification,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29498
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Currently there are 4 types of notifications: 'info', 'success', 'warning' & 'danger', but in fact 'danger' should be an 'error' notification. Thus `showDangerNotification` should be removed; `showErrorNotification` already exists.

*For QA*: notifications should work as before.

#### Checklist:
- [ ] ~Coding standards (`$ composer fix-cs`)~
- [x] Ready for Code Review
