### PR TITLE
EZP-29709: RequestLocaleListener tries to match SiteAccess on /_fos_user_context_hash

### DIFF
--- a/src/lib/EventListener/RequestLocaleListener.php
+++ b/src/lib/EventListener/RequestLocaleListener.php
@@ -41,7 +41,7 @@ class RequestLocaleListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 13],
+            KernelEvents::REQUEST => ['onKernelRequest', 6],
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29709](https://jira.ez.no/browse/EZP-29709)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The `RequestLocaleListener` is called too early. In case of request to `/_fos_user_context_hash` it tries to resolve SiteAccess from the request, but since this route is not SiteAccess aware it ends-up with an Exception thrown from: https://github.com/ezsystems/ezplatform-admin-ui/blob/master/src/lib/Specification/SiteAccess/IsAdmin.php#L39

The `FOS\HttpCacheBundle\EventListener\UserContextSubscriber::onKernelRequest()` should be called before, therefore I've decreased the priority of the `RequestLocaleListener`.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
