### PR TITLE
EZP-29599: Improved spacing among field types in Edit view

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -42,3 +42,31 @@
         }
     }
 }
+
+.ez-content-edit {
+    .ez-field-edit {
+        margin: calculateRem(24px) 0;
+
+        &__label-wrapper {
+            .ez-field-edit {
+                &__label {
+                    margin-top: 0;
+                }
+            }
+        }
+
+        &--ezdate,
+        &--eztime,
+        &--ezdatetime {
+            .ez-field-edit__data {
+                .form-control {
+                    margin-bottom: calculateRem(-8px);
+                }
+            }
+        }
+    }
+
+    .card-body {
+        padding: 0 calculateRem(20px);
+    }
+}

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezobjectrelationlist.scss
@@ -29,6 +29,7 @@
     }
 
     .ez-relations__table {
+        margin-bottom: 0;
         word-break: break-all;
 
         &-header {

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container mt-4 px-5">
+    <section class="container mt-4 mb-5 px-5">
         <div class="card ez-card">
             <div class="card-body">
                 {{ parent() }}

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container mt-4 px-5">
+    <section class="container mt-4 px-5 mb-5">
         <div class="card ez-card">
             <div class="card-body">
                 {{ parent() }}

--- a/src/bundle/Resources/views/content/content_edit/user_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_create.html.twig
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container mt-4 px-5">
+    <section class="container mt-4 mb-5 px-5">
         <div class="card ez-card">
             <div class="card-body">
                 {{ parent() }}

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container mt-4 px-5">
+    <section class="container mt-4 mb-5 px-5">
         <div class="card ez-card">
             <div class="card-body">
                 {{ parent() }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29599](https://jira.ez.no/browse/EZP-29599)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspects:
- Harmonized spacing among field types in Edit view, so that this view has a balanced UI structure making it easier to scan information for users;
- Added extra off-set margin-bottom.

![ez platform 12](https://user-images.githubusercontent.com/9256718/45320932-f25c3200-b511-11e8-8ef1-9178e591c938.png)
![ez platform 13](https://user-images.githubusercontent.com/9256718/45320933-f2f4c880-b511-11e8-9aff-44221fdaa4e4.png)
![ez platform 14](https://user-images.githubusercontent.com/9256718/45320935-f2f4c880-b511-11e8-8dd9-486b309a5b39.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
