### PR TITLE
EZP-29576: Location Swap and Sort Order panels are using one cell <table> elements

### DIFF
--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -133,26 +133,20 @@
     ground: 'ground-base'
 } %}
 
-<table class="table ez-table--no-border">
-    <tbody>
-    <tr>
-        <td data-sort-field="{{ sort_field_clause_map[location.sortField] }}" data-sort-order="{{ location.sortOrder ? "ascending" : "descending" }}">
-            {{ form_start(form_location_update, {
-                'method': 'POST',
-                'action': path('ezplatform.location.update'),
-                'attr': {'class': 'form-inline ez-form-inline'}
-                }) }}
+<div class="bg-white p-3 mb-5" data-sort-field="{{ sort_field_clause_map[location.sortField] }}" data-sort-order="{{ location.sortOrder ? 'ascending' : 'descending' }}">
+    {{ form_start(form_location_update, {
+        'method': 'POST',
+        'action': path('ezplatform.location.update'),
+        'attr': {'class': 'form-inline ez-form-inline justify-content-start'}
+        }) }}
 
-                {{ form_label(form_location_update.sort_field, 'tab.details.sub_items_listing_by.order_by'|trans|desc('Order by')) }}
-                {{ form_widget(form_location_update.sort_field) }}
+        {{ form_label(form_location_update.sort_field, 'tab.details.sub_items_listing_by.order_by'|trans|desc('Order by')) }}
+        {{ form_widget(form_location_update.sort_field) }}
 
-                {{ form_label(form_location_update.sort_order, 'tab.details.sub_items_listing_by.in'|trans|desc('in')) }}
-                {{ form_widget(form_location_update.sort_order) }}
+        {{ form_label(form_location_update.sort_order, 'tab.details.sub_items_listing_by.in'|trans|desc('in')) }}
+        {{ form_widget(form_location_update.sort_order) }}
 
-                {{ form_widget(form_location_update.update, { 'label': 'tab.details.sub_items_listing_by_set'|trans|desc('Set'), 'translation_domain': false, 'attr': {'class': 'btn-secondary'} }) }}
+        {{ form_widget(form_location_update.update, { 'label': 'tab.details.sub_items_listing_by_set'|trans|desc('Set'), 'translation_domain': false, 'attr': {'class': 'btn-secondary'} }) }}
 
-            {{ form_end(form_location_update) }}
-        </td>
-    </tr>
-    </tbody>
-</table>
+    {{ form_end(form_location_update) }}
+</div>

--- a/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/panel_swap.html.twig
@@ -6,20 +6,14 @@
 } %}
 
 {{ form_start(form, {'action': path('ezplatform.location.swap')}) }}
-<table class="table ez-table--no-border">
-    <tbody>
-    <tr>
-        <td>
-            {{ 'tab.locations.swap_with_another'|trans()|desc('Swap the content item at this location with another') }}
-            {{ form_widget(form.swap, {'attr': {
-                'disabled': not can_swap,
-                'class': 'btn-outline-secondary btn--udw-swap ml-5',
-                'data-udw-config': ez_udw_config('single_container', {})
-            }}) }}
-            {{ form_widget(form.current_location) }}
-            {{ form_widget(form.new_location) }}
-        </td>
-    </tr>
-    </tbody>
-</table>
+<div class="bg-white p-3 mb-5">
+    {{ 'tab.locations.swap_with_another'|trans()|desc('Swap the content item at this location with another') }}
+    {{ form_widget(form.swap, {'attr': {
+        'disabled': not can_swap,
+        'class': 'btn-outline-secondary btn--udw-swap ml-5',
+        'data-udw-config': ez_udw_config('single_container', {})
+    }}) }}
+    {{ form_widget(form.current_location) }}
+    {{ form_widget(form.new_location) }}
+</div>
 {{ form_end(form) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29576
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

I recommend drinking a coffee or two before committing one cell tables to any repository.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
