### PR TITLE
EZP-29653: Image asset is not properly styled on Safari

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/preview/_ezimageasset.scss
+++ b/src/bundle/Resources/public/scss/fieldType/preview/_ezimageasset.scss
@@ -9,6 +9,7 @@
 
         &__image-meta {
             flex-basis: 43%;
+            max-width: 43%;
         }
 
         &__actions-wrapper {

--- a/src/bundle/Resources/views/fieldtypes/preview/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/ezimageasset.html.twig
@@ -13,7 +13,9 @@
     <table class="ez-field-preview__image-meta">
         <thead>
             <tr>
-                <th>{{ 'ezimageasset.image_file_properties'|trans|desc('Image file properties') }}:</th>
+                <th colspan="2">
+                    {{ 'ezimageasset.image_file_properties'|trans|desc('Image file properties') }}:
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -42,11 +44,13 @@
                 <td>{{ 'ezimageasset.ratio'|trans|desc('Ratio') }}:</td>
                 <td>{{ (field.value.width/field.value.height)|round(2) }}</td>
             </tr>
-
         </tbody>
     </table>
     <div class="ez-field-preview__actions-wrapper">
-        <a class="ez-field-preview__action ez-field-preview__action--preview" href="{{ field.value.uri }}" target="_blank">
+        <a
+            class="ez-field-preview__action ez-field-preview__action--preview"
+            href="{{ field.value.uri }}"
+            target="_blank">
             <svg class="ez-icon ez-icon--medium ez-icon--light">
                 <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#open-newtab"></use>
             </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29653
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<img width="1172" alt="screen shot 2018-10-03 at 12 40 32 pm" src="https://user-images.githubusercontent.com/1654712/46405763-8da78800-c709-11e8-8117-f625648d0f67.png">


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
