### PR TITLE
EZP-29862: Trash button is disabled after using browser back button

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.trash.list.js
+++ b/src/bundle/Resources/public/js/scripts/admin.trash.list.js
@@ -51,31 +51,31 @@
     const buttonRestoreUnderNewParent = doc.querySelector('#trash_item_restore_location_select_content');
     const buttonDelete = doc.querySelector('#delete-trash-items');
 
-    const enableButtons = (event) => {
-        const deleteCheckbox = doc.querySelector(
-            'form[name="trash_item_delete"] input[type="checkbox"][value="' + event.target.value + '"]'
-        );
-        const isNonEmptySelection = checkboxes.some((el) => el.checked);
+    const enableButtons = () => {
+        const isEmptySelection = checkboxes.every((el) => !el.checked);
         const isMissingParent = checkboxes.some((el) => el.checked && parseInt(el.dataset.isParentInTrash, 10) === 1);
 
-        if (deleteCheckbox) {
-            deleteCheckbox.checked = event.target.checked;
-        }
-
-        if (isNonEmptySelection && !isMissingParent) {
-            buttonRestore.removeAttribute('disabled');
-        } else {
-            buttonRestore.setAttribute('disabled', true);
-        }
-
-        if (isNonEmptySelection) {
-            buttonRestoreUnderNewParent.removeAttribute('disabled');
-            buttonDelete.removeAttribute('disabled');
-        } else {
-            buttonRestoreUnderNewParent.setAttribute('disabled', true);
-            buttonDelete.setAttribute('disabled', true);
-        }
+        buttonRestore.disabled = isEmptySelection || isMissingParent;
+        buttonDelete.disabled = isEmptySelection;
+        buttonRestoreUnderNewParent.disabled = isEmptySelection;
     };
+    const updateTrashForm = (checkboxes) => {
+        checkboxes.forEach((checkbox) => {
+            const trashFormCheckbox = doc.querySelector(
+                'form[name="trash_item_delete"] input[type="checkbox"][value="' + checkbox.value + '"]'
+            );
 
-    checkboxes.forEach((checkbox) => checkbox.addEventListener('change', enableButtons, false));
+            if (trashFormCheckbox) {
+                trashFormCheckbox.checked = checkbox.checked;
+            }
+        });
+    };
+    const handleCheckboxChange = (event) => {
+        updateTrashForm([event.target])
+        enableButtons();
+    }; 
+
+    updateTrashForm(checkboxes);
+    enableButtons()
+    checkboxes.forEach((checkbox) => checkbox.addEventListener('change', handleCheckboxChange, false));
 })(window, document, window.eZ, window.React, window.ReactDOM, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/button.state.radio.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.radio.toggle.js
@@ -1,17 +1,16 @@
-(function (global, doc) {
+(function(global, doc) {
     const toggleForms = [...doc.querySelectorAll('.ez-toggle-btn-state-radio')];
 
     toggleForms.forEach((toggleForm) => {
         const radioInputs = [...toggleForm.querySelectorAll('input[type="radio"]')];
         const toggleButtonState = () => {
             const button = doc.querySelector(toggleForm.dataset.toggleButtonId);
-            const oneIsSelected = radioInputs.some(el => el.checked);
+            const isAnythingSelected = radioInputs.some((el) => el.checked);
 
-            if (oneIsSelected) {
-                button['removeAttribute']('disabled', true);
-            }
+            button.disabled = !isAnythingSelected;
         };
 
-        radioInputs.forEach(radioInput => radioInput.addEventListener('change', toggleButtonState, false));
+        toggleButtonState();
+        radioInputs.forEach((radioInput) => radioInput.addEventListener('change', toggleButtonState, false));
     });
 })(window, document);

--- a/src/bundle/Resources/public/js/scripts/button.state.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.toggle.js
@@ -1,15 +1,16 @@
-(function (global, doc) {
+(function(global, doc) {
     const toggleForms = [...doc.querySelectorAll('.ez-toggle-btn-state')];
 
-    toggleForms.forEach(toggleForm => {
+    toggleForms.forEach((toggleForm) => {
         const checkboxes = [...toggleForm.querySelectorAll('.ez-table__cell.ez-table__cell--has-checkbox input[type="checkbox"]')];
         const toggleButtonState = () => {
-            const methodName = checkboxes.some(el => el.checked) ? 'removeAttribute' : 'setAttribute';
+            const isAnythingSelected = checkboxes.some((el) => el.checked);
             const buttonRemove = doc.querySelector(toggleForm.dataset.toggleButtonId);
 
-            buttonRemove[methodName]('disabled', true);
+            buttonRemove.disabled = !isAnythingSelected;
         };
 
-        checkboxes.forEach(checkbox => checkbox.addEventListener('change', toggleButtonState, false));
+        toggleButtonState();
+        checkboxes.forEach((checkbox) => checkbox.addEventListener('change', toggleButtonState, false));
     });
 })(window, document);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29862
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


After using "back button" in a browser, browser sets inputs values to values entered by a user before. 
Thus, we cannot assume that all checkboxes/radios are unchecked at the beginning, therefore we need to check at the start their values and set disabled state accordingly.

**For QA**: fix will affect all tables with checkboxes and Trash buttons + it will affect trash modal for content item with Immage Asset field.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
