### PR TITLE
EZP-29546: Updated icons in Edit view for Object State and Role Polic…

### DIFF
--- a/src/lib/Menu/Admin/ObjectState/ObjectStateEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateEditRightSidebarBuilder.php
@@ -60,7 +60,7 @@ class ObjectStateEditRightSidebarBuilder extends AbstractBuilder implements Tran
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
-                    'extras' => ['icon' => 'publish'],
+                    'extras' => ['icon' => 'save'],
                 ]
             ),
             self::ITEM__CANCEL => $this->createMenuItem(

--- a/src/lib/Menu/Admin/ObjectState/ObjectStateGroupEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateGroupEditRightSidebarBuilder.php
@@ -59,7 +59,7 @@ class ObjectStateGroupEditRightSidebarBuilder extends AbstractBuilder implements
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
-                    'extras' => ['icon' => 'publish'],
+                    'extras' => ['icon' => 'save'],
                 ]
             ),
             self::ITEM__CANCEL => $this->createMenuItem(

--- a/src/lib/Menu/Admin/Role/PolicyEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/PolicyEditRightSidebarBuilder.php
@@ -63,7 +63,7 @@ class PolicyEditRightSidebarBuilder extends AbstractBuilder implements Translati
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
-                    'extras' => ['icon' => 'save'],
+                    'extras' => ['icon' => 'publish'],
                 ]
             ),
             self::ITEM__CANCEL => $this->createMenuItem(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29546](https://jira.ez.no/browse/EZP-29546)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
Icons in `ez-context-menu` in Edit view for both Object State (OS group and OS) and for specific Role Policy limitation are not correct for the actions they represent:

- Save changes goes with Save icon;
- And Update changes goes with Publish icon;

![ez platform 14](https://user-images.githubusercontent.com/9256718/44421431-7abc6800-a54e-11e8-8123-558045600bdc.png)
![ez platform 15](https://user-images.githubusercontent.com/9256718/44421432-7abc6800-a54e-11e8-966e-f5855841d528.png)
![ez platform 16](https://user-images.githubusercontent.com/9256718/44421433-7abc6800-a54e-11e8-946f-73945b238c30.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
