### PR TITLE
EZP-29080: Select data range - date selectors are too close

### DIFF
--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -19,6 +19,10 @@
         &-label {
             margin-bottom: 0;
             font-weight: 700;
+
+            &--date-range {
+                flex-basis: 45%;
+            }
         }
 
         &--creator {

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -77,11 +77,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <label class="ez-filters__item-label">{{ 'search.date.from'|trans|desc('From:') }}
+                <label class="ez-filters__item-label ez-filters__item-label--date-range">{{ 'search.date.from'|trans|desc('From:') }}
                     <input type="text" class="form-control ez-date-select ez-date-select--start" data-target-selector="#modified-start-range">
                     <input type="text" id="modified-start-range" hidden>
                 </label>
-                <label class="ez-filters__item-label">{{ 'search.date.to'|trans|desc('To:') }}
+                <label class="ez-filters__item-label ez-filters__item-label--date-range">{{ 'search.date.to'|trans|desc('To:') }}
                     <input type="text" class="form-control ez-date-select ez-date-select--end" data-target-selector="#modified-end-range">
                     <input type="text" id="modified-end-range" hidden>
                 </label>
@@ -109,11 +109,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <label class="ez-filters__item-label">{{ 'search.date.from'|trans|desc('From:') }}
+                <label class="ez-filters__item-label ez-filters__item-label--date-range">{{ 'search.date.from'|trans|desc('From:') }}
                     <input type="text" class="form-control ez-date-select ez-date-select--start" data-target-selector="#created-start-range">
                     <input type="text" id="created-start-range" hidden>
                 </label>
-                <label class="ez-filters__item-label">{{ 'search.date.to'|trans|desc('To:') }}
+                <label class="ez-filters__item-label ez-filters__item-label--date-range">{{ 'search.date.to'|trans|desc('To:') }}
                     <input type="text" class="form-control ez-date-select ez-date-select--end" data-target-selector="#created-end-range">
                     <input type="text" id="created-end-range" hidden>
                 </label>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29080
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Firefox: 
![firefox2018-10-04 at 2 01 11 pm](https://user-images.githubusercontent.com/1654712/46472875-db41f480-c7de-11e8-9a90-fd1cceb5814d.png)

Safari:
![screen shot 2018-10-04 at 2 10 41 pm](https://user-images.githubusercontent.com/1654712/46473083-599e9680-c7df-11e8-897b-97fd281eeb32.png)

Chrome:
<img width="582" alt="safari2018-10-04 at 2 07 00 pm" src="https://user-images.githubusercontent.com/1654712/46472877-db41f480-c7de-11e8-95a9-97f66ff5801b.png">


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
