### PR TITLE
EZP-29510: Editing a draft should be able to cancel if user has version remove permission

### DIFF
--- a/src/lib/Menu/ContentEditRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentEditRightSidebarBuilder.php
@@ -99,7 +99,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
 
         $canPublish = $this->permissionResolver->canUser('content', 'publish', $content);
         $canEdit = $this->permissionResolver->canUser('content', 'edit', $content);
-        $canDelete = $this->permissionResolver->canUser('content', 'remove', $content);
+        $canDelete = $this->permissionResolver->canUser('content', 'versionremove', $content);
 
         $publishAttributes = [
             'class' => self::BTN_TRIGGER_CLASS,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://jira.ez.no/browse/EZP-29510
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2414
