### PR TITLE
EZEE-2234: Extend context of Create component to pass language

### DIFF
--- a/src/bundle/Controller/ContentOnTheFlyController.php
+++ b/src/bundle/Controller/ContentOnTheFlyController.php
@@ -83,7 +83,7 @@ class ContentOnTheFlyController extends Controller
         ]);
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid() && $form->getClickedButton()) {
             $this->contentActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
             if ($response = $this->contentActionDispatcher->getResponse()) {
                 return $response;

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -54,13 +54,15 @@
 {% block form_before %}
     {{ ezplatform_admin_ui_component_group('content-create-form-before', {
         'parentLocation': parentLocation,
-        'contentType': contentType
+        'contentType': contentType,
+        'language': language
     }) }}
 {% endblock %}
 
 {% block form_after %}
     {{ ezplatform_admin_ui_component_group('content-create-form-after', {
         'parentLocation': parentLocation,
-        'contentType': contentType
+        'contentType': contentType,
+        'language': language
     }) }}
 {% endblock %}

--- a/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/content/content_on_the_fly/content_create_on_the_fly.html.twig
@@ -41,13 +41,15 @@
 {% block form_before %}
     {{ ezplatform_admin_ui_component_group('content-create-form-before', {
         'parentLocation': parentLocation,
-        'contentType': contentType
+        'contentType': contentType,
+        'language': language
     }) }}
 {% endblock %}
 
 {% block form_after %}
     {{ ezplatform_admin_ui_component_group('content-create-form-after', {
         'parentLocation': parentLocation,
-        'contentType': contentType
+        'contentType': contentType,
+        'language': language
     }) }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | Required by https://jira.ez.no/browse/EZEE-2234
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

We need language as a context parameter for components in Content Create. 
<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
