### PR TITLE
EZP-29848: Make existing AdminUI tabs extendable by allowing template path and parameters change

### DIFF
--- a/src/bundle/Resources/config/services/tabs.yml
+++ b/src/bundle/Resources/config/services/tabs.yml
@@ -25,7 +25,7 @@ services:
         abstract: true
         lazy: true
 
-    EzSystems\EzPlatformAdminUi\Tab\EventDispatchingAbstractTab:
+    EzSystems\EzPlatformAdminUi\Tab\AbstractEventDispatchingTab:
         parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
         abstract: true
         autowire: true

--- a/src/bundle/Resources/config/services/tabs.yml
+++ b/src/bundle/Resources/config/services/tabs.yml
@@ -25,6 +25,14 @@ services:
         abstract: true
         lazy: true
 
+    EzSystems\EzPlatformAdminUi\Tab\EventDispatchingAbstractTab:
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        abstract: true
+        autowire: true
+        autoconfigure: false
+        public: false
+        lazy: true
+
     EzSystems\EzPlatformAdminUi\Tab\AbstractRouteBasedTab:
         parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
         abstract: true

--- a/src/bundle/Resources/views/content/tab/versions/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/tab.html.twig
@@ -5,87 +5,98 @@
 {% form_theme form_version_remove_draft '@ezdesign/form_fields.html.twig' %}
 {% form_theme form_version_remove_archived '@ezdesign/form_fields.html.twig' %}
 
-{% if draft_pager.currentPageResults is not empty %}
-    <section>
-        {{ form_start(form_version_remove_draft, {
-            'action': path('ezplatform.version.remove'),
-            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_draft.remove.vars.id }
-        }) }}
-        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'), tools: tab.table_header_tools(form_version_remove_draft) } %}
-        {{ include('@ezdesign/content/tab/versions/table.html.twig', {
-            'versions': draft_pager.currentPageResults,
-            'is_draft': true,
-            'form': form_version_remove_draft,
-            'haveToPaginate': draft_pager.haveToPaginate,
-            'content_is_user': content_is_user
-        }) }}
-        {{ form_end(form_version_remove_draft) }}
+{% set table_template_path = table_template_path|default('@ezdesign/content/tab/versions/table.html.twig') %}
+{% set show_drafts_table = show_drafts_table|default(draft_pager.currentPageResults is not empty) %}
 
-        {% if draft_pager.haveToPaginate %}
-            <div class="row justify-content-center align-items-center mb-2">
-                <span class="ez-pagination__text">
-                    {{ 'pagination.viewing'|trans({
-                        '%viewing%': draft_pager.currentPageResults|length,
-                        '%total%': draft_pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
-                </span>
-            </div>
-            <div class="row justify-content-center align-items-center ez-pagination__btn mb-4">
-                {{ pagerfanta(draft_pager, 'ez',{
-                    'routeName': draft_pagination_params.route_name,
-                    'routeParams': draft_pagination_params.route_params|merge({
-                        '_fragment': constant('EzSystems\\EzPlatformAdminUi\\Tab\\LocationView\\VersionsTab::URI_FRAGMENT'),
-                    }),
-                    'pageParameter': '[page][version_draft]'
+{% block tab_content %}
+    {% block table_wrapper_drafts %}
+        {% if show_drafts_table %}
+            <section>
+                {{ form_start(form_version_remove_draft, {
+                    'action': path('ezplatform.version.remove'),
+                    'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_draft.remove.vars.id }
                 }) }}
-            </div>
-        {% endif %}
-    </section>
-    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
-{% endif %}
+                {% block table_drafts %}
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
+                        'headerText': 'tab.versions.draft_under_edit'|trans()|desc('Draft under edit'),
+                        'tools': tab.table_header_tools(form_version_remove_draft)
+                    } %}
+                    {% include table_template_path with {
+                        'versions': draft_pager.currentPageResults,
+                        'is_draft': true,
+                        'form': form_version_remove_draft,
+                        'haveToPaginate': draft_pager.haveToPaginate,
+                        'content_is_user': content_is_user
+                    } %}
 
-{% if published_versions is not empty %}
-    <section>
-        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.published_version'|trans()|desc('Published version') } %}
+                    {% if draft_pager.haveToPaginate %}
+                        <div class="row justify-content-center align-items-center mb-2">
+                            <span class="ez-pagination__text">
+                                {{ 'pagination.viewing'|trans({ '%viewing%': draft_pager.currentPageResults|length, '%total%': draft_pager.nbResults }, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                            </span>
+                        </div>
+                        <div class="row justify-content-center align-items-center ez-pagination__btn mb-4">
+                            {{ pagerfanta(draft_pager, 'ez', {
+                                'routeName': draft_pagination_params.route_name,
+                                'routeParams': draft_pagination_params.route_params|merge({
+                                    '_fragment': constant('EzSystems\\EzPlatformAdminUi\\Tab\\LocationView\\VersionsTab::URI_FRAGMENT'),
+                                }),
+                                'pageParameter': '[page][version_draft]'
+                            }) }}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+                {{ form_end(form_version_remove_draft) }}
+            </section>
+            {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
+        {% endif %}
+    {% endblock %}
+
+    {% block table_wrapper_published %}
         {% if published_versions is not empty %}
-            {{ include('@ezdesign/content/tab/versions/table.html.twig', { 'versions': published_versions }) }}
-        {% else %}
-            <p>
-                {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
-            </p>
+            <section>
+                {% block table_published %}
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
+                        'headerText': 'tab.versions.published_version'|trans()|desc('Published version')
+                    } %}
+                    {% include table_template_path with { 'versions': published_versions } %}
+                {% endblock %}
+            </section>
         {% endif %}
-    </section>
-{% endif %}
+    {% endblock %}
 
-{% if archived_versions is not empty %}
-    <section>
-        {{ form_start(form_version_remove_archived, {
-            'action': path('ezplatform.version.remove'),
-            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_archived.remove.vars.id }
-        }) }}
-        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.versions.archived_versions'|trans()|desc('Archived versions'), tools: tab.table_header_tools(form_version_remove_archived) } %}
+    {% block table_wrapper_archived %}
         {% if archived_versions is not empty %}
-            {{ include('@ezdesign/content/tab/versions/table.html.twig', {
-                'versions': archived_versions,
-                'form': form_version_remove_archived,
-                'is_archived': true,
-                'form_archived_version_restore': form_archived_version_restore,
-                'content_is_user': content_is_user
-            }) }}
-        {% else %}
-            <p>
-                {{ 'tab.versions.no_permission'|trans()|desc('You don\'t have access to view the content item\'s versions') }}
-            </p>
+            <section>
+                {{ form_start(form_version_remove_archived, {
+                    'action': path('ezplatform.version.remove'),
+                    'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-translations-' ~ form_version_remove_archived.remove.vars.id }
+                }) }}
+                {% block table_archived %}
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
+                        'headerText': 'tab.versions.archived_versions'|trans()|desc('Archived versions'),
+                        'tools': tab.table_header_tools(form_version_remove_archived)
+                    } %}
+                    {% include table_template_path with {
+                        'versions': archived_versions,
+                        'form': form_version_remove_archived,
+                        'is_archived': true,
+                        'form_archived_version_restore': form_archived_version_restore,
+                        'content_is_user': content_is_user
+                    } %}
+                {% endblock %}
+                {{ form_end(form_version_remove_archived) }}
+            </section>
         {% endif %}
-        {{ form_end(form_version_remove_archived) }}
-    </section>
-{% endif %}
 
-{{ form_start(form_archived_version_restore, {
-    'action': path('ezplatform.content.edit'),
-    'attr': { 'class': 'ez-edit-content-form'}
-}) }}
-{{ form_widget(form_archived_version_restore.language, {'attr': {'hidden': 'hidden'}}) }}
-{{ form_end(form_archived_version_restore) }}
+        {{ form_start(form_archived_version_restore, {
+            'action': path('ezplatform.content.edit'),
+            'attr': { 'class': 'ez-edit-content-form'}
+        }) }}
+        {{ form_widget(form_archived_version_restore.language, {'attr': {'hidden': 'hidden'}}) }}
+        {{ form_end(form_archived_version_restore) }}
+    {% endblock %}
+{% endblock %}
 
 {% macro table_header_tools(form) %}
     {% set modal_data_target = 'modal-' ~ form.remove.vars.id %}

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -12,6 +12,7 @@
         {% endif %}
         <th>{{ 'tab.versions.table.version'|trans()|desc('Version') }}</th>
         <th>{{ 'tab.versions.table.modified_language'|trans()|desc('Modified language') }}</th>
+        {% block custom_column_headers %}{% endblock %}
         <th>{{ 'tab.versions.table.contributor'|trans()|desc('Contributor') }}</th>
         {% if not is_draft_conflict %}
         <th>{{ 'tab.versions.table.created'|trans()|desc('Created') }}</th>
@@ -48,6 +49,7 @@
             <td class="ez-table__cell">
                 {{ admin_ui_config.languages.mappings[version.initialLanguageCode].name }}
             </td>
+            {% block custom_columns %}{% endblock %}
             <td class="ez-table__cell">
                 {% if version.author is not empty %}
                     {{ ez_content_name(version.author) }}

--- a/src/lib/Tab/AbstractEventDispatchingTab.php
+++ b/src/lib/Tab/AbstractEventDispatchingTab.php
@@ -19,7 +19,7 @@ use Twig\Environment;
  *
  * It extends AbstractTab by adding Event Dispatching before rendering view.
  */
-abstract class EventDispatchingAbstractTab extends AbstractTab
+abstract class AbstractEventDispatchingTab extends AbstractTab
 {
     /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
     protected $eventDispatcher;

--- a/src/lib/Tab/Event/TabEvents.php
+++ b/src/lib/Tab/Event/TabEvents.php
@@ -26,7 +26,7 @@ class TabEvents
     const TAB_PRE_RENDER = 'ezplatform.tab.pre_render';
 
     /**
-     * Is dispatched on tabs extending EventDispatchingAbstractTab.
+     * Is dispatched on tabs extending AbstractEventDispatchingTab.
      *
      * Allows to manipulate template path and parameters before rendering by Twig.
      */

--- a/src/lib/Tab/Event/TabEvents.php
+++ b/src/lib/Tab/Event/TabEvents.php
@@ -24,4 +24,11 @@ class TabEvents
      * Happens just before rendering tab.
      */
     const TAB_PRE_RENDER = 'ezplatform.tab.pre_render';
+
+    /**
+     * Is dispatched on tabs extending EventDispatchingAbstractTab.
+     *
+     * Allows to manipulate template path and parameters before rendering by Twig.
+     */
+    const TAB_RENDER = 'ezplatform.tab.render';
 }

--- a/src/lib/Tab/Event/TabViewRenderEvent.php
+++ b/src/lib/Tab/Event/TabViewRenderEvent.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tab\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class TabViewRenderEvent extends Event
+{
+    /** @var string */
+    private $tabIdentifier;
+
+    /** @var string */
+    private $template;
+
+    /** @var array */
+    private $parameters;
+
+    /**
+     * @param string $tabIdentifier
+     * @param string $template
+     * @param array $parameters
+     */
+    public function __construct(string $tabIdentifier, string $template, array $parameters = [])
+    {
+        $this->tabIdentifier = $tabIdentifier;
+        $this->template = $template;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTabIdentifier(): string
+    {
+        return $this->tabIdentifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    /**
+     * @param string $template
+     */
+    public function setTemplate(string $template): void
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/lib/Tab/EventDispatchingAbstractTab.php
+++ b/src/lib/Tab/EventDispatchingAbstractTab.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tab;
+
+use EzSystems\EzPlatformAdminUi\Tab\Event\TabViewRenderEvent;
+use EzSystems\EzPlatformAdminUi\Tab\Event\TabEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
+
+/**
+ * Base class representing Tab using EventDisaptcher for extensibility.
+ *
+ * It extends AbstractTab by adding Event Dispatching before rendering view.
+ */
+abstract class EventDispatchingAbstractTab extends AbstractTab
+{
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
+    protected $eventDispatcher;
+
+    /**
+     * @param \Twig\Environment $twig
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(
+        Environment $twig,
+        TranslatorInterface $translator,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        parent::__construct($twig, $translator);
+
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderView(array $parameters): string
+    {
+        $event = new TabViewRenderEvent(
+            $this->getIdentifier(),
+            $this->getTemplate(),
+            $this->getTemplateParameters($parameters)
+        );
+        $this->eventDispatcher->dispatch(TabEvents::TAB_RENDER, $event);
+
+        return $this->twig->render(
+            $event->getTemplate(),
+            $event->getParameters()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getTemplate(): string;
+
+    /**
+     * @param mixed[] $contextParameters
+     *
+     * @return mixed[]
+     */
+    abstract public function getTemplateParameters(array $contextParameters = []): array;
+}

--- a/src/lib/Tab/LocationView/RolesTab.php
+++ b/src/lib/Tab/LocationView/RolesTab.php
@@ -11,17 +11,18 @@ namespace EzSystems\EzPlatformAdminUi\Tab\LocationView;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUser;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUserGroup;
 use EzSystems\EzPlatformAdminUi\Specification\OrSpecification;
-use EzSystems\EzPlatformAdminUi\Tab\AbstractTab;
 use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
+use EzSystems\EzPlatformAdminUi\Tab\AbstractEventDispatchingTab;
 use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 use eZ\Publish\API\Repository\PermissionResolver;
 
-class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTabInterface
+class RolesTab extends AbstractEventDispatchingTab implements OrderedTabInterface, ConditionalTabInterface
 {
     const URI_FRAGMENT = 'ez-tab-location-view-roles';
 
@@ -44,6 +45,7 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
      * @param array $userContentTypeIdentifier
      * @param array $userGroupContentTypeIdentifier
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
      */
     public function __construct(
         Environment $twig,
@@ -51,9 +53,10 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
         DatasetFactory $datasetFactory,
         array $userContentTypeIdentifier,
         array $userGroupContentTypeIdentifier,
-        PermissionResolver $permissionResolver
+        PermissionResolver $permissionResolver,
+        EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($twig, $translator);
+        parent::__construct($twig, $translator, $eventDispatcher);
 
         $this->datasetFactory = $datasetFactory;
         $this->userContentTypeIdentifier = $userContentTypeIdentifier;
@@ -115,24 +118,22 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
     }
 
     /**
-     * @param array $parameters
-     *
-     * @return string
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
-     * @throws \Twig_Error_Syntax
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Loader
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * {@inheritdoc}
      */
-    public function renderView(array $parameters): string
+    public function getTemplate(): string
+    {
+        return '@ezdesign/content/tab/roles/tab.html.twig';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateParameters(array $contextParameters = []): array
     {
         /** @var \eZ\Publish\API\Repository\Values\Content\Location $location */
-        $location = $parameters['location'];
+        $location = $contextParameters['location'];
 
-        $rolesPaginationParams = $parameters['roles_pagination_params'];
+        $rolesPaginationParams = $contextParameters['roles_pagination_params'];
 
         $rolesDataset = $this->datasetFactory->roles();
         $rolesDataset->load($location);
@@ -149,9 +150,6 @@ class RolesTab extends AbstractTab implements OrderedTabInterface, ConditionalTa
             'roles_pagination_params' => $rolesPaginationParams,
         ];
 
-        return $this->twig->render(
-            '@ezdesign/content/tab/roles/tab.html.twig',
-            array_merge($viewParameters, $parameters)
-        );
+        return array_replace($contextParameters, $viewParameters);
     }
 }

--- a/src/lib/Tab/LocationView/VersionsTab.php
+++ b/src/lib/Tab/LocationView/VersionsTab.php
@@ -16,7 +16,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Version\VersionRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Specification\ContentIsUser;
 use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
-use EzSystems\EzPlatformAdminUi\Tab\EventDispatchingAbstractTab;
+use EzSystems\EzPlatformAdminUi\Tab\AbstractEventDispatchingTab;
 use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use Pagerfanta\Adapter\ArrayAdapter;
@@ -27,7 +27,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 
-class VersionsTab extends EventDispatchingAbstractTab implements OrderedTabInterface, ConditionalTabInterface
+class VersionsTab extends AbstractEventDispatchingTab implements OrderedTabInterface, ConditionalTabInterface
 {
     public const FORM_REMOVE_DRAFT = 'version_remove_draft';
     public const FORM_REMOVE_ARCHIVED = 'version_remove_archived';


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29848
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


1. Introduced new abstract class `EventDispatchingAbstractTab` which dispatches `TabEvents::ON_RENDER` event before rendering tab. This gives a flexibility of changing template and accessing parameters to modify them.
2. I've added some useful twig blocks to Versions tab allowing to add custom columns and tables from other bundles. It's being used by upcoming Workflow bundle. 

#### TODO
- [x] Implement `EventDispatchingAbstractTab` in other tabs after validating idea on code review