### PR TITLE
EZP-29712 Run nightly Behat tests on demo metarepos

### DIFF
--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -31,8 +31,8 @@ class ContentViewContext extends BusinessContext
     }
 
     /**
-     * @given I start editing the content
-     * @Given I start editing the content in :language language
+     * @Given I start editing the current content
+     * @Given I start editing the current content in :language language
      */
     public function startEditingContent(string $language = null): void
     {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29712](https://jira.ez.no/browse/EZP-29712)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Run nightly Behat tests on demo metarepos

There is one ambiguous step in admin-ui contexts. Did not appear earlier because flex-workflow tests does not need `AdministrationContext` hence this context was not a part of the FWF profile.

```
And I start editing the content
      Ambiguous match of "I start editing the content":
      to `I start editing the content` from EzSystems\EzPlatformAdminUi\Behat\BusinessContext\ContentViewContext::startEditingContent()
      to `I start editing :itemType :itemName` from EzSystems\EzPlatformAdminUi\Behat\BusinessContext\AdministrationContext::iStartEditingItem()
```

is required by https://github.com/ezsystems/flex-workflow/pull/116

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
