### PR TITLE
[EZP-29819] Set config providers which use dynamic settings to lazy

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -29,6 +29,7 @@ services:
 
     ezsystems.ezplatform_admin_ui.ui.config.provider.image_variations:
         class: EzSystems\EzPlatformAdminUi\UI\Config\Provider\Value
+        lazy: true
         arguments:
             $value: '$image_variations$'
         tags:
@@ -36,6 +37,7 @@ services:
 
     ezsystems.ezplatform_admin_ui.ui.config.provider.content_edit_form_templates:
         class: EzSystems\EzPlatformAdminUi\UI\Config\Provider\Value
+        lazy: true
         arguments:
             $value: '$admin_ui_forms.content_edit_form_templates$'
         tags:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29819
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This fixes an issue where the dynamic parameters in arguments are injected to the config provider services in the `default` scope instead of `admin` scope, resulting in admin content edit interface without any styles.

I have not been able to deduce why this is happening, though, since it seems that clean eZ Platform install works fine. It maybe a combination of some other config, but anyway, setting these services to lazy helps.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review