### PR TITLE
EZP-29655: Removed extra spacing in content within Field Types, View tab Content View

### DIFF
--- a/src/bundle/Resources/public/scss/_field-group.scss
+++ b/src/bundle/Resources/public/scss/_field-group.scss
@@ -50,4 +50,16 @@
             border-radius: 0 0 5px 5px;
         }
     }
+
+    .ez-field-preview--ezobjectrelationlist {
+        .table {
+            margin-bottom: 0;
+        }
+    }
+
+    .ez-content-field-value {
+        .ezcountry-field {
+            margin-bottom: 0;
+        }
+    }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29655](https://jira.ez.no/browse/EZP-29655)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspects:
Removed extra spacing in content within Field Types, View tab Content View
- Removed extra space assigned to tables when rendered within Single and/or Multiple Relations;
- Removed extra space for Country, selected country.

![ez platform 10](https://user-images.githubusercontent.com/9256718/45840777-f8a69700-bce5-11e8-92a3-372dfdc11993.png)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
