### PR TITLE
EZP-29731: Fixed missing icon in RichText Custom Tags UI config

### DIFF
--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
+
+use ArrayObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * UI Config Mapper test for RichText Custom Tags configuration.
+ *
+ * @see \EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag
+ */
+class CustomTagTest extends TestCase
+{
+    /**
+     * @covers \EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag::mapConfig
+     *
+     * @dataProvider providerForTestMapConfig
+     */
+    public function testMapConfig(array $customTagsConfiguration, array $enabledCustomTags, array $expectedConfig)
+    {
+        $mapper = new CustomTag(
+            $customTagsConfiguration,
+            $this->getTranslatorMock(),
+            'custom_tags',
+            $this->getPackagesMock(),
+            new ArrayObject([
+                new CustomTag\ChoiceAttributeMapper(),
+                new CustomTag\CommonAttributeMapper(),
+            ])
+        );
+
+        $actualConfig = $mapper->mapConfig($enabledCustomTags);
+
+        self::assertEquals($expectedConfig, $actualConfig);
+    }
+
+    /**
+     * Data provider for {@see testMapConfig}.
+     *
+     * @return array
+     */
+    public function providerForTestMapConfig(): array
+    {
+        return [
+            [
+                [
+                    'ezyoutube' => [
+                        'template' => '@ezdesign/fields/ezrichtext/custom_tags/ezyoutube.html.twig',
+                        'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#video',
+                        'attributes' => [
+                            'width' => [
+                                'type' => 'number',
+                                'required' => true,
+                                'default_value' => 640,
+                            ],
+                            'height' => [
+                                'type' => 'number',
+                                'required' => true,
+                                'default_value' => 360,
+                            ],
+                            'autoplay' => [
+                                'type' => 'boolean',
+                                'default_value' => false,
+                                'required' => false,
+                            ],
+                        ],
+                    ],
+                    'eztwitter' => [
+                        'template' => '@ezdesign/fields/ezrichtext/custom_tags/eztwitter.html.twig',
+                        'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#twitter',
+                        'attributes' => [
+                            'tweet_url' => [
+                                'type' => 'string',
+                                'required' => true,
+                                'default_value' => null,
+                            ],
+                            'cards' => [
+                                'type' => 'choice',
+                                'required' => false,
+                                'default_value' => '',
+                                'choices' => [
+                                    '',
+                                    'hidden',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                ['ezyoutube', 'eztwitter'],
+                [
+                    'ezyoutube' => [
+                        'label' => 'ezrichtext.custom_tags.ezyoutube.label',
+                        'description' => 'ezrichtext.custom_tags.ezyoutube.description',
+                        'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#video',
+                        'attributes' => [
+                            'width' => [
+                                'label' => 'ezrichtext.custom_tags.ezyoutube.attributes.width.label',
+                                'type' => 'number',
+                                'required' => true,
+                                'defaultValue' => 640,
+                            ],
+                            'height' => [
+                                'label' => 'ezrichtext.custom_tags.ezyoutube.attributes.height.label',
+                                'type' => 'number',
+                                'required' => true,
+                                'defaultValue' => 360,
+                            ],
+                            'autoplay' => [
+                                'label' => 'ezrichtext.custom_tags.ezyoutube.attributes.autoplay.label',
+                                'type' => 'boolean',
+                                'required' => false,
+                                'defaultValue' => false,
+                            ],
+                        ],
+                    ],
+                    'eztwitter' => [
+                        'label' => 'ezrichtext.custom_tags.eztwitter.label',
+                        'description' => 'ezrichtext.custom_tags.eztwitter.description',
+                        'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#twitter',
+                        'attributes' => [
+                            'tweet_url' => [
+                                'label' => 'ezrichtext.custom_tags.eztwitter.attributes.tweet_url.label',
+                                'type' => 'string',
+                                'required' => true,
+                                'defaultValue' => null,
+                            ],
+                            'cards' => [
+                                'label' => 'ezrichtext.custom_tags.eztwitter.attributes.cards.label',
+                                'type' => 'choice',
+                                'required' => false,
+                                'defaultValue' => '',
+                                'choices' => [
+                                    '',
+                                    'hidden',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return \Symfony\Component\Translation\TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getTranslatorMock(): MockObject
+    {
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock
+            ->expects($this->any())
+            ->method('trans')
+            ->withAnyParameters()
+            ->willReturnArgument(0);
+
+        return $translatorMock;
+    }
+
+    /**
+     * @return \Symfony\Component\Asset\Packages|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getPackagesMock(): MockObject
+    {
+        $packagesMock = $this->createMock(Packages::class);
+        $packagesMock
+            ->expects($this->any())
+            ->method('getUrl')
+            ->withAnyParameters()
+            ->willReturnArgument(0);
+
+        return $packagesMock;
+    }
+}

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -71,16 +71,17 @@ class CustomTag
 
             $customTagConfiguration = $this->customTagsConfiguration[$tagName];
 
+            $config[$tagName] = [
+                'label' => "ezrichtext.custom_tags.{$tagName}.label",
+                'description' => "ezrichtext.custom_tags.{$tagName}.description",
+            ];
+
             if (!empty($customTagConfiguration['icon'])) {
                 $config[$tagName]['icon'] = $this->packages->getUrl(
                     $customTagConfiguration['icon']
                 );
             }
 
-            $config[$tagName] = [
-                'label' => "ezrichtext.custom_tags.{$tagName}.label",
-                'description' => "ezrichtext.custom_tags.{$tagName}.description",
-            ];
             foreach ($customTagConfiguration['attributes'] as $attributeName => $properties) {
                 $typeMapper = $this->getAttributeTypeMapper(
                     $tagName,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29731](https://jira.ez.no/browse/EZP-29731)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Create unit test for RichText CustomTags Admin UI Config Mapper (ca82656).
- [x] Fix missing icon in RichText Custom Tags UI config (fd698ac).
- [x] Ready for Code Review
