### PR TITLE
EZP-29562: Harmonized background color contrast of multiple input fields when grouped in Edit view

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
@@ -63,7 +63,7 @@
         display: flex;
         flex-wrap: nowrap;
         padding: 0 1.25rem;
-        background: $ez-ground-base;
+        background: $ez-ground-base-medium;
 
         &__visual {
             flex: 1 1 auto;

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezauthor.scss
@@ -1,6 +1,6 @@
 .ez-field-edit--ezauthor {
     .ez-data-source__author {
-        background-color: $ez-ground-base;
+        background-color: $ez-ground-base-medium;
         padding: 1rem 1rem 1.25rem 1rem;
 
         &.form-row {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezgmaplocation.scss
@@ -1,7 +1,7 @@
 .ez-field-edit--ezgmaplocation {
     .ez-field-edit__data {
         padding: 16px;
-        background: $ez-ground-base;
+        background: $ez-ground-base-medium;
     }
 
     .ez-data-source {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezurl.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezurl.scss
@@ -1,6 +1,6 @@
 .ez-field-edit--ezurl {
     .ez-field-edit__data {
-        background-color:  $ez-ground-base;
+        background-color:  $ez-ground-base-medium;
         padding: 1rem;
     }
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezuser.scss
@@ -1,6 +1,6 @@
 .ez-field-edit--ezuser {
     .ez-field-edit__data {
-        background: $ez-ground-base;
+        background: $ez-ground-base-medium;
         padding: 10px 16px;
 
         .ez-data-source {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29562](https://jira.ez.no/browse/EZP-29562)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspect:
- Harmonized background color contrast of multiple input fields when grouped in Content section Create & Edit views. It's hard to distinguish for users, specially in monitors with low screen resolution, when there are several input fields grouped. Changed to color `$ez-ground-base-medium` (= #ededed).

![ez platform 1](https://user-images.githubusercontent.com/9256718/44550450-57322280-a6f2-11e8-9069-ff4c5ec2143a.png)
![ez platform 2](https://user-images.githubusercontent.com/9256718/44550451-57322280-a6f2-11e8-8ec0-071c3ea14de9.png)
![ez platform 3](https://user-images.githubusercontent.com/9256718/44550452-57322280-a6f2-11e8-8d2f-2a29a77aee10.png)
![ez platform 5](https://user-images.githubusercontent.com/9256718/44550453-57322280-a6f2-11e8-9f36-33009181929e.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
