### PR TITLE
EZP-29700: Syntax error after logging out

### DIFF
--- a/src/bundle/Resources/config/bazinga_js_translation.yml
+++ b/src/bundle/Resources/config/bazinga_js_translation.yml
@@ -2,3 +2,4 @@ active_domains:
     - 'universal_discovery_widget'
     - 'alloy_editor'
     - 'fieldtypes_edit'
+    - 'notifications'

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -1,5 +1,6 @@
 (function(global, doc, eZ, React, ReactDOM, Translator) {
     let currentPageLink = null;
+    let getNotificationsStatusErrorShowed = false;
     const SELECTOR_MODAL_ITEM = '.ez-notifications-modal__item';
     const SELECTOR_MODAL_RESULTS = '.ez-notifications-modal__results';
     const SELECTOR_MODAL_TITLE = '.modal-title';
@@ -10,9 +11,8 @@
     const CLASS_MODAL_LOADING = 'ez-notifications-modal--loading';
     const INTERVAL = 30000;
     const modal = doc.querySelector('.ez-notifications-modal');
-    const showErrorNotification = eZ.helpers.notification.showErrorNotification;
-    const getJsonFromResponse = eZ.helpers.request.getJsonFromResponse;
-    const getTextFromResponse = eZ.helpers.request.getTextFromResponse;
+    const { showErrorNotification, showWarningNotification } = eZ.helpers.notification;
+    const { getJsonFromResponse, getTextFromResponse } = eZ.helpers.request;
     const markAsRead = (notification, response) => {
         if (response.status === 'success') {
             notification.classList.add('ez-notifications-modal__item--read');
@@ -65,8 +65,28 @@
             .then((notificationsInfo) => {
                 setPendingNotificationCount(notificationsInfo);
                 updateModalTitleTotalInfo(notificationsInfo.total);
+                getNotificationsStatusErrorShowed = false;
             })
-            .catch(console.error);
+            .catch(onGetNotificationsStatusFailure);
+    };
+
+    /**
+     * Handle a failure while getting notifications status
+     *
+     * @method onGetNotificationsStatusFailure
+     */
+    const onGetNotificationsStatusFailure = (error) => {
+        const message = Translator.trans(
+            /* @Desc("Cannot update notifications count") */ 'notifications.modal.message.error',
+            { error: error.message },
+            'notifications'
+        );
+
+        if (!getNotificationsStatusErrorShowed) {
+            showWarningNotification(message);
+        }
+
+        getNotificationsStatusErrorShowed = true;
     };
     const updateModalTitleTotalInfo = (notificationsCount) => {
         const modalTitle = modal.querySelector(SELECTOR_MODAL_TITLE);

--- a/src/bundle/Resources/translations/notifications.en.xliff
+++ b/src/bundle/Resources/translations/notifications.en.xliff
@@ -56,6 +56,11 @@
         <target state="new">Notifications</target>
         <note>key: notifications</note>
       </trans-unit>
+      <trans-unit id="79036b8a9fecbed5d0c14a94c5639d611c6ab6d1" resname="notifications.modal.message.error">
+        <source>Cannot update notifications count</source>
+        <target state="new">Cannot update notifications count</target>
+        <note>key: notifications.modal.message.error</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2018-10-05 at 4 19 56 pm](https://user-images.githubusercontent.com/1654712/46540773-8c698d00-c8ba-11e8-8371-242dbb5f0242.png)

When a user has logged out a notification with information is show one time. When the user is logged back in and log out again information is shown again.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

