### PR TITLE
EZP-29650: Fix Selection field (Content Type fields) arrow color

### DIFF
--- a/src/bundle/Resources/public/scss/core/_custom.dropdown.scss
+++ b/src/bundle/Resources/public/scss/core/_custom.dropdown.scss
@@ -3,7 +3,6 @@
         position: relative;
         color: $ez-color-base-dark;
         font-weight: 700;
-        cursor: pointer;
     }
 
     &__selection-info {
@@ -20,6 +19,7 @@
         display: flex;
         align-items: center;
         flex-wrap: wrap;
+        cursor: pointer;
 
         &:before {
             content: '';

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezselection.scss
@@ -3,6 +3,5 @@
         position: relative;
         color: $ez-color-base-dark;
         font-weight: bold;
-        cursor: pointer;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29650
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixes 1. problem - pointer cursor.
2. problem was fixed in: https://github.com/ezsystems/ezplatform-admin-ui/pull/648 by the by of other task.
Previous PR to this task was closed: https://github.com/ezsystems/ezplatform-admin-ui/pull/644.
More info in JIRA.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
