### PR TITLE
EZP-29662: Reviewed Send to Trash modal in Content Type Editing view

### DIFF
--- a/src/bundle/Resources/public/scss/_card.scss
+++ b/src/bundle/Resources/public/scss/_card.scss
@@ -27,11 +27,13 @@
         }
 
         &--sticky-top {
+            // -webkit-sticky fixes bug for Safari 12.0
+            position: -webkit-sticky;
             position: sticky;
             top: 0;
             padding: .25rem 1.25rem;
             justify-content: space-between;
-            z-index: 9999;
+            z-index: 1040;
 
             .form-inline {
                 .btn-danger {

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -17,6 +17,7 @@
         .ez-modal-body__main,
         .ez-modal-body__explanation {
             margin-bottom: 0;
+            color: $ez-black;
         }
     }
 

--- a/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/delete_confirmation_modal.html.twig
@@ -15,7 +15,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary btn--no" data-dismiss="modal">{{ 'modal.cancel'|trans|desc('Cancel') }}</button>
-                {{ form_widget(form.removeFieldDefinition, { attr: { class: 'btn btn-danger'}, label: 'modal.delete'|trans|desc('Delete')}) }}
+                {{ form_widget(form.removeFieldDefinition, { attr: { class: 'btn btn-danger font-weight-bold'}, label: 'modal.delete'|trans|desc('Delete')}) }}
             </div>
         </div>
     </div>

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -62,10 +62,11 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>
-
-                    {% include '@ezdesign/admin/content_type/delete_confirmation_modal.html.twig' with {'form': form} %}
                 </div>
             </div>
+
+            {% include '@ezdesign/admin/content_type/delete_confirmation_modal.html.twig' with {'form': form} %}
+            
             <div class="card-body">
                 {% set language_code = content_type.mainLanguageCode %}
                 {% for field_definition in form.fieldDefinitionsData %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29662](https://jira.ez.no/browse/EZP-29662)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Most important aspects: 
When in Admin section > specific Content Type > Editing view and sending a field type to the Trash, .ez-card__header component interacts at the same layer level as the modal;
- Reviewed `z-index` conflict;
- Added `$ez-black` as color for `.ez-modal-body__explanation`;
- Added bold font-weight to Delete button.

![ez platform 16](https://user-images.githubusercontent.com/9256718/45987295-a4314d80-c03e-11e8-8975-8b7a50fc1943.png)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
