### PR TITLE
EZP-29660: Ezobjectrelationlist ignores allowed content types when creating content via UDW

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/relation_base.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/relation_base.html.twig
@@ -4,6 +4,7 @@
     {% set limit = limit|default(0) %}
     {% set default_location = default_location|default(1) %}
     {% set has_relations = relations|length > 0 %}
+    {% set allowed_content_types = form.parent.vars.value.fieldDefinition.fieldSettings.selectionContentTypes %}
     <div class="ez-relations__wrapper" {% if not has_relations %}hidden="true"{% endif %}>
         <table class="table ez-relations__table">
             <thead>
@@ -17,9 +18,17 @@
                 <th class="ez-relations__table-actions">
                     <button
                         {% if limit == 1 %}
-                            data-udw-config="{{ ez_udw_config('single', {'type': 'object_relation', 'starting_location_id' : default_location}) }}"
+                            data-udw-config="{{ ez_udw_config('single', {
+                                'type': 'object_relation',
+                                'starting_location_id' : default_location,
+                                'allowed_content_types': allowed_content_types
+                            }) }}"
                         {% else %}
-                            data-udw-config="{{ ez_udw_config('multiple', {'type': 'object_relation', 'starting_location_id' : default_location} ) }}"
+                            data-udw-config="{{ ez_udw_config('multiple', {
+                                'type': 'object_relation',
+                                'starting_location_id' : default_location,
+                                'allowed_content_types': allowed_content_types
+                            }) }}"
                         {% endif %}
                         type="button"
                         class="ez-relations__table-action--create btn btn-primary"
@@ -65,9 +74,17 @@
         </p>
         <button
                 {% if limit == 1 %}
-                    data-udw-config="{{ ez_udw_config('single', {'type': 'object_relation', 'starting_location_id' : default_location}) }}"
+                    data-udw-config="{{ ez_udw_config('single', {
+                        'type': 'object_relation',
+                        'starting_location_id' : default_location,
+                        'allowed_content_types': allowed_content_types
+                    }) }}"
                 {% else %}
-                    data-udw-config="{{ ez_udw_config('multiple', {'type': 'object_relation', 'starting_location_id' : default_location} ) }}"
+                    data-udw-config="{{ ez_udw_config('multiple', {
+                        'type': 'object_relation',
+                        'starting_location_id' : default_location,
+                        'allowed_content_types': allowed_content_types
+                    }) }}"
                 {% endif %}
                 class="ez-relations__cta-btn btn btn-primary"
                 type="button">

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber;
+
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConfigResolveEvent::NAME => ['onUdwConfigResolve'],
+        ];
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent $event
+     */
+    public function onUdwConfigResolve(ConfigResolveEvent $event): void
+    {
+        $context = $event->getContext();
+        $config = $event->getConfig();
+
+        if (!in_array($event->getConfigName(), ['single', 'multiple'])) {
+            return;
+        }
+
+        if (
+            !isset($context['type'], $context['allowed_content_types'])
+            || 'object_relation' !== $context['type']
+        ) {
+            return;
+        }
+
+        $config['content_on_the_fly']['allowed_content_types'] = array_unique(
+            array_merge(
+                $config['content_on_the_fly']['allowed_content_types'],
+                $context['allowed_content_types']
+            )
+        );
+
+        $event->setConfig($config);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29660](https://jira.ez.no/browse/EZP-29660)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Currentlym ezobjectrelationlist doesn't take CT's set as allowed via UI into account - only settings from `/src/bundle/Resources/config/universal_discovery_widget.yml` are visible.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
