### PR TITLE
EZP-29651: Reviewed ez-main-sub-nav styling

### DIFF
--- a/src/bundle/Resources/public/scss/_main-nav.scss
+++ b/src/bundle/Resources/public/scss/_main-nav.scss
@@ -43,7 +43,6 @@
     background-color: $white;
     padding: 0;
     font-size: .875rem;
-    border-bottom: 1px solid $ez-color-base-pale;
 
     .navbar-nav {
         .nav-link {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29651](https://jira.ez.no/browse/EZP-29651)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Most important aspect:
- Remove property border-bottom from `.ez-main-sub-nav` in order to align design to Page Builder bars (`.ez-page-info-bar` and `c-timeline`)
- Connected to PRs:  [EZEE-2315](https://github.com/ezsystems/ezplatform-page-builder/pull/170) and [EZEE-2317](https://github.com/ezsystems/ezplatform-page-builder/pull/171)

![ez platform 1](https://user-images.githubusercontent.com/9256718/45793127-9eaebe80-bc5e-11e8-9343-4fc3a15ea964.png)
![ez platform 2](https://user-images.githubusercontent.com/9256718/45793128-9eaebe80-bc5e-11e8-8305-2d108577acb3.png)
![ez platform 3](https://user-images.githubusercontent.com/9256718/45793129-9eaebe80-bc5e-11e8-9c76-18aed307850f.png)
![ez platform 4](https://user-images.githubusercontent.com/9256718/45793130-9eaebe80-bc5e-11e8-8329-093d2ffd3415.png)
![ez platform 5](https://user-images.githubusercontent.com/9256718/45793131-9eaebe80-bc5e-11e8-83dd-a7e65a9a6c9e.png)
![link manager](https://user-images.githubusercontent.com/9256718/45793137-a8d0bd00-bc5e-11e8-8149-d876a8a6e728.png)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
