### PR TITLE
EZP-29832: Unable to use AdminUI without admin rights

### DIFF
--- a/src/lib/Menu/Admin/ReorderMenuListener.php
+++ b/src/lib/Menu/Admin/ReorderMenuListener.php
@@ -21,6 +21,9 @@ class ReorderMenuListener
     {
         $menu = $event->getMenu();
 
+        if (!$menu->getChild(MainMenuBuilder::ITEM_ADMIN)) {
+            return;
+        }
         $manipulator = new MenuManipulator();
         $manipulator->moveToLastPosition($menu[MainMenuBuilder::ITEM_ADMIN]);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29832
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
