### PR TITLE
EZP-29617: No route found after adding new translation

### DIFF
--- a/src/bundle/Resources/config/services/form_processors.yml
+++ b/src/bundle/Resources/config/services/form_processors.yml
@@ -19,5 +19,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\RepositoryForms\Form\Processor\Content\UrlRedirectProcessor:
         public: true
+        decorates: EzSystems\RepositoryForms\Form\Processor\SystemUrlRedirectProcessor
         arguments:
             $siteaccessGroups: '%ezpublish.siteaccess.groups%'
+            $systemUrlRedirectProcessor: '@EzSystems\EzPlatformAdminUi\RepositoryForms\Form\Processor\Content\UrlRedirectProcessor.inner'

--- a/src/lib/RepositoryForms/Form/Processor/Content/UrlRedirectProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/Content/UrlRedirectProcessor.php
@@ -121,7 +121,7 @@ class UrlRedirectProcessor implements EventSubscriberInterface
             ? $this->router->generate(
                 '_ezpublishLocation',
                 [
-                    'locationId' => $location->getContentInfo()->mainLocationId,
+                    'locationId' => $location->id,
                 ],
                 UrlGeneratorInterface::ABSOLUTE_URL
             )

--- a/src/lib/RepositoryForms/Form/Processor/Content/UrlRedirectProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/Content/UrlRedirectProcessor.php
@@ -120,15 +120,23 @@ class UrlRedirectProcessor implements EventSubscriberInterface
         /* If target URL was set to something else than Location, do nothing */
         try {
             $targetUrlAlias = $this->urlAliasService->lookup(
-                $response->getTargetUrl()
+                $response->getTargetUrl(),
+                null,
+                true
             );
-        } catch (InvalidArgumentException $e) {
-            return;
-        } catch (NotFoundException $e) {
+        } catch (InvalidArgumentException | NotFoundException $e) {
+            $event->setResponse(new RedirectResponse($this->router->generate(
+                'ezplatform.dashboard',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )));
+
             return;
         }
 
         if ($targetUrlAlias->type !== URLAlias::LOCATION) {
+            $event->setResponse(new RedirectResponse($targetUrlAlias->destination));
+
             return;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29617
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes (locally, depends on repository-forms)
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This solves redirect problem, when published content do not match any siteaccess. 

Flow of redirect is changed - repository-forms redirects now to `_ezpublishLocation` route, and adminUI handles the redirect in terms of frontend / adminUI side.

https://github.com/ezsystems/repository-forms/pull/256

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
