### PR TITLE
EZP-29636: Additional Update button visible on User Setting update screen

### DIFF
--- a/src/bundle/Resources/views/user/settings/update.html.twig
+++ b/src/bundle/Resources/views/user/settings/update.html.twig
@@ -27,6 +27,7 @@
     <div class="bg-white p-4">
         {{ form_row(form.value) }}
     </div>
+    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
     {{ form_end(form) }}
 
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29636
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![image](https://user-images.githubusercontent.com/10212760/45672846-7f624500-bb29-11e8-95dd-8d94580d7a0b.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
