### PR TITLE
EZP-29610: 'Create new URL alias' modal is rendered when user select URL tab

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.add.custom_url.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.add.custom_url.js
@@ -1,27 +1,30 @@
 (function (global, doc) {
     const modal = doc.querySelector('#ez-modal--custom-url-alias');
-    const discardBtns = [...modal.querySelectorAll('[data-dismiss="modal"]')];
-    const submitBtn = modal.querySelector('[type="submit"]');
-    const input = modal.querySelector('[required="required"]');
-    const checkboxes = [...modal.querySelectorAll('.ez-field-edit--ezboolean input')];
-    const toggleButtonState = () => {
-        const hasValue = input.value.trim().length !== 0;
-        const methodName = hasValue ? 'removeAttribute' : 'setAttribute';
 
-        submitBtn[methodName]('disabled', true);
-    };
-    const toggleCheckbox = (event) => {
-        const checkbox = event.target;
-        const methodName = checkbox.checked ? 'add' : 'remove';
+    if (modal) {
+        const discardBtns = [...modal.querySelectorAll('[data-dismiss="modal"]')];
+        const submitBtn = modal.querySelector('[type="submit"]');
+        const input = modal.querySelector('[required="required"]');
+        const checkboxes = [...modal.querySelectorAll('.ez-field-edit--ezboolean input')];
+        const toggleButtonState = () => {
+            const hasValue = input.value.trim().length !== 0;
+            const methodName = hasValue ? 'removeAttribute' : 'setAttribute';
 
-        checkbox.closest('.ez-data-source__label').classList[methodName]('is-checked');
-    };
-    const clearValues = () => {
-        input.value = '';
-        toggleButtonState();
-    };
+            submitBtn[methodName]('disabled', true);
+        };
+        const toggleCheckbox = (event) => {
+            const checkbox = event.target;
+            const methodName = checkbox.checked ? 'add' : 'remove';
 
-    input.addEventListener('input', toggleButtonState, false);
-    checkboxes.forEach(checkbox => checkbox.addEventListener('change', toggleCheckbox, false));
-    discardBtns.forEach(btn => btn.addEventListener('click', clearValues, false));
+            checkbox.closest('.ez-data-source__label').classList[methodName]('is-checked');
+        };
+        const clearValues = () => {
+            input.value = '';
+            toggleButtonState();
+        };
+
+        input.addEventListener('input', toggleButtonState, false);
+        checkboxes.forEach(checkbox => checkbox.addEventListener('change', toggleCheckbox, false));
+        discardBtns.forEach(btn => btn.addEventListener('click', clearValues, false));
+    }
 })(window, document);

--- a/src/bundle/Resources/views/content/tab/urls.html.twig
+++ b/src/bundle/Resources/views/content/tab/urls.html.twig
@@ -57,19 +57,34 @@
     }) }}
 {% endif %}
 
-{% include '@ezdesign/content/tab/url/modal_add_custom_url.html.twig' with {'form': form_custom_url_add, 'parent_name': parent_name} only %}
+{% if can_edit_custom_url %}
+    {% include '@ezdesign/content/tab/url/modal_add_custom_url.html.twig' with {
+        'form': form_custom_url_add,
+        'parent_name': parent_name
+    } only %}
+{% endif %}
 
 {% macro table_header_tools(form_custom_url_remove, can_edit_custom_url) %}
     {% if can_edit_custom_url %}
-        <button class="btn btn-primary ez-btn--prevented" data-toggle="modal" data-target="#ez-modal--custom-url-alias" title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
+        <button
+            class="btn btn-primary ez-btn--prevented"
+            data-toggle="modal"
+            data-target="#ez-modal--custom-url-alias"
+            title="{{ 'tab.urls.action.add'|trans|desc('Add Custom URL') }}">
             <svg class="ez-icon ez-icon-create">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
             </svg>
         </button>
 
         {% set modal_data_target = 'delete-custom-url-modal' %}
-        <button id="delete-custom-urls" type="button" class="btn btn-danger" disabled data-toggle="modal"
-                data-target="#{{ modal_data_target }}" title="{{ 'tab.urls.action.delete'|trans|desc('Delete Custom URL') }}">
+        <button
+            id="delete-custom-urls"
+            type="button"
+            class="btn btn-danger"
+            disabled
+            data-toggle="modal"
+            data-target="#{{ modal_data_target }}"
+            title="{{ 'tab.urls.action.delete'|trans|desc('Delete Custom URL') }}">
             <svg class="ez-icon ez-icon-trash">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
             </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29610
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When the user can not add Custom URL modal is not rendered (it depends on `content/urltranslator` policy.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
