### PR TITLE
EZEE-2487: Version conflict pop-up missing for My scheduled on Dashboard

### DIFF
--- a/src/bundle/Resources/views/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard/dashboard.html.twig
@@ -34,6 +34,7 @@
         {{ form_widget(form_edit.language, {'attr': {'hidden': 'hidden', 'class': 'language-input'}}) }}
         {{ form_end(form_edit) }}
     </div>
+    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -42,7 +42,6 @@
         {% endfor %}
         </tbody>
     </table>
-    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
 {% else %}
     <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
 {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2487
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As there was problem with displaying modal included on different tab (prolly some display none issue) and including it second time made it duplicated I have moved this modal from single tab into dashboard.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review