### PR TITLE
EZEE-2323: Fixes js error in MS Edge

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -22,7 +22,7 @@
                         }
 
                         if (oldValue.constructor.name === objectConstructorName && newValue.constructor.name === objectConstructorName) {
-                            return { ...oldValue, ...newValue };
+                            return Object.assign({}, oldValue, newValue);
                         }
                     };
 


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2323
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


MS Edge does not support spread in object literals natively yet.
Browser compatibility: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Browser_compatibility


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
