### PR TITLE
EZP-29676: Arrow pointing into Filters is too thin in Edge

### DIFF
--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -62,12 +62,12 @@
 
     &:before {
         border-color: $ez-color-secondary transparent;
-        top: calculateRem(-10px);
+        top: calculateRem(-11px);
     }
 
     &:after {
         border-color: $ez-ground-base-light transparent;
-        top: calculateRem(-9px);
+        top: calculateRem(-10px);
     }
 
     &__btns {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29676
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Chrome:
![chrome2018-10-05 at 11 33 56 am](https://user-images.githubusercontent.com/1654712/46528615-8660b580-c894-11e8-9d25-832aa016708f.png)

Edge:
![edge 2018-10-05 at 11 21 25 am](https://user-images.githubusercontent.com/1654712/46528617-8660b580-c894-11e8-8529-12313f43e138.png)

Firefox
![firefox 2018-10-05 at 11 33 18 am](https://user-images.githubusercontent.com/1654712/46528618-8660b580-c894-11e8-88f9-2c2771dd65e1.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
