### PR TITLE
EZP-29813: Pass custom parameters to menu item templates in right sidebar

### DIFF
--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -20,7 +20,7 @@
             {{ block('element') }}
         {%- endif %}
         {%- if item.extras.template is defined -%}
-            {% include(item.extras.template)  %}
+            {% include item.extras.template with item.extras.template_parameters|default({}) %}
         {%- endif -%}
     {%- endif -%}
 {%- endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29813
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


# Usage
Adding menu item in an event listener:
```php
            $root->addChild(
                'custom_menu_item',
                [
                    'extras' => [
                        'template' => 'MyBundle::menu_item_template.html.twig',
                        'template_parameters' => [
                            'custom_parameter' => 'value',
                        ],
                    ],
                ]
            );
```

Later in `MyBundle::menu_item_template.html.twig` variable `custom_parameter` is available:
```yaml
{# MyBundle::menu_item_template.html.twig #}

{{ dump(custom_parameter) }}
```


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
