### PR TITLE
EZP-29615: User is unable to redo the same step after using web browser back button

### DIFF
--- a/src/bundle/Resources/views/content/widgets/content_create.html.twig
+++ b/src/bundle/Resources/views/content/widgets/content_create.html.twig
@@ -3,7 +3,7 @@
 <div class="ez-extra-actions ez-extra-actions--create ez-extra-actions--hidden bg-secondary" data-actions="create">
     <div class="ez-extra-actions__header">{{ 'content.create.choose_content_type'|trans|desc('Create your content') }}</div>
     <div class="ez-extra-actions__content">
-        {{ form_start(form, { 'action': path('ezplatform.content.create') }) }}
+        {{ form_start(form, { 'action': path('ezplatform.content.create'), 'attr': { 'autocomplete': 'off' } }) }}
             {% if form.language.vars.choices|length == 1 %}
                 {{ form_widget(form.language, {'attr': {'hidden': true}}) }}
             {% else %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29615
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Disables browser autocomplete in form resposible for creating new content (side menu).


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
