### PR TITLE
EZP-29714: Fix failing to detect disabled next button

### DIFF
--- a/src/lib/Behat/PageElement/Pagination.php
+++ b/src/lib/Behat/PageElement/Pagination.php
@@ -17,7 +17,7 @@ class Pagination extends Element
     {
         parent::__construct($context);
         $this->fields = [
-            'nextButton' => '.pagination .page-item.next',
+            'nextButton' => '.pagination .page-item.next:not(.disabled)',
             'spinner' => '.m-sub-items__spinner-wrapper',
         ];
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | http://jira.ez.no/browse/EZP-29714
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | should
| Doc needed?   | yes/no

Current ezplatform-ee-demo master branch build is failing, it hangs on `Changes can be discarded while creating Content Type` test, on `And there's no "Test Content Type" on "Content" "Content Type Group" list`. This is caused by incorrectly detecting that the Next button is disabled, sending the tests into an infinite loop 😓 This change fixes the issue.

Build for this PR: https://github.com/ezsystems/ezplatform-page-builder/pull/271 should be green (it has this PR added as a dependency: https://github.com/mnocon/ezplatform-ee-demo/commit/d03c88b23c5f8dfb3e19c0d4980c8237e03ca3f6)

- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review