### PR TITLE
EZP-29687: eZ(date)Picker field clear button (X) does not clear date in flatpickr instance

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.picker.js
+++ b/src/bundle/Resources/public/js/scripts/admin.picker.js
@@ -1,4 +1,4 @@
-(function (global, doc, flatpickr) {
+(function(global, doc, flatpickr) {
     const SELECTOR_PICKER = '.ez-picker';
     const SELECTOR_PICKER_INPUT = '.ez-picker__input';
     const SELECTOR_FORM_INPUT = '.ez-picker__form-input';
@@ -7,7 +7,7 @@
     const pickerConfig = {
         enableTime: true,
         time_24hr: true,
-        formatDate: (date) => (new Date(date)).toLocaleString(),
+        formatDate: (date) => new Date(date).toLocaleString(),
     };
     const updateInputValue = (formInput, date) => {
         if (!date.length) {
@@ -19,6 +19,11 @@
         date = new Date(date[0]);
         formInput.value = Math.floor(date.getTime() / 1000);
     };
+    const onClearBtnClick = (flatpickrInstance, event) => {
+        event.preventDefault();
+
+        flatpickrInstance.setDate(null, true);
+    };
     const initFlatPickr = (field) => {
         const formInput = field.querySelector(SELECTOR_FORM_INPUT);
         const pickerInput = field.querySelector(SELECTOR_PICKER_INPUT);
@@ -29,17 +34,15 @@
             defaultDate = new Date(formInput.value * 1000);
         }
 
-        btnClear.addEventListener('click', (event) => {
-            event.preventDefault();
+        const flatpickrInstance = flatpickr(
+            pickerInput,
+            Object.assign({}, pickerConfig, {
+                onChange: updateInputValue.bind(null, formInput),
+                defaultDate,
+            })
+        );
 
-            pickerInput.value = '';
-            formInput.value = '';
-        }, false);
-
-        flatpickr(pickerInput, Object.assign({}, pickerConfig, {
-            onChange: updateInputValue.bind(null, formInput),
-            defaultDate,
-        }));
+        btnClear.addEventListener('click', onClearBtnClick.bind(null, flatpickrInstance), false);
     };
 
     pickers.forEach(initFlatPickr);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29687
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


In ezPicker field after clicking "clear" button (X) date in flatpickr instance is not cleared.

For QA: when it comes to fields `date`, `datetime`, `time` from CI edit, these are other fields. You can find eZPicker in e.g. Scheduler tab in Page Builder.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
