### PR TITLE
EZEE-2306: Add new Page Builder tests

### DIFF
--- a/features/ContentTypeFields.feature
+++ b/features/ContentTypeFields.feature
@@ -20,26 +20,26 @@ Feature: Content fields setting and editing
         | Field    | <value1> | <value2> | <value3> |
 
     Examples:
-      | fieldInternalName    | fieldName                    | label1    | value1                | label2     | value2                | label3  | value3   | contentItemName           |
-      | ezselection          | Selection                    | value     | Test-value            |            |                       |         |          | Test-value                |
-      | ezgmaplocation       | Map location                 | latitude  | 32                    | longitude  | 132                   | address | Acapulco | Acapulco                  |
-      | ezauthor             | Authors                      | name      | Test Name             | email      | email@example.com     |         |          | Test Name                 |
-      | ezboolean            | Checkbox                     | value     | true                  |            |                       |         |          | 1                         |
-      | ezobjectrelation     | Content relation (single)    | value     | Media/Images          |            |                       |         |          | Images                    |
-      | ezobjectrelationlist | Content relations (multiple) | firstItem | Media/Images          | secondItem | Media/Files           |         |          | Images Files              |
-      | ezcountry            | Country                      | value     | Poland                |            |                       |         |          | Poland                    |
-      | ezdate               | Date                         | value     | 11/23/2019            |            |                       |         |          | Saturday 23 November 2019 |
-      | ezdatetime           | Date and time                | date      | 11/23/2019            | time       | 14:45                 |         |          | Sat 2019-23-11 14:45:00   |
-      | ezemail              | Email address               | value     | email@example.com     |            |                       |         |          | email@example.com         |
-      | ezfloat              | Float                        | value     | 11.11                 |            |                       |         |          | 11.11                     |
-      | ezisbn               | ISBN                         | value     | 978-3-16-148410-0     |            |                       |         |          | 978-3-16-148410-0         |
-      | ezinteger            | Integer                      | value     | 1111                  |            |                       |         |          | 1111                      |
-      | ezkeyword            | Keywords                     | value     | first keyword, second |            |                       |         |          | first keyword, second     |
-      | ezrichtext           | Rich text                    | value     | Lorem ipsum dolor sit |            |                       |         |          | Lorem ipsum dolor sit     |
-      | eztext               | Text block                   | value     | Lorem ipsum dolor     |            |                       |         |          | Lorem ipsum dolor         |
-      | ezstring             | Text line                    | value     | Lorem ipsum           |            |                       |         |          | Lorem ipsum               |
-      | eztime               | Time                         | value     | 14:45                 |            |                       |         |          | 2:45:00 pm                |
-      | ezurl                | URL                          | text      | Test URL              | url        | http://www.google.com |         |          | Test URL                  |
+      | fieldInternalName    | fieldName                    | label1    | value1                    | label2     | value2                | label3  | value3   | contentItemName           |
+      | ezselection          | Selection                    | value     | Test-value                |            |                       |         |          | Test-value                |
+      | ezgmaplocation       | Map location                 | latitude  | 32                        | longitude  | 132                   | address | Acapulco | Acapulco                  |
+      | ezauthor             | Authors                      | name      | Test Name                 | email      | email@example.com     |         |          | Test Name                 |
+      | ezboolean            | Checkbox                     | value     | true                      |            |                       |         |          | 1                         |
+      | ezobjectrelation     | Content relation (single)    | value     | Media/Images              |            |                       |         |          | Images                    |
+      | ezobjectrelationlist | Content relations (multiple) | firstItem | Media/Images              | secondItem | Media/Files           |         |          | Images Files              |
+      | ezcountry            | Country                      | value     | Poland                    |            |                       |         |          | Poland                    |
+      | ezdate               | Date                         | value     | 11/23/2019                |            |                       |         |          | Saturday 23 November 2019 |
+      | ezdatetime           | Date and time                | date      | 11/23/2019                | time       | 14:45                 |         |          | Sat 2019-23-11 14:45:00   |
+      | ezemail              | Email address                | value     | email@example.com         |            |                       |         |          | email@example.com         |
+      | ezfloat              | Float                        | value     | 11.11                     |            |                       |         |          | 11.11                     |
+      | ezisbn               | ISBN                         | value     | 978-3-16-148410-0         |            |                       |         |          | 978-3-16-148410-0         |
+      | ezinteger            | Integer                      | value     | 1111                      |            |                       |         |          | 1111                      |
+      | ezkeyword            | Keywords                     | value     | first keyword, second     |            |                       |         |          | first keyword, second     |
+      | ezrichtext           | Rich text                    | value     | Lorem ipsum dolor sit     |            |                       |         |          | Lorem ipsum dolor sit     |
+      | eztext               | Text block                   | value     | Lorem ipsum dolor         |            |                       |         |          | Lorem ipsum dolor         |
+      | ezstring             | Text line                    | value     | Lorem ipsum               |            |                       |         |          | Lorem ipsum               |
+      | eztime               | Time                         | value     | 14:45                     |            |                       |         |          | 2:45:00 pm                |
+      | ezurl                | URL                          | text      | Test URL                  | url        | http://www.google.com |         |          | Test URL                  |
       | ezmedia              | Media                        | value     | video1.mp4.zip            |            |                       |         |          | video1.mp4                |
       | ezimage              | Image                        | value     | image1.png.zip            |            |                       |         |          | image1.png                |
       | ezbinaryfile         | File                         | value     | binary1.txt.zip           |            |                       |         |          | binary1.txt               |

--- a/src/lib/Behat/PageElement/DateAndTimePopup.php
+++ b/src/lib/Behat/PageElement/DateAndTimePopup.php
@@ -16,12 +16,12 @@ class DateAndTimePopup extends Element
 
     private const DATETIME_FORMAT = 'm/d/Y, g:i:s a';
 
-    public function __construct(UtilityContext $context, bool $isInline = false)
+    public function __construct(UtilityContext $context, bool $isInline = false, $containerSelector = '')
     {
         parent::__construct($context);
         $calendarSelector = $isInline ? '.flatpickr-calendar.inline' : '.flatpickr-calendar.open';
         $this->fields = [
-            'openedCalendar' => $calendarSelector,
+            'openedCalendar' => sprintf('%s %s', $containerSelector, $calendarSelector),
             'pickerDaySelector' => '.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)',
             'pickerDayValue' => 'aria-label',
             'hourSelector' => '.flatpickr-hour',
@@ -43,6 +43,7 @@ class DateAndTimePopup extends Element
         } else {
             $referenceDateElement = $this->context->findElement(sprintf('%s %s', $this->fields['openedCalendar'], $this->fields['selectedDaySelector']));
         }
+
         $currentDate = DateTime::createFromFormat($dateFormat, $referenceDateElement->getAttribute($this->fields['pickerDayValue']));
 
         $dateToDiff = $this->deleteDayFromDate($date);

--- a/src/lib/Behat/PageElement/ElementFactory.php
+++ b/src/lib/Behat/PageElement/ElementFactory.php
@@ -33,12 +33,20 @@ class ElementFactory
         self::$installType = $installType;
     }
 
+    public static function getPreviewType(string $contentType)
+    {
+        /* Note: no return type to enable type-hinting */
+        $factory = self::getFactory(self::$installType);
+
+        return $factory::getPreviewType($contentType);
+    }
+
     /**
      * @param int $installType
      *
      * @return EnterpriseElementFactory|PlatformElementFactory
      */
-    private static function getFactory(int $installType): ElementFactory
+    private static function getFactory(int $installType): PlatformElementFactory
     {
         switch ($installType) {
             case InstallType::PLATFORM:

--- a/src/lib/Behat/PageElement/PlatformElementFactory.php
+++ b/src/lib/Behat/PageElement/PlatformElementFactory.php
@@ -161,13 +161,25 @@ class PlatformElementFactory extends ElementFactory
                     return new DateAndTimePopup($context);
                 }
 
-                return new DateAndTimePopup($context, $parameters[0]);
+                if (!array_key_exists(1, $parameters)) {
+                    return new DateAndTimePopup($context, $parameters[0]);
+                }
+
+                return new DateAndTimePopup($context, $parameters[0], $parameters[1]);
             case ContentTypePicker::ELEMENT_NAME:
                 return new ContentTypePicker($context);
             case UniversalDiscoveryWidget::ELEMENT_NAME:
                 return new UniversalDiscoveryWidget($context);
             default:
                 throw new \InvalidArgumentException(sprintf('Unrecognized element name: %s', $elementName));
+        }
+    }
+
+    public static function getPreviewType(string $elementName)
+    {
+        switch ($elementName) {
+            default:
+                throw new \InvalidArgumentException(sprintf('Unrecognized preview for element name: %s', $elementName));
         }
     }
 }

--- a/src/lib/Behat/PageObject/FolderPreview.php
+++ b/src/lib/Behat/PageObject/FolderPreview.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageObject;
+
+class FolderPreview extends PreviewPage
+{
+    /** @var string Name by which Page is recognised */
+    public const PAGE_NAME = 'Folder Preview';
+
+    /** @var string Name of Content Type this Preview is for */
+    public const CONTENT_TYPE = 'Folder';
+
+    public function getPageTitle(): string
+    {
+        return $this->context->findElement('h2')->getText();
+    }
+
+    public function verifyElements(): void
+    {
+    }
+}

--- a/src/lib/Behat/PageObject/PageObjectFactory.php
+++ b/src/lib/Behat/PageObject/PageObjectFactory.php
@@ -34,6 +34,14 @@ class PageObjectFactory
         self::$installType = $installType;
     }
 
+    public static function getPreviewType(string $contentType)
+    {
+        /* Note: no return type to enable type-hinting */
+        $factory = self::getFactory(self::$installType);
+
+        return $factory::getPreviewType($contentType);
+    }
+
     /**
      * @param int $installType
      *

--- a/src/lib/Behat/PageObject/PlatformPageObjectFactory.php
+++ b/src/lib/Behat/PageObject/PlatformPageObjectFactory.php
@@ -56,8 +56,20 @@ class PlatformPageObjectFactory extends PageObjectFactory
                 return new ContentPreviewPage($context, $parameters[0]);
             case TrashPage::PAGE_NAME:
                 return new TrashPage($context);
+            case FolderPreview::PAGE_NAME:
+                return new FolderPreview($context);
             default:
                 throw new \InvalidArgumentException(sprintf('Unrecognised page name: %s', $pageName));
+        }
+    }
+
+    public static function getPreviewType(string $contentType): string
+    {
+        switch ($contentType) {
+            case FolderPreview::CONTENT_TYPE:
+                return FolderPreview::PAGE_NAME;
+            default:
+                throw new \InvalidArgumentException(sprintf('Unrecognised preview for content type: %s', $contentType));
         }
     }
 }

--- a/src/lib/Behat/PageObject/PreviewPage.php
+++ b/src/lib/Behat/PageObject/PreviewPage.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageObject;
+
+abstract class PreviewPage extends Page
+{
+    public function setTitle(string $title): void
+    {
+        $this->pageTitle = $title;
+    }
+}

--- a/src/lib/Behat/lib/drag-mock.js
+++ b/src/lib/Behat/lib/drag-mock.js
@@ -1,0 +1,30 @@
+/* drag-mock library
+https://github.com/andywer/drag-mock
+version 1.4.0
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Andy Wermke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+
+!function t(e,n,r){function a(i,u){if(!n[i]){if(!e[i]){var s="function"==typeof require&&require;if(!u&&s)return s(i,!0);if(o)return o(i,!0);var c=new Error("Cannot find module '"+i+"'");throw c.code="MODULE_NOT_FOUND",c}var f=n[i]={exports:{}};e[i][0].call(f.exports,function(t){var n=e[i][1][t];return a(n?n:t)},f,f.exports,t,e,n,r)}return n[i].exports}for(var o="function"==typeof require&&require,i=0;i<r.length;i++)a(r[i]);return a}({1:[function(t){var e=t("./src/index.js");"function"==typeof define&&define("dragMock",function(){return e}),window.dragMock=e},{"./src/index.js":5}],2:[function(t,e){function n(t,e){var n=t.indexOf(e);n>=0&&t.splice(n,1)}var r=function(){this.dataByFormat={},this.dropEffect="none",this.effectAllowed="all",this.files=[],this.types=[]};r.prototype.clearData=function(t){t?(delete this.dataByFormat[t],n(this.types,t)):(this.dataByFormat={},this.types=[])},r.prototype.getData=function(t){return this.dataByFormat[t]},r.prototype.setData=function(t,e){return this.dataByFormat[t]=e,this.types.indexOf(t)<0&&this.types.push(t),!0},r.prototype.setDragImage=function(){},e.exports=r},{}],3:[function(t,e){function n(){}function r(t,e,r){if("function"==typeof e&&(r=e,e=null),!t||"object"!=typeof t)throw new Error("Expected first parameter to be a targetElement. Instead got: "+t);return{targetElement:t,eventProperties:e||{},configCallback:r||n}}function a(t,e,n){e&&(e.length<2?n&&e(t):e(t,t.type))}function o(t,e,n,r,o,u){e.forEach(function(e){var s=i.createEvent(e,o,r),c=e===n;a(s,u,c),t.dispatchEvent(s)})}var i=t("./eventFactory"),u=t("./DataTransfer"),s=function(){this.lastDragSource=null,this.lastDataTransfer=null,this.pendingActionsQueue=[]};s.prototype._queue=function(t){this.pendingActionsQueue.push(t),1===this.pendingActionsQueue.length&&this._queueExecuteNext()},s.prototype._queueExecuteNext=function(){if(0!==this.pendingActionsQueue.length){var t=this,e=this.pendingActionsQueue[0],n=function(){t.pendingActionsQueue.shift(),t._queueExecuteNext()};0===e.length?(e.call(this),n()):e.call(this,n)}},s.prototype.dragStart=function(t,e,n){var a=r(t,e,n),i=["mousedown","dragstart","drag"],s=new u;return this._queue(function(){o(a.targetElement,i,"drag",s,a.eventProperties,a.configCallback),this.lastDragSource=t,this.lastDataTransfer=s}),this},s.prototype.dragOver=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseover","dragover"];return this._queue(function(){o(a.targetElement,i,"drag",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.dragLeave=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseover","dragleave"];return this._queue(function(){o(a.targetElement,i,"dragleave",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.drop=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseup","drop"],u=["dragend"];return this._queue(function(){o(a.targetElement,i,"drop",this.lastDataTransfer,a.eventProperties,a.configCallback),this.lastDragSource&&o(this.lastDragSource,u,"drop",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.then=function(t){return this._queue(function(){t.call(this)}),this},s.prototype.delay=function(t){return this._queue(function(e){window.setTimeout(e,t)}),this},e.exports=s},{"./DataTransfer":2,"./eventFactory":4}],4:[function(t,e){function n(t,e){for(var n in e)e.hasOwnProperty(n)&&(t[n]=e[n]);return t}function r(t,e,r){"DragEvent"===e&&(e="CustomEvent");var a=window[e],o={view:window,bubbles:!0,cancelable:!0};n(o,r);var i=new a(t,o);return n(i,r),i}function a(t,e,r){var a;switch(e){case"MouseEvent":a=document.createEvent("MouseEvent"),a.initEvent(t,!0,!0);break;default:a=document.createEvent("CustomEvent"),a.initCustomEvent(t,!0,!0,0)}return r&&n(a,r),a}function o(t,e,n){try{return r(t,e,n)}catch(o){return a(t,e,n)}}var i=t("./DataTransfer"),u=["drag","dragstart","dragover","dragend","drop","dragleave"],s={createEvent:function(t,e,n){var r="CustomEvent";t.match(/^mouse/)&&(r="MouseEvent");var a=o(t,r,e);return u.indexOf(t)>-1&&(a.dataTransfer=n||new i),a}};e.exports=s},{"./DataTransfer":2}],5:[function(t,e){function n(t,e,n){return t[e].apply(t,n)}var r=t("./DragDropAction"),a={dragStart:function(){return n(new r,"dragStart",arguments)},dragOver:function(){return n(new r,"dragOver",arguments)},dragLeave:function(){return n(new r,"dragLeave",arguments)},drop:function(){return n(new r,"drop",arguments)},delay:function(){return n(new r,"delay",arguments)},DataTransfer:t("./DataTransfer"),DragDropAction:t("./DragDropAction"),eventFactory:t("./eventFactory")};e.exports=a},{"./DataTransfer":2,"./DragDropAction":3,"./eventFactory":4}]},{},[1]);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2306
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR is required by https://github.com/ezsystems/ezplatform-page-builder/pull/254/files

What has been done:
- extract JS-based drag and drop so that it can be used outside of PageBuilderEditor (it was needed in Collection and Content Scheduler blocks).
- make debugging easier by adding more details to `ElementNotFoundException`
- add parent container to DateTimePicker - it's required for Pages with more than 1 DatePicker (Content Scheduler airtime)
- add Content Type Preview skeleton - it's an object created for representing Pages rendered on the frontend (and in Page Builder).

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review