### PR TITLE
EZP:29553 Harmonized breadcrumbs positioning across the UI

### DIFF
--- a/src/bundle/Resources/views/admin/base.html.twig
+++ b/src/bundle/Resources/views/admin/base.html.twig
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/language/base.html.twig
+++ b/src/bundle/Resources/views/admin/language/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state/base.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/object_state_group/base.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/policy/base.html.twig
+++ b/src/bundle/Resources/views/admin/policy/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/role/base.html.twig
+++ b/src/bundle/Resources/views/admin/role/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/role_assignment/base.html.twig
+++ b/src/bundle/Resources/views/admin/role_assignment/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/admin/section/base.html.twig
+++ b/src/bundle/Resources/views/admin/section/base.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% block breadcrumbs_admin %}
                     {% endblock %}

--- a/src/bundle/Resources/views/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/link_manager/edit.html.twig
@@ -7,7 +7,7 @@
 {%- block content -%}
     <div class="row align-items-stretch ez-main-row">
         <div class="col-sm-11 px-0 pb-4">
-            <div class="ez-header pt-4">
+            <div class="ez-header">
                 <div class="container">
                     {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
                         { value: 'url.list'|trans, url: path('ezplatform.link_manager.list') },


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29553](https://jira.ez.no/browse/EZP-29553)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Harmonized breadcrumbs positioning across the UI. Some view showed breadcrumbs moved down, specially Edit views in Admin Panel section. Added changes so that all `ez-header` have now same format (unless they contain tabs)

![editing language _english united kingdom _](https://user-images.githubusercontent.com/9256718/44475244-85383980-a602-11e8-9dea-2b05ecea4f01.png)
![ez platform 30 copy 2](https://user-images.githubusercontent.com/9256718/44475245-85383980-a602-11e8-966f-6663ce66dee5.png)
![ez platform 30 copy 3](https://user-images.githubusercontent.com/9256718/44475246-85383980-a602-11e8-8c7a-37dd684d9a3f.png)
![ez platform 30 copy 4](https://user-images.githubusercontent.com/9256718/44475247-85383980-a602-11e8-8e2a-e97ceec45763.png)
![ez platform 30 copy 5](https://user-images.githubusercontent.com/9256718/44475248-85383980-a602-11e8-8456-3d20a47eced7.png)
![ez platform 30 copy 6](https://user-images.githubusercontent.com/9256718/44475250-85383980-a602-11e8-97b9-5d6de5a01689.png)
![ez platform 30 copy 7](https://user-images.githubusercontent.com/9256718/44475251-85383980-a602-11e8-9ec4-f768ff5fa825.png)
![ez platform 30 copy 8](https://user-images.githubusercontent.com/9256718/44475252-85d0d000-a602-11e8-9420-1efb9a4ec480.png)
![ez platform 30 copy 9](https://user-images.githubusercontent.com/9256718/44475253-85d0d000-a602-11e8-8dcf-29ab860d5e0f.png)
![ez platform 30 copy](https://user-images.githubusercontent.com/9256718/44475254-85d0d000-a602-11e8-937f-3be791431f49.png)
![ez platform 30](https://user-images.githubusercontent.com/9256718/44475255-85d0d000-a602-11e8-9547-ce72f90144f3.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
