### PR TITLE
EZP-29575: Provide editing interface for User Preferences in AdminUI

### DIFF
--- a/src/bundle/Controller/User/UserSettingsController.php
+++ b/src/bundle/Controller/User/UserSettingsController.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Controller\User;
+
+use EzSystems\EzPlatformAdminUi\Form\Data\User\Setting\UserSettingUpdateData;
+use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
+use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
+use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta\UserSettingsAdapter;
+use EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService;
+use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class UserSettingsController extends Controller
+{
+    /** @var \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory */
+    private $formFactory;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Form\SubmitHandler */
+    private $submitHandler;
+
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService */
+    private $userSettingService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    private $notificationHandler;
+
+    /** @var int */
+    private $defaultPaginationLimit;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
+     * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService $userSettingService
+     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param int $defaultPaginationLimit
+     */
+    public function __construct(
+        FormFactory $formFactory,
+        SubmitHandler $submitHandler,
+        TranslatorInterface $translator,
+        UserSettingService $userSettingService,
+        NotificationHandlerInterface $notificationHandler,
+        int $defaultPaginationLimit
+    ) {
+        $this->formFactory = $formFactory;
+        $this->submitHandler = $submitHandler;
+        $this->translator = $translator;
+        $this->userSettingService = $userSettingService;
+        $this->notificationHandler = $notificationHandler;
+        $this->defaultPaginationLimit = $defaultPaginationLimit;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listAction(int $page = 1): Response
+    {
+        $pagerfanta = new Pagerfanta(
+            new UserSettingsAdapter($this->userSettingService)
+        );
+
+        $pagerfanta->setMaxPerPage($this->defaultPaginationLimit);
+        $pagerfanta->setCurrentPage(min($page, $pagerfanta->getNbPages()));
+
+        return $this->render('@ezdesign/user/settings/list.html.twig', [
+            'pager' => $pagerfanta,
+        ]);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param string $identifier
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function updateAction(Request $request, string $identifier): Response
+    {
+        $userSetting = $this->userSettingService->getUserSetting($identifier);
+        $data = new UserSettingUpdateData($identifier, $userSetting->value);
+
+        $form = $this->formFactory->updateUserSetting($identifier, $data);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $result = $this->submitHandler->handle($form, function (UserSettingUpdateData $data) {
+                $this->userSettingService->setUserSetting($data->getIdentifier(), $data->getValue());
+
+                $this->notificationHandler->success(
+                    $this->translator->trans(
+                        /** @Desc("User setting '%identifier%' updated.") */
+                        'user_setting.update.success',
+                        ['%identifier%' => $data->getIdentifier()],
+                        'user_settings'
+                    )
+                );
+
+                return new RedirectResponse($this->generateUrl('ezplatform.user_settings.list'));
+            });
+
+            if ($result instanceof Response) {
+                return $result;
+            }
+        }
+
+        return $this->render('@ezdesign/user/settings/update.html.twig', [
+            'form' => $form->createView(),
+            'user_setting' => $userSetting,
+        ]);
+    }
+}

--- a/src/bundle/Controller/User/UserSettingsController.php
+++ b/src/bundle/Controller/User/UserSettingsController.php
@@ -14,6 +14,7 @@ use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta\UserSettingsAdapter;
 use EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry;
 use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -35,6 +36,9 @@ class UserSettingsController extends Controller
     /** @var \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService */
     private $userSettingService;
 
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry */
+    private $valueDefinitionRegistry;
+
     /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
     private $notificationHandler;
 
@@ -46,6 +50,7 @@ class UserSettingsController extends Controller
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService $userSettingService
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry $valueDefinitionRegistry
      * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
      * @param int $defaultPaginationLimit
      */
@@ -54,6 +59,7 @@ class UserSettingsController extends Controller
         SubmitHandler $submitHandler,
         TranslatorInterface $translator,
         UserSettingService $userSettingService,
+        ValueDefinitionRegistry $valueDefinitionRegistry,
         NotificationHandlerInterface $notificationHandler,
         int $defaultPaginationLimit
     ) {
@@ -61,6 +67,7 @@ class UserSettingsController extends Controller
         $this->submitHandler = $submitHandler;
         $this->translator = $translator;
         $this->userSettingService = $userSettingService;
+        $this->valueDefinitionRegistry = $valueDefinitionRegistry;
         $this->notificationHandler = $notificationHandler;
         $this->defaultPaginationLimit = $defaultPaginationLimit;
     }
@@ -81,6 +88,7 @@ class UserSettingsController extends Controller
 
         return $this->render('@ezdesign/user/settings/list.html.twig', [
             'pager' => $pagerfanta,
+            'value_definitions' => $this->valueDefinitionRegistry->getValueDefinitions(),
         ]);
     }
 
@@ -90,7 +98,6 @@ class UserSettingsController extends Controller
      *
      * @return \Symfony\Component\HttpFoundation\Response
      *
-     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */

--- a/src/bundle/DependencyInjection/Compiler/UserSetting/FormMapperPass.php
+++ b/src/bundle/DependencyInjection/Compiler/UserSetting/FormMapperPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UserSetting;
+
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FormMapperPass implements CompilerPassInterface
+{
+    public const TAG_NAME = 'ezplatform.admin_ui.user_setting.form_mapper';
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     *
+     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(FormMapperRegistry::class)) {
+            return;
+        }
+
+        $registryDefinition = $container->getDefinition(FormMapperRegistry::class);
+        $taggedServiceIds = $container->findTaggedServiceIds(self::TAG_NAME);
+
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['identifier'])) {
+                    throw new InvalidArgumentException(
+                        $taggedServiceId,
+                        sprintf("Tag '%s' must contain 'identifier' argument.", self::TAG_NAME)
+                    );
+                }
+
+                $registryDefinition->addMethodCall(
+                    'addFormMapper',
+                    [$tag['identifier'], new Reference($taggedServiceId)]
+                );
+            }
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/UserSetting/ValueDefinitionPass.php
+++ b/src/bundle/DependencyInjection/Compiler/UserSetting/ValueDefinitionPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UserSetting;
+
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ValueDefinitionPass implements CompilerPassInterface
+{
+    public const TAG_NAME = 'ezplatform.admin_ui.user_setting.value';
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     *
+     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @throws \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(ValueDefinitionRegistry::class)) {
+            return;
+        }
+
+        $registryDefinition = $container->getDefinition(ValueDefinitionRegistry::class);
+        $taggedServiceIds = $container->findTaggedServiceIds(self::TAG_NAME);
+
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['identifier'])) {
+                    throw new InvalidArgumentException(
+                        $taggedServiceId,
+                        sprintf("Tag '%s' must contain 'identifier' argument.", self::TAG_NAME)
+                    );
+                }
+
+                $registryDefinition->addMethodCall('addValueDefinition', [$tag['identifier'], new Reference($taggedServiceId)]);
+            }
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *              trash_limit: 10
  *              section_limit: 10
  *              language_limit: 10
+ *              user_settings_limit: 10
  * ```
  */
 class Pagination extends AbstractParser
@@ -55,6 +56,7 @@ class Pagination extends AbstractParser
                     ->scalarNode('content_role_limit')->isRequired()->end()
                     ->scalarNode('content_policy_limit')->isRequired()->end()
                     ->scalarNode('notification_limit')->isRequired()->end()
+                    ->scalarNode('user_settings_limit')->isRequired()->end()
                 ->end()
             ->end();
     }
@@ -85,6 +87,7 @@ class Pagination extends AbstractParser
             'content_role_limit',
             'content_policy_limit',
             'notification_limit',
+            'user_settings_limit',
         ];
 
         foreach ($keys as $key) {

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUiBundle;
 
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UserSetting;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\AdminThemePathPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ComponentPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SecurityLoginPass;
@@ -60,6 +61,8 @@ class EzPlatformAdminUiBundle extends Bundle
         $container->addCompilerPass(new ComponentPass());
         $container->addCompilerPass(new SecurityLoginPass());
         $container->addCompilerPass(new ViewBuilderRegistryPass());
+        $container->addCompilerPass(new UserSetting\ValueDefinitionPass());
+        $container->addCompilerPass(new UserSetting\FormMapperPass());
         $container->addCompilerPass(new AdminThemePathPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -21,6 +21,7 @@ parameters:
     ezsettings.default.pagination.content_policy_limit: 5
     ezsettings.default.pagination.bookmark_limit: 10
     ezsettings.default.pagination.notification_limit: 5
+    ezsettings.default.pagination.user_settings_limit: 10
 
     # Security
     ezsettings.default.security.token_interval_spec: PT1H

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -575,6 +575,25 @@ ezplatform.user.reset_password:
         _controller: 'EzPlatformAdminUiBundle:User\UserForgotPassword:userResetPassword'
 
 #
+# User Settings
+#
+
+ezplatform.user_settings.list:
+    path: /user/settings/list/{page}
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:User\UserSettings:list'
+        page: 1
+    requirements:
+        page: \d+
+
+ezplatform.user_settings.update:
+    path: /user/settings/update/{identifier}
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:User\UserSettings:update'
+    requirements:
+        identifier: .+
+
+#
 # Profile
 #
 
@@ -698,6 +717,7 @@ ezplatform.udw.preselected_location.data:
 #
 # Bookmark manager
 #
+
 ezplatform.bookmark.list:
     path: /bookmark/list
     methods: ['GET']
@@ -713,6 +733,7 @@ ezplatform.bookmark.remove:
 #
 # Notifications
 #
+
 ezplatform.notifications.get:
     path: /notifications/{offset}/{limit}
     defaults:

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -16,6 +16,7 @@ imports:
     - { resource: services/form_ui_action_mappers.yml }
     - { resource: services/views.yml }
     - { resource: services/translation.yml }
+    - { resource: services/user_settings.yml }
 
 services:
     _defaults:

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -149,3 +149,5 @@ services:
     EzSystems\EzPlatformAdminUi\EventListener\MenuPermissionsListener:
         tags:
             - {name: kernel.event_subscriber, priority: -250}
+
+    EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UserPreferencesGlobalExtension: ~

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -96,7 +96,6 @@ services:
         arguments:
             $notificationPaginationLimit: '$pagination.notification_limit$'
 
-
     EzSystems\EzPlatformAdminUiBundle\Controller\User\UserSettingsController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -95,3 +95,9 @@ services:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $notificationPaginationLimit: '$pagination.notification_limit$'
+
+
+    EzSystems\EzPlatformAdminUiBundle\Controller\User\UserSettingsController:
+        parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
+        arguments:
+            $defaultPaginationLimit: '$pagination.user_settings_limit$'

--- a/src/bundle/Resources/config/services/menu.yml
+++ b/src/bundle/Resources/config/services/menu.yml
@@ -153,3 +153,9 @@ services:
         public: true
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.object_state_edit.sidebar_right }
+
+
+    EzSystems\EzPlatformAdminUi\Menu\UserSetting\UserSettingUpdateRightSidebarBuilder:
+        public: true
+        tags:
+            - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.user_setting_update.sidebar_right }

--- a/src/bundle/Resources/config/services/menu.yml
+++ b/src/bundle/Resources/config/services/menu.yml
@@ -154,7 +154,6 @@ services:
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.object_state_edit.sidebar_right }
 
-
     EzSystems\EzPlatformAdminUi\Menu\UserSetting\UserSettingUpdateRightSidebarBuilder:
         public: true
         tags:

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -1,0 +1,17 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService: ~
+    EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry: ~
+    EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry: ~
+
+    #
+    # User Settings Implementations
+    #
+    EzSystems\EzPlatformAdminUi\UserSetting\Setting\Timezone:
+        tags:
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: timezone }
+            - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: timezone }

--- a/src/bundle/Resources/translations/menu.en.xliff
+++ b/src/bundle/Resources/translations/menu.en.xliff
@@ -361,6 +361,11 @@
         <target state="new">Logout</target>
         <note>key: user__content</note>
       </trans-unit>
+      <trans-unit id="d4a0cfb90774164e94f11e2a4f019a2538faebcf" resname="user__settings">
+        <source>User Settings</source>
+        <target state="new">User Settings</target>
+        <note>key: user__settings</note>
+      </trans-unit>
       <trans-unit id="40679174821cfa2ce3d3a4dc046f0ef65df6f483" resname="user_create__sidebar_right__cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>

--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="fb1d64fdeabb5f2fe1671d4f3fb72ccca7722ed3" resname="list.action.edit">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note>key: list.action.edit</note>
+      </trans-unit>
+      <trans-unit id="9f3b1a45a0ce10a940f96bdba73bba914cc78bb6" resname="list.title">
+        <source>User Settings</source>
+        <target state="new">User Settings</target>
+        <note>key: list.title</note>
+      </trans-unit>
+      <trans-unit id="0b3e3c43abe2511b50431eb05045a7e5dbd7a36c" resname="my_account_settings.password.action.edit">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note>key: my_account_settings.password.action.edit</note>
+      </trans-unit>
+      <trans-unit id="49c8574da3abcfb5465e079bec34d32654da7535" resname="my_account_settings.password.description">
+        <source>Current password</source>
+        <target state="new">Current password</target>
+        <note>key: my_account_settings.password.description</note>
+      </trans-unit>
+      <trans-unit id="2273b0c5061ff374bd0d5a75e9301721f7312b65" resname="my_account_settings.password.title">
+        <source>Password</source>
+        <target state="new">Password</target>
+        <note>key: my_account_settings.password.title</note>
+      </trans-unit>
+      <trans-unit id="ecbb0cf3b32660e173d0b1e4af6a5c8470045128" resname="section.my_account_settings">
+        <source>My Account Settings</source>
+        <target state="new">My Account Settings</target>
+        <note>key: section.my_account_settings</note>
+      </trans-unit>
+      <trans-unit id="a225cd02a97a3cff5001bf4651bbe84dc62c3631" resname="section.my_preferences">
+        <source>My Preferences</source>
+        <target state="new">My Preferences</target>
+        <note>key: section.my_preferences</note>
+      </trans-unit>
+      <trans-unit id="dac7ffb84bac8bc5a682388098bded0f8f49d841" resname="settings.timezone.value.description">
+        <source><![CDATA[Time Zone in use for displaying Date & Time]]></source>
+        <target state="new"><![CDATA[Time Zone in use for displaying Date & Time]]></target>
+        <note>key: settings.timezone.value.description</note>
+      </trans-unit>
+      <trans-unit id="eb891d0f4283045b518a04aa757810f1ba0b90c9" resname="settings.timezone.value.title">
+        <source>Time Zone</source>
+        <target state="new">Time Zone</target>
+        <note>key: settings.timezone.value.title</note>
+      </trans-unit>
+      <trans-unit id="7f90e23e086f56c5f7b4a82c6e4b8f40732e6e6a" resname="user_setting.update.success">
+        <source>User setting '%identifier%' updated.</source>
+        <target state="new">User setting '%identifier%' updated.</target>
+        <note>key: user_setting.update.success</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/user-profile/change_user_password.html.twig
+++ b/src/bundle/Resources/views/user-profile/change_user_password.html.twig
@@ -1,3 +1,5 @@
+{# @todo move to view/user/settings in next major #}
+
 {% extends '@ezdesign/admin/base.html.twig' %}
 
 {% form_theme form_change_user_password '@ezdesign/user-profile/form_fields.html.twig'  %}

--- a/src/bundle/Resources/views/user-profile/form_fields.html.twig
+++ b/src/bundle/Resources/views/user-profile/form_fields.html.twig
@@ -1,3 +1,5 @@
+{# @todo move to view/user/preferences in the future #}
+
 {% use 'bootstrap_4_layout.html.twig' %}
 
 {% trans_default_domain 'change_user_password' %}

--- a/src/bundle/Resources/views/user/settings/list.html.twig
+++ b/src/bundle/Resources/views/user/settings/list.html.twig
@@ -1,0 +1,118 @@
+{% extends "@ezdesign/layout.html.twig" %}
+
+{% trans_default_domain 'user_settings' %}
+
+{% block breadcrumbs %}
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
+        { value: 'list.title'|trans|desc('User Settings') }
+    ]} %}
+{% endblock %}
+
+{% block page_title %}
+    {% include '@ezdesign/parts/page_title.html.twig' with {
+        title: 'list.title'|trans|desc('User Settings'),
+        iconName: 'user'
+    } %}
+    <ul class="nav nav-tabs ez-nav-tabs--role px-4 ez-tabs" role="tablist">
+        <li role="presentation" class="nav-item">
+            <a href="#my-preferences" class="nav-link active" role="tab" data-toggle="tab">
+                {{ 'section.my_preferences'|trans|desc('My Preferences') }}
+            </a>
+        </li>
+        <li role="presentation" class="nav-item">
+            <a href="#my-account-settings" class="nav-link" role="tab" data-toggle="tab">
+                {{ 'section.my_account_settings'|trans|desc('My Account Settings') }}
+            </a>
+        </li>
+    </ul>
+{% endblock %}
+
+{% block body_class %}ez-user-settings-list-view{% endblock %}
+
+{% block content %}
+    <section class="container mt-4 px-5 tab-content">
+        <div role="tabpanel" class="tab-pane active" id="my-preferences">
+
+            {% for user_setting in pager %}
+                <div class="ez-table-header">
+                    <div class="ez-table-header__headline">{{ user_setting.name }}</div>
+                </div>
+
+                <table class="table mb-3">
+                    {% if user_setting.description is not empty %}
+                        <thead>
+                            <tr>
+                                <th colspan="2">{{ user_setting.description }}</th>
+                            </tr>
+                        </thead>
+                    {% endif %}
+                    <tbody>
+                        <tr>
+                            <td>
+                                {{ user_setting.value|raw }}
+                            </td>
+                            <td class="text-right">
+                                <a
+                                    title="{{ 'list.action.edit'|trans|desc('Edit') }}"
+                                    href="{{ path('ezplatform.user_settings.update', { 'identifier': user_setting.identifier }) }}"
+                                    class="btn btn-icon mx-3">
+                                    <svg class="ez-icon ez-icon-edit">
+                                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                                    </svg>
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            {% endfor %}
+
+            {% if pager.haveToPaginate %}
+                <div class="row justify-content-center align-items-center ez-pagination__spacing mb-2">
+                <span class="ez-pagination__text">
+                    {{ 'pagination.viewing'|trans({
+                        '%viewing%': pager.currentPageResults|length,
+                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                </span>
+                </div>
+                <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
+                    {{ pagerfanta(pager, 'ez') }}
+                </div>
+            {% endif %}
+        </div>
+        <div role="tabpanel" class="tab-pane" id="my-account-settings">
+            <div class="ez-table-header">
+                <div class="ez-table-header__headline">{{ 'my_account_settings.password.title'|trans|desc('Password') }}</div>
+            </div>
+
+            <table class="table mb-3">
+                <tbody>
+                <tr>
+                    <td>
+                        {{ 'my_account_settings.password.description'|trans|desc('Current password') }}
+                    </td>
+                    <td class="text-right">
+                        <a title="{{ 'my_account_settings.password.action.edit'|trans|desc('Edit') }}"
+                           href="{{ path('ezplatform.user_profile.change_password') }}"
+                           class="btn btn-icon mx-3">
+                            <svg class="ez-icon ez-icon-edit">
+                                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                            </svg>
+                        </a>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </section>
+
+{% endblock %}
+
+{% block javascripts %}
+    {%  javascripts
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.content.edit.js'
+    %}
+        <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/bundle/Resources/views/user/settings/list.html.twig
+++ b/src/bundle/Resources/views/user/settings/list.html.twig
@@ -105,14 +105,4 @@
         </div>
 
     </section>
-
-{% endblock %}
-
-{% block javascripts %}
-    {%  javascripts
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.content.edit.js'
-    %}
-        <script type="text/javascript" src="{{ asset_url }}"></script>
-    {% endjavascripts %}
 {% endblock %}

--- a/src/bundle/Resources/views/user/settings/update.html.twig
+++ b/src/bundle/Resources/views/user/settings/update.html.twig
@@ -1,0 +1,38 @@
+{% extends '@ezdesign/admin/base.html.twig' %}
+
+{% trans_default_domain 'user_settings' %}
+
+{% block breadcrumbs_admin %}
+    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
+        { value: 'list.title'|trans|desc('User Settings') }
+    ]} %}
+{% endblock %}
+
+{% block page_title_admin %}
+    {% include '@ezdesign/parts/page_title.html.twig' with {
+        title: 'list.title'|trans|desc('User Settings'),
+        iconName: 'user'
+    } %}
+{% endblock %}
+
+{% block body_class %}ez-user-settings-update-view{% endblock %}
+
+{% block form %}
+    {% form_theme form '@ezdesign/form_fields.html.twig' %}
+    {{ form_start(form) }}
+    {{ form_widget(form.identifier, {'attr': {'hidden': 'hidden'}}) }}
+    <div class="ez-table-header ground-base">
+        <div class="ez-table-header__headline">{{ user_setting.name }}</div>
+    </div>
+    <div class="bg-white p-4">
+        {{ form_row(form.value) }}
+    </div>
+    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
+    {{ form_end(form) }}
+
+{% endblock %}
+
+{% block right_sidebar %}
+    {% set user_setting_update_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.user_setting_update.sidebar_right', [], {'user_setting': user_setting}) %}
+    {{ knp_menu_render(user_setting_update_sidebar_right, {'template': '@ezdesign/parts/menu/sidebar_right.html.twig'}) }}
+{% endblock %}

--- a/src/bundle/Resources/views/user/settings/update.html.twig
+++ b/src/bundle/Resources/views/user/settings/update.html.twig
@@ -27,7 +27,6 @@
     <div class="bg-white p-4">
         {{ form_row(form.value) }}
     </div>
-    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
     {{ form_end(form) }}
 
 {% endblock %}

--- a/src/bundle/Templating/Twig/UserPreferencesGlobalExtension.php
+++ b/src/bundle/Templating/Twig/UserPreferencesGlobalExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
+
+use EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+/**
+ * @internal
+ *
+ * @todo provide extensibility to map selected settings
+ */
+class UserPreferencesGlobalExtension extends AbstractExtension implements GlobalsInterface
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService */
+    protected $userSettingService;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService $userSettingService
+     */
+    public function __construct(
+        UserSettingService $userSettingService
+    ) {
+        $this->userSettingService = $userSettingService;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function getGlobals(): array
+    {
+        return [
+            'ez_user_settings' => $this->getUserSettings(),
+        ];
+    }
+
+    /**
+     * @return array
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function getUserSettings(): array
+    {
+        return [
+            'timezone' => $this->getTimezoneValue(),
+        ];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function getTimezoneValue(): string
+    {
+        return $this->userSettingService->getUserSetting('timezone')->value;
+    }
+}

--- a/src/lib/Form/Data/User/Setting/UserSettingUpdateData.php
+++ b/src/lib/Form/Data/User/Setting/UserSettingUpdateData.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Data\User\Setting;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @property-read string $identifier
+ * @property-read string $value
+ */
+class UserSettingUpdateData
+{
+    /**
+     * @Assert\NotBlank()
+     *
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * @param string $identifier
+     * @param string $value
+     */
+    public function __construct(?string $identifier = null, ?string $value = null)
+    {
+        $this->identifier = $identifier;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setValue(?string $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/lib/Form/Data/User/Setting/UserSettingUpdateData.php
+++ b/src/lib/Form/Data/User/Setting/UserSettingUpdateData.php
@@ -10,10 +10,6 @@ namespace EzSystems\EzPlatformAdminUi\Form\Data\User\Setting;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @property-read string $identifier
- * @property-read string $value
- */
 class UserSettingUpdateData
 {
     /**

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -63,6 +63,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashEmptyData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashItemDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashItemRestoreData;
+use EzSystems\EzPlatformAdminUi\Form\Data\User\Setting\UserSettingUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\User\UserPasswordChangeData;
 use EzSystems\EzPlatformAdminUi\Form\Data\User\UserDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\User\UserPasswordForgotData;
@@ -99,6 +100,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStateGroupsDeleteTyp
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStatesDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyCreateWithLimitationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Trash\TrashItemDeleteType;
+use EzSystems\EzPlatformAdminUi\Form\Type\User\Setting\UserSettingUpdateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\User\UserPasswordChangeType;
 use EzSystems\EzPlatformAdminUi\Form\Type\User\UserDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ContentObjectStateUpdateType;
@@ -1212,5 +1214,27 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(BookmarkRemoveType::class);
 
         return $this->formFactory->createNamed($name, BookmarkRemoveType::class, $data);
+    }
+
+    /**
+     * @param string $userSettingIdentifier
+     * @param \EzSystems\EzPlatformAdminUi\Form\Data\User\Setting\UserSettingUpdateData $data
+     * @param string|null $name
+     *
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    public function updateUserSetting(
+        string $userSettingIdentifier,
+        UserSettingUpdateData $data = null,
+        ?string $name = null
+    ): FormInterface {
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(UserSettingUpdateType::class);
+
+        return $this->formFactory->createNamed(
+            $name,
+            UserSettingUpdateType::class,
+            $data,
+            ['user_setting_identifier' => $userSettingIdentifier]
+        );
     }
 }

--- a/src/lib/Form/Type/User/Setting/UserSettingUpdateType.php
+++ b/src/lib/Form/Type/User/Setting/UserSettingUpdateType.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\User\Setting;
+
+use EzSystems\EzPlatformAdminUi\Form\Data\User\Setting\UserSettingUpdateData;
+use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserSettingUpdateType extends AbstractType
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry */
+    protected $formMapperRegistry;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry */
+    protected $valueDefinitionRegistry;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry $formMapperRegistry
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry $valueDefinitionRegistry
+     */
+    public function __construct(
+        FormMapperRegistry $formMapperRegistry,
+        ValueDefinitionRegistry $valueDefinitionRegistry
+    ) {
+        $this->formMapperRegistry = $formMapperRegistry;
+        $this->valueDefinitionRegistry = $valueDefinitionRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $formMapper = $this->formMapperRegistry->getFormMapper($options['user_setting_identifier']);
+        $valueDefinition = $this->valueDefinitionRegistry->getValueDefinition($options['user_setting_identifier']);
+
+        $builder
+            ->add('identifier', TextType::class, [])
+            ->add($formMapper->mapFieldForm($builder, $valueDefinition))
+            ->add('update', SubmitType::class, [])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setRequired('user_setting_identifier')
+            ->setAllowedTypes('user_setting_identifier', 'string')
+            ->setAllowedValues('user_setting_identifier', array_keys($this->formMapperRegistry->getFormMappers()))
+            ->setDefaults([
+                'data_class' => UserSettingUpdateData::class,
+                'translation_domain' => 'forms',
+            ]);
+    }
+}

--- a/src/lib/Form/Type/User/Setting/UserSettingUpdateType.php
+++ b/src/lib/Form/Type/User/Setting/UserSettingUpdateType.php
@@ -11,9 +11,10 @@ namespace EzSystems\EzPlatformAdminUi\Form\Type\User\Setting;
 use EzSystems\EzPlatformAdminUi\Form\Data\User\Setting\UserSettingUpdateData;
 use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperRegistry;
 use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry;
+use RuntimeException;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -48,10 +49,14 @@ class UserSettingUpdateType extends AbstractType
         $valueDefinition = $this->valueDefinitionRegistry->getValueDefinition($options['user_setting_identifier']);
 
         $builder
-            ->add('identifier', TextType::class, [])
+            ->add('identifier', HiddenType::class, [])
             ->add($formMapper->mapFieldForm($builder, $valueDefinition))
             ->add('update', SubmitType::class, [])
         ;
+
+        if (!$builder->has('value')) {
+            throw new RuntimeException("FormMapper should create 'value' field");
+        }
     }
 
     /**
@@ -66,6 +71,7 @@ class UserSettingUpdateType extends AbstractType
             ->setDefaults([
                 'data_class' => UserSettingUpdateData::class,
                 'translation_domain' => 'forms',
-            ]);
+            ])
+        ;
     }
 }

--- a/src/lib/Menu/Event/ConfigureMenuEvent.php
+++ b/src/lib/Menu/Event/ConfigureMenuEvent.php
@@ -45,6 +45,7 @@ class ConfigureMenuEvent extends Event
     const OBJECT_STATE_GROUP_EDIT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.object_state_group_edit_sidebar_right';
     const OBJECT_STATE_CREATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.object_state_create_sidebar_right';
     const OBJECT_STATE_EDIT_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.object_state_edit_sidebar_right';
+    const USER_SETTING_UPDATE_SIDEBAR_RIGHT = 'ezplatform_admin_ui.menu_configure.user_setting_update_sidebar_right';
 
     /** @var FactoryInterface */
     private $factory;

--- a/src/lib/Menu/UserMenuBuilder.php
+++ b/src/lib/Menu/UserMenuBuilder.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Menu;
 
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
-use InvalidArgumentException;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Knp\Menu\ItemInterface;
@@ -25,16 +24,17 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
 {
     const ITEM_LOGOUT = 'user__content';
     const ITEM_CHANGE_PASSWORD = 'user__change_password';
+    const ITEM_USER_SETTINGS = 'user__settings';
     const ITEM_BOOKMARK = 'user__bookmark';
     const ITEM_NOTIFICATION = 'menu.notification';
 
-    /** @var TokenStorageInterface */
+    /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface */
     private $tokenStorage;
 
     /**
      * @param MenuItemFactory $factory
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param TokenStorageInterface $tokenStorage
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage
      */
     public function __construct(
         MenuItemFactory $factory,
@@ -46,6 +46,9 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         $this->tokenStorage = $tokenStorage;
     }
 
+    /**
+     * @return string
+     */
     protected function getConfigureEventName(): string
     {
         return ConfigureMenuEvent::USER_MENU;
@@ -54,9 +57,9 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
     /**
      * @param array $options
      *
-     * @return ItemInterface
+     * @return \Knp\Menu\ItemInterface
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function createStructure(array $options): ItemInterface
     {
@@ -66,6 +69,9 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         if (null !== $token && is_object($token->getUser())) {
             $menu->addChild(
                 $this->createMenuItem(self::ITEM_CHANGE_PASSWORD, ['route' => 'ezplatform.user_profile.change_password'])
+            );
+            $menu->addChild(
+                $this->createMenuItem(self::ITEM_USER_SETTINGS, ['route' => 'ezplatform.user_settings.list'])
             );
             $menu->addChild(
                 $this->createMenuItem(self::ITEM_BOOKMARK, ['route' => 'ezplatform.bookmark.list'])
@@ -97,6 +103,7 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         return [
             (new Message(self::ITEM_LOGOUT, 'menu'))->setDesc('Logout'),
             (new Message(self::ITEM_CHANGE_PASSWORD, 'menu'))->setDesc('Change password'),
+            (new Message(self::ITEM_USER_SETTINGS, 'menu'))->setDesc('User Settings'),
             (new Message(self::ITEM_BOOKMARK, 'menu'))->setDesc('Bookmarks'),
             (new Message(self::ITEM_NOTIFICATION, 'notifications'))->setDesc('View Notifications'),
         ];

--- a/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
+++ b/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Menu\UserSetting;
+
+use EzSystems\EzPlatformAdminUi\Menu\AbstractBuilder;
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use InvalidArgumentException;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Knp\Menu\ItemInterface;
+
+/**
+ * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
+ *
+ * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
+ */
+class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements TranslationContainerInterface
+{
+    /* Menu items */
+    const ITEM__SAVE = 'object_state_edit__sidebar_right__save';
+    const ITEM__CANCEL = 'object_state_edit__sidebar_right__cancel';
+
+    /**
+     * @return string
+     */
+    protected function getConfigureEventName(): string
+    {
+        return ConfigureMenuEvent::USER_SETTING_UPDATE_SIDEBAR_RIGHT;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return ItemInterface
+     *
+     * @throws InvalidArgumentException
+     */
+    public function createStructure(array $options): ItemInterface
+    {
+        /** @var ItemInterface|ItemInterface[] $menu */
+        $menu = $this->factory->createItem('root');
+
+        $menu->setChildren([
+            self::ITEM__SAVE => $this->createMenuItem(
+                self::ITEM__SAVE,
+                [
+                    'attributes' => [
+                        'class' => 'btn--trigger',
+                        'data-click' => '#user_setting_update_update',
+                    ],
+                    'extras' => ['icon' => 'publish'],
+                ]
+            ),
+            self::ITEM__CANCEL => $this->createMenuItem(
+                self::ITEM__CANCEL,
+                [
+                    'route' => 'ezplatform.user_settings.list',
+                    'extras' => ['icon' => 'circle-close'],
+                ]
+            ),
+        ]);
+
+        return $menu;
+    }
+
+    /**
+     * @return Message[]
+     */
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message(self::ITEM__SAVE, 'menu'))->setDesc('Save'),
+            (new Message(self::ITEM__CANCEL, 'menu'))->setDesc('Discard changes'),
+        ];
+    }
+}

--- a/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
+++ b/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
@@ -10,13 +10,12 @@ namespace EzSystems\EzPlatformAdminUi\Menu\UserSetting;
 
 use EzSystems\EzPlatformAdminUi\Menu\AbstractBuilder;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
-use InvalidArgumentException;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Knp\Menu\ItemInterface;
 
 /**
- * KnpMenuBundle Menu Builder service implementation for AdminUI Section Edit contextual sidebar menu.
+ * KnpMenuBundle Menu Builder service implementation for User Setting Edit contextual sidebar menu.
  *
  * @see https://symfony.com/doc/current/bundles/KnpMenuBundle/menu_builder_service.html
  */
@@ -37,9 +36,9 @@ class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements Tr
     /**
      * @param array $options
      *
-     * @return ItemInterface
+     * @return \Knp\Menu\ItemInterface
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function createStructure(array $options): ItemInterface
     {
@@ -70,7 +69,7 @@ class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements Tr
     }
 
     /**
-     * @return Message[]
+     * @return \JMS\TranslationBundle\Model\Message[]
      */
     public static function getTranslationMessages(): array
     {

--- a/src/lib/Pagination/Pagerfanta/UserSettingsAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/UserSettingsAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta;
+
+use EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService;
+use Pagerfanta\Adapter\AdapterInterface;
+
+class UserSettingsAdapter implements AdapterInterface
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService */
+    private $userSettingService;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService $userSettingService
+     */
+    public function __construct(UserSettingService $userSettingService)
+    {
+        $this->userSettingService = $userSettingService;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getNbResults(): int
+    {
+        return $this->userSettingService->countUserSettings();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function getSlice($offset, $length): array
+    {
+        return $this->userSettingService->loadUserSettings($offset, $length);
+    }
+}

--- a/src/lib/UserSetting/FormMapperInterface.php
+++ b/src/lib/UserSetting/FormMapperInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+use Symfony\Component\Form\FormBuilderInterface;
+
+interface FormMapperInterface
+{
+    /**
+     * Creates 'value' form type representing editing control for setting user preference value.
+     *
+     * @param \Symfony\Component\Form\FormBuilderInterface $formBuilder
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface $value
+     *
+     * @return \Symfony\Component\Form\FormBuilderInterface
+     */
+    public function mapFieldForm(
+        FormBuilderInterface $formBuilder,
+        ValueDefinitionInterface $value
+    ): FormBuilderInterface;
+}

--- a/src/lib/UserSetting/FormMapperRegistry.php
+++ b/src/lib/UserSetting/FormMapperRegistry.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * @internal
+ */
+class FormMapperRegistry
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface[] */
+    protected $formMappers;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface[] $formMappers
+     */
+    public function __construct(array $formMappers = [])
+    {
+        $this->formMappers = $formMappers;
+    }
+
+    /**
+     * @param string $identifier
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface $formMapper
+     */
+    public function addFormMapper(
+        string $identifier,
+        FormMapperInterface $formMapper
+    ): void {
+        $this->formMappers[$identifier] = $formMapper;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getFormMapper(string $identifier): FormMapperInterface
+    {
+        if (!isset($this->formMappers[$identifier])) {
+            throw new InvalidArgumentException(
+                '$identifier',
+                sprintf('There is no Form Mapper registered for \'%s\' identifier', $identifier)
+            );
+        }
+
+        return $this->formMappers[$identifier];
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface[]
+     */
+    public function getFormMappers(): array
+    {
+        return $this->formMappers;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface[] $formMappers
+     */
+    public function setFormMappers(array $formMappers): void
+    {
+        $this->formMappers = $formMappers;
+    }
+}

--- a/src/lib/UserSetting/FormMapperRegistry.php
+++ b/src/lib/UserSetting/FormMapperRegistry.php
@@ -63,12 +63,4 @@ class FormMapperRegistry
     {
         return $this->formMappers;
     }
-
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface[] $formMappers
-     */
-    public function setFormMappers(array $formMappers): void
-    {
-        $this->formMappers = $formMappers;
-    }
 }

--- a/src/lib/UserSetting/Setting/Timezone.php
+++ b/src/lib/UserSetting/Setting/Timezone.php
@@ -80,8 +80,11 @@ class Timezone implements ValueDefinitionInterface, FormMapperInterface
      */
     private function getTranslatedName(): string
     {
-        return /** @Desc("Time Zone") */
-            $this->translator->trans('settings.timezone.value.title', [], 'user_settings');
+        return $this->translator->trans(
+            /** @Desc("Time Zone") */ 'settings.timezone.value.title',
+            [],
+            'user_settings'
+        );
     }
 
     /**
@@ -89,7 +92,10 @@ class Timezone implements ValueDefinitionInterface, FormMapperInterface
      */
     private function getTranslatedDescription(): string
     {
-        return /** @Desc("Time Zone in use for displaying Date & Time") */
-            $this->translator->trans('settings.timezone.value.description', [], 'user_settings');
+        return $this->translator->trans(
+            /** @Desc("Time Zone in use for displaying Date & Time") */ 'settings.timezone.value.description',
+            [],
+            'user_settings'
+        );
     }
 }

--- a/src/lib/UserSetting/Setting/Timezone.php
+++ b/src/lib/UserSetting/Setting/Timezone.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting\Setting;
+
+use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class Timezone implements ValueDefinitionInterface, FormMapperInterface
+{
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    /**
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->getTranslatedName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): string
+    {
+        return $this->getTranslatedDescription();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDisplayValue(string $storageValue): string
+    {
+        return $storageValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValue(): string
+    {
+        return date_default_timezone_get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFieldForm(FormBuilderInterface $formBuilder, ValueDefinitionInterface $value): FormBuilderInterface
+    {
+        return $formBuilder->create(
+            'value',
+            TimezoneType::class,
+            [
+                'multiple' => false,
+                'required' => true,
+                'label' => $this->getTranslatedDescription(),
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedName(): string
+    {
+        return /** @Desc("Time Zone") */
+            $this->translator->trans('settings.timezone.value.title', [], 'user_settings');
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedDescription(): string
+    {
+        return /** @Desc("Time Zone in use for displaying Date & Time") */
+            $this->translator->trans('settings.timezone.value.description', [], 'user_settings');
+    }
+}

--- a/src/lib/UserSetting/UserSetting.php
+++ b/src/lib/UserSetting/UserSetting.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+class UserSetting extends ValueObject
+{
+    /** @var string */
+    protected $identifier;
+
+    /** @var string */
+    protected $name;
+
+    /** @var string */
+    protected $description;
+
+    /** @var string */
+    protected $value;
+}

--- a/src/lib/UserSetting/UserSettingService.php
+++ b/src/lib/UserSetting/UserSettingService.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\UserPreferenceService;
+use eZ\Publish\API\Repository\Values\UserPreference\UserPreferenceSetStruct;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+
+/**
+ * @internal
+ */
+class UserSettingService
+{
+    /** @var \eZ\Publish\API\Repository\UserPreferenceService */
+    protected $userPreferenceService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry */
+    protected $valueRegistry;
+
+    /**
+     * @param \eZ\Publish\API\Repository\UserPreferenceService $userPreferenceService
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionRegistry $valueRegistry
+     */
+    public function __construct(
+        UserPreferenceService $userPreferenceService,
+        ValueDefinitionRegistry $valueRegistry
+    ) {
+        $this->userPreferenceService = $userPreferenceService;
+        $this->valueRegistry = $valueRegistry;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $value
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
+     */
+    public function setUserSetting(string $identifier, string $value): void
+    {
+        $userPreferenceSetStructs = [
+            new UserPreferenceSetStruct(['name' => $identifier, 'value' => $value]),
+        ];
+
+        $this->userPreferenceService->setUserPreference($userPreferenceSetStructs);
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\UserSetting
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function getUserSetting(string $identifier): UserSetting
+    {
+        if (!$this->valueRegistry->hasValueDefinition($identifier)) {
+            throw new InvalidArgumentException(
+                '$identifier',
+                sprintf("There is no ValueDefinition for '%s'. Did you register the service?", $identifier)
+            );
+        }
+
+        $value = $this->valueRegistry->getValueDefinition($identifier);
+
+        try {
+            $userPreference = $this->userPreferenceService->getUserPreference($identifier);
+            $userPreferenceValue = $userPreference->value;
+        } catch (NotFoundException $e) {
+            $userPreferenceValue = $value->getDefaultValue();
+        }
+
+        return $this->createUserSetting($identifier, $value, $userPreferenceValue);
+    }
+
+    /**
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function loadUserSettings(int $offset = 0, int $limit = 25): array
+    {
+        $values = $this->valueRegistry->getValueDefinitions();
+        /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $slice */
+        $slice = \array_slice($values, $offset, $limit, true);
+
+        $userPreferences = [];
+        foreach ($slice as $identifier => $userSettingDefinition) {
+            try {
+                $userPreference = $this->userPreferenceService->getUserPreference($identifier);
+                $userPreferenceValue = $userPreference->value;
+            } catch (NotFoundException $e) {
+                $userPreferenceValue = $userSettingDefinition->getDefaultValue();
+            }
+            $userPreferences[$identifier] = $userPreferenceValue;
+        }
+
+        return $this->createUserSettings($values, $userPreferences);
+    }
+
+    /**
+     * @return int
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function countUserSettings(): int
+    {
+        // @todo fix as soon as UserPreferenceService has appropriate method
+        return $this->userPreferenceService->loadUserPreferences(0, 1)->totalCount;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $values
+     * @param array $userPreferences
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\UserSetting[]
+     */
+    private function createUserSettings(array $values, array $userPreferences): array
+    {
+        $userSettings = [];
+
+        foreach ($values as $identifier => $value) {
+            $userSettings[] = $this->createUserSetting($identifier, $value, $userPreferences[$identifier]);
+        }
+
+        return $userSettings;
+    }
+
+    /**
+     * @param string $identifier
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface $value
+     * @param string $userPreferenceValue
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\UserSetting
+     */
+    private function createUserSetting(
+        string $identifier,
+        ValueDefinitionInterface $value,
+        string $userPreferenceValue
+    ): UserSetting {
+        return new UserSetting([
+            'identifier' => $identifier,
+            'name' => $value->getName(),
+            'description' => $value->getDescription(),
+            'value' => $value->getDisplayValue($userPreferenceValue),
+        ]);
+    }
+}

--- a/src/lib/UserSetting/UserSettingService.php
+++ b/src/lib/UserSetting/UserSettingService.php
@@ -92,13 +92,10 @@ class UserSettingService
 
     /**
      * @return int
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function countUserSettings(): int
     {
-        // @todo fix as soon as UserPreferenceService has appropriate method
-        return $this->userPreferenceService->loadUserPreferences(0, 1)->totalCount;
+        return $this->userPreferenceService->getUserPreferenceCount();
     }
 
     /**

--- a/src/lib/UserSetting/ValueDefinitionInterface.php
+++ b/src/lib/UserSetting/ValueDefinitionInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+/**
+ * Interface for displaying User Preferences in the Admin UI.
+ *
+ * User Preferences are not displayed by default unless
+ * ValueDefinitionInterface implementation is provided.
+ */
+interface ValueDefinitionInterface
+{
+    /**
+     * Returns name of a User Preference displayed in UI.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Returns description of a User Preference displayed in UI.
+     *
+     * @return string
+     */
+    public function getDescription(): string;
+
+    /**
+     * Returns formatted value to be displayed in UI.
+     *
+     * @param string $storageValue
+     *
+     * @return string
+     */
+    public function getDisplayValue(string $storageValue): string;
+
+    /**
+     * Returns default value for User Preference if none is defined.
+     *
+     * @return string
+     */
+    public function getDefaultValue(): string;
+}

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * @internal
+ */
+class ValueDefinitionRegistry
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] */
+    protected $valueDefinitions;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $valueDefinitions
+     */
+    public function __construct(array $valueDefinitions = [])
+    {
+        $this->valueDefinitions = $valueDefinitions;
+    }
+
+    /**
+     * @param string $identifier
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface $valueDefinition
+     */
+    public function addValueDefinition(
+        string $identifier,
+        ValueDefinitionInterface $valueDefinition
+    ): void {
+        $this->valueDefinitions[$identifier] = $valueDefinition;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getValueDefinition(string $identifier): ValueDefinitionInterface
+    {
+        if (!isset($this->valueDefinitions[$identifier])) {
+            throw new InvalidArgumentException(
+                '$identifier',
+                sprintf('There is no User Setting Value registered for \'%s\' identifier', $identifier)
+            );
+        }
+
+        return $this->valueDefinitions[$identifier];
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return bool
+     */
+    public function hasValueDefinition(string $identifier): bool
+    {
+        return isset($this->valueDefinitions[$identifier]);
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[]
+     */
+    public function getValueDefinitions(): array
+    {
+        return $this->valueDefinitions;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $valueDefinitions
+     */
+    public function setValueDefinitions(array $valueDefinitions): void
+    {
+        $this->valueDefinitions = $valueDefinitions;
+    }
+}

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -49,7 +49,7 @@ class ValueDefinitionRegistry
         if (!isset($this->valueDefinitions[$identifier])) {
             throw new InvalidArgumentException(
                 '$identifier',
-                sprintf('There is no User Setting Value registered for \'%s\' identifier', $identifier)
+                sprintf('There is no ValueDefinition service registered for \'%s\' identifier', $identifier)
             );
         }
 
@@ -72,13 +72,5 @@ class ValueDefinitionRegistry
     public function getValueDefinitions(): array
     {
         return $this->valueDefinitions;
-    }
-
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $valueDefinitions
-     */
-    public function setValueDefinitions(array $valueDefinitions): void
-    {
-        $this->valueDefinitions = $valueDefinitions;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29575
| Requires | https://github.com/ezsystems/ezpublish-kernel/pull/2426
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds editing interface for User Preferences API added in https://github.com/ezsystems/ezpublish-kernel/pull/2426. 

### How it works?
It uses UP API as a storage which means you need to provide a service implementing `ValueDefinitionInterface` and `FormMapperInterface`. AdminUI won't display all User Preferences out-of-the-box unless you provide:
- `ValueDefinitionInterface` defining how User Preference is displayed in the UI (name, description, formatted value)
- `FormMapperInterface` mapping UP to form type i.e. checkbox, dropdown, input, textarea

To avoid names confusion I used UserSetting name to differentiate it from Preferences.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
