### PR TITLE
EZP-29614: Application does not respond after downloading a file.

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.prevent.click.js
+++ b/src/bundle/Resources/public/js/scripts/admin.prevent.click.js
@@ -1,4 +1,4 @@
-(function (global, doc) {
+(function(global, doc) {
     global.onbeforeunload = function() {
         doc.querySelector('body').classList.add('ez-prevent-click');
 

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -209,7 +209,7 @@
             </svg>
             {{ field.value.fileName }}
             {{ field.value.fileSize|ez_file_size( 1 ) }}
-            <a href="{{ path( route_reference ) }}">
+            <a download href="{{ path( route_reference ) }}">
                 <svg class="ez-icon ez-icon--download ez-icon--light">
                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#download"></use>
                 </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29614
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This behavior is caused by firing an `onbeforeunload` event when the file is downloading.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
