### PR TITLE
EZP-29674: Translation extractor displays error when processing Tag/Style mappers

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/mappers.yml
+++ b/src/bundle/Resources/config/services/ui_config/mappers.yml
@@ -5,8 +5,6 @@ services:
     # RichText Custom Tags UI config attribute type mappers
     EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\CommonAttributeMapper:
         autowire: true
-        arguments:
-            $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
         tags:
             - { name: ezplatform.admin_ui.richtext_custom_tag_attribute_mapper, priority: 0 }
 

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -77,20 +77,8 @@ class CustomTag
                 );
             }
 
-            $config[$tagName]['label'] = $this->translator->trans(
-                sprintf('ezrichtext.custom_tags.%s.label', $tagName),
-                [],
-                $this->translationDomain
-            );
-            $config[$tagName]['description'] = $this->translator->trans(
-                sprintf(
-                    'ezrichtext.custom_tags.%s.description',
-                    $tagName
-                ),
-                [],
-                $this->translationDomain
-            );
-
+            $config[$tagName]['label'] = "ezrichtext.custom_tags.{$tagName}.label";
+            $config[$tagName]['description'] = "ezrichtext.custom_tags.{$tagName}.description";
             foreach ($customTagConfiguration['attributes'] as $attributeName => $properties) {
                 $typeMapper = $this->getAttributeTypeMapper(
                     $tagName,
@@ -105,7 +93,7 @@ class CustomTag
             }
         }
 
-        return $config;
+        return $this->translateLabels($config);
     }
 
     /**
@@ -136,5 +124,45 @@ class CustomTag
         throw new RuntimeException(
             "RichText Custom Tag configuration: unsupported attribute type '{$attributeType}' of '{$attributeName}' attribute of '{$tagName}' Custom Tag"
         );
+    }
+
+    /**
+     * Process Custom Tags config and translate labels for UI.
+     *
+     * @param array $config
+     *
+     * @return array processed Custom Tags config with translated labels
+     */
+    private function translateLabels(array $config): array
+    {
+        foreach ($config as $tagName => $tagConfig) {
+            $config[$tagName]['label'] = $this->translator->trans(
+                /** @Ignore */
+                $tagConfig['label'],
+                [],
+                $this->translationDomain
+            );
+            $config[$tagName]['description'] = $this->translator->trans(
+                /** @Ignore */
+                $tagConfig['description'],
+                [],
+                $this->translationDomain
+            );
+
+            if (empty($tagConfig['attributes'])) {
+                continue;
+            }
+
+            foreach ($tagConfig['attributes'] as $attributeName => $attributeConfig) {
+                $config[$tagName]['attributes'][$attributeName]['label'] = $this->translator->trans(
+                    /** @Ignore */
+                    $attributeConfig['label'],
+                    [],
+                    $this->translationDomain
+                );
+            }
+        }
+
+        return $config;
     }
 }

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -77,8 +77,10 @@ class CustomTag
                 );
             }
 
-            $config[$tagName]['label'] = "ezrichtext.custom_tags.{$tagName}.label";
-            $config[$tagName]['description'] = "ezrichtext.custom_tags.{$tagName}.description";
+            $config[$tagName] = [
+                'label' => "ezrichtext.custom_tags.{$tagName}.label",
+                'description' => "ezrichtext.custom_tags.{$tagName}.description",
+            ];
             foreach ($customTagConfiguration['attributes'] as $attributeName => $properties) {
                 $typeMapper = $this->getAttributeTypeMapper(
                     $tagName,

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/CommonAttributeMapper.php
@@ -8,25 +8,11 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag;
 
-use Symfony\Component\Translation\TranslatorInterface;
-
 /**
  * Map RichText Custom Tag attribute of any type to proper UI config.
  */
 class CommonAttributeMapper implements AttributeMapper
 {
-    /** @var TranslatorInterface */
-    protected $translator;
-
-    /** @var string */
-    protected $translationDomain;
-
-    public function __construct(TranslatorInterface $translator, string $translationDomain)
-    {
-        $this->translator = $translator;
-        $this->translationDomain = $translationDomain;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -44,15 +30,7 @@ class CommonAttributeMapper implements AttributeMapper
         array $customTagAttributeProperties
     ): array {
         return [
-            'label' => $this->translator->trans(
-                sprintf(
-                    'ezrichtext.custom_tags.%s.attributes.%s.label',
-                    $tagName,
-                    $attributeName
-                ),
-                [],
-                $this->translationDomain
-            ),
+            'label' => "ezrichtext.custom_tags.{$tagName}.attributes.{$attributeName}.label",
             'type' => $customTagAttributeProperties['type'],
             'required' => $customTagAttributeProperties['required'],
             'defaultValue' => $customTagAttributeProperties['default_value'],


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29674](https://jira.ez.no/browse/EZP-29674)
| **Target version** | **2.2**
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

JMS Translation extractor has to ignore dynamic labels that are translated by Custom Tags UI configuration mapper. Otherwise it will display the error described in the [JIRA issue](https://jira.ez.no/browse/EZP-29674).

The change also involves refactoring - moving responsibility of translating labels
to a separate method, so it's more readable. For 2.3 we could refactor this even further moving that responsibility to a custom translation extractor, which is clearly needed here, in AdminUI.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
- [ ] On merge up to 1.3 (master, for eZ Platform 2.3) - apply the same logic for Custom Styles.
