### PR TITLE
EZP-29572: Harmonized modal footer buttons in Content section

### DIFF
--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -70,6 +70,14 @@
     justify-content: center;
 }
 
+.ez-modal {
+    .modal-footer {
+        .btn {
+            margin: 0 .625rem;
+        }
+    }
+}
+
 .ez-modal--send-to-trash {
     .modal-header {
         .close {
@@ -82,6 +90,7 @@
         .btn {
             line-height: 1.25;
             padding: .5rem .75rem;
+            font-size: 1rem;
         }
 
         .btn-secondary {
@@ -93,6 +102,10 @@
                 border-color: $ez-color-base-medium-hover;
             }
         }
+
+        .btn-danger {
+            margin-right: 0;
+        }
     }
 }
 
@@ -100,9 +113,17 @@
 .ez-trash-list-view {
     .ez-modal--send-to-trash {
         .modal-footer {
-            .btn {
-                font-size: 1rem;
-                padding-bottom: .5rem;
+            .form-check-inline {
+                margin-right: 0;
+
+                .btn {
+                    font-size: 1rem;
+                    padding-bottom: .5rem;
+                }
+
+                .btn-danger {
+                    margin-right: 0;
+                }
             }
         }
     }

--- a/src/bundle/Resources/views/admin/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/bulk_delete_confirmation_modal.html.twig
@@ -15,7 +15,7 @@
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'modal.cancel'|trans|desc('Cancel') }}
                 </button>
-                <button class="btn btn-danger btn--trigger" data-click="{{ data_click }}">
+                <button class="btn btn-danger font-weight-bold btn--trigger" data-click="{{ data_click }}">
                     {{ 'modal.delete'|trans|desc('Delete') }}
                 </button>
             </div>

--- a/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/trash/empty_trash_confirmation_modal.html.twig
@@ -26,7 +26,7 @@
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">
                     {{ 'trash.delete.button.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.empty, {'attr': {'class': 'btn-danger'}}) }}
+                {{ form_widget(form.empty, {'attr': {'class': 'btn-danger font-weight-bold'}}) }}
                 {{ form_widget(form.empty_trash, {'label_attr': {'class': 'checkbox-inline'}, 'attr': {'hidden': true}}) }}
                 {{ form_end(form) }}
             </div>

--- a/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/bulk_delete_confirmation_modal.html.twig
@@ -15,7 +15,7 @@
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'modal.cancel'|trans|desc('Cancel') }}
                 </button>
-                <button class="btn btn-danger btn--trigger" data-click="{{ data_click }}">
+                <button class="btn btn-danger font-weight-bold btn--trigger" data-click="{{ data_click }}">
                     {{ 'modal.delete'|trans|desc('Delete') }}
                 </button>
             </div>

--- a/src/bundle/Resources/views/content/modal_add_translation.html.twig
+++ b/src/bundle/Resources/views/content/modal_add_translation.html.twig
@@ -24,7 +24,7 @@
                 <button type="button" class="btn btn-dark" data-dismiss="modal">
                     {{ 'tab.translations.add.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary ez-btn--wide ez-btn--create-translation', 'disabled': 'disabled'}}) }}
+                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary font-weight-bold ez-btn--create-translation', 'disabled': 'disabled'}}) }}
             </div>
             {{ form_end(form) }}
         </div>

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -20,7 +20,7 @@
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'trash.form.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.trash, {'attr': {'class': 'btn-danger'}}) }}
+                {{ form_widget(form.trash, {'attr': {'class': 'btn-danger font-weight-bold'}}) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/content/modal_user_delete.html.twig
+++ b/src/bundle/Resources/views/content/modal_user_delete.html.twig
@@ -22,7 +22,7 @@
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">
                     {{ 'delete.form.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.delete, {'attr': {'class': 'btn btn-danger'}}) }}
+                {{ form_widget(form.delete, {'attr': {'class': 'btn btn-danger font-weight-bold'}}) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
+++ b/src/bundle/Resources/views/content/tab/url/modal_add_custom_url.html.twig
@@ -40,7 +40,7 @@
                 <button type="button" class="btn btn-dark" data-dismiss="modal">
                     {{ 'tab.urls.add.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary ez-btn--wide', 'disabled': 'disabled'}}) }}
+                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary font-weight-bold', 'disabled': 'disabled'}}) }}
             </div>
         </div>
         {{ form_end(form) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29572](https://jira.ez.no/browse/EZP-29572)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
Harmonized modal footer buttons in Content section in order to get a consistent view of them across the UI. This work is aligned with buttons in Page Builder modals.
- Removed unnecessary padding (`btn--wide`);
- Added Bootstrap's `font-weight-bold` for the primary action button within the modal we want to highlight;
- Aligned footer buttons with `.modal-header` `.close` button.

![ez platform 1](https://user-images.githubusercontent.com/9256718/44793020-91de0400-aba5-11e8-83de-fad60aaf26c5.png)
![ez platform 2](https://user-images.githubusercontent.com/9256718/44793021-91de0400-aba5-11e8-8cd9-169ff13f1138.png)
![ez platform 3](https://user-images.githubusercontent.com/9256718/44793022-92769a80-aba5-11e8-8006-01e4a8ed8b74.png)
![ez platform 4](https://user-images.githubusercontent.com/9256718/44793023-92769a80-aba5-11e8-9d34-4babf0366002.png)
![ez platform 11](https://user-images.githubusercontent.com/9256718/44793151-e84b4280-aba5-11e8-8ef4-6f8a6303c38e.png)
![ez platform 5](https://user-images.githubusercontent.com/9256718/44793024-92769a80-aba5-11e8-9bd7-40c6cc3962a8.png)
![ez platform 6](https://user-images.githubusercontent.com/9256718/44793025-92769a80-aba5-11e8-8912-210c4f7c9f60.png)
![ez platform 7](https://user-images.githubusercontent.com/9256718/44793026-92769a80-aba5-11e8-9236-4e4d54b29813.png)
![ez platform 8](https://user-images.githubusercontent.com/9256718/44793027-930f3100-aba5-11e8-8974-7a6c20a71095.png)
![ez platform 9](https://user-images.githubusercontent.com/9256718/44793028-930f3100-aba5-11e8-94cc-2bcc0e8317ba.png)
![ez platform 10](https://user-images.githubusercontent.com/9256718/44793029-930f3100-aba5-11e8-95c9-6fc4b8761c24.png)
![object state groups](https://user-images.githubusercontent.com/9256718/44793030-930f3100-aba5-11e8-9baa-46316881034b.png)
![trash 1](https://user-images.githubusercontent.com/9256718/44793032-93a7c780-aba5-11e8-8e41-1837f9f75c33.png)
![trash](https://user-images.githubusercontent.com/9256718/44793034-93a7c780-aba5-11e8-8155-61da6720ec36.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
