### PR TITLE
EZP-29174: Updated ez-user-menu styling

### DIFF
--- a/src/bundle/Resources/public/scss/_notifications-menu.scss
+++ b/src/bundle/Resources/public/scss/_notifications-menu.scss
@@ -1,27 +1,45 @@
-.n-pending-notifications {
-    &:before {
-        content: attr(data-count);
-        width: 1rem;
-        height: 1rem;
-        border-radius: 50%;
-        background: $ez-color-danger;
-        position: absolute;
-        vertical-align: middle;
-        text-align: center;
-        font-size: .75rem;
-        color: $ez-white;
-    }
-}
+.ez-main-nav {    
+    .ez-user-menu {
 
-.ez-user-menu__item--notifications {
-    position: relative;
+        &__name-wrapper {
+            .n-pending-notifications {
+                &:before {
+                    content: attr(data-count);
+                    width: 1rem;
+                    height: 1rem;
+                    border-radius: 50%;
+                    background: $ez-color-danger;
+                    position: absolute;
+                    vertical-align: middle;
+                    text-align: center;
+                    font-size: calculateRem(12px);
+                    color: $ez-white;
+                }
+            }
+        }
 
-    &:before {
-        content: attr(data-count);
-        position: absolute;
-        left: .25rem;
-        top: 50%;
-        transform: translateY(-50%);
-        color: $ez-color-base-light;
+        &__item {
+            
+            &--notifications {
+                position: relative;
+
+                &:before {
+                    content: attr(data-count);
+                    position: absolute;
+                    left: .35rem;
+                    top: 48%;
+                    transform: translateY(-50%);
+                    font-size: calculateRem(14px);
+                    color: $ez-black;
+                }
+
+                &:hover {
+
+                    &:before {
+                        color: $ez-black;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/bundle/Resources/public/scss/_user-menu.scss
+++ b/src/bundle/Resources/public/scss/_user-menu.scss
@@ -1,67 +1,81 @@
-.ez-user-menu {
-    position: relative;
-    cursor: pointer;
-    z-index: 1050;
-
-    &__name-wrapper {
-        padding: .5rem 2rem .5rem 0;
-
-        .ez-user-menu__name {
-            font-size: 0.75rem;
-            font-weight: 700;
-        }
-
-        &:before,
-        &:after {
-            content: "";
-            height: 10px;
-            width: 2px;
-            position: absolute;
-            top: 50%;
-            right: 1rem;
-            background-color: $ez-black;
-        }
-
-        &:before {
-            transform: translate(3px, -50%)  rotate(-135deg);
-        }
-
-        &:after {
-            transform: translate(-3px, -50%)  rotate(135deg);
-        }
-    }
-
-    &__avatar {
-        border-radius: 50%;
-        width: 40px;
-        height: 40px;
-    }
-
-    &__items {
-        position: absolute;
-        top: 100%;
-        right: 0;
-        min-width: 100%;
-        background-color: $ez-white;
-        border-radius: 5px;
-        box-shadow: 0 0 10px 0 rgba(0,0,0,.25);
-        height: auto;
-        transform-origin: top center;
-        transition: all .2s $ez-admin-transition;
-
-        &--hidden {
-            height: 0;
-            overflow: hidden;
-        }
-    }
-
-    &__item {
-        width: 100%;
+.ez-main-nav {    
+    .ez-user-menu {
+        position: relative;
         cursor: pointer;
-        padding-left: 1.5rem;
+        z-index: 1050;
 
-        &:not(:last-child) {
-            border-bottom: 1px solid $ez-ground-base-dark;
+        &__name-wrapper {
+            padding: .5rem 2rem .5rem 0;
+
+            .ez-user-menu__name {
+                font-size: calculateRem(12px);
+            }
+
+            &:before,
+            &:after {
+                content: "";
+                height: 10px;
+                width: 2px;
+                position: absolute;
+                top: 50%;
+                right: 1rem;
+                background-color: $ez-black;
+            }
+
+            &:before {
+                transform: translate(3px, -50%)  rotate(-135deg);
+            }
+
+            &:after {
+                transform: translate(-3px, -50%)  rotate(135deg);
+            }
+        }
+
+        &__avatar {
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+        }
+
+        &__items {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            min-width: 100%;
+            background-color: $ez-white;
+            box-shadow: 0 2px 4px 0 rgba(0,0,0,.45);
+            height: auto;
+            transform-origin: top center;
+            transition: all .2s $ez-admin-transition;
+
+            &--hidden {
+                height: 0;
+                overflow: hidden;
+            }
+        }
+
+        &__item {
+            width: 100%;
+            cursor: pointer;
+            padding-left: 1.5rem;
+
+            .nav-link {
+                color: $ez-black;
+                font-size: calculateRem(14px);
+            }
+
+            &:not(:last-child) {
+                border-bottom: 1px solid $ez-ground-base-dark;
+            }
+
+            &:hover {
+                background-color: $ez-secondary-ground-pale;
+                cursor: pointer;
+
+                .nav-link {
+                    color: $ez-black;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29174](https://jira.ez.no/browse/EZP-29174)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most interesting aspects:
- Update `ez-user-menu__item` based on consistency for hover states and box-shadow too. 
(Reviewed also `ez-user-menu__name` font-weight).

![ez platform 3](https://user-images.githubusercontent.com/9256718/45570286-24ca9f80-b830-11e8-8319-74a24c00c514.png)
![screen shot 2018-09-14 at 3 08 09 pm](https://user-images.githubusercontent.com/9256718/45570295-2b591700-b830-11e8-9a02-f686e455ca54.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
