### PR TITLE
EZP-29613: As a developer I want access ContentType on Content to avoid re-loading it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "^7.3@dev",
+        "ezsystems/ezpublish-kernel": "^7.4@dev",
         "ezsystems/repository-forms": "^2.3@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.3@dev",
         "ezsystems/ez-support-tools": "^0.2@dev",

--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -208,10 +208,7 @@ class ContentViewController extends Controller
      */
     private function supplyContentType(ContentView $view): void
     {
-        $content = $view->getContent();
-        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId, $this->siteAccessLanguages);
-
-        $view->addParameters(['contentType' => $contentType]);
+        $view->addParameters(['contentType' => $view->getContent()->getContentType()]);
     }
 
     /**

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -117,11 +117,7 @@ class LocationController extends Controller
                 $location = $data->getLocation();
                 $newParentLocation = $data->getNewParentLocation();
 
-                $newParentContentType = $this->contentTypeService->loadContentType(
-                    $newParentLocation->getContentInfo()->contentTypeId
-                );
-
-                if (!$newParentContentType->isContainer) {
+                if (!$newParentLocation->getContent()->getContentType()->isContainer) {
                     throw new InvalidArgumentException(
                         '$newParentLocation',
                         'Cannot move location to a parent that is not a container'
@@ -173,11 +169,7 @@ class LocationController extends Controller
                 $location = $data->getLocation();
                 $newParentLocation = $data->getNewParentLocation();
 
-                $newParentContentType = $this->contentTypeService->loadContentType(
-                    $newParentLocation->getContentInfo()->contentTypeId
-                );
-
-                if (!$newParentContentType->isContainer) {
+                if (!$newParentLocation->getContent()->getContentType()->isContainer) {
                     throw new InvalidArgumentException(
                         '$newParentLocation',
                         'Cannot copy location to a parent that is not a container'
@@ -283,7 +275,7 @@ class LocationController extends Controller
                 $newLocation = $data->getNewLocation();
 
                 $childCount = $this->locationService->getLocationChildCount($currentLocation);
-                $contentType = $this->contentTypeService->loadContentType($newLocation->getContentInfo()->contentTypeId);
+                $contentType = $newLocation->getContent()->getContentType();
 
                 if (!$contentType->isContainer && $childCount) {
                     throw new \InvalidArgumentException(

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -244,7 +244,7 @@ class SectionController extends Controller
             $assignedContent[] = [
                 'id' => $content->id,
                 'name' => $content->getName(),
-                'type' => $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId)->getName(),
+                'type' => $content->getContentType()->getName(),
                 'path' => $this->pathService->loadPathLocations(
                     $this->locationService->loadLocation($content->contentInfo->mainLocationId)
                 ),

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -145,7 +145,7 @@ class TrashController extends Controller
 
         /** @var \eZ\Publish\API\Repository\Values\Content\TrashItem $item */
         foreach ($pagerfanta->getCurrentPageResults() as $item) {
-            $contentType = $this->contentTypeService->loadContentType($item->contentInfo->contentTypeId);
+            $contentType = $item->getContent()->getContentType();
             $ancestors = $this->uiPathService->loadPathLocations($item);
 
             $trashItemsList[] = new TrashItemData($item, $contentType, $ancestors);

--- a/src/lib/EventListener/ContentTranslateViewFilterParametersListener.php
+++ b/src/lib/EventListener/ContentTranslateViewFilterParametersListener.php
@@ -53,9 +53,8 @@ class ContentTranslateViewFilterParametersListener implements EventSubscriberInt
         }
 
         $contentInfo = $view->getContent()->contentInfo;
-        $contentType = $this->contentTypeService->loadContentType(
-            $contentInfo->contentTypeId
-        );
+        $contentType = $view->getContent()->getContentType();
+
         $event->getParameterBag()->add([
             'form' => $view->getFormView(),
             'location' => $view->getLocation(),

--- a/src/lib/Menu/ContentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentCreateRightSidebarBuilder.php
@@ -91,7 +91,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
         $parentLocation = $options['parentLocation'];
         /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
         $contentType = $options['content_type'];
-        $parentContentType = $this->contentTypeService->loadContentType($parentLocation->contentInfo->contentTypeId);
+        $parentContentType = $parentLocation->getContent()->getContentType();
         /** @var \eZ\Publish\API\Repository\Values\Content\Language $language */
         $language = $options['language'];
         /** @var \Knp\Menu\ItemInterface|\Knp\Menu\ItemInterface[] $menu */

--- a/src/lib/Specification/Location/IsContainer.php
+++ b/src/lib/Specification/Location/IsContainer.php
@@ -12,28 +12,13 @@ use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
 
 class IsContainer extends AbstractSpecification
 {
-    /** @var \eZ\Publish\API\Repository\ContentTypeService */
-    private $contentTypeService;
-
-    /**
-     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
-     */
-    public function __construct($contentTypeService)
-    {
-        $this->contentTypeService = $contentTypeService;
-    }
-
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\Location $item
      *
      * @return bool
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function isSatisfiedBy($item): bool
     {
-        return $this->contentTypeService->loadContentType(
-            $item->getContentInfo()->contentTypeId
-        )->isContainer;
+        return $item->getContent()->getContentType()->isContainer;
     }
 }

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -51,7 +51,7 @@ class PagerContentToDataMapper
         $data = [];
 
         foreach ($pager as $content) {
-            $contentInfo = $this->contentService->loadContentInfo($content->id);
+            $contentInfo = $content->getVersionInfo()->getContentInfo();
 
             $contributor = (new UserExists($this->userService))->isSatisfiedBy($contentInfo->ownerId)
                 ? $this->userService->loadUser($contentInfo->ownerId) : null;
@@ -62,7 +62,7 @@ class PagerContentToDataMapper
                 'language' => $contentInfo->mainLanguageCode,
                 'contributor' => $contributor,
                 'version' => $content->versionInfo->versionNo,
-                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'type' => $content->getContentType()->getName(),
                 'modified' => $content->versionInfo->modificationDate,
                 'initialLanguageCode' => $content->versionInfo->initialLanguageCode,
                 'content_is_user' => (new ContentIsUser($this->userService))->isSatisfiedBy($content),

--- a/src/lib/Tab/LocationView/RelationsTab.php
+++ b/src/lib/Tab/LocationView/RelationsTab.php
@@ -106,22 +106,17 @@ class RelationsTab extends AbstractTab implements OrderedTabInterface, Condition
     {
         /** @var Content $content */
         $content = $parameters['content'];
-        $versionInfo = $content->getVersionInfo();
         $relationsDataset = $this->datasetFactory->relations();
-        $relationsDataset->load($versionInfo);
+        $relationsDataset->load($content);
 
-        $contentTypes = [];
+        $contentTypeIds = [];
 
         $relations = $relationsDataset->getRelations();
 
         $viewParameters = [];
 
         foreach ($relations as $relation) {
-            $contentTypeId = $relation->getDestinationContentInfo()->contentTypeId;
-
-            if (!isset($contentTypes[$contentTypeId])) {
-                $contentTypes[$contentTypeId] = $this->contentTypeService->loadContentType($contentTypeId);
-            }
+            $contentTypeIds[] = $relation->getDestinationContentInfo()->contentTypeId;
         }
 
         $viewParameters['relations'] = $relations;
@@ -130,17 +125,17 @@ class RelationsTab extends AbstractTab implements OrderedTabInterface, Condition
             $reverseRelations = $relationsDataset->getReverseRelations();
 
             foreach ($reverseRelations as $relation) {
-                $contentTypeId = $relation->getSourceContentInfo()->contentTypeId;
-
-                if (!isset($contentTypes[$contentTypeId])) {
-                    $contentTypes[$contentTypeId] = $this->contentTypeService->loadContentType($contentTypeId);
-                }
+                $contentTypeIds[] = $relation->getSourceContentInfo()->contentTypeId;
             }
 
             $viewParameters['reverse_relations'] = $reverseRelations;
         }
 
-        $viewParameters['contentTypes'] = $contentTypes;
+        if (!empty($contentTypeIds)) {
+            $viewParameters['contentTypes'] = $this->contentTypeService->loadContentTypeList(array_unique($contentTypeIds));
+        } else {
+            $viewParameters['contentTypes'] = [];
+        }
 
         return $this->twig->render(
             '@ezdesign/content/tab/relations/tab.html.twig',

--- a/src/lib/UI/Config/Provider/User.php
+++ b/src/lib/UI/Config/Provider/User.php
@@ -70,12 +70,7 @@ class User implements ProviderInterface
      */
     private function resolveProfilePictureField(ApiUser $user): ?Field
     {
-        try {
-            $contentType = $this->contentTypeService->loadContentType($user->contentInfo->contentTypeId);
-        } catch (\Exception $e) {
-            return null;
-        }
-
+        $contentType = $user->getContentType();
         foreach ($user->getFields() as $field) {
             $fieldDef = $contentType->getFieldDefinition($field->fieldDefIdentifier);
 

--- a/src/lib/UI/Dataset/PoliciesDataset.php
+++ b/src/lib/UI/Dataset/PoliciesDataset.php
@@ -84,8 +84,8 @@ class PoliciesDataset
     public function load(Location $location): self
     {
         $roleAssignments = [];
-        $content = $this->contentService->loadContentByContentInfo($location->contentInfo);
-        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+        $content = $location->getContent();
+        $contentType = $content->getContentType();
 
         if ((new ContentTypeIsUser($this->userContentTypeIdentifier))->isSatisfiedBy($contentType)) {
             $user = $this->userService->loadUser($content->id);

--- a/src/lib/UI/Dataset/RelationsDataset.php
+++ b/src/lib/UI/Dataset/RelationsDataset.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
-use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
 use EzSystems\EzPlatformAdminUi\UI\Value as UIValue;
 
@@ -47,16 +47,16 @@ class RelationsDataset
      *
      * @throws UnauthorizedException
      */
-    public function load(VersionInfo $versionInfo): self
+    public function load(Content $content): self
     {
-        $contentInfo = $versionInfo->getContentInfo();
+        $versionInfo = $content->getVersionInfo();
 
         foreach ($this->contentService->loadRelations($versionInfo) as $relation) {
-            $this->relations[] = $this->valueFactory->createRelation($relation, $contentInfo);
+            $this->relations[] = $this->valueFactory->createRelation($relation, $content);
         }
 
         foreach ($this->contentService->loadReverseRelations($versionInfo->getContentInfo()) as $reverseRelation) {
-            $this->reverseRelations[] = $this->valueFactory->createRelation($reverseRelation, $contentInfo);
+            $this->reverseRelations[] = $this->valueFactory->createRelation($reverseRelation, $content);
         }
 
         return $this;

--- a/src/lib/UI/Dataset/RolesDataset.php
+++ b/src/lib/UI/Dataset/RolesDataset.php
@@ -83,9 +83,10 @@ class RolesDataset
     public function load(Location $location): self
     {
         $roleAssignment = [];
-        $content = $this->contentService->loadContentByContentInfo($location->contentInfo);
-        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+        $content = $location->getContent();
+        $contentType = $content->getContentType();
 
+        // @todo $content should just have been instance of User or UserGroup direclty so we don't need to re-load data
         if ((new ContentTypeIsUser($this->userContentTypeIdentifier))->isSatisfiedBy($contentType)) {
             $user = $this->userService->loadUser($content->id);
             $roleAssignment = $this->roleService->getRoleAssignmentsForUser($user, true);

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\ObjectStateService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -136,23 +137,23 @@ class ValueFactory
 
     /**
      * @param Relation $relation
-     * @param ContentInfo $contentInfo
+     * @param Content $content
      *
      * @return UIValue\Content\Relation
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function createRelation(Relation $relation, ContentInfo $contentInfo): UIValue\Content\Relation
+    public function createRelation(Relation $relation, Content $content): UIValue\Content\Relation
     {
-        $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+        $contentType = $content->getContentType();
         $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
 
         return new UIValue\Content\Relation($relation, [
             'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
             'relationContentTypeName' => $contentType->getName(),
-            'relationLocation' => $this->locationService->loadLocation($contentInfo->mainLocationId),
-            'relationName' => $contentInfo->name,
+            'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
+            'relationName' => $content->getName(),
         ]);
     }
 
@@ -248,10 +249,8 @@ class ValueFactory
         return new UIValue\Location\Bookmark(
             $location,
             [
-                'contentType' => $this->contentTypeService->loadContentType($location->contentInfo->contentTypeId),
-                'pathLocations' => $this->pathService->loadPathLocations(
-                    $this->locationService->loadLocation($location->contentInfo->mainLocationId)
-                ),
+                'contentType' => $location->getContent()->getContentType(),
+                'pathLocations' => $this->pathService->loadPathLocations($location),
                 'userCanEdit' => $this->permissionResolver->canUser('content', 'edit', $location->contentInfo),
             ]
         );

--- a/src/lib/UniversalDiscovery/Event/Subscriber/SectionAssign.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/SectionAssign.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber;
 
 use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
 use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
@@ -87,19 +86,18 @@ class SectionAssign implements EventSubscriberInterface
      */
     private function getRestrictedContentTypes(array $hasAccess): array
     {
-        $restrictedContentTypes = [];
         $restrictedContentTypesIds = $this->permissionChecker->getRestrictions($hasAccess, ContentTypeLimitation::class);
-
-        foreach ($restrictedContentTypesIds as $restrictedContentTypeId) {
-            // TODO: Change to `contentTypeService->loadContentTypeList($restrictedContentTypesIds)` after #2444 will be merged
-            try {
-                $identifier = $this->contentTypeService->loadContentType($restrictedContentTypeId)->identifier;
-                $restrictedContentTypes[] = $identifier;
-            } catch (NotFoundException $e) {
-            }
+        if (empty($restrictedContentTypesIds)) {
+            return [];
         }
 
-        return $restrictedContentTypes;
+        $restrictedContentTypesIdentifiers = [];
+        $restrictedContentTypes = $this->contentTypeService->loadContentTypeList($restrictedContentTypesIds);
+        foreach ($restrictedContentTypes as $restrictedContentType) {
+            $restrictedContentTypesIdentifiers[] = $restrictedContentType->identifier;
+        }
+
+        return $restrictedContentTypesIdentifiers;
     }
 
     /**

--- a/src/lib/Validator/Constraints/LocationIsContainerValidator.php
+++ b/src/lib/Validator/Constraints/LocationIsContainerValidator.php
@@ -8,25 +8,12 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Validator\Constraints;
 
-use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use EzSystems\EzPlatformAdminUi\Specification\Location\IsContainer;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 class LocationIsContainerValidator extends ConstraintValidator
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Service\ContentTypeService */
-    private $contentTypeService;
-
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\Service\ContentTypeService $contentTypeService
-     */
-    public function __construct(ContentTypeService $contentTypeService)
-    {
-        $this->contentTypeService = $contentTypeService;
-    }
-
     /**
      * Checks if the passed value is valid.
      *
@@ -41,13 +28,9 @@ class LocationIsContainerValidator extends ConstraintValidator
             return;
         }
 
-        $isContainer = new IsContainer($this->contentTypeService);
-        try {
-            if (!$isContainer->isSatisfiedBy($location)) {
-                $this->context->addViolation($constraint->message);
-            }
-        } catch (NotFoundException $e) {
-            $this->context->addViolation($e->getMessage());
+        $isContainer = new IsContainer();
+        if (!$isContainer->isSatisfiedBy($location)) {
+            $this->context->addViolation($constraint->message);
         }
     }
 }

--- a/src/lib/View/Filter/ContentTranslateViewFilter.php
+++ b/src/lib/View/Filter/ContentTranslateViewFilter.php
@@ -92,7 +92,7 @@ class ContentTranslateViewFilter implements EventSubscriberInterface
             $request->attributes->get('contentId'),
             null !== $baseLanguageCode ? [$baseLanguageCode] : null
         );
-        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+        $contentType = $content->getContentType();
 
         $toLanguage = $this->languageService->loadLanguage($languageCode);
         $fromLanguage = $baseLanguageCode ? $this->languageService->loadLanguage($baseLanguageCode) : null;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29613](https://jira.ez.no/browse/EZP-29613)
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Uses https://github.com/ezsystems/ezpublish-kernel/pull/2444, and `$location->getContent()`
(v2.2) in order avoid several repository loads not needed anymore.

Besides avoiding executing unneeded PHP code, here are some numbers for cache lookups on clean install, expect difference to be bigger when you have more data _(demo or project)_:

dashboard:
- 418 / 1240 (33.71%) _(master)_
- 468 / 1315 (35.59%) _(with kernel PR, only)_*
- 364 / 1043 (34.9%) _(with this PR + kernel PR)_

content structure:
- 478 / 1401 (34.12%)  _(master)_
- 450 / 1359 (33.11%) _(with kernel PR, only)_
- 436 / 1327 (32.86%) _(with this PR + kernel PR)_

_**EDIT: These numbers are now outdated, newer versions of admin-ui adds new load calls for among others users**_

_* So without this patch there is a slight regression with more cache loads with the kernel PR on dashboard. Probably due to kernel now always loading content types from API instead of falling back to using SPI, and via api language loading and mapping is needed. With this PR we get rid of the duplicated loads, and for other apps the extra language load and much much more will go away once we have inMemory cache again (v2.4)._

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Tests  **NOTE: There is a TMP commit here to get travis to test against kernel PR for it to pass**
- [x] Ready for Code Review
