### PR TITLE
EZP-29707: Cannot read property remove of null error from Selection

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -81,7 +81,11 @@
                     .querySelector(SELECTOR_SELECTION_INFO)
                     .insertAdjacentHTML('beforeend', this[createSelectedItem](value, element.innerHTML));
             } else {
-                this.container.querySelector(`${SELECTOR_SELECTION_INFO} [data-value="${value}"]`).remove();
+                const valueNode = this.container.querySelector(`${SELECTOR_SELECTION_INFO} [data-value="${value}"]`);
+
+                if (valueNode) {
+                    valueNode.remove();
+                }
             }
 
             if (this[canSelectOnlyOne] && !selected && this.hasDefaultSelection) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29707
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
