### PR TITLE
EZP-29168: Add tooltips to Discovery & Action bars

### DIFF
--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -10,6 +10,7 @@
     {%- if item.displayed -%}
         {%- set attributes = item.attributes|merge({'class': (item.attributes.class|default('') ~ ' ' ~ default_classes|default('btn btn-dark btn-block'))|trim}) -%}
         {%- set attributes = attributes|merge({'id': item.name ~ '-tab'}) -%}
+        {%- set attributes = attributes|merge({'title': block('label')}) -%}
 
         {%- if item.uri is not empty %}
             {% set attributes = attributes|merge({'href': item.uri}) %}
@@ -29,15 +30,14 @@
     {% import 'knp_menu.html.twig' as macros %}
     {% set element = element|default('a') %}
     <{{ element }}{{ macros.attributes(attributes) }}>
-    {{ block('label') }}
+        {{ block('icon') }}
     </{{ element }}>
 {% endblock %}
 
-{% block label %}
+{% block icon %}
     {% if item.extras.icon is defined and item.extras.icon != '' %}
         <svg class="ez-icon ez-icon-{{ item.extras.icon }}">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ item.extras.icon }}"></use>
         </svg>
     {% endif %}
-    {{ parent() }}
 {% endblock %}

--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -10,7 +10,9 @@
     {%- if item.displayed -%}
         {%- set attributes = item.attributes|merge({'class': (item.attributes.class|default('') ~ ' ' ~ default_classes|default('btn btn-dark btn-block'))|trim}) -%}
         {%- set attributes = attributes|merge({'id': item.name ~ '-tab'}) -%}
-        {%- set attributes = attributes|merge({'title': block('label')}) -%}
+        {%- if item.attributes.title is defined %}
+            {%- set attributes = attributes|merge({'title': item.attributes.title|trans(domain='menu')}) -%}
+        {%- endif %}
 
         {%- if item.uri is not empty %}
             {% set attributes = attributes|merge({'href': item.uri}) %}
@@ -30,14 +32,15 @@
     {% import 'knp_menu.html.twig' as macros %}
     {% set element = element|default('a') %}
     <{{ element }}{{ macros.attributes(attributes) }}>
-        {{ block('icon') }}
+        {{ block('label') }}
     </{{ element }}>
 {% endblock %}
 
-{% block icon %}
+{% block label %}
     {% if item.extras.icon is defined and item.extras.icon != '' %}
         <svg class="ez-icon ez-icon-{{ item.extras.icon }}">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ item.extras.icon }}"></use>
         </svg>
     {% endif %}
+    {{ parent() }}
 {% endblock %}

--- a/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeCreateRightSidebarBuilder.php
@@ -57,7 +57,9 @@ class ContentTypeCreateRightSidebarBuilder extends AbstractBuilder implements Tr
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -70,6 +72,10 @@ class ContentTypeCreateRightSidebarBuilder extends AbstractBuilder implements Tr
                     'route' => 'ezplatform.content_type_group.view',
                     'routeParameters' => [
                         'contentTypeGroupId' => $group->id,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeEditRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class ContentTypeEditRightSidebarBuilder extends AbstractBuilder implements Tran
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $contentTypeEditFormView['publishContentType']->vars['id']),
                     ],
@@ -65,7 +67,9 @@ class ContentTypeEditRightSidebarBuilder extends AbstractBuilder implements Tran
             self::ITEM__CANCEL => $this->createMenuItem(
                 self::ITEM__CANCEL,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $contentTypeEditFormView['removeDraft']->vars['id']),
                     ],

--- a/src/lib/Menu/Admin/ContentType/ContentTypeGroupCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeGroupCreateRightSidebarBuilder.php
@@ -51,7 +51,9 @@ class ContentTypeGroupCreateRightSidebarBuilder extends AbstractBuilder implemen
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#content_type_group_create_create',
                     ],
@@ -62,6 +64,10 @@ class ContentTypeGroupCreateRightSidebarBuilder extends AbstractBuilder implemen
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.content_type_group.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/ContentType/ContentTypeGroupEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ContentType/ContentTypeGroupEditRightSidebarBuilder.php
@@ -53,7 +53,9 @@ class ContentTypeGroupEditRightSidebarBuilder extends AbstractBuilder implements
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -64,6 +66,10 @@ class ContentTypeGroupEditRightSidebarBuilder extends AbstractBuilder implements
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.content_type_group.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/Language/LanguageCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Language/LanguageCreateRightSidebarBuilder.php
@@ -51,7 +51,9 @@ class LanguageCreateRightSidebarBuilder extends AbstractBuilder implements Trans
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#language_create_save',
                     ],
@@ -62,6 +64,10 @@ class LanguageCreateRightSidebarBuilder extends AbstractBuilder implements Trans
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.language.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/Language/LanguageEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Language/LanguageEditRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class LanguageEditRightSidebarBuilder extends AbstractBuilder implements Transla
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -66,6 +68,10 @@ class LanguageEditRightSidebarBuilder extends AbstractBuilder implements Transla
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.language.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/ObjectState/ObjectStateCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateCreateRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class ObjectStateCreateRightSidebarBuilder extends AbstractBuilder implements Tr
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#object_state_create_create',
                     ],
@@ -68,6 +70,10 @@ class ObjectStateCreateRightSidebarBuilder extends AbstractBuilder implements Tr
                     'route' => 'ezplatform.object_state.group.view',
                     'routeParameters' => [
                         'objectStateGroupId' => $groupId,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/ObjectState/ObjectStateEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateEditRightSidebarBuilder.php
@@ -56,7 +56,9 @@ class ObjectStateEditRightSidebarBuilder extends AbstractBuilder implements Tran
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -69,6 +71,10 @@ class ObjectStateEditRightSidebarBuilder extends AbstractBuilder implements Tran
                     'route' => 'ezplatform.object_state.group.view',
                     'routeParameters' => [
                         'objectStateGroupId' => $groupId,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/ObjectState/ObjectStateGroupCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateGroupCreateRightSidebarBuilder.php
@@ -53,7 +53,9 @@ class ObjectStateGroupCreateRightSidebarBuilder extends AbstractBuilder implemen
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#object_state_group_create_create',
                     ],
@@ -64,6 +66,10 @@ class ObjectStateGroupCreateRightSidebarBuilder extends AbstractBuilder implemen
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.object_state.groups.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/ObjectState/ObjectStateGroupEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/ObjectState/ObjectStateGroupEditRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class ObjectStateGroupEditRightSidebarBuilder extends AbstractBuilder implements
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -66,6 +68,10 @@ class ObjectStateGroupEditRightSidebarBuilder extends AbstractBuilder implements
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.object_state.groups.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/Role/PolicyCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/PolicyCreateRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class PolicyCreateRightSidebarBuilder extends AbstractBuilder implements Transla
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#policy_create_save',
                     ],
@@ -68,6 +70,10 @@ class PolicyCreateRightSidebarBuilder extends AbstractBuilder implements Transla
                     'route' => 'ezplatform.role.view',
                     'routeParameters' => [
                         'roleId' => $role->id,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/Role/PolicyEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/PolicyEditRightSidebarBuilder.php
@@ -59,7 +59,9 @@ class PolicyEditRightSidebarBuilder extends AbstractBuilder implements Translati
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#%s', $saveId),
                     ],
@@ -72,6 +74,10 @@ class PolicyEditRightSidebarBuilder extends AbstractBuilder implements Translati
                     'route' => 'ezplatform.role.view',
                     'routeParameters' => [
                         'roleId' => $role->id,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/Role/RoleAssignmentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/RoleAssignmentCreateRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class RoleAssignmentCreateRightSidebarBuilder extends AbstractBuilder implements
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => '#role_assignment_create_save',
                     ],
@@ -68,6 +70,10 @@ class RoleAssignmentCreateRightSidebarBuilder extends AbstractBuilder implements
                     'route' => 'ezplatform.role.view',
                     'routeParameters' => [
                         'roleId' => $role->id,
+                    ],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]

--- a/src/lib/Menu/Admin/Role/RoleCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/RoleCreateRightSidebarBuilder.php
@@ -51,7 +51,9 @@ class RoleCreateRightSidebarBuilder extends AbstractBuilder implements Translati
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#role_create_save',
                     ],
@@ -62,6 +64,10 @@ class RoleCreateRightSidebarBuilder extends AbstractBuilder implements Translati
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.role.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/Admin/Role/RoleEditRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/RoleEditRightSidebarBuilder.php
@@ -55,7 +55,9 @@ class RoleEditRightSidebarBuilder extends AbstractBuilder implements Translation
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#update-role-%d_save', $role->id),
                     ],
@@ -66,6 +68,10 @@ class RoleEditRightSidebarBuilder extends AbstractBuilder implements Translation
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.role.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/ContentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentCreateRightSidebarBuilder.php
@@ -104,14 +104,17 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
         $canCreate = $this->permissionResolver->canUser('content', 'create', $contentCreateStruct, [$locationCreateStruct]) && $parentContentType->isContainer;
         $canPreview = $this->permissionResolver->canUser('content', 'versionread', $contentCreateStruct, [$locationCreateStruct]);
         $publishAttributes = [
+            'title' => self::ITEM__PUBLISH,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_publish',
         ];
         $createAttributes = [
+            'title' => self::ITEM__SAVE_DRAFT,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_saveDraft',
         ];
         $previewAttributes = [
+            'title' => self::ITEM__PREVIEW,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_preview',
         ];
@@ -120,6 +123,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
             self::ITEM__PUBLISH => $this->createMenuItem(
                 self::ITEM__PUBLISH,
                 [
+                    'label' => false,
                     'attributes' => $canCreate && $canPublish
                         ? $publishAttributes
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
@@ -129,6 +133,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
             self::ITEM__SAVE_DRAFT => $this->createMenuItem(
                 self::ITEM__SAVE_DRAFT,
                 [
+                    'label' => false,
                     'attributes' => $canCreate
                         ? $createAttributes
                         : array_merge($createAttributes, self::BTN_DISABLED_ATTR),
@@ -138,6 +143,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
             self::ITEM__PREVIEW => $this->createMenuItem(
                 self::ITEM__PREVIEW,
                 [
+                    'label' => false,
                     'attributes' => $canPreview
                         ? $previewAttributes
                         : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
@@ -147,7 +153,9 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
             self::ITEM__CANCEL => $this->createMenuItem(
                 self::ITEM__CANCEL,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                         'class' => self::BTN_TRIGGER_CLASS,
                         'data-click' => '#ezrepoforms_content_edit_cancel',
                     ],

--- a/src/lib/Menu/ContentEditRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentEditRightSidebarBuilder.php
@@ -102,14 +102,17 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
         $canDelete = $this->permissionResolver->canUser('content', 'versionremove', $content);
 
         $publishAttributes = [
+            'title' => self::ITEM__PUBLISH,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_publish',
         ];
         $editAttributes = [
+            'title' => self::ITEM__SAVE_DRAFT,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_saveDraft',
         ];
         $deleteAttributes = [
+            'title' => self::ITEM__CANCEL,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_cancel',
         ];
@@ -118,6 +121,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
             self::ITEM__PUBLISH => $this->createMenuItem(
                 self::ITEM__PUBLISH,
                 [
+                    'label' => false,
                     'attributes' => $canEdit && $canPublish
                         ? $publishAttributes
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
@@ -127,6 +131,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
             self::ITEM__SAVE_DRAFT => $this->createMenuItem(
                 self::ITEM__SAVE_DRAFT,
                 [
+                    'label' => false,
                     'attributes' => $canEdit
                         ? $editAttributes
                         : array_merge($editAttributes, self::BTN_DISABLED_ATTR),
@@ -145,6 +150,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
         $items[self::ITEM__CANCEL] = $this->createMenuItem(
             self::ITEM__CANCEL,
             [
+                'label' => false,
                 'attributes' => $canDelete
                     ? $deleteAttributes
                     : array_merge($deleteAttributes, self::BTN_DISABLED_ATTR),
@@ -209,6 +215,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
         );
 
         $previewAttributes = [
+            'title' => self::ITEM__PREVIEW,
             'class' => self::BTN_TRIGGER_CLASS,
             'data-click' => '#ezrepoforms_content_edit_preview',
         ];
@@ -216,6 +223,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
         return $this->createMenuItem(
             self::ITEM__PREVIEW,
             [
+                'label' => false,
                 'attributes' => $canPreview && !empty($siteaccesses)
                     ? $previewAttributes
                     : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -162,15 +162,18 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         );
 
         $createAttributes = [
+            'title' => self::ITEM__CREATE,
             'class' => 'ez-btn--extra-actions ez-btn--create',
             'data-actions' => 'create',
             'data-focus-element' => '.ez-instant-filter__input',
         ];
         $sendToTrashAttributes = [
+            'title' => self::ITEM__SEND_TO_TRASH,
             'data-toggle' => 'modal',
             'data-target' => '#trash-location-modal',
         ];
         $copySubtreeAttributes = [
+            'title' => self::ITEM__COPY_SUBTREE,
             'class' => 'ez-btn--udw-copy-subtree',
             'data-root-location' => $this->configResolver->getParameter(
                 'universal_discovery_widget_module.default_location_id'
@@ -202,6 +205,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                 self::ITEM__CREATE,
                 [
                     'extras' => ['icon' => 'create'],
+                    'label' => false,
                     'attributes' => $canCreate
                         ? $createAttributes
                         : array_merge($createAttributes, ['disabled' => 'disabled']),
@@ -216,7 +220,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                 self::ITEM__MOVE,
                 [
                     'extras' => ['icon' => 'move'],
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__MOVE,
                         'class' => 'btn--udw-move',
                         'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
                         'data-root-location' => $this->configResolver->getParameter(
@@ -232,7 +238,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                 self::ITEM__COPY,
                 [
                     'extras' => ['icon' => 'copy'],
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__COPY,
                         'class' => 'btn--udw-copy',
                         'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
                         'data-root-location' => $this->configResolver->getParameter(
@@ -248,6 +256,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                 self::ITEM__COPY_SUBTREE,
                 [
                     'extras' => ['icon' => 'copy-subtree'],
+                    'label' => false,
                     'attributes' => $canCopySubtree
                         ? $copySubtreeAttributes
                         : array_merge($copySubtreeAttributes, ['disabled' => 'disabled']),
@@ -261,7 +270,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     self::ITEM__DELETE,
                     [
                         'extras' => ['icon' => 'trash'],
+                        'label' => false,
                         'attributes' => [
+                            'title' => self::ITEM__DELETE,
                             'data-toggle' => 'modal',
                             'data-target' => '#delete-user-modal',
                         ],
@@ -276,6 +287,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     self::ITEM__SEND_TO_TRASH,
                     [
                         'extras' => ['icon' => 'trash-send'],
+                        'label' => false,
                         'attributes' => $sendToTrashAttributes,
                     ]
                 )
@@ -313,10 +325,12 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
     private function addEditMenuItem(ItemInterface $menu, bool $contentIsUser, bool $canEdit): void
     {
         $editAttributes = [
+            'title' => self::ITEM__EDIT,
             'class' => 'ez-btn--extra-actions ez-btn--edit',
             'data-actions' => 'edit',
         ];
         $editUserAttributes = [
+            'title' => self::ITEM__EDIT,
             'class' => 'ez-btn--extra-actions ez-btn--edit-user',
             'data-actions' => 'edit-user',
         ];
@@ -327,6 +341,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     self::ITEM__EDIT,
                     [
                         'extras' => ['icon' => 'edit'],
+                        'label' => false,
                         'attributes' => $canEdit
                             ? $editUserAttributes
                             : array_merge($editUserAttributes, ['disabled' => 'disabled']),
@@ -339,6 +354,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     self::ITEM__EDIT,
                     [
                         'extras' => ['icon' => 'edit'],
+                        'label' => false,
                         'attributes' => $canEdit
                             ? $editAttributes
                             : array_merge($editAttributes, ['disabled' => 'disabled']),

--- a/src/lib/Menu/LeftSidebarBuilder.php
+++ b/src/lib/Menu/LeftSidebarBuilder.php
@@ -85,13 +85,19 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
                 [
                     'route' => 'ezplatform.search',
                     'extras' => ['icon' => 'search'],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__SEARCH,
+                    ],
                 ]
             ),
             self::ITEM__BROWSE => $this->createMenuItem(
                 self::ITEM__BROWSE,
                 [
                     'extras' => ['icon' => 'browse'],
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__BROWSE,
                         'class' => 'btn--udw-browse',
                         'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single', [
                             'type' => 'content_create',
@@ -107,6 +113,10 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
                 [
                     'route' => 'ezplatform.bookmark.list',
                     'extras' => ['icon' => 'bookmark-manager'],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__BOOKMARK,
+                    ],
                 ]
             ),
         ];
@@ -117,6 +127,10 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
                 [
                     'route' => 'ezplatform.trash.list',
                     'extras' => ['icon' => 'trash'],
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__TRASH,
+                    ],
                 ]
             );
         }

--- a/src/lib/Menu/SectionCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/SectionCreateRightSidebarBuilder.php
@@ -50,7 +50,9 @@ class SectionCreateRightSidebarBuilder extends AbstractBuilder implements Transl
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#section_create_create',
                     ],
@@ -61,6 +63,10 @@ class SectionCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.section.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/SectionEditRightSidebarBuilder.php
+++ b/src/lib/Menu/SectionEditRightSidebarBuilder.php
@@ -54,7 +54,9 @@ class SectionEditRightSidebarBuilder extends AbstractBuilder implements Translat
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#update-section-%d_update', $section->id),
                     ],
@@ -65,6 +67,10 @@ class SectionEditRightSidebarBuilder extends AbstractBuilder implements Translat
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.section.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/TrashRightSidebarBuilder.php
+++ b/src/lib/Menu/TrashRightSidebarBuilder.php
@@ -77,12 +77,17 @@ class TrashRightSidebarBuilder extends AbstractBuilder implements TranslationCon
         /** @var ItemInterface|ItemInterface[] $menu */
         $menu = $this->factory->createItem('root');
 
+        $trashAttributes = [
+            'title' => self::ITEM__EMPTY,
+        ];
+
         $menu->addChild(
             $this->createMenuItem(self::ITEM__EMPTY, [
                 'extras' => ['icon' => 'trash-empty'],
+                'label' => false,
                 'attributes' => $canDelete > 0 && $trashItemsCount > 0
-                    ? ['data-toggle' => 'modal', 'data-target' => '#confirmEmptyTrash']
-                    : ['class' => 'disabled'],
+                    ? array_merge($trashAttributes, ['data-toggle' => 'modal', 'data-target' => '#confirmEmptyTrash'])
+                    : array_merge($trashAttributes, ['class' => 'disabled']),
             ])
         );
 

--- a/src/lib/Menu/URLEditRightSidebarBuilder.php
+++ b/src/lib/Menu/URLEditRightSidebarBuilder.php
@@ -35,7 +35,9 @@ class URLEditRightSidebarBuilder extends AbstractBuilder implements TranslationC
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => sprintf('#url-update', $url->id),
                     ],
@@ -46,6 +48,10 @@ class URLEditRightSidebarBuilder extends AbstractBuilder implements TranslationC
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.link_manager.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/UserCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/UserCreateRightSidebarBuilder.php
@@ -50,7 +50,9 @@ class UserCreateRightSidebarBuilder extends AbstractBuilder implements Translati
             self::ITEM__CREATE => $this->createMenuItem(
                 self::ITEM__CREATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CREATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#ezrepoforms_user_create_create',
                     ],
@@ -60,7 +62,9 @@ class UserCreateRightSidebarBuilder extends AbstractBuilder implements Translati
             self::ITEM__CANCEL => $this->createMenuItem(
                 self::ITEM__CANCEL,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                         'class' => 'btn--trigger',
                         'data-click' => '#ezrepoforms_user_create_cancel',
                     ],

--- a/src/lib/Menu/UserEditRightSidebarBuilder.php
+++ b/src/lib/Menu/UserEditRightSidebarBuilder.php
@@ -50,7 +50,9 @@ class UserEditRightSidebarBuilder extends AbstractBuilder implements Translation
             self::ITEM__UPDATE => $this->createMenuItem(
                 self::ITEM__UPDATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__UPDATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#ezrepoforms_user_update_update',
                     ],
@@ -60,7 +62,9 @@ class UserEditRightSidebarBuilder extends AbstractBuilder implements Translation
             self::ITEM__CANCEL => $this->createMenuItem(
                 self::ITEM__CANCEL,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__CANCEL,
                         'class' => 'btn--trigger',
                         'data-click' => '#ezrepoforms_user_update_cancel',
                     ],

--- a/src/lib/Menu/UserPasswordChangeRightSidebarBuilder.php
+++ b/src/lib/Menu/UserPasswordChangeRightSidebarBuilder.php
@@ -52,7 +52,9 @@ class UserPasswordChangeRightSidebarBuilder extends AbstractBuilder implements T
             self::ITEM__UPDATE => $this->createMenuItem(
                 self::ITEM__UPDATE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__UPDATE,
                         'class' => 'btn--trigger',
                         'data-click' => '#user_password_change_change',
                     ],
@@ -63,6 +65,10 @@ class UserPasswordChangeRightSidebarBuilder extends AbstractBuilder implements T
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.dashboard',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),

--- a/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
+++ b/src/lib/Menu/UserSetting/UserSettingUpdateRightSidebarBuilder.php
@@ -49,7 +49,9 @@ class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements Tr
             self::ITEM__SAVE => $this->createMenuItem(
                 self::ITEM__SAVE,
                 [
+                    'label' => false,
                     'attributes' => [
+                        'title' => self::ITEM__SAVE,
                         'class' => 'btn--trigger',
                         'data-click' => '#user_setting_update_update',
                     ],
@@ -60,6 +62,10 @@ class UserSettingUpdateRightSidebarBuilder extends AbstractBuilder implements Tr
                 self::ITEM__CANCEL,
                 [
                     'route' => 'ezplatform.user_settings.list',
+                    'label' => false,
+                    'attributes' => [
+                        'title' => self::ITEM__CANCEL,
+                    ],
                     'extras' => ['icon' => 'circle-close'],
                 ]
             ),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29169
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Removes labels from Discovery & Action bars and adds tooltips to buttons.

## A few screenshots - after changes

![screen shot 2018-11-26 at 10 10 35](https://user-images.githubusercontent.com/10233057/49004594-d9543c00-f164-11e8-8aa5-f568e826fd89.png)

![screen shot 2018-11-27 at 13 19 30](https://user-images.githubusercontent.com/10233057/49081558-899a7100-f247-11e8-8f80-6c6158e7a636.png)

![screen shot 2018-11-27 at 13 13 14](https://user-images.githubusercontent.com/10233057/49083464-f5cba380-f24c-11e8-82e2-150a6dcbb1ad.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
