### PR TITLE
Fix Behat DateTime tests

### DIFF
--- a/src/lib/Behat/PageElement/DateAndTimePopup.php
+++ b/src/lib/Behat/PageElement/DateAndTimePopup.php
@@ -47,6 +47,7 @@ class DateAndTimePopup extends Element
 
         $dateToDiff = $this->deleteDayFromDate($date);
         $currentDateToDiff = $this->deleteDayFromDate($currentDate);
+        $dateToDiff->modify('+1 day');
         $interval = $dateToDiff->diff($currentDateToDiff);
         $monthsDiff = 12 * $interval->y + $interval->m;
 
@@ -70,7 +71,7 @@ class DateAndTimePopup extends Element
 
     public function deleteDayFromDate(DateTime $dateTime): DateTime
     {
-        return DateTime::createFromFormat('Y-m', $dateTime->format('Y-m'));
+        return DateTime::createFromFormat('!Y-m', $dateTime->format('Y-m'));
     }
 
     public function switchToNextMonth(): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Currently the tests are failing because of how difference between two dates (in months) is calculated.

Current logic (this can be tested in interactive shell):
```
$dateToSet = new DateTime('2019-12-30 00:00:00.000000');
$currentDate = new DateTime('2019-11-23 10:41:31.000000');

$dateToDiff = DateTime::createFromFormat('Y-m', $dateToSet->format('Y-m')); // 2019-12-31 10:43:37.000000
$currentDateToDiff = DateTime::createFromFormat('Y-m', $currentDate->format('Y-m')); //2019-12-01 10:43:40.000000

$interval = $dateToDiff->diff($currentDateToDiff);

var_dump($interval); // $interval->m = 0
```

In format `!` is missing, as written in the doc (http://php.net/manual/en/datetime.createfromformat.php):
```
If format does not contain the character ! then portions of the generated time which are not specified in format will be set to the current system time.
```

I've decided to add one day after the days are subtracted from the month, because the interval between `2019-12-01 00:00:00.000000` and `2019-11-01 00:00:00.000000` is 30 days ($interval->m is 0 again). Adding one day is enough to make sure that month are properly calculated.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review