### PR TITLE
EZP-29232: ez-user-menu covered by ez-context-menu in Safari

### DIFF
--- a/src/bundle/Resources/public/scss/_user-menu.scss
+++ b/src/bundle/Resources/public/scss/_user-menu.scss
@@ -1,6 +1,7 @@
 .ez-user-menu {
     position: relative;
     cursor: pointer;
+    z-index: 1050;
 
     &__name-wrapper {
         padding: .5rem 2rem .5rem 0;
@@ -44,7 +45,6 @@
         background-color: $ez-white;
         border-radius: 5px;
         box-shadow: 0 0 10px 0 rgba(0,0,0,.25);
-        z-index: 1050;
         height: auto;
         transform-origin: top center;
         transition: all .2s $ez-admin-transition;
@@ -52,7 +52,6 @@
         &--hidden {
             height: 0;
             overflow: hidden;
-            z-index: initial;
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29232](https://jira.ez.no/browse/EZP-29232)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspect:
- `ez-user-menu` covered by `ez-context-menu` in Safari (Safari on iOS do not interpret `z-index: initial` correctly - [Recurrent issue in cross-browser testing](https://stackoverflow.com/a/42142794/4551872)
- Tested solution on Safari 11.1.2, Firefox Dev Ed 62.0b13, Firefox 61.0.2, Opera 54.0.2952.71 all for IOS

![safari_user_menu_bug](https://user-images.githubusercontent.com/9256718/44154471-cc8b5dec-a078-11e8-9a66-d5859802be09.png)

![screen shot 2018-08-15 at 10 34 12 am](https://user-images.githubusercontent.com/9256718/44154484-d4034bc0-a078-11e8-88b0-0091678998fd.png)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
