### PR TITLE
EZP-29089: Usability bug when deleting containers

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -406,6 +406,12 @@ ezplatform.location.trash:
     defaults:
         _controller: 'EzPlatformAdminUiBundle:Location:trash'
 
+ezplatform.location.trash_container:
+    path: /location/trash_container
+    methods: ['POST']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Location:trashContainer'
+
 ezplatform.location.update:
     path: /location/update
     methods: ['POST']

--- a/src/bundle/Resources/public/js/scripts/admin.trash.container.js
+++ b/src/bundle/Resources/public/js/scripts/admin.trash.container.js
@@ -1,0 +1,18 @@
+(function (global, doc) {
+    const toggleForm = doc.querySelector('form[name="location_trash_container"]');
+    const hasAsset = toggleForm.dataset.hasAsset;
+    const hasUniqueAsset = toggleForm.dataset.hasUniqueAsset;
+
+    const openTrashImageAssetModal = (event) => {
+        if (!hasAsset && !hasUniqueAsset) {
+            return;
+        }
+
+        event.preventDefault();
+
+        $('#trash-container-modal').modal('hide');
+        $('#trash-with-asset-modal').modal('show');
+    };
+
+    toggleForm.addEventListener('submit', openTrashImageAssetModal, false);
+})(window, document);

--- a/src/bundle/Resources/public/js/scripts/button.state.checkbox.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.checkbox.toggle.js
@@ -1,0 +1,28 @@
+(function (global, doc) {
+    const toggleForms = doc.querySelectorAll('.ez-toggle-btn-state-checkbox');
+    const ALL_CHECKED = 'all-checked';
+    const ANY_CHECKED = 'any-checked';
+
+    const toggleButtonState = (button, validateCheckboxStatus) => {
+        let methodName = 'setAttribute';
+
+        if (validateCheckboxStatus()) {
+            methodName = 'removeAttribute';
+        }
+
+        button[methodName]('disabled', true);
+    };
+
+    toggleForms.forEach((toggleForm) => {
+        const checkboxInputs = [...toggleForm.querySelectorAll('input[type="checkbox"]')];
+        const button = doc.querySelector(toggleForm.dataset.toggleButtonId);
+        const toggleMode = toggleForm.dataset.toggleMode || ANY_CHECKED;
+        const validateCheckboxStatus = () =>
+            (checkboxInputs.some(el => el.checked) && ALL_CHECKED === toggleMode) ||
+            (checkboxInputs.every(el => el.checked) && ANY_CHECKED === toggleMode);
+
+        checkboxInputs.forEach(input =>
+            input.addEventListener('change', toggleButtonState.bind(input, button, validateCheckboxStatus), false)
+        );
+    });
+})(window, document);

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -150,7 +150,8 @@
     }
 }
 
-.ez-modal--trash-with-asset {
+.ez-modal--trash-with-asset,
+.ez-modal--trash-container {
     .modal-dialog {
         max-width: calculateRem(800px);
     }

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -156,6 +156,11 @@
         <target state="new">Send to Trash</target>
         <note>key: location_trash_form.trash</note>
       </trans-unit>
+      <trans-unit id="f9887d04de58202b07207b1521880373c00c8201" resname="location_trash_form.trash_container">
+        <source>%children_count% content items under location %content_name%</source>
+        <target state="new">%children_count% content items under location %content_name%</target>
+        <note>key: location_trash_form.trash_container</note>
+      </trans-unit>
       <trans-unit id="2598fe0050f38f3c02014a404ed14aee248e27d1" resname="location_trash_form.trash_with_asset">
         <source>Delete %content_name% (%content_type%) and its related image assets</source>
         <target state="new">Delete %content_name% (%content_type%) and its related image assets</target>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -274,6 +274,16 @@
         <target state="new">You are about to delete a content with one or several asset(s) field(s).</target>
         <note>key: trash_asset_single.modal.message_main</note>
       </trans-unit>
+      <trans-unit id="a70d984d62d43229009fefdbfdc740199ede75ca" resname="trash_container.modal.header">
+        <source>Deleting content</source>
+        <target state="new">Deleting content</target>
+        <note>key: trash_container.modal.header</note>
+      </trans-unit>
+      <trans-unit id="1e6a1d97cca01a288e47d2d14479274b90e6c6c1" resname="trash_container.modal.message_main">
+        <source>Deleting %content_name% will also delete its sub-items, under its location(s). To confirm, please check below</source>
+        <target state="new">Deleting %content_name% will also delete its sub-items, under its location(s). To confirm, please check below</target>
+        <note>key: trash_container.modal.message_main</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/translations/validators.en.xliff
+++ b/src/bundle/Resources/translations/validators.en.xliff
@@ -51,6 +51,11 @@
         <target state="new">Selected Location have assets that can't be removed.</target>
         <note>key: ezplatform.trash.have_used_assets</note>
       </trans-unit>
+      <trans-unit id="50f88ff616406e9f9474c6f78937aadb1303868e" resname="ezplatform.trash.location_has_no_children">
+        <source>Selected Location has no children locations.</source>
+        <target state="new">Selected Location has no children locations.</target>
+        <note>key: ezplatform.trash.location_has_no_children</note>
+      </trans-unit>
       <trans-unit id="cf558f546b83d94f1272929f81c64bd33d2997bc" resname="js.error.address_not_found">
         <source>Provided address does not exist</source>
         <target state="new">Provided address does not exist</target>

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -93,7 +93,7 @@
                     {% endif %}
                 </div>
             </div>
-            {%  if form_location_trash is defined %}
+            {%  if form_location_trash is defined and form_location_trash_container is not defined %}
                 {% include '@ezdesign/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
             {% endif %}
             {%  if form_user_delete is defined %}
@@ -114,6 +114,14 @@
             {{ form(form_location_copy, {'action': path('ezplatform.location.copy')}) }}
             {{ form(form_location_move, {'action': path('ezplatform.location.move')}) }}
             {{ form(form_location_copy_subtree, {'action': path('ezplatform.location.copy_subtree')}) }}
+            {%  if form_location_trash_container is defined %}
+                {% include '@ezdesign/content/modal_location_trash_container.html.twig' with {
+                    'form': form_location_trash_container,
+                    'content_name': content.name,
+                    'has_asset': form_location_trash_with_asset is defined,
+                    'has_unique_asset': form_location_trash_with_single_asset is defined
+                } only %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/src/bundle/Resources/views/content/modal_location_trash_container.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash_container.html.twig
@@ -1,0 +1,52 @@
+{% form_theme form '@ezdesign/form_fields.html.twig' %}
+
+<div class="modal fade ez-modal ez-modal--trash-container" id="trash-container-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{ 'trash_container.modal.header'|trans|desc('Deleting content') }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <svg class="ez-icon ez-icon--medium" aria-hidden="true">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="ez-modal-body__main">
+                    {{ 'trash_container.modal.message_main'|trans({'%content_name%': content_name})|desc('Deleting %content_name% will also delete its sub-items, under its location(s). To confirm, please check below') }}
+                </p>
+                {{ form_start(form, {
+                    'action': path('ezplatform.location.trash_container'),
+                    'attr' : {
+                        'class' : 'ez-toggle-btn-state-checkbox',
+                        'data-toggle-button-id' : '#location_trash_container_trash',
+                        'data-has-asset': has_asset,
+                        'data-has-unique-asset': has_unique_asset
+                    },
+                }) }}
+                {{ form_widget(form.trashContainer) }}
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-dark btn--no" data-dismiss="modal">
+                    {{ 'trash.form.cancel'|trans|desc('Cancel') }}
+                </button>
+                {{ form_widget(form.trash, {
+                    'attr': {
+                        'class': 'btn-danger',
+                        'disabled' : 'disabled'
+                    }
+                }) }}
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% block javascripts %}
+    {% javascripts
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.checkbox.toggle.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.trash.container.js'
+    %}
+        <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}

--- a/src/lib/Form/Data/Location/LocationTrashContainerData.php
+++ b/src/lib/Form/Data/Location/LocationTrashContainerData.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Data\Location;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\EzPlatformAdminUi\Validator\Constraints as AdminUiAssert;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class LocationTrashContainerData
+{
+    /**
+     * @var Location|null
+     * @AdminUiAssert\LocationIsContainer()
+     * @AdminUiAssert\LocationHasChildren()
+     */
+    private $location;
+
+    /**
+     * @var array|null
+     *
+     * @Assert\NotBlank()
+     */
+    private $trashContainer;
+
+    /**
+     * @param Location|null $location
+     * @param array|null $trashContainer
+     */
+    public function __construct(?Location $location = null, ?array $trashContainer = null)
+    {
+        $this->location = $location;
+        $this->trashContainer = $trashContainer;
+    }
+
+    /**
+     * @return Location|null
+     */
+    public function getLocation(): ?Location
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param Location|null $location
+     */
+    public function setLocation(?Location $location): void
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getTrashContainer(): ?array
+    {
+        return $this->trashContainer;
+    }
+
+    /**
+     * @param array|null $trashContainer
+     */
+    public function setTrashContainer(?array $trashContainer): void
+    {
+        $this->trashContainer = $trashContainer;
+    }
+}

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -34,6 +34,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationCopySubtreeData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationMoveData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationSwapData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashWithAssetData;
+use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashContainerData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationUpdateVisibilityData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationUpdateData;
@@ -99,6 +100,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationCopyType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationMoveType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationSwapType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationTrashWithAssetType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationTrashContainerType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationUpdateVisibilityType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationTrashType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationUpdateType;
@@ -1309,5 +1311,20 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(ContentRemoveType::class);
 
         return $this->formFactory->createNamed($name, ContentRemoveType::class, $data);
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashContainerData|null $data
+     * @param string|null $name
+     *
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    public function trashContainerLocation(
+        LocationTrashContainerData $data = null,
+        ?string $name = null
+    ): FormInterface {
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(LocationTrashContainerType::class);
+
+        return $this->formFactory->createNamed($name, LocationTrashContainerType::class, $data);
     }
 }

--- a/src/lib/Form/Type/Location/LocationTrashContainerType.php
+++ b/src/lib/Form/Type/Location/LocationTrashContainerType.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\Location;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\LocationService;
+use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationTrashContainerData;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\LocationType;
+use EzSystems\EzPlatformAdminUi\Specification\Location\HasChildren;
+use EzSystems\EzPlatformAdminUi\Specification\Location\IsContainer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class LocationTrashContainerType extends AbstractType
+{
+    const TRASH_WITH_CHILDREN = 'trash_with_children';
+
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /**
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \eZ\Publish\Core\Repository\LocationService $locationService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        LocationService $locationService,
+        ContentTypeService $contentTypeService
+    ) {
+        $this->translator = $translator;
+        $this->locationService = $locationService;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'location',
+                LocationType::class,
+                ['label' => false]
+            )
+            ->add(
+                'trashContainer',
+                ChoiceType::class,
+                [
+                    'expanded' => true,
+                    'multiple' => true,
+                ]
+            )
+            ->add(
+                'trash',
+                SubmitType::class,
+                ['label' => /** @Desc("Send to Trash") */
+                    'location_trash_form.trash', ]
+            );
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $this->addTrashContainerField(
+                $event->getForm(),
+                $event->getData()->getLocation()
+            );
+        });
+
+        $builder->get('location')->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            $this->addTrashContainerField(
+                $event->getForm()->getParent(),
+                $event->getForm()->getData()
+            );
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => LocationTrashContainerData::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormInterface $form
+     * @param \eZ\Publish\API\Repository\Values\Content\Location|null $location
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
+     */
+    private function addTrashContainerField(FormInterface $form, Location $location = null): void
+    {
+        if (null === $location) {
+            return;
+        }
+
+        $isContainer = new IsContainer($this->contentTypeService);
+        $hasChildren = new HasChildren($this->locationService);
+
+        if (!$isContainer->and($hasChildren)->isSatisfiedBy($location)) {
+            return;
+        }
+
+        $locationChildren = $this->locationService->loadLocationChildren($location);
+
+        $translatorParameters = [
+            '%children_count%' => $locationChildren->totalCount,
+            '%content_name%' => $location->getContent()->getName(),
+        ];
+
+        $form->add('trashContainer', ChoiceType::class, [
+            'expanded' => true,
+            'multiple' => true,
+            'choices' => [
+                /** @Desc("%children_count% content items under location %content_name%") */
+                $this->translator->trans('location_trash_form.trash_container', $translatorParameters, 'forms') => self::TRASH_WITH_CHILDREN,
+            ],
+        ]);
+    }
+}

--- a/src/lib/Specification/Location/HasChildren.php
+++ b/src/lib/Specification/Location/HasChildren.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Specification\Location;
+
+use eZ\Publish\API\Repository\LocationService;
+use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
+
+class HasChildren extends AbstractSpecification
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     */
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $item
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($item): bool
+    {
+        $children = $this->locationService->loadLocationChildren($item);
+
+        return 0 < $children->totalCount;
+    }
+}

--- a/src/lib/Validator/Constraints/LocationHasChildren.php
+++ b/src/lib/Validator/Constraints/LocationHasChildren.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Validator\Constraints;
+
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class LocationHasChildren extends Constraint implements TranslationContainerInterface
+{
+    public $message = 'ezplatform.trash.location_has_no_children';
+
+    public static function getTranslationMessages()
+    {
+        return [
+            Message::create('ezplatform.trash.location_has_no_children', 'validators')
+                ->setDesc('Selected Location has no children locations.'),
+        ];
+    }
+}

--- a/src/lib/Validator/Constraints/LocationHasChildrenValidator.php
+++ b/src/lib/Validator/Constraints/LocationHasChildrenValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Validator\Constraints;
+
+use eZ\Publish\Core\Repository\LocationService;
+use EzSystems\EzPlatformAdminUi\Specification\Location\HasChildren;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class LocationHasChildrenValidator extends ConstraintValidator
+{
+    /** @var \eZ\Publish\Core\Repository\LocationService */
+    private $locationService;
+
+    /**
+     * @param \eZ\Publish\Core\Repository\LocationService $locationService
+     */
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location The value that should be validated
+     * @param \Symfony\Component\Validator\Constraint $constraint The constraint for the validation
+     */
+    public function validate($location, Constraint $constraint)
+    {
+        if (null === $location) {
+            $this->context->addViolation($constraint->message);
+
+            return;
+        }
+
+        $hasChildren = new HasChildren($this->locationService);
+
+        if (!$hasChildren->isSatisfiedBy($location)) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29089
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Description

This checks if location is non-empty container and if it is displays additional info modal. If content have asset fieldtype additional modals are displayed after first one.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
