### PR TITLE
EZP-29603: Improved styling of Search and Search filters

### DIFF
--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -137,3 +137,23 @@
 .ez-btn--cotf-create {
     display: flex;
 }
+
+.ez-search-view {
+    .input-group-btn {
+        display: flex;
+
+        .ez-btn--search,
+        .ez-btn--filter {
+            display: flex;
+            align-items: center;
+
+            .ez-icon {
+                margin-right: calculateRem(4px);
+            }
+        }
+
+        .ez-btn--search {
+            border-radius: 0 calculateRem(4px) calculateRem(4px) 0;
+        }
+    }
+}

--- a/src/bundle/Resources/public/scss/_content-type-selector.scss
+++ b/src/bundle/Resources/public/scss/_content-type-selector.scss
@@ -4,8 +4,9 @@
     position: absolute;
     max-width: 34rem;
     background: $ez-ground-base-dark;
-    padding: 1rem;
+    padding: calculateRem(16px) calculateRem(24px);
     border-radius: 5px;
+    box-shadow: 0 calculateRem(2px) calculateRem(4px) 0 rgba(0, 0, 0, 0.45);
     transform: scaleY(1);
     transform-origin: top center;
     transition: transition .2s $ez-admin-transition;
@@ -26,6 +27,14 @@
     &__item {
         flex-basis: 33%;
         display: flex;
+
+        .form-check-inline {
+            margin: calculateRem(4px);
+
+            .form-check-label {
+                font-size: calculateRem(14px);
+            }
+        }
     }
 
     &__group-title {
@@ -73,6 +82,12 @@
 
             #{$selector}__group-title:after {
                 transform: translate(2px, -50%) rotate(-45deg);
+            }
+        }
+
+        &:last-of-type {
+            .ez-content-type-selector__list {
+                margin-bottom: calculateRem(8px);
             }
         }
     }

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -6,6 +6,7 @@
     transform-origin: top center;
     transition: all 0.2s $ez-admin-transition;
     flex-wrap: wrap;
+    position: relative;
 
     &--collapsed {
         transform: scaleY(0);
@@ -17,6 +18,7 @@
 
         &-label {
             margin-bottom: 0;
+            font-weight: 700;
         }
 
         &--creator {
@@ -44,6 +46,28 @@
                 }
             }
         }
+    }
+
+    &:before,
+    &:after {
+        content: '';
+        position: absolute;
+        left: 93.75%;
+        border-style: solid;
+        border-width: 0 calculateRem(10px) calculateRem(10px);
+        display: block;
+        width: 0;
+        z-index: 1;
+    }
+
+    &:before {
+        border-color: $ez-color-secondary transparent;
+        top: calculateRem(-10px);
+    }
+
+    &:after {
+        border-color: $ez-ground-base-light transparent;
+        top: calculateRem(-9px);
     }
 
     &__btns {

--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -61,12 +61,6 @@
     }
 }
 
-.ez-icon-search-button {
-    fill: $ez-white;
-    height: 1rem;
-    width: 1rem;
-}
-
 .ez-table-header {
     .ez-icon {
         width: 1.5rem;

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -111,6 +111,7 @@
     
     .modal-footer  {
         border-top: none;
+        justify-content: center;
     }
 }
 

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -22,56 +22,60 @@
 
                 {% if results is defined %}
 
-                    <div class="ez-table-header mt-3">
+                    <div class="ez-table-header mt-3 ml-4">
                         <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
                     </div>
 
                     {% if results is empty %}
-                        <table class="table">
-                            <tr>
-                                <td colspan="4">
-                                    <span>{{ 'search.no_result'|trans({'%query%': form.vars.value.query})|desc('Sorry, no results were found for "%query%".') }}</span>
-                                </td>
-                            </tr>
-                        </table>
-                        <div class="ez-main-row">
-                            <h6>{{ 'search.tips.headline'|trans|desc('Some helpful search tips:') }}</h6>
-                            <ul>
-                                <li>{{ 'search.tips.check_spelling'|trans|desc('Check spelling of keywords.') }}</li>
-                                <li>{{ 'search.tips.different_keywords'|trans|desc('Try different keywords.') }}</li>
-                                <li>{{ 'search.tips.more_general_keywords'|trans|desc('Try more general keywords.') }}</li>
-                                <li>{{ 'search.tips.fewer_keywords'|trans|desc('Try fewer keywords. Reducing keywords result in more matches.') }}</li>
-                            </ul>
+                        <div class="ml-4">
+                            <table class="table">
+                                <tr>
+                                    <td colspan="4">
+                                        <span>{{ 'search.no_result'|trans({'%query%': form.vars.value.query})|desc('Sorry, no results were found for "%query%".') }}</span>
+                                    </td>
+                                </tr>
+                            </table>
+                            <div class="ez-main-row">
+                                <h6>{{ 'search.tips.headline'|trans|desc('Some helpful search tips:') }}</h6>
+                                <ul>
+                                    <li>{{ 'search.tips.check_spelling'|trans|desc('Check spelling of keywords.') }}</li>
+                                    <li>{{ 'search.tips.different_keywords'|trans|desc('Try different keywords.') }}</li>
+                                    <li>{{ 'search.tips.more_general_keywords'|trans|desc('Try more general keywords.') }}</li>
+                                    <li>{{ 'search.tips.fewer_keywords'|trans|desc('Try fewer keywords. Reducing keywords result in more matches.') }}</li>
+                                </ul>
+                            </div>
                         </div>
                     {% else %}
-                        <table class="table">
-                            <thead>
-                            <tr>
-                                <th>{{ 'search.name'|trans|desc('Name') }}</th>
-                                <th>{{ 'search.modified'|trans|desc('Modified') }}</th>
-                                <th>{{ 'search.type'|trans|desc('Content Type') }}</th>
-                                <th></th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            {% for row in results %}
-                                {% include '@ezdesign/admin/search/search_table_row.html.twig' with { row: row } %}
-                            {% endfor %}
-                            </tbody>
-                        </table>
+                        <div class="mr-4">
+                            <table class="table mx-4">
+                                <thead>
+                                <tr>
+                                    <th>{{ 'search.name'|trans|desc('Name') }}</th>
+                                    <th>{{ 'search.modified'|trans|desc('Modified') }}</th>
+                                    <th>{{ 'search.type'|trans|desc('Content Type') }}</th>
+                                    <th></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for row in results %}
+                                    {% include '@ezdesign/admin/search/search_table_row.html.twig' with { row: row } %}
+                                {% endfor %}
+                                </tbody>
+                            </table>
 
-                        {% if pager.haveToPaginate %}
-                            <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
-                                <span class="ez-pagination__text">
-                                    {{ 'pagination.viewing'|trans({
-                                        '%viewing%': pager.currentPageResults|length,
-                                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
-                                </span>
-                            </div>
-                            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
-                                {{ pagerfanta(pager, 'ez', {'pageParameter': '[search][page]'}) }}
-                            </div>
-                        {% endif %}
+                            {% if pager.haveToPaginate %}
+                                <div class="row justify-content-center align-items-center mb-2 ml-4 ez-pagination__spacing">
+                                    <span class="ez-pagination__text">
+                                        {{ 'pagination.viewing'|trans({
+                                            '%viewing%': pager.currentPageResults|length,
+                                            '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                                    </span>
+                                </div>
+                                <div class="row justify-content-center align-items-center ez-pagination__btn mb-5 ml-4">
+                                    {{ pagerfanta(pager, 'ez', {'pageParameter': '[search][page]'}) }}
+                                </div>
+                            {% endif %}
+                        </div>
                     {% endif %}
 
                     {% form_theme form_edit '@ezdesign/parts/form/flat_widgets.html.twig' %}

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -3,23 +3,23 @@
 {% trans_default_domain 'search' %}
 
 {{ form_start(form) }}
-<div class="input-group">
+<div class="input-group pl-4">
     {{ form_widget(form.query) }}
 
     <span class="input-group-btn">
-        <button type="submit" class="btn btn-primary">
-            <svg class="ez-icon ez-icon-search-button">
+        <button type="submit" class="btn btn-primary font-weight-bold ez-btn--search">
+            <svg class="ez-icon ez-icon--medium ez-icon--light">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#search"></use>
             </svg>
-            {{ 'search.perform'|trans|desc('Search') }}</button>
+            <span class="ez-btn ez-btn--search-label">{{ 'search.perform'|trans|desc('Search') }}</span></button>
         <button type="submit" class="btn btn-dark ez-btn--filter ml-4">
-            <svg class="ez-icon ez-icon--small ez-icon--light ez-icon-filters">
+            <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-filters">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#filters"></use>
             </svg>
-            {{ 'search.filter'|trans|desc('Filter') }}</button>
+            <span class="ez-btn ez-btn--filter-label">{{ 'search.filters'|trans|desc('Filters') }}</span></button>
     </span>
 </div>
-<div class="ez-filters mt-4 pt-2{% if not filters_expanded %} ez-filters--collapsed{% endif %}">
+<div class="ez-filters mt-4 ml-4 pt-2{% if not filters_expanded %} ez-filters--collapsed{% endif %}">
     <div class="ez-filters__item ez-filters__item--content-type">
         <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
         <select class="form-control ez-filters__select ez-filters__select--content-type">
@@ -58,7 +58,7 @@
     <div class="ez-filters__btns">
         <button class="btn btn-dark ez-btn-clear">
             {{ 'search.clear'|trans|desc('Clear') }}</button>
-        <button type="submit" class="btn btn-secondary ez-btn-apply" disabled>
+        <button type="submit" class="btn btn-secondary ez-btn-apply font-weight-bold" disabled>
             {{ 'search.apply'|trans|desc('Apply') }}</button>
     </div>
 </div>
@@ -90,7 +90,7 @@
                 <button type="button" class="btn btn-dark" data-dismiss="modal">
                     {{ 'modal.cancel'|trans|desc('Cancel') }}
                 </button>
-                <button class="btn btn-secondary ez-btn--select" data-dismiss="modal" disabled>
+                <button class="btn btn-secondary ez-btn--select font-weight-bold" data-dismiss="modal" disabled>
                     {{ 'modal.select'|trans|desc('Select') }}
                 </button>
             </div>
@@ -122,7 +122,7 @@
                 <button type="button" class="btn btn-dark" data-dismiss="modal">
                     {{ 'modal.cancel'|trans|desc('Cancel') }}
                 </button>
-                <button class="btn btn-secondary ez-btn--select" data-dismiss="modal" disabled>
+                <button class="btn btn-secondary ez-btn--select font-weight-bold" data-dismiss="modal" disabled>
                     {{ 'modal.select'|trans|desc('Select') }}
                 </button>
             </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29603](https://jira.ez.no/browse/EZP-29603)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no

Most important aspects:
- Adjusted offset margins to the rest of the UI views within the app;
- Added font-weight 700 to Search button and increase font-size of icons within buttons (styled according to approach used for buttons with icons in Edit view);
- Added a caret pointing up in the border-top when filters are displayed;
- Added font-weight for filter labels (700);
- Reviewed spacing and font-size for Content-type dropdown;
- Updated Custom range modal based on defined Ui standards for modals already implemented in the UI (center alignment & bolded font-weight for primary action).

![search](https://user-images.githubusercontent.com/9256718/45437176-5c93e480-b682-11e8-91e4-d9f8f9231396.png)
![search 1](https://user-images.githubusercontent.com/9256718/45437183-60276b80-b682-11e8-915b-785f0cc0d300.png)
![search 2](https://user-images.githubusercontent.com/9256718/45437184-60276b80-b682-11e8-9ea8-db72e7aa1e17.png)
![search 3](https://user-images.githubusercontent.com/9256718/45437185-60276b80-b682-11e8-9741-d73cd92fa122.png)
![search 4](https://user-images.githubusercontent.com/9256718/45437186-60276b80-b682-11e8-8976-a99f9b4cc9e1.png)
![search 5](https://user-images.githubusercontent.com/9256718/45437187-60276b80-b682-11e8-825b-4b63d691cf4d.png)
![search 6](https://user-images.githubusercontent.com/9256718/45437188-60276b80-b682-11e8-8616-55fda2169442.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
