### PR TITLE
EZP-29602: Large images do not fit in the editor window

### DIFF
--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -989,6 +989,10 @@
   line-height: 18px;
 }
 
+.ez-embed-type-image img {
+  max-width: 100%;
+}
+
 [class*="ae-icon-"],
 [class*=" ae-icon-"] {
   font-size: 14px;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29602](https://jira.ez.no/browse/EZP-29602)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Before:
![before](https://user-images.githubusercontent.com/34310128/45759150-8f604e80-bc27-11e8-9030-1f1ee17e2f4c.png)

After:
![after](https://user-images.githubusercontent.com/34310128/45759109-7788ca80-bc27-11e8-9ee4-820a162ffeaf.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
