### PR TITLE
EZP-29639: Labels for checkboxes and radioboxes are misaligned with inputs

### DIFF
--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -13,7 +13,6 @@ form:not(.form-inline) {
         &:not(.ez-data-source__label) {
             @include label-required();
         }
-
     }
 
     .col-form-legend {
@@ -47,7 +46,7 @@ form:not(.form-inline) {
     .col-form-label,
     .form-control,
     .ez-field-edit__label {
-        margin-right: .5rem;
+        margin-right: 0.5rem;
     }
 }
 
@@ -56,22 +55,6 @@ form:not(.form-inline) {
         display: flex;
         flex-flow: row wrap;
         justify-content: flex-start;
-    }
-}
-
-.form-check {
-    margin-bottom: 0;
-
-    &-label {
-        display: flex;
-        align-items: center;
-        margin-bottom: 0;
-    }
-
-    &-input {
-        position: initial;
-        margin-bottom: .25rem;
-        margin-right: .5rem;
     }
 }
 
@@ -90,7 +73,7 @@ form:not(.form-inline) {
             position: relative;
 
             &:before {
-                content : '!';
+                content: '!';
                 position: absolute;
                 top: 0;
                 left: -20px;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29639
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

Note for QA: This code was introduced to fix this issue: https://jira.ez.no/browse/EZP-28641
From my briefly testing is not occur, but please check it.