### PR TITLE
EZP-29683: Status in link manager is misaligned

### DIFF
--- a/src/bundle/Resources/views/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/link_manager/list.html.twig
@@ -21,27 +21,21 @@
 
 {%- block content -%}
     <section class="container mt-4">
-        {{ form_start(form, {'attr': {'class': 'form-inline'}}) }}
-            <div class="row w-100 justify-content-between">
-                <div class="col-lg-6">
-                    <div class="input-group">
-                        {{ form_widget(form.searchQuery, { attr: {
-                            'placeholder': 'url.search.placeholder'|trans,
-                        }}) }}
+        {{ form_start(form, {'attr': {'class': 'form-inline justify-content-between'}}) }}
+            <div class="input-group">
+                {{ form_widget(form.searchQuery, { attr: {
+                    'placeholder': 'url.search.placeholder'|trans,
+                }}) }}
 
-                        <span class="input-group-btn">
-                            <button class="btn btn-primary">
-                                {{ 'url.search'|trans }}
-                            </button>
-                        </span>
-                    </div>
-                </div>
-                <div class="col-auto">
-                    <div class="d-inline-flex">
-                        {{ form_label(form.status) }} &nbsp;
-                        {{ form_widget(form.status) }}
-                    </div>
-                </div>
+                <span class="input-group-btn">
+                    <button class="btn btn-primary">
+                        {{ 'url.search'|trans }}
+                    </button>
+                </span>
+            </div>
+            <div class="d-inline-flex">
+                {{ form_label(form.status) }} &nbsp;
+                {{ form_widget(form.status) }}
             </div>
 
         {{ form_widget(form.page, { attr: { value: '1' }}) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29683
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![screen shot 2018-10-03 at 9 52 33 am](https://user-images.githubusercontent.com/1654712/46397344-4d88db00-c6f2-11e8-814a-fab1d991e82d.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
