### PR TITLE
EZP-29279: Fix value displayed by the Date Field Type being affected by browser time zone

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -89,6 +89,8 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
+
+            defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
         }
 
         btnClear.addEventListener('click', (event) => {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29279](https://jira.ez.no/browse/EZP-29279)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
Currently the value for Date Field Type displayed in the backoffice (in edit mode) is affected by the browser's timezone, meaning that if the browser has timezone below (west of) UTC, then the previous day is displayed.
Value stored in the database is always midnight in UTC.
Javascript automatically uses the browser's timezone when handling Date objects, so in this PR I fix the issue by manually adding the offset before passing the Date object to flatpickr library.

Similar to https://github.com/ezsystems/PlatformUIBundle/pull/984.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
