### PR TITLE
WIP EZP-29639: Labels for checkboxes and radioboxes are misaligned with inputs

### DIFF
--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -61,18 +61,12 @@ form:not(.form-inline) {
 
 .form-check {
     margin-bottom: 0;
+}
 
-    &-label {
-        display: flex;
-        align-items: center;
-        margin-bottom: 0;
-    }
-
-    &-input {
-        position: initial;
-        margin-bottom: .25rem;
-        margin-right: .5rem;
-    }
+.form-check-input {
+    position: initial;
+    margin-bottom: .25rem;
+    margin-right: .5rem;
 }
 
 .ez-field {

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -141,3 +141,43 @@
         {{ block('form_widget') }}
     </div>
 {%- endblock -%}
+
+{% block checkbox_radio_label -%}
+    {#- Do not display the label if widget is not defined in order to prevent double label rendering -#}
+    {%- if widget is defined -%}
+        {% set is_parent_custom = parent_label_class is defined and ('checkbox-custom' in parent_label_class or 'radio-custom' in parent_label_class) %}
+        {% set is_custom = label_attr.class is defined and ('checkbox-custom' in label_attr.class or 'radio-custom' in label_attr.class) %}
+        {%- if is_parent_custom or is_custom -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' custom-control-label')|trim}) -%}
+        {%- else %}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-check-label')|trim}) -%}
+        {%- endif %}
+        {%- if not compound -%}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif -%}
+        {%- if required -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) -%}
+        {%- endif -%}
+        {%- if parent_label_class is defined -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|replace({'checkbox-inline': '', 'radio-inline': '', 'checkbox-custom': '', 'radio-custom': ''})|trim}) -%}
+        {%- endif -%}
+        {%- if label is not same as(false) and label is empty -%}
+            {%- if label_format is not empty -%}
+                {%- set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) -%}
+            {%- else -%}
+                {%- set label = name|humanize -%}
+            {%- endif -%}
+        {%- endif -%}
+
+        {{ widget|raw }}
+        {%- if label is not same as(false) -%}
+            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{- label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
+                {{- form_errors(form) -}}
+            </label>
+        {%- endif -%}
+    {%- endif -%}
+{%- endblock checkbox_radio_label %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29639
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Tests pass?   | yes
| Doc needed?   | ?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixes rendering & CSS styles of all checkboxes + radioboxes. 
For QA: All checkboxes and radioboxes shoul look like nothing happened.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
