### PR TITLE
EZP-29650: [Content Type Fields] Selection field UI issues

### DIFF
--- a/src/bundle/Resources/public/scss/core/_custom.dropdown.scss
+++ b/src/bundle/Resources/public/scss/core/_custom.dropdown.scss
@@ -27,7 +27,7 @@
             height: 0;
             border-style: solid;
             border-width: calculateRem(10px) calculateRem(5px) 0 calculateRem(5px);
-            border-color: $ez-white $ez-black $ez-black $ez-black;
+            border-color: $ez-white $ez-color-secondary $ez-color-secondary $ez-color-secondary;
             position: absolute;
             z-index: 1;
             right: calculateRem(16px);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29650
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixes color of arrow in Selection field.

![screen shot 2018-09-26 at 15 15 28](https://user-images.githubusercontent.com/10233057/46082275-06a15f80-c19f-11e8-8bf3-26dceafa81fc.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
