### PR TITLE
EZP-29606: As a developer I want to have a generic interface for drag and drop interactions

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/draggable.js
+++ b/src/bundle/Resources/public/js/scripts/core/draggable.js
@@ -1,0 +1,120 @@
+(function(global, doc) {
+    const SELECTOR_PLACEHOLDER = '.ez-draggable__placeholder';
+    const TIMEOUT_REMOVE_PLACEHOLDERS = 500;
+    const DEFAULTS = {
+        afterInit: () => {},
+        afterDragStart: () => {},
+        afterDragOver: () => {},
+        afterDrop: () => {},
+        attachCustomEventHandlersToItem: () => {},
+    };
+
+    const attachEventHandlersToItem = Symbol('attachEventHandlersToItem');
+    const onDragStart = Symbol('onDragStart');
+    const onDragOver = Symbol('onDragOver');
+    const onDrop = Symbol('onDrop');
+    const addPlaceholder = Symbol('addPlaceholder');
+    const removePlaceholder = Symbol('removePlaceholder');
+    const removePlaceholderAfterTimeout = Symbol('removePlaceholderAfterTimeout');
+    const draggedItem = Symbol('draggedItem');
+    const placeholder = Symbol('placeholder');
+    const onDragOverTimeout = Symbol('onDragOverTimeout');
+
+    class Draggable {
+        constructor(config) {
+            this[draggedItem] = null;
+            this[placeholder] = null;
+            this[onDragOverTimeout] = null;
+            this.itemsContainer = config.itemsContainer;
+            this.selectorItem = config.selectorItem;
+            this.selectorPlaceholder = config.selectorPlaceholder || SELECTOR_PLACEHOLDER;
+            this.afterInit = config.afterInit || DEFAULTS.afterInit;
+            this.afterDragStart = config.afterDragStart || DEFAULTS.afterDragStart;
+            this.afterDragOver = config.afterDragOver || DEFAULTS.afterDragOver;
+            this.afterDrop = config.afterDrop || DEFAULTS.afterDrop;
+            this.attachCustomEventHandlersToItem = config.attachCustomEventHandlersToItem || DEFAULTS.attachCustomEventHandlersToItem;
+
+            this[onDragStart] = this[onDragStart].bind(this);
+            this[onDragOver] = this[onDragOver].bind(this);
+            this[onDrop] = this[onDrop].bind(this);
+            this[addPlaceholder] = this[addPlaceholder].bind(this);
+            this[removePlaceholder] = this[removePlaceholder].bind(this);
+            this[removePlaceholderAfterTimeout] = this[removePlaceholderAfterTimeout].bind(this);
+            this[attachEventHandlersToItem] = this[attachEventHandlersToItem].bind(this);
+        }
+
+        [attachEventHandlersToItem](item) {
+            item.ondragstart = this[onDragStart];
+            item.ondrag = this[removePlaceholderAfterTimeout];
+
+            this.attachCustomEventHandlersToItem(item);
+        }
+
+        [onDragStart](event) {
+            event.dataTransfer.dropEffect = 'move';
+            event.dataTransfer.setData('text/html', event.currentTarget);
+
+            this[draggedItem] = event.currentTarget;
+            this.afterDragStart(this[draggedItem]);
+        }
+
+        [onDragOver](event) {
+            const item = event.target.closest(`${this.selectorItem}:not(${this.selectorPlaceholder})`);
+
+            if (!item) {
+                return false;
+            }
+
+            this[removePlaceholder]();
+            this[addPlaceholder](item, event.clientY);
+            this.afterDragOver();
+        }
+
+        [onDrop]() {
+            this.itemsContainer.insertBefore(this[draggedItem], this.itemsContainer.querySelector(this.selectorPlaceholder));
+            this[removePlaceholder]();
+            this.afterDrop(this[draggedItem]);
+        }
+
+        [addPlaceholder](element, positionY) {
+            const container = doc.createElement('div');
+            const rect = element.getBoundingClientRect();
+            const middlePositionY = rect.top + rect.height / 2;
+            const where = positionY <= middlePositionY ? element : element.nextSibling;
+
+            container.insertAdjacentHTML('beforeend', this.itemsContainer.dataset.placeholder);
+
+            this[placeholder] = container.querySelector(this.selectorPlaceholder);
+
+            this.itemsContainer.insertBefore(this[placeholder], where);
+            this[removePlaceholderAfterTimeout]();
+        }
+
+        [removePlaceholder]() {
+            if (this[placeholder]) {
+                this[placeholder].remove();
+            }
+        }
+
+        [removePlaceholderAfterTimeout]() {
+            global.clearTimeout(this[onDragOverTimeout]);
+
+            this[onDragOverTimeout] = global.setTimeout(() => this[removePlaceholder](), TIMEOUT_REMOVE_PLACEHOLDERS);
+        }
+
+        init() {
+            this.itemsContainer.ondragover = this[onDragOver];
+            this.itemsContainer.addEventListener('drop', this[onDrop], false);
+
+            this.itemsContainer.querySelectorAll(this.selectorItem).forEach(this[attachEventHandlersToItem]);
+        }
+
+        reinit() {
+            this.itemsContainer.removeEventListener('drop', this[onDrop]);
+
+            this.init();
+        }
+    }
+
+    global.eZ.addConfig('core.Draggable', Draggable);
+})(window, window.document);

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -135,6 +135,7 @@
             '@BazingaJsTranslationBundle/Resources/public/js/translator.min.js'
             'js/translations/config.js'
             'js/translations/*.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/core/draggable.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29606
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## FOR QA
There is nothing to test in this PR. This developer feature will be used in other PRs.

## How to use it?
Prepare the HTML structure like this:
```html
<div class="items-container" data-placeholder="HTML template for placeholder"></div>
```

In your JS code follow the convention:

```javascript
const draggable = new global.eZ.core.Draggable({
        itemsContainer: HTMLElement of .items-container,
        selectorItem: String,
        selectorPlaceholder: String,
});
```

## Options

- `itemsContainer` - a reference to DOM node containing a draggable items,
- `selectorItem` - a CSS selector of a draggable item,
- `selectorPlaceholder` - a CSS selector of a placeholder,
- `afterInit` - a callback function invoked after interface initialization (optional),
- `afterDragStart` - a callback function invoked after starting to drag (optional),
- `afterDragOver` - a callback function invoked after moving onto a droppable element (optional),
- `afterDrop` - a callback function invoked after dropping an element (optional),
- `attachCustomEventHandlersToItem` - a function to be invoked while attaching event handlers to every item in the items container (optional).