### PR TITLE
EZP-29496: Improved styling of ez_author field type buttons in edit view

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
@@ -1,7 +1,11 @@
 .ez-field-edit--ezauthor {
     .ez-data-source__author {
         background-color: $ez-ground-base;
-        padding: 1rem;
+        padding: 1rem 1rem 1.25rem 1rem;
+
+        &.form-row {
+            align-items: flex-end;
+        }
     }
 
     .ez-data-source__label-wrapper {
@@ -10,10 +14,15 @@
         }
     }
 
+    .ez-data-source__input-wrapper {
+        .form-control {
+            margin-bottom: 0;
+        }
+    }
+
     .ez-data-source__actions {
         display: flex;
         align-items: center;
-        padding-top: 2.5rem;
 
         button {
             margin: 0 .35rem;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29496](https://jira.ez.no/browse/EZP-29496)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Reviewed alignment of buttons in `ez_author` field type.

![ez_author_btns](https://user-images.githubusercontent.com/9256718/43726686-ce377976-996d-11e8-9199-07e7db04873b.png)
![ez_author_btns_2](https://user-images.githubusercontent.com/9256718/43726691-d0ccfd78-996d-11e8-8082-53afffb25f8e.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
