### PR TITLE
EZP-29652 - Multilingual support for ezbinaryfile download in admin UI

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -201,7 +201,7 @@
 {% block ezbinaryfile_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier } ) %}
+        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier, 'inLanguage': content.prioritizedFieldLanguageCode } ) %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezbinaryfile')|trim}) %}
         <div {{ block( 'field_attributes' ) }}>
             <svg class="ez-icon ez-icon--file">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29652](https://jira.ez.no/browse/EZP-29652)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


For now, in the admin, if you display the main view of a content in another language than the default one, it will display the correct link (with the filename in the correct language) but if you click on the download button, you will always get the content of the file in the language of the admin.

I hope that this fix could be convenient, I tried it on two of my projects and it fixed the wrong behaviour with no side effect so far and basic tests running fine. I used native eZ elements (the prioritizedFieldLanguageCode of the content and the preconfigured inLanguage option for the route).


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
