### PR TITLE
EZP-29769: Added discovery bar to the Drafts interface

### DIFF
--- a/src/bundle/Resources/views/admin/content_draft/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_draft/list.html.twig
@@ -10,112 +10,112 @@
 
 {% block body_class %}ez-drafts-list-view{% endblock %}
 
-{% block breadcrumbs %}
-    {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
-        { value: 'drafts.list'|trans|desc('Drafts') }
-    ]} %}
-{% endblock %}
-
-{%- block page_title -%}
-    {% include '@ezdesign/parts/page_title.html.twig' with {
-        title: 'drafts.list'|trans|desc('Drafts'),
-        iconName: 'content-draft'
-    } %}
-{%- endblock -%}
-
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
-        <section class="container mt-4 px-5">
-            {{ form_start(form_remove, {
-                'action': path('ezplatform.content_draft.remove'),
-                'attr': {
-                    'class': 'ez-toggle-btn-state',
-                    'data-toggle-button-id': '#confirm-' ~ form_remove.remove.vars.id
-                }
-            }) }}
+        {% block left_sidebar %}
+            {{ parent() }}
+        {% endblock left_sidebar %}
 
-            {% include '@ezdesign/parts/table_header.html.twig' with {
-                ground: 'mt-3',
-                headerText: 'drafts.table.header'|trans|desc('Drafts') ~ ' (' ~ pager.count ~ ')',
-                tools: macros.table_header_tools(form_remove)
-             } %}
-            <table class="ez-table table">
-                <thead>
-                    <tr>
-                        <th></th>
-                        <th>{{ 'drafts.list.name'|trans|desc('Name') }}</th>
-                        <th>{{ 'drafts.list.content_type'|trans|desc('Content Type') }}</th>
-                        <th>{{ 'drafts.list.modified_language'|trans|desc('Modified Language') }}</th>
-                        <th>{{ 'drafts.list.version'|trans|desc('Version') }}</th>
-                        <th>{{ 'drafts.list.last_saved'|trans|desc('Last Saved') }}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                {% if pager.count is same as(0) %}
-                    <tr>
-                        <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
-                            <span class="mb-0 py-1 pl-0">
-                                {{ 'drafts.list.empty'|trans|desc('The draft list is empty. Any Content draft you create will end up here.') }}
+        <div class="col-sm-10 px-0">
+            <section class="container mt-5">
+                {% include '@ezdesign/parts/page_title.html.twig' with {
+                    title: 'drafts.list'|trans|desc('Drafts'),
+                    iconName: 'content-draft'
+                } %}
+
+                <div class="px-4">
+                    {{ form_start(form_remove, {
+                        'action': path('ezplatform.content_draft.remove'),
+                        'attr': {
+                            'class': 'ez-toggle-btn-state',
+                            'data-toggle-button-id': '#confirm-' ~ form_remove.remove.vars.id
+                        }
+                    }) }}
+
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
+                        ground: 'mt-3',
+                        headerText: 'drafts.table.header'|trans|desc('Drafts') ~ ' (' ~ pager.count ~ ')',
+                        tools: macros.table_header_tools(form_remove)
+                     } %}
+                    <table class="ez-table table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>{{ 'drafts.list.name'|trans|desc('Name') }}</th>
+                                <th>{{ 'drafts.list.content_type'|trans|desc('Content Type') }}</th>
+                                <th>{{ 'drafts.list.modified_language'|trans|desc('Modified Language') }}</th>
+                                <th>{{ 'drafts.list.version'|trans|desc('Version') }}</th>
+                                <th>{{ 'drafts.list.last_saved'|trans|desc('Last Saved') }}</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% if pager.count is same as(0) %}
+                            <tr>
+                                <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                                    <span class="mb-0 py-1 pl-0">
+                                        {{ 'drafts.list.empty'|trans|desc('The draft list is empty. Any Content draft you create will end up here.') }}
+                                    </span>
+                                </td>
+                            </tr>
+                        {% else %}
+                            {% for row in pager.currentPageResults %}
+                                {% set content_draft_edit_url = content_is_user|default(false) ? 'ez_user_update' : 'ez_content_draft_edit' %}
+                                <tr>
+                                    <td class="ez-table__cell ez-table__cell--has-checkbox">
+                                         {{ form_widget(form_remove.versions[row.id ~ '']) }}
+                                    </td>
+                                    <td class="ez-table__cell">{{ row.name }}</td>
+                                    <td class="ez-table__cell">{{ row.type }}</td>
+                                    <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
+                                    <td class="ez-table__cell">{{ row.version }}</td>
+                                    <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>
+                                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                                        <button class="btn btn-icon mx-2 ez-btn--content-draft-edit"
+                                                title="{{ 'drafts.list.action.edit'|trans|desc('Edit Draft') }}"
+                                                data-content-draft-edit-url="{{ path(content_draft_edit_url, {
+                                                    'contentId': row.contentId,
+                                                    'versionNo': row.version,
+                                                    'language': row.language
+                                                }) }}"
+                                                data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                                                    'contentId': row.contentId,
+                                                    'versionNo': row.version,
+                                                    'languageCode': row.language
+                                                }) }}">
+                                            <svg class="ez-icon ez-icon-edit">
+                                                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                                            </svg>
+                                        </button>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                        </tbody>
+                    </table>
+                    {{ form_widget(form_remove.remove, {
+                        'attr': {
+                            'hidden': true
+                        }
+                    }) }}
+                    {{ form_end(form_remove) }}
+
+                    {% if pager.haveToPaginate %}
+                        <div class="row justify-content-center align-items-center ez-pagination__spacing mb-2">
+                            <span class="ez-pagination__text">
+                                {{ 'pagination.viewing'|trans({
+                                    '%viewing%': pager.currentPageResults|length,
+                                    '%total%': pager.nbResults
+                                }, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                             </span>
-                        </td>
-                    </tr>
-                {% else %}
-                    {% for row in pager.currentPageResults %}
-                        {% set content_draft_edit_url = content_is_user|default(false) ? 'ez_user_update' : 'ez_content_draft_edit' %}
-                        <tr>
-                            <td class="ez-table__cell ez-table__cell--has-checkbox">
-                                 {{ form_widget(form_remove.versions[row.id ~ '']) }}
-                            </td>
-                            <td class="ez-table__cell">{{ row.name }}</td>
-                            <td class="ez-table__cell">{{ row.type }}</td>
-                            <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
-                            <td class="ez-table__cell">{{ row.version }}</td>
-                            <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>
-                            <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-                                <button class="btn btn-icon mx-2 ez-btn--content-draft-edit"
-                                        title="{{ 'drafts.list.action.edit'|trans|desc('Edit Draft') }}"
-                                        data-content-draft-edit-url="{{ path(content_draft_edit_url, {
-                                            'contentId': row.contentId,
-                                            'versionNo': row.version,
-                                            'language': row.language
-                                        }) }}"
-                                        data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
-                                            'contentId': row.contentId,
-                                            'versionNo': row.version,
-                                            'languageCode': row.language
-                                        }) }}">
-                                    <svg class="ez-icon ez-icon-edit">
-                                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
-                                    </svg>
-                                </button>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                {% endif %}
-                </tbody>
-            </table>
-            {{ form_widget(form_remove.remove, {
-                'attr': {
-                    'hidden': true
-                }
-            }) }}
-            {{ form_end(form_remove) }}
-
-            {% if pager.haveToPaginate %}
-                <div class="row justify-content-center align-items-center ez-pagination__spacing mb-2">
-                    <span class="ez-pagination__text">
-                        {{ 'pagination.viewing'|trans({
-                            '%viewing%': pager.currentPageResults|length,
-                            '%total%': pager.nbResults
-                        }, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
-                    </span>
+                        </div>
+                        <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
+                            {{ pagerfanta(pager, 'ez') }}
+                        </div>
+                    {% endif %}
                 </div>
-                <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
-                    {{ pagerfanta(pager, 'ez') }}
-                </div>
-            {% endif %}
-        </section>
+            </section>
+        </div>
     </div>
 
     {% include '@ezdesign/content/modal_version_conflict.html.twig' %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29769
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![zrzut ekranu 2018-10-31 o 16 32 39](https://user-images.githubusercontent.com/211967/47799470-9e5c1580-dd2a-11e8-96ee-0c907c2aeb64.png)


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
