### PR TITLE
[i18n] Added missing UI translations

### DIFF
--- a/src/bundle/Resources/translations/content_url.en.xliff
+++ b/src/bundle/Resources/translations/content_url.en.xliff
@@ -126,11 +126,6 @@
         <target state="new">URL</target>
         <note>key: tab.urls.url</note>
       </trans-unit>
-      <trans-unit id="8cbd9ea97c79240d3a2f41a84328c79908cd8265" resname="tabs.urls.add.site_root.helper.no_parent_name">
-        <source>Unchecked will create the new alias under the parent of the location</source>
-        <target state="new">Unchecked will create the new alias under the parent of the location</target>
-        <note>key: tabs.urls.add.site_root.helper.no_parent_name</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/translations/ezrepoforms_content_type.en.xliff
+++ b/src/bundle/Resources/translations/ezrepoforms_content_type.en.xliff
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="e03e262fad0802fdee49aac136644b35450e1eab" resname="field_definition.ezobjectrelation.selection_root_udw_button">
+        <source>field_definition.ezobjectrelation.selection_root_udw_button</source>
+        <target state="new">field_definition.ezobjectrelation.selection_root_udw_button</target>
+        <note>key: field_definition.ezobjectrelation.selection_root_udw_button</note>
+      </trans-unit>
+      <trans-unit id="d892163a41d816c03db3c4a04e35550f02169c11" resname="field_definition.ezobjectrelation.selection_root_udw_title">
+        <source>field_definition.ezobjectrelation.selection_root_udw_title</source>
+        <target state="new">field_definition.ezobjectrelation.selection_root_udw_title</target>
+        <note>key: field_definition.ezobjectrelation.selection_root_udw_title</note>
+      </trans-unit>
+      <trans-unit id="1592c36df8d445c3154d1f639027f97a90739856" resname="field_definition.ezobjectrelationlist.selection_root_udw_button">
+        <source>field_definition.ezobjectrelationlist.selection_root_udw_button</source>
+        <target state="new">field_definition.ezobjectrelationlist.selection_root_udw_button</target>
+        <note>key: field_definition.ezobjectrelationlist.selection_root_udw_button</note>
+      </trans-unit>
+      <trans-unit id="17d8f3e8bbd5b5f0f5b4b02ddaeaf2af82b0d222" resname="field_definition.ezobjectrelationlist.selection_root_udw_title">
+        <source>field_definition.ezobjectrelationlist.selection_root_udw_title</source>
+        <target state="new">field_definition.ezobjectrelationlist.selection_root_udw_title</target>
+        <note>key: field_definition.ezobjectrelationlist.selection_root_udw_title</note>
+      </trans-unit>
+      <trans-unit id="14a95e986cd6b94301e0f44fd5ef2d5e7cdf90a4" resname="field_definition.ezselection.add_option">
+        <source>field_definition.ezselection.add_option</source>
+        <target state="new">field_definition.ezselection.add_option</target>
+        <note>key: field_definition.ezselection.add_option</note>
+      </trans-unit>
+      <trans-unit id="c8017c71074191e0e6ebe4eb1a3a278eecbcc874" resname="field_definition.ezselection.remove_selected_options">
+        <source>field_definition.ezselection.remove_selected_options</source>
+        <target state="new">field_definition.ezselection.remove_selected_options</target>
+        <note>key: field_definition.ezselection.remove_selected_options</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/ezrepoforms_role.en.xliff
+++ b/src/bundle/Resources/translations/ezrepoforms_role.en.xliff
@@ -11,6 +11,11 @@
         <target state="new">Update</target>
         <note>key: policy_create.save</note>
       </trans-unit>
+      <trans-unit id="c418f83922f6a4ea7412120a3b731a3e8665eead" resname="policy_create.update">
+        <source>Update</source>
+        <target state="new">Update</target>
+        <note>key: policy_create.update</note>
+      </trans-unit>
       <trans-unit id="05cc1fd4658faa760de6e98cb71e1054157e63a0" resname="policy_delete.delete">
         <source>Delete</source>
         <target state="new">Delete</target>
@@ -30,6 +35,21 @@
         <source>All modules / All functions</source>
         <target state="new">All modules / All functions</target>
         <note>key: role.policy.all_modules_all_functions</note>
+      </trans-unit>
+      <trans-unit id="0eda0d605bd42eb8989a82e546d09ace8bc1b4d9" resname="role.policy.limitation.location.udw_button">
+        <source>role.policy.limitation.location.udw_button</source>
+        <target state="new">role.policy.limitation.location.udw_button</target>
+        <note>key: role.policy.limitation.location.udw_button</note>
+      </trans-unit>
+      <trans-unit id="73a82ac42476a68fb0216ebecd04f01f11bf44b2" resname="role.policy.limitation.location.udw_title">
+        <source>role.policy.limitation.location.udw_title</source>
+        <target state="new">role.policy.limitation.location.udw_title</target>
+        <note>key: role.policy.limitation.location.udw_title</note>
+      </trans-unit>
+      <trans-unit id="be8159ab7985797bd281cb0f7f58bb4d2c925159" resname="role.policy.limitation.not_implemented">
+        <source>role.policy.limitation.not_implemented</source>
+        <target state="new">role.policy.limitation.not_implemented</target>
+        <note>key: role.policy.limitation.not_implemented</note>
       </trans-unit>
       <trans-unit id="d3c70d265ab037db5ade02a8b738b5981353c7ac" resname="role.policy.type">
         <source>Type</source>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -71,10 +71,10 @@
         <target state="new">To:</target>
         <note>key: search.date.to</note>
       </trans-unit>
-      <trans-unit id="9db82102d1da5efb63380ca328a83d13732a02ee" resname="search.filter">
-        <source>Filter</source>
-        <target state="new">Filter</target>
-        <note>key: search.filter</note>
+      <trans-unit id="bf24ae2c9083c948931ad1b4d4405b6261eb9bc6" resname="search.filters">
+        <source>Filters</source>
+        <target state="new">Filters</target>
+        <note>key: search.filters</note>
       </trans-unit>
       <trans-unit id="0ec8148d681b43e87a6d0751fff188517be1ea26" resname="search.header">
         <source>Search results (%total%)</source>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR adds missing AdminUI translations related to several parts of the user interface.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
