### PR TITLE
EZP-29508: As an editor I want to manage ALT field with an image asset field type

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -133,6 +133,7 @@
         updateData(destinationContentId, destinationContentName, destinationLocationId, image) {
             const preview = this.fieldContainer.querySelector('.ez-field-edit__preview');
             const previewImg = preview.querySelector('.ez-field-edit-preview__media');
+            const previewAlt = preview.querySelector('.ez-field-edit-preview__image-alt input');
             const previewActionPreview = preview.querySelector('.ez-field-edit-preview__action--preview');
             const assetNameContainer = preview.querySelector('.ez-field-edit-preview__asset-name a');
             const destinationLocationUrl = global.Routing.generate('_ezpublishLocation', {
@@ -141,6 +142,7 @@
 
             previewImg.setAttribute('src', image ? image.uri : '://0');
             previewImg.classList.toggle('d-none', image === null);
+            previewAlt.value = image.alternativeText;
             previewActionPreview.setAttribute('href', destinationLocationUrl);
             assetNameContainer.innerHTML = destinationContentName;
             assetNameContainer.setAttribute('href', destinationLocationUrl);

--- a/src/bundle/Resources/views/fieldtypes/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimageasset.html.twig
@@ -102,6 +102,9 @@
                     </a>
                 </span>
             </div>
+            <div class="ez-field-edit-preview__image-alt">
+                {{ form_row(form.alternativeText) }}
+            </div>
         </div>
         <div class="ez-field-edit-preview__actions">
             <button type="button" class="ez-field-edit-preview__action--remove">

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -403,7 +403,7 @@
             viewType: 'preview_ezimageasset',
             noLayout: true,
             params: {
-                parameters: parameters|default({})
+                parameters: parameters|default({})|merge({ alternativeText: field.value.alternativeText })
             }
         }))}}
     </div>

--- a/src/bundle/Resources/views/fieldtypes/preview/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/ezimageasset.html.twig
@@ -27,7 +27,7 @@
             </tr>
             <tr>
                 <td>{{ 'ezimageasset.alternative_text'|trans|desc('Alternative text') }}:</td>
-                <td>{{ field.value.alternativeText }}</td>
+                <td>{{ parameters.alternativeText|default(field.value.alternativeText) }}</td>
             </tr>
             <tr>
                 <td>{{ 'ezimageasset.master_dimensions'|trans|desc('Master dimensions') }}:</td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29508
| Depends on  | https://github.com/ezsystems/ezpublish-kernel/pull/2451, https://github.com/ezsystems/repository-forms/pull/254
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Impl. possibility to define Alternative Text for Image Asset. 

<img width="1016" alt="zrzut ekranu 2018-09-18 o 13 03 44" src="https://user-images.githubusercontent.com/211967/45683251-49ca5580-bb43-11e8-8709-7ae707155106.png">

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
