### PR TITLE
EZP-29766: As an editor, I want to filter the search using subtree parameter

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -108,6 +108,7 @@ class SearchController extends Controller
         $contentTypes = [];
         $lastModified = $search['last_modified'] ?? [];
         $created = $search['created'] ?? [];
+        $subtree = $search['subtree'] ?? null;
 
         if (!empty($search['section'])) {
             $section = $this->sectionService->loadSection($search['section']);
@@ -119,7 +120,7 @@ class SearchController extends Controller
         }
 
         $form = $this->formFactory->createSearchForm(
-            new SearchData($limit, $page, $query, $section, $contentTypes, $lastModified, $created, $creator),
+            new SearchData($limit, $page, $query, $section, $contentTypes, $lastModified, $created, $creator, $subtree),
             'search',
             [
                 'method' => Request::METHOD_GET,
@@ -139,6 +140,7 @@ class SearchController extends Controller
                 $lastModified = $data->getLastModified();
                 $created = $data->getCreated();
                 $creator = $data->getCreator();
+                $subtree = $data->getSubtree();
                 $query = new Query();
                 $criteria = [];
 
@@ -171,6 +173,9 @@ class SearchController extends Controller
                         Criterion\Operator::EQ,
                         $creator->id
                     );
+                }
+                if (null !== $subtree) {
+                    $criteria[] = new Criterion\Subtree($subtree);
                 }
                 if (!empty($criteria)) {
                     $query->filter = new Criterion\LogicalAnd($criteria);

--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -95,3 +95,5 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\DateFormat:
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'dateFormat' }
+
+    EzSystems\EzPlatformAdminUiBundle\Templating\Twig\PathStringExtension: ~

--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -20,7 +20,6 @@
     const listGroupsTitle = [...doc.querySelectorAll('.ez-content-type-selector__group-title')];
     const contentTypeCheckboxes = [...doc.querySelectorAll('.ez-content-type-selector__item [type="checkbox"]')];
     const subtreeInput = doc.querySelector('#search_subtree');
-
     const clearFilters = (event) => {
         event.preventDefault();
 

--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -63,7 +63,7 @@
         const isModifiedSelected = !!lastModifiedSelect.value;
         const isCreatedSelected = !!lastCreatedSelect.value;
         const isCreatorSelected = !!searchCreatorInput.value;
-        const isSubtreeSelected = !!subtreeInput.value;
+        const isSubtreeSelected = !!subtreeInput.value.trim().length;
         const isEnabled = isContentTypeSelected || isSectionSelected || isModifiedSelected || isCreatedSelected || isCreatorSelected || isSubtreeSelected;
         const methodName = isEnabled ? 'removeAttribute' : 'setAttribute';
 

--- a/src/bundle/Resources/public/js/scripts/admin.search.filters.js
+++ b/src/bundle/Resources/public/js/scripts/admin.search.filters.js
@@ -19,6 +19,8 @@
     const resetCreatorBtn = doc.querySelector('.ez-filters__item--creator .ez-icon--reset');
     const listGroupsTitle = [...doc.querySelectorAll('.ez-content-type-selector__group-title')];
     const contentTypeCheckboxes = [...doc.querySelectorAll('.ez-content-type-selector__item [type="checkbox"]')];
+    const subtreeInput = doc.querySelector('#search_subtree');
+
     const clearFilters = (event) => {
         event.preventDefault();
 
@@ -48,6 +50,7 @@
         lastModifiedEnd.value = '';
         lastCreatedPeriod.value = '';
         lastCreatedEnd.value = '';
+        subtreeInput.value = '';
 
         handleResetUser();
 
@@ -60,7 +63,8 @@
         const isModifiedSelected = !!lastModifiedSelect.value;
         const isCreatedSelected = !!lastCreatedSelect.value;
         const isCreatorSelected = !!searchCreatorInput.value;
-        const isEnabled = isContentTypeSelected || isSectionSelected || isModifiedSelected || isCreatedSelected || isCreatorSelected;
+        const isSubtreeSelected = !!subtreeInput.value;
+        const isEnabled = isContentTypeSelected || isSectionSelected || isModifiedSelected || isCreatedSelected || isCreatorSelected || isSubtreeSelected;
         const methodName = isEnabled ? 'removeAttribute' : 'setAttribute';
 
         applyBtn[methodName]('disabled', !isEnabled);
@@ -276,6 +280,7 @@
         sectionSelect.addEventListener('change', toggleDisabledStateOnApplyBtn, false);
     }
 
+    subtreeInput.addEventListener('change', toggleDisabledStateOnApplyBtn, false);
     lastModifiedSelect.addEventListener('change', toggleModalVisibility, false);
     lastCreatedSelect.addEventListener('change', toggleModalVisibility, false);
     creatorInput.addEventListener('keyup', handleTyping, false);

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -1,0 +1,94 @@
+(function (global, doc, React, ReactDOM, Translator) {
+    const btns = doc.querySelectorAll('.ez-btn--udw-select-location');
+    const udwContainer = doc.getElementById('react-udw');
+    const token = doc.querySelector('meta[name="CSRF-Token"]').content;
+    const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
+
+    const findLocationsByIdList = (idList, callback) => {
+        const body = JSON.stringify({
+            ViewInput: {
+                identifier: `udw-locations-by-path-string-${idList.join('-')}`,
+                public: false,
+                LocationQuery: {
+                    Criteria: {},
+                    FacetBuilders: {},
+                    SortClauses: { SectionIdentifier: 'ascending' },
+                    Filter: { LocationIdCriterion: idList.join(',') },
+                    limit: 50,
+                    offset: 0,
+                },
+            },
+        });
+
+        const request = new Request('/api/ezp/v2/views', {
+            method: 'POST',
+            headers: {
+                Accept: 'application/vnd.ez.api.View+json; version=1.1',
+                'Content-Type': 'application/vnd.ez.api.ViewInput+json; version=1.1',
+                'X-Requested-With' : 'XMLHttpRequest',
+                'X-Siteaccess': siteaccess,
+                'X-CSRF-Token': token
+            },
+            body,
+            mode: 'same-origin',
+            credentials: 'same-origin',
+        });
+
+        const errorMessage = Translator.trans(
+            /*@Desc("Cannot find children locations with given id list")*/ 'select_location.error',
+            {},
+            'universal_discovery_widget'
+        );
+        fetch(request)
+            .then(window.eZ.helpers.request.getJsonFromResponse)
+            .then((json) => callback(json))
+            .catch(() => window.eZ.helpers.notification.showErrorNotification(errorMessage));
+    };
+
+    const removeRootFromPathString = (pathString) => {
+        const pathArray = pathString.split('/').filter((val) => val);
+
+        return pathArray.splice(1, pathArray.length - 1);
+    };
+    const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
+    const onConfirm = (btn, items) => {
+        closeUDW();
+
+        const pathString = items[0].pathString;
+        const displayWrapper = doc.querySelector(btn.dataset.displayWrapper);
+        const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
+
+        pathStringInput.value = pathString;
+        pathStringInput.dispatchEvent(new Event('change'));
+
+        if (!displayWrapper) {
+            return;
+        }
+
+        findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
+            const searchHitList = data.View.Result.searchHits.searchHit;
+            const pathStringNames = searchHitList.map((searchHit) => {
+                return searchHit.value.Location.ContentInfo.Content.Name;
+            }).join(' / ');
+
+            displayWrapper.querySelector(btn.dataset.selectedContentNameSelector).innerHTML = pathStringNames;
+        });
+    };
+    const onCancel = () => closeUDW();
+    const openUDW = (event) => {
+        event.preventDefault();
+
+        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
+
+        ReactDOM.render(React.createElement(global.eZ.modules.UniversalDiscovery, Object.assign({
+            onConfirm: onConfirm.bind(null, event.currentTarget),
+            onCancel,
+            title: event.currentTarget.dataset.universalDiscoveryTitle,
+            multiple: false,
+            startingLocationId: window.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
+            restInfo: { token, siteaccess }
+        }, config)), udwContainer);
+    };
+
+    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
+})(window, window.document, window.React, window.ReactDOM, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -64,7 +64,7 @@
     const setLocationPath = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
         const contentBreadcrumbsContainer = doc.querySelector(
-            `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__subtree__breadcrumbs`
+            `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__breadcrumbs`
         );
 
         pathStringInput.value = pathString;

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -1,4 +1,4 @@
-(function(global, doc, eZ, React, ReactDOM, Translator){
+(function(global, doc, eZ, React, ReactDOM, Translator) {
     const btns = doc.querySelectorAll('.ez-btn--udw-select-location');
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
@@ -38,9 +38,9 @@
         );
 
         fetch(request)
-            .then(window.eZ.helpers.request.getJsonFromResponse)
-            .then((json) => callback(json))
-            .catch(() => window.eZ.helpers.notification.showErrorNotification(errorMessage));
+            .then(eZ.helpers.request.getJsonFromResponse)
+            .then(callback)
+            .catch(() => eZ.helpers.notification.showErrorNotification(errorMessage));
     };
     const removeRootFromPathString = (pathString) => {
         const pathArray = pathString.split('/').filter((val) => val);
@@ -52,22 +52,23 @@
 
         return searchHitList.map((searchHit) => searchHit.value.Location.ContentInfo.Content.Name).join(' / ');
     };
-    const toggleVisibility = (btn, pathString) => {
-        btn.hidden = !!pathString;
-
+    const toggleVisibility = (btn, isLocationSelected) => {
         const contentBreadcrumbsWrapper = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
 
+        btn.hidden = isLocationSelected;
+
         if (contentBreadcrumbsWrapper) {
-            contentBreadcrumbsWrapper.hidden = !pathString;
+            contentBreadcrumbsWrapper.hidden = !isLocationSelected;
         }
     };
     const setPath = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
+        const contentBreadcrumbsContainer = doc.querySelector(
+            `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__subtree__breadcrumbs`
+        );
 
         pathStringInput.value = pathString;
         pathStringInput.dispatchEvent(new Event('change'));
-
-        const contentBreadcrumbsContainer = doc.querySelector(`${btn.dataset.contentBreadcrumbsSelector} ez-filters__subtree__breadcrumbs`);
 
         if (!contentBreadcrumbsContainer) {
             return;
@@ -88,7 +89,7 @@
         const pathString = items[0].pathString;
 
         setPath(btn, pathString);
-        toggleVisibility(btn, pathString);
+        toggleVisibility(btn, !!pathString);
     };
     const onCancel = () => closeUDW();
     const openUDW = (event) => {
@@ -98,7 +99,7 @@
 
         ReactDOM.render(
             React.createElement(
-                global.eZ.modules.UniversalDiscovery,
+                eZ.modules.UniversalDiscovery,
                 Object.assign(
                     {
                         onConfirm: onConfirm.bind(null, event.currentTarget),
@@ -116,7 +117,7 @@
     };
     const clearValue = (btn) => {
         setPath(btn, '');
-        toggleVisibility(btn, '');
+        toggleVisibility(btn, false);
     };
 
     btns.forEach((btn) => {

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -61,7 +61,7 @@
             contentBreadcrumbsWrapper.hidden = !isLocationSelected;
         }
     };
-    const setPath = (btn, pathString) => {
+    const setLocationPath = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
         const contentBreadcrumbsContainer = doc.querySelector(
             `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__subtree__breadcrumbs`
@@ -88,7 +88,7 @@
 
         const pathString = items[0].pathString;
 
-        setPath(btn, pathString);
+        setLocationPath(btn, pathString);
         toggleVisibility(btn, !!pathString);
     };
     const onCancel = () => closeUDW();
@@ -115,8 +115,8 @@
             udwContainer
         );
     };
-    const clearValue = (btn) => {
-        setPath(btn, '');
+    const clearSelection = (btn) => {
+        setLocationPath(btn, '');
         toggleVisibility(btn, false);
     };
 
@@ -126,7 +126,7 @@
         const clearBtn = doc.querySelector(btn.dataset.clearBtnSelector);
 
         if (clearBtn) {
-            clearBtn.addEventListener('click', clearValue.bind(null, btn), false);
+            clearBtn.addEventListener('click', clearSelection.bind(null, btn), false);
         }
     });
 })(window, document, window.eZ, window.React, window.ReactDOM, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -55,10 +55,10 @@
     const toggleVisibility = (btn, pathString) => {
         btn.hidden = !!pathString;
 
-        const contentNameWrapper = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
+        const contentBreadcrumbsWrapper = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
 
-        if (contentNameWrapper) {
-            contentNameWrapper.hidden = !pathString;
+        if (contentBreadcrumbsWrapper) {
+            contentBreadcrumbsWrapper.hidden = !pathString;
         }
     };
     const setPath = (btn, pathString) => {
@@ -67,17 +67,17 @@
         pathStringInput.value = pathString;
         pathStringInput.dispatchEvent(new Event('change'));
 
-        const contentNameContainer = doc.querySelector(`${btn.dataset.contentBreadcrumbsSelector} div`);
+        const contentBreadcrumbsContainer = doc.querySelector(`${btn.dataset.contentBreadcrumbsSelector} ez-filters__subtree__breadcrumbs`);
 
-        if (!contentNameContainer) {
+        if (!contentBreadcrumbsContainer) {
             return;
         }
 
         if (!pathString) {
-            contentNameContainer.innerHTML = '';
+            contentBreadcrumbsContainer.innerHTML = '';
         } else {
             findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
-                contentNameContainer.innerHTML = buildBreadcrumbsString(data);
+                contentBreadcrumbsContainer.innerHTML = buildBreadcrumbsString(data);
             });
         }
     };

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -63,26 +63,26 @@
     };
     const updateBreadcrumbsState = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
-        const contentBreadcrumbs = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
-        const contentBreadcrumbsContainer = contentBreadcrumbs.querySelector('.ez-filters__breadcrumbs');
-        const contentBreadcrumbsSpinner = contentBreadcrumbs.querySelector('.ez-filters__breadcrumbs-spinner');
+        const contentBreadcrumbsContainer = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
+        const contentBreadcrumbs = contentBreadcrumbsContainer.querySelector('.ez-filters__breadcrumbs');
+        const contentBreadcrumbsSpinner = contentBreadcrumbsContainer.querySelector('.ez-filters__breadcrumbs-spinner');
 
         pathStringInput.value = pathString;
         pathStringInput.dispatchEvent(new Event('change'));
 
-        if (!contentBreadcrumbsContainer || !contentBreadcrumbsSpinner) {
+        if (!contentBreadcrumbs || !contentBreadcrumbsSpinner) {
             return;
         }
 
         if (!pathString) {
-            contentBreadcrumbsContainer.innerHTML = '';
-            contentBreadcrumbsContainer.hidden = true;
+            contentBreadcrumbs.innerHTML = '';
+            contentBreadcrumbs.hidden = true;
         } else {
             contentBreadcrumbsSpinner.hidden = false;
             findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
-                contentBreadcrumbsContainer.innerHTML = buildBreadcrumbsString(data);
+                contentBreadcrumbs.innerHTML = buildBreadcrumbsString(data);
                 contentBreadcrumbsSpinner.hidden = true;
-                contentBreadcrumbsContainer.hidden = false;
+                contentBreadcrumbs.hidden = false;
             });
         }
     };

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -1,4 +1,4 @@
-(function(global, doc, React, ReactDOM, Translator) {
+(function(global, doc, eZ, React, ReactDOM, Translator){
     const btns = doc.querySelectorAll('.ez-btn--udw-select-location');
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
@@ -47,7 +47,7 @@
 
         return pathArray.splice(1, pathArray.length - 1);
     };
-    const buildBreadCrumbsString = (viewData) => {
+    const buildBreadcrumbsString = (viewData) => {
         const searchHitList = viewData.View.Result.searchHits.searchHit;
 
         return searchHitList.map((searchHit) => searchHit.value.Location.ContentInfo.Content.Name).join(' / ');
@@ -55,7 +55,7 @@
     const toggleVisibility = (btn, pathString) => {
         btn.hidden = !!pathString;
 
-        const contentNameWrapper = doc.querySelector(btn.dataset.selectedContentNameSelector);
+        const contentNameWrapper = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
 
         if (contentNameWrapper) {
             contentNameWrapper.hidden = !pathString;
@@ -67,7 +67,7 @@
         pathStringInput.value = pathString;
         pathStringInput.dispatchEvent(new Event('change'));
 
-        const contentNameContainer = doc.querySelector(`${btn.dataset.selectedContentNameSelector} span`);
+        const contentNameContainer = doc.querySelector(`${btn.dataset.contentBreadcrumbsSelector} div`);
 
         if (!contentNameContainer) {
             return;
@@ -77,7 +77,7 @@
             contentNameContainer.innerHTML = '';
         } else {
             findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
-                contentNameContainer.innerHTML = buildBreadCrumbsString(data);
+                contentNameContainer.innerHTML = buildBreadcrumbsString(data);
             });
         }
     };
@@ -105,7 +105,7 @@
                         onCancel,
                         title: event.currentTarget.dataset.universalDiscoveryTitle,
                         multiple: false,
-                        startingLocationId: window.eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
+                        startingLocationId: eZ.adminUiConfig.universalDiscoveryWidget.startingLocationId,
                         restInfo: { token, siteaccess },
                     },
                     config
@@ -128,4 +128,4 @@
             clearBtn.addEventListener('click', clearValue.bind(null, btn), false);
         }
     });
-})(window, window.document, window.React, window.ReactDOM, window.Translator);
+})(window, document, window.eZ, window.React, window.ReactDOM, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -61,7 +61,7 @@
             contentBreadcrumbsWrapper.hidden = !isLocationSelected;
         }
     };
-    const setLocationPath = (btn, pathString) => {
+    const updateBreadcrumbsState = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
         const contentBreadcrumbsContainer = doc.querySelector(
             `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__breadcrumbs`
@@ -88,7 +88,7 @@
 
         const pathString = items[0].pathString;
 
-        setLocationPath(btn, pathString);
+        updateBreadcrumbsState(btn, pathString);
         toggleVisibility(btn, !!pathString);
     };
     const onCancel = () => closeUDW();
@@ -116,7 +116,7 @@
         );
     };
     const clearSelection = (btn) => {
-        setLocationPath(btn, '');
+        updateBreadcrumbsState(btn, '');
         toggleVisibility(btn, false);
     };
 

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -63,22 +63,26 @@
     };
     const updateBreadcrumbsState = (btn, pathString) => {
         const pathStringInput = doc.querySelector(btn.dataset.locationPathInputSelector);
-        const contentBreadcrumbsContainer = doc.querySelector(
-            `${btn.dataset.contentBreadcrumbsSelector} .ez-filters__breadcrumbs`
-        );
+        const contentBreadcrumbs = doc.querySelector(btn.dataset.contentBreadcrumbsSelector);
+        const contentBreadcrumbsContainer = contentBreadcrumbs.querySelector('.ez-filters__breadcrumbs');
+        const contentBreadcrumbsSpinner = contentBreadcrumbs.querySelector('.ez-filters__breadcrumbs-spinner');
 
         pathStringInput.value = pathString;
         pathStringInput.dispatchEvent(new Event('change'));
 
-        if (!contentBreadcrumbsContainer) {
+        if (!contentBreadcrumbsContainer || !contentBreadcrumbsSpinner) {
             return;
         }
 
         if (!pathString) {
             contentBreadcrumbsContainer.innerHTML = '';
+            contentBreadcrumbsContainer.hidden = true;
         } else {
+            contentBreadcrumbsSpinner.hidden = false;
             findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
                 contentBreadcrumbsContainer.innerHTML = buildBreadcrumbsString(data);
+                contentBreadcrumbsSpinner.hidden = true;
+                contentBreadcrumbsContainer.hidden = false;
             });
         }
     };

--- a/src/bundle/Resources/public/js/scripts/udw/select.location.js
+++ b/src/bundle/Resources/public/js/scripts/udw/select.location.js
@@ -3,7 +3,6 @@
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
-
     const findLocationsByIdList = (idList, callback) => {
         const body = JSON.stringify({
             ViewInput: {
@@ -35,8 +34,8 @@
         });
 
         const errorMessage = Translator.trans(
-            /*@Desc("Cannot find children locations with given id list")*/ 'select_location.error',
-            {},
+            /*@Desc("Cannot find children locations with given id - %idList%")*/ 'select_location.error',
+            { idList: idList.join(',') },
             'universal_discovery_widget'
         );
         fetch(request)
@@ -44,11 +43,16 @@
             .then((json) => callback(json))
             .catch(() => window.eZ.helpers.notification.showErrorNotification(errorMessage));
     };
-
     const removeRootFromPathString = (pathString) => {
         const pathArray = pathString.split('/').filter((val) => val);
 
         return pathArray.splice(1, pathArray.length - 1);
+    };
+    const buildBreadCrumbsString = (viewData) => {
+        const searchHitList = viewData.View.Result.searchHits.searchHit;
+        return searchHitList.map((searchHit) => {
+            return searchHit.value.Location.ContentInfo.Content.Name;
+        }).join(' / ');
     };
     const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
     const onConfirm = (btn, items) => {
@@ -66,12 +70,7 @@
         }
 
         findLocationsByIdList(removeRootFromPathString(pathString), (data) => {
-            const searchHitList = data.View.Result.searchHits.searchHit;
-            const pathStringNames = searchHitList.map((searchHit) => {
-                return searchHit.value.Location.ContentInfo.Content.Name;
-            }).join(' / ');
-
-            displayWrapper.querySelector(btn.dataset.selectedContentNameSelector).innerHTML = pathStringNames;
+            displayWrapper.querySelector(btn.dataset.selectedContentNameSelector).innerHTML = buildBreadCrumbsString(data);
         });
     };
     const onCancel = () => closeUDW();

--- a/src/bundle/Resources/public/scss/_content-type-selector.scss
+++ b/src/bundle/Resources/public/scss/_content-type-selector.scss
@@ -26,6 +26,7 @@
         color: $ez-color-secondary;
         position: relative;
         cursor: pointer;
+        padding-right: calculateRem(24px);
 
         &:before,
         &:after {
@@ -40,11 +41,11 @@
         }
 
         &:before {
-            transform: translate(-3px, -50%) rotate(135deg);
+            transform: translate(-27px, -50%) rotate(135deg);
         }
 
         &:after {
-            transform: translate(2px, -50%) rotate(45deg);
+            transform: translate(-22px, -50%) rotate(45deg);
         }
     }
 
@@ -63,11 +64,11 @@
             }
 
             #{$selector}__group-title:before {
-                transform: translate(-3px, -20%) rotate(45deg);
+                transform: translate(-27px, -20%) rotate(45deg);
             }
 
             #{$selector}__group-title:after {
-                transform: translate(-3px, -80%) rotate(-45deg);
+                transform: translate(-27px, -80%) rotate(-45deg);
             }
         }
 

--- a/src/bundle/Resources/public/scss/_content-type-selector.scss
+++ b/src/bundle/Resources/public/scss/_content-type-selector.scss
@@ -1,31 +1,16 @@
 .ez-content-type-selector {
     $selector: '.ez-content-type-selector';
-
-    position: absolute;
-    max-width: 34rem;
-    background: $ez-ground-base-dark;
     padding: calculateRem(16px) calculateRem(24px);
-    border-radius: 5px;
-    box-shadow: 0 calculateRem(2px) calculateRem(4px) 0 rgba(0, 0, 0, 0.45);
-    transform: scaleY(1);
-    transform-origin: top center;
-    transition: transition .2s $ez-admin-transition;
-    z-index: 3;
-
-    &--collapsed {
-        transform: scaleY(0);
-        height: 0;
-    }
 
     &__list {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 150px);
+        justify-content: space-between;
         list-style: none;
         padding: 0;
     }
 
     &__item {
-        flex-basis: 33%;
         display: flex;
 
         .form-check-inline {
@@ -73,15 +58,16 @@
         &--collapsed {
             #{$selector}__list {
                 transform: scaleY(0);
+                opacity: 0;
                 height: 0;
             }
 
             #{$selector}__group-title:before {
-                transform: translate(-3px, -50%) rotate(45deg);
+                transform: translate(-3px, -20%) rotate(45deg);
             }
 
             #{$selector}__group-title:after {
-                transform: translate(2px, -50%) rotate(-45deg);
+                transform: translate(-3px, -80%) rotate(-45deg);
             }
         }
 

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -78,6 +78,7 @@
         padding: calculateRem(8px) calculateRem(48px) calculateRem(8px)  calculateRem(8px);
         display: inline-block;
         position: relative;
+        height: calculateRem(38px);
 
         .ez-icon--reset {
             display: block;
@@ -87,10 +88,10 @@
             cursor: pointer;
             fill: $ez-black;
         }
+    }
 
-        &__breadcrumbs {
-            line-height: calculateRem(22px);
-        }
+    &__breadcrumbs {
+        line-height: calculateRem(22px);
     }
 
     &:before,

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -73,21 +73,23 @@
     }
 
     &__subtree {
-        height: calculateRem(38px);
         border-radius: calculateRem(4px);
-        background: #dbdbdb;
-        padding: calculateRem(8px);
-        padding-right: calculateRem(48px);
+        background: $ez-color-base-pale;
+        padding: calculateRem(8px) calculateRem(48px) calculateRem(8px)  calculateRem(8px);
         display: inline-block;
         position: relative;
 
         .ez-icon--reset {
             display: block;
             position: absolute;
-            bottom: calculateRem(7px);
+            top: calculateRem(7px);
             right: calculateRem(6px);
             cursor: pointer;
-            fill: #333;
+            fill: $ez-black;
+        }
+
+        &__breadcrumbs {
+            line-height: calculateRem(22px);
         }
     }
 

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -1,21 +1,31 @@
 .ez-filters {
-    display: flex;
-    justify-content: space-between;
-    border-top: 1px solid $ez-color-secondary;
+    border-color: $ez-color-secondary;
+    border-style: solid;
+    border-width: calculateRem(1px) 0;
     transform: scaleY(1);
     transform-origin: top center;
     transition: all 0.2s $ez-admin-transition;
     flex-wrap: wrap;
     position: relative;
+    padding: calculateRem(8px) calculateRem(8px) 0 calculateRem(8px);
 
     &--collapsed {
         transform: scaleY(0);
         height: 0;
+        opacity: 0;
+    }
+
+    &__row {
+        background: $ez-ground-base-medium;
+        padding: calculateRem(16px);
+        border-radius: calculateRem(4px);
+        margin-bottom: calculateRem(16px);
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        grid-column-gap: 10%;
     }
 
     &__item {
-        flex-basis: 18%;
-
         &-label {
             margin-bottom: 0;
             font-weight: 700;
@@ -23,6 +33,16 @@
             &--date-range {
                 flex-basis: 45%;
             }
+        }
+
+        &--content-type {
+            grid-column-start: 1;
+            grid-column-end: -1;
+        }
+
+        &--subtree {
+            grid-column-start: 2;
+            grid-column-end: -1;
         }
 
         &--creator {
@@ -37,14 +57,14 @@
                     cursor: auto;
                     background-color: $ez-color-base-dark;
                     color: $ez-white;
-                    padding-right: 2rem;
+                    padding-right: calculateRem(32px);
                     text-overflow: ellipsis;
 
                     & + .ez-icon {
                         display: block;
                         position: absolute;
-                        bottom: .4375rem;
-                        right: .375rem;
+                        bottom: calculateRem(7px);
+                        right: calculateRem(6px);
                         cursor: pointer;
                     }
                 }
@@ -52,11 +72,30 @@
         }
     }
 
+    &__subtree {
+        height: calculateRem(38px);
+        border-radius: calculateRem(4px);
+        background: #dbdbdb;
+        padding: calculateRem(8px);
+        padding-right: calculateRem(48px);
+        display: inline-block;
+        position: relative;
+
+        .ez-icon--reset {
+            display: block;
+            position: absolute;
+            bottom: calculateRem(7px);
+            right: calculateRem(6px);
+            cursor: pointer;
+            fill: #333;
+        }
+    }
+
     &:before,
     &:after {
         content: '';
         position: absolute;
-        left: 93.75%;
+        right: calculateRem(40px);
         border-style: solid;
         border-width: 0 calculateRem(10px) calculateRem(10px);
         display: block;
@@ -78,7 +117,7 @@
         flex-basis: 100%;
         display: flex;
         justify-content: center;
-        margin-top: 2rem;
+        margin: calculateRem(16px);
 
         .btn {
             margin: 0 1rem;
@@ -95,14 +134,14 @@
         position: absolute;
         right: 0;
         min-width: 100%;
-        border-radius: 5px;
+        border-radius: calculateRem(5px);
         margin-bottom: 0;
         background-color: $ez-ground-base-dark;
-        max-height: 300px;
+        max-height: calculateRem(300px);
         overflow: auto;
         transform: scaleY(1);
         transform-origin: top center;
-        transition: transform .2s $ez-admin-transition;
+        transition: transform 0.2s $ez-admin-transition;
 
         &--hidden {
             transform: scaleY(0);
@@ -110,7 +149,7 @@
     }
 
     &__user-item {
-        padding: .5rem 1rem;
+        padding: calculateRem(8px) calculateRem(16px);
         cursor: pointer;
     }
 }

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -78,7 +78,6 @@
         padding: calculateRem(8px) calculateRem(48px) calculateRem(8px)  calculateRem(8px);
         display: inline-block;
         position: relative;
-        height: calculateRem(38px);
 
         .ez-icon--reset {
             display: block;

--- a/src/bundle/Resources/public/scss/_filters.scss
+++ b/src/bundle/Resources/public/scss/_filters.scss
@@ -94,6 +94,12 @@
         line-height: calculateRem(22px);
     }
 
+    &__breadcrumbs-spinner {
+        .ez-icon {
+            fill: $ez-black;
+        }
+    }
+
     &:before,
     &:after {
         content: '';

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -136,6 +136,16 @@
         <target state="new">Section:</target>
         <note>key: search.section</note>
       </trans-unit>
+      <trans-unit id="1ac4d5da88d06451590cade73ec7e2c4a8b98c2e" resname="search.select_content">
+        <source>Select Content</source>
+        <target state="new">Select Content</target>
+        <note>key: search.select_content</note>
+      </trans-unit>
+      <trans-unit id="b484be9d33f5cd9961f4ddd89c628f2cbca2a6a1" resname="search.subtree">
+        <source>Subtree:</source>
+        <target state="new">Subtree:</target>
+        <note>key: search.subtree</note>
+      </trans-unit>
       <trans-unit id="777cc1ef279096d5a978aa3553e9434d828f8248" resname="search.tips.check_spelling">
         <source>Check spelling of keywords.</source>
         <target state="new">Check spelling of keywords.</target>
@@ -165,6 +175,11 @@
         <source>Content Type</source>
         <target state="new">Content Type</target>
         <note>key: search.type</note>
+      </trans-unit>
+      <trans-unit id="c33e03cc28d02c59ac241dba3a1bb3ea0ab1f358" resname="search.udw.select_content">
+        <source>Select Content</source>
+        <target state="new">Select Content</target>
+        <note>key: search.udw.select_content</note>
       </trans-unit>
       <trans-unit id="fe647ff0e12d67501403559464217be468dba3d8" resname="search.viewing">
         <source>Viewing %viewing% out of %total% sub-items</source>

--- a/src/bundle/Resources/translations/universal_discovery_widget.en.xliff
+++ b/src/bundle/Resources/translations/universal_discovery_widget.en.xliff
@@ -47,8 +47,8 @@
         <note>key: restore_under_new_location.title</note>
       </trans-unit>
       <trans-unit id="5b8a9a5fceb4991b77b50983c34df8a18a900a09" resname="select_location.error">
-        <source>Cannot find children locations with given id list</source>
-        <target state="new">Cannot find children locations with given id list</target>
+        <source>Cannot find children locations with given id - %idList%</source>
+        <target state="new">Cannot find children locations with given id - %idList%</target>
         <note>key: select_location.error</note>
       </trans-unit>
       <trans-unit id="987330c357d2475b80942e5c449e4215b623a459" resname="subtree.title">

--- a/src/bundle/Resources/translations/universal_discovery_widget.en.xliff
+++ b/src/bundle/Resources/translations/universal_discovery_widget.en.xliff
@@ -46,6 +46,11 @@
         <target state="new">Select a location to restore you content item(s)</target>
         <note>key: restore_under_new_location.title</note>
       </trans-unit>
+      <trans-unit id="5b8a9a5fceb4991b77b50983c34df8a18a900a09" resname="select_location.error">
+        <source>Cannot find children locations with given id list</source>
+        <target state="new">Cannot find children locations with given id list</target>
+        <note>key: select_location.error</note>
+      </trans-unit>
       <trans-unit id="987330c357d2475b80942e5c449e4215b623a459" resname="subtree.title">
         <source>Select location</source>
         <target state="new">Select location</target>

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -94,8 +94,9 @@
 
 {% block javascripts %}
     {%  javascripts
-        'bundles/ezplatformadminui/js/scripts/button.content.edit.js'
-        'bundles/ezplatformadminui/js/scripts/admin.search.filters.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.content.edit.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.search.filters.js'
+        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/select.location.js'
     %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -55,6 +55,29 @@
         </svg>
         <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
     </div>
+    <div class="ez-filters__item ez-filters__item--subtree">
+        <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
+        {% set subtree = form.vars.data.subtree %}
+        <button data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
+                class="ez-button-tree pure-button ez-font-icon ez-button btn btn-secondary ez-btn--udw-select-location"
+                data-location-path-input-selector="#{{form.subtree.vars.id}}"
+                data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
+                data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+                data-display-wrapper=".ez-filters__item--subtree"
+        >{{'search.select_content'|trans|desc('Select Content')}}</button>
+        <div id="{{form.subtree.vars.id}}-selected-content-name">
+            <span class="{{form.subtree.vars.id}}-selected-content-name">
+                {% if form.subtree.vars.value is not empty %}
+                    {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
+                    {% for location in locationList %}
+                        {{ ez_content_name(location.contentInfo) }}
+                        {% if loop.revindex > 1 %}/{% endif %}
+                    {% endfor %}
+                {% endif %}
+            </span>
+        </div>
+        {{ form_widget(form.subtree) }}
+    </div>
     <div class="ez-filters__btns">
         <button class="btn btn-dark ez-btn-clear">
             {{ 'search.clear'|trans|desc('Clear') }}</button>

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -38,7 +38,6 @@
         {% endif %}
         <div class="ez-filters__item ez-filters__item--subtree">
             <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
-            {% set subtree = form.vars.data.subtree %}
             <div>
                 <button class="btn btn-secondary ez-btn--udw-select-location"
                     type="button"
@@ -49,8 +48,10 @@
                     data-clear-btn-selector="#{{form.subtree.vars.id}}-clear-btn"
                     data-udw-config="{{ ez_udw_config('single_container', {}) }}"
                     >{{'search.select_content'|trans|desc('Select Content')}}</button>
-                <div class="ez-filters__subtree" id="{{form.subtree.vars.id}}-content-breadcrumbs">
-                    <div class="ez-filters__subtree__breadcrumbs">
+                <div class="ez-filters__subtree" 
+                    {% if form.subtree.vars.value is empty %} hidden="true" {% endif %}
+                    id="{{form.subtree.vars.id}}-content-breadcrumbs">
+                    <div class="ez-filters__breadcrumbs">
                         {% if form.subtree.vars.value is not empty %}
                             {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
                             {% for location in locationList %}

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -59,14 +59,14 @@
         <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
         {% set subtree = form.vars.data.subtree %}
         <button data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
-                class="ez-button-tree pure-button ez-font-icon ez-button btn btn-secondary ez-btn--udw-select-location"
-                data-location-path-input-selector="#{{form.subtree.vars.id}}"
-                data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
-                data-udw-config="{{ ez_udw_config('single_container', {}) }}"
-                data-display-wrapper=".ez-filters__item--subtree"
+            class="ez-button-tree ez-font-icon ez-button btn btn-secondary ez-btn--udw-select-location"
+            data-location-path-input-selector="#{{form.subtree.vars.id}}"
+            data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
+            data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+            data-display-wrapper=".ez-filters__item--subtree"
         >{{'search.select_content'|trans|desc('Select Content')}}</button>
-        <div id="{{form.subtree.vars.id}}-selected-content-name">
-            <span class="{{form.subtree.vars.id}}-selected-content-name">
+        <div>
+            <span id="{{form.subtree.vars.id}}-selected-content-name">
                 {% if form.subtree.vars.value is not empty %}
                     {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
                     {% for location in locationList %}

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -45,12 +45,12 @@
                     {% if form.subtree.vars.value is not empty %} hidden="true" {% endif %}
                     data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
                     data-location-path-input-selector="#{{form.subtree.vars.id}}"
-                    data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
+                    data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
                     data-clear-btn-selector="#{{form.subtree.vars.id}}-clear-btn"
                     data-udw-config="{{ ez_udw_config('single_container', {}) }}"
                     >{{'search.select_content'|trans|desc('Select Content')}}</button>
-                <div class="ez-filters__subtree" id="{{form.subtree.vars.id}}-selected-content-name">
-                    <span>
+                <div class="ez-filters__subtree" id="{{form.subtree.vars.id}}-content-breadcrumbs">
+                    <div class="ez-filters__subtree__breadcrumbs">
                         {% if form.subtree.vars.value is not empty %}
                             {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
                             {% for location in locationList %}
@@ -58,7 +58,7 @@
                                 {% if loop.revindex > 1 %}/{% endif %}
                             {% endfor %}
                         {% endif %}
-                    </span>
+                    </div>
                     <svg id="{{form.subtree.vars.id}}-clear-btn"
                         class="ez-icon ez-icon--medium ez-icon--reset">
                         <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -12,71 +12,86 @@
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#search"></use>
             </svg>
             <span class="ez-btn ez-btn--search-label">{{ 'search.perform'|trans|desc('Search') }}</span></button>
-        <button type="submit" class="btn btn-dark ez-btn--filter ml-4">
+        <button type="button" class="btn btn-dark ez-btn--filter ml-4">
             <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-filters">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#filters"></use>
             </svg>
             <span class="ez-btn ez-btn--filter-label">{{ 'search.filters'|trans|desc('Filters') }}</span></button>
     </span>
 </div>
-<div class="ez-filters mt-4 ml-4 pt-2{% if not filters_expanded %} ez-filters--collapsed{% endif %}">
-    <div class="ez-filters__item ez-filters__item--content-type">
-        <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
-        <select class="form-control ez-filters__select ez-filters__select--content-type">
-            <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any content type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any content type') }}</option>
-        </select>
-        {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
-    </div>
-    {% if form.section is defined %}
-        <div class="ez-filters__item ez-filters__item--section">
-            <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
-            {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
+<div class="ez-filters mt-4 ml-4 pt-2 {% if not filters_expanded %} ez-filters--collapsed{% endif %}">
+    <div class="ez-filters__row">
+        <div class="ez-filters__item ez-filters__item--content-type">
+            <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
+            <select class="form-control ez-filters__select ez-filters__select--content-type" hidden="true">
+                <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any content type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any content type') }}</option>
+            </select>
+            {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
         </div>
-    {% endif %}
-    <div class="ez-filters__item ez-filters__item--modified">
-        <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
-        {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-modified-range'}}) }}
     </div>
-    <div class="ez-filters__item ez-filters__item--created">
-        <label class="ez-filters__item-label">{{ 'search.created'|trans|desc('Created:') }}</label>
-        {{ form_widget(form.created_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-created-range'}}) }}
-    </div>
-    <div class="ez-filters__item ez-filters__item--creator">
-        <label class="ez-filters__item-label">{{ 'search.creator'|trans|desc('Creator:') }}</label>
-        {% set creator = form.vars.data.creator %}
-        <input type="text"
-            class="form-control ez-filters__input"
-            data-content-type-identifiers="{{ user_content_type_identifier|join(',') }}"
-            value="{{ creator is not empty ? ez_content_name(creator) }}"
-            {{ creator is not empty ? 'disabled'  }}
-        >
-        <svg class="ez-icon ez-icon--light ez-icon--medium ez-icon--reset">
-            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
-        </svg>
-        <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
-    </div>
-    <div class="ez-filters__item ez-filters__item--subtree">
-        <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
-        {% set subtree = form.vars.data.subtree %}
-        <button data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
-            class="ez-button-tree ez-font-icon ez-button btn btn-secondary ez-btn--udw-select-location"
-            data-location-path-input-selector="#{{form.subtree.vars.id}}"
-            data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
-            data-udw-config="{{ ez_udw_config('single_container', {}) }}"
-            data-display-wrapper=".ez-filters__item--subtree"
-        >{{'search.select_content'|trans|desc('Select Content')}}</button>
-        <div>
-            <span id="{{form.subtree.vars.id}}-selected-content-name">
-                {% if form.subtree.vars.value is not empty %}
-                    {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
-                    {% for location in locationList %}
-                        {{ ez_content_name(location.contentInfo) }}
-                        {% if loop.revindex > 1 %}/{% endif %}
-                    {% endfor %}
-                {% endif %}
-            </span>
+    <div class="ez-filters__row">
+        {% if form.section is defined %}
+            <div class="ez-filters__item ez-filters__item--section">
+                <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
+                {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
+            </div>
+        {% endif %}
+        <div class="ez-filters__item ez-filters__item--subtree">
+            <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
+            {% set subtree = form.vars.data.subtree %}
+            <div>
+                <button class="btn btn-secondary ez-btn--udw-select-location"
+                    type="button"
+                    {% if form.subtree.vars.value is not empty %} hidden="true" {% endif %}
+                    data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
+                    data-location-path-input-selector="#{{form.subtree.vars.id}}"
+                    data-selected-content-name-selector="#{{form.subtree.vars.id}}-selected-content-name"
+                    data-clear-btn-selector="#{{form.subtree.vars.id}}-clear-btn"
+                    data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+                    >{{'search.select_content'|trans|desc('Select Content')}}</button>
+                <div class="ez-filters__subtree" id="{{form.subtree.vars.id}}-selected-content-name">
+                    <span>
+                        {% if form.subtree.vars.value is not empty %}
+                            {% set locationList = ez_path_string_to_locations(form.subtree.vars.value) %}
+                            {% for location in locationList %}
+                                {{ ez_content_name(location.contentInfo) }}
+                                {% if loop.revindex > 1 %}/{% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </span>
+                    <svg id="{{form.subtree.vars.id}}-clear-btn"
+                        class="ez-icon ez-icon--medium ez-icon--reset">
+                        <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
+                    </svg>
+                </div>
+            </div>
+            {{ form_widget(form.subtree) }}
         </div>
-        {{ form_widget(form.subtree) }}
+    </div>
+    <div class="ez-filters__row">
+        <div class="ez-filters__item ez-filters__item--modified">
+            <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
+            {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-modified-range'}}) }}
+        </div>
+        <div class="ez-filters__item ez-filters__item--created">
+            <label class="ez-filters__item-label">{{ 'search.created'|trans|desc('Created:') }}</label>
+            {{ form_widget(form.created_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-created-range'}}) }}
+        </div>
+        <div class="ez-filters__item ez-filters__item--creator">
+            <label class="ez-filters__item-label">{{ 'search.creator'|trans|desc('Creator:') }}</label>
+            {% set creator = form.vars.data.creator %}
+            <input type="text"
+                class="form-control ez-filters__input"
+                data-content-type-identifiers="{{ user_content_type_identifier|join(',') }}"
+                value="{{ creator is not empty ? ez_content_name(creator) }}"
+                placeholder="{{ 'search.creator_input.placeholder'|trans|desc('Type creator') }}"
+                {{ creator is not empty ? 'disabled'  }}
+            >
+            <svg class="ez-icon ez-icon--light ez-icon--medium ez-icon--reset">
+                <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
+            </svg>
+            <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
+        </div>
     </div>
     <div class="ez-filters__btns">
         <button class="btn btn-dark ez-btn-clear">

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -60,6 +60,11 @@
                             {% endfor %}
                         {% endif %}
                     </div>
+                    <div class="ez-filters__breadcrumbs-spinner" hidden>
+                        <svg class="ez-icon ez-icon--medium ez-spin">
+                            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#spinner"></use>
+                        </svg>
+                    </div>
                     <svg id="{{form.subtree.vars.id}}-clear-btn"
                         class="ez-icon ez-icon--medium ez-icon--reset">
                         <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>

--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -23,7 +23,7 @@
     <div class="ez-filters__row">
         <div class="ez-filters__item ez-filters__item--content-type">
             <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
-            <select class="form-control ez-filters__select ez-filters__select--content-type" hidden="true">
+            <select class="form-control ez-filters__select ez-filters__select--content-type" hidden>
                 <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any content type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any content type') }}</option>
             </select>
             {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
@@ -41,7 +41,7 @@
             <div>
                 <button class="btn btn-secondary ez-btn--udw-select-location"
                     type="button"
-                    {% if form.subtree.vars.value is not empty %} hidden="true" {% endif %}
+                    {% if form.subtree.vars.value is not empty %} hidden {% endif %}
                     data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
                     data-location-path-input-selector="#{{form.subtree.vars.id}}"
                     data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
@@ -49,7 +49,7 @@
                     data-udw-config="{{ ez_udw_config('single_container', {}) }}"
                     >{{'search.select_content'|trans|desc('Select Content')}}</button>
                 <div class="ez-filters__subtree" 
-                    {% if form.subtree.vars.value is empty %} hidden="true" {% endif %}
+                    {% if form.subtree.vars.value is empty %} hidden {% endif %}
                     id="{{form.subtree.vars.id}}-content-breadcrumbs">
                     <div class="ez-filters__breadcrumbs">
                         {% if form.subtree.vars.value is not empty %}

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -37,10 +37,10 @@
 {%- endblock -%}
 
 {%- block _search_content_types_widget -%}
-    <div class="ez-content-type-selector ez-content-type-selector--collapsed">
+    <div class="ez-content-type-selector">
     {%- set options = choices -%}
     {%- for group_label, choice in options -%}
-        <div class="ez-content-type-selector__group">
+        <div class="ez-content-type-selector__group {% if not loop.first %}ez-content-type-selector__group--collapsed{% endif %}">
             <span class="ez-content-type-selector__group-title">
                 {{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}
             </span>

--- a/src/bundle/Templating/Twig/PathStringExtension.php
+++ b/src/bundle/Templating/Twig/PathStringExtension.php
@@ -25,7 +25,7 @@ class PathStringExtension extends Twig_Extension
     /**
      * @return array
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new Twig_SimpleFunction(
@@ -35,6 +35,14 @@ class PathStringExtension extends Twig_Extension
         ];
     }
 
+    /**
+     * @param string $pathString
+     *
+     * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
     public function getLocationList(string $pathString): array
     {
         $pathStringParts = explode('/', trim($pathString, '/'));

--- a/src/bundle/Templating/Twig/PathStringExtension.php
+++ b/src/bundle/Templating/Twig/PathStringExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
+
+use eZ\Publish\Core\Repository\LocationService;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+class PathStringExtension extends Twig_Extension
+{
+    private $locationService;
+
+    public function __construct(
+        LocationService $locationService
+    ) {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return [
+            new Twig_SimpleFunction(
+                'ez_path_string_to_locations',
+                [$this, 'getLocationList']
+            ),
+        ];
+    }
+
+    public function getLocationList(string $pathString): array
+    {
+        $pathStringParts = explode('/', trim($pathString, '/'));
+        array_shift($pathStringParts);
+
+        $locationList = [];
+        foreach ($pathStringParts as $locationId) {
+            $locationList[] = $this->locationService->loadLocation($locationId);
+        }
+
+        return $locationList;
+    }
+}

--- a/src/lib/Form/Data/Search/SearchData.php
+++ b/src/lib/Form/Data/Search/SearchData.php
@@ -44,6 +44,9 @@ class SearchData
     /** @var \eZ\Publish\API\Repository\Values\User\User */
     private $creator;
 
+    /** @var string|null */
+    private $subtree;
+
     /**
      * SimpleSearchData constructor.
      *
@@ -55,6 +58,7 @@ class SearchData
      * @param array $lastModified
      * @param array $created
      * @param \eZ\Publish\API\Repository\Values\User\User|null $creator
+     * @param string|null $subtree
      */
     public function __construct(
         int $limit = 10,
@@ -64,7 +68,8 @@ class SearchData
         array $contentTypes = [],
         array $lastModified = [],
         array $created = [],
-        ?User $creator = null
+        ?User $creator = null,
+        ?string $subtree = null
     ) {
         $this->limit = $limit;
         $this->page = $page;
@@ -74,6 +79,7 @@ class SearchData
         $this->lastModified = $lastModified;
         $this->created = $created;
         $this->creator = $creator;
+        $this->subtree = $subtree;
     }
 
     /**
@@ -221,6 +227,22 @@ class SearchData
     }
 
     /**
+     * @return string|null
+     */
+    public function getSubtree(): ?string
+    {
+        return $this->subtree;
+    }
+
+    /**
+     * @param string|null $subtree
+     */
+    public function setSubtree(?string $subtree): void
+    {
+        $this->subtree = $subtree;
+    }
+
+    /**
      * @return bool
      */
     public function isFiltered(): bool
@@ -230,7 +252,14 @@ class SearchData
         $lastModified = $this->getLastModified();
         $created = $this->getCreated();
         $creator = $this->getCreator();
+        $subtree = $this->getSubtree();
 
-        return !empty($contentTypes) || null !== $section || !empty($lastModified) || !empty($created) || !empty($creator);
+        return
+            !empty($contentTypes) ||
+            null !== $section ||
+            !empty($lastModified) ||
+            !empty($created) ||
+            !empty($creator) ||
+            null !== $subtree;
     }
 }

--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -64,6 +64,9 @@ class SearchType extends AbstractType
                 'placeholder' => /** @Desc("Any time") */ 'search.any_time',
                 'mapped' => false,
             ])
+            ->add('subtree', HiddenType::class, [
+                'required' => false,
+            ])
         ;
 
         if ($this->permissionResolver->hasAccess('section', 'view')) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29766
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Description
This PR only adds filtering by subtree and simple displaying selected path.

## Restyling
This PR also includes restyling of Search filters.

![screen shot 2018-11-20 at 11 15 51](https://user-images.githubusercontent.com/10233057/48767277-b0403100-ecb6-11e8-9486-f45c721645b9.png)

###  Subtree button styling:

![screen shot 2018-11-20 at 11 23 57](https://user-images.githubusercontent.com/10233057/48767357-e1b8fc80-ecb6-11e8-8c77-dcb1bf8391c9.png)

![screen shot 2018-11-28 at 14 15 27](https://user-images.githubusercontent.com/10233057/49155634-c33cac00-f31b-11e8-981f-3772f1a5a1d3.png)

![screen shot 2018-11-20 at 11 23 50](https://user-images.githubusercontent.com/10233057/48767361-e382c000-ecb6-11e8-9dfd-352cdc3fe40d.png)

#### in case of longer breadcrumb:

![screen shot 2018-11-20 at 14 57 45](https://user-images.githubusercontent.com/10233057/48778164-c4932680-ecd4-11e8-8490-46a87ae6d68d.png)


## Basic responsiveness to window width:

View should adapt to window width; 
e.g number of columns in "Content type" filters now changes accordingly to window width:

![screen shot 2018-11-20 at 11 18 41](https://user-images.githubusercontent.com/10233057/48767494-25ac0180-ecb7-11e8-9ca9-81aa00543012.png)

Arrow always point to the center of the filters button: 

![screen shot 2018-11-20 at 11 17 06](https://user-images.githubusercontent.com/10233057/48767542-44aa9380-ecb7-11e8-96ae-2935862ca28d.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
