### PR TITLE
EZP-29857: Unable to upload audio to Media field type

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezmedia.html.twig
@@ -5,7 +5,11 @@
 {%- block ezplatform_fieldtype_ezmedia_row -%}
     {% set preview_block_name = 'ezmedia_preview' %}
     {% set max_file_size = min(form.parent.vars.value.fieldDefinition.validatorConfiguration.FileSizeValidator.maxFileSize * 1024 * 1024, max_upload_size)|round %}
-    {% set attr = attr|merge({'accept': 'video/*'}) %}
+    {% if form.parent.vars.value.fieldDefinition.fieldSettings.mediaType == "html5_audio" %}
+        {% set attr = attr|merge({'accept': 'audio/*'}) %}
+    {% else %}
+        {% set attr = attr|merge({'accept': 'video/*'}) %}
+    {% endif %}
     {{ block('binary_base_row') }}
 {%- endblock -%}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29857
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass? | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Adds conditional selecting of MIME type for Media field type in Twig template. When HTML5 Audio (html5_audio) is selected, accepted MIME type is set to `audio/*`, in all other cases it is set to `video/*`. Note that this does not change behaviour for Flash, SilverLight, and QuickTime types.

#### Checklist:
- [x] Ready for Code Review
