### PR TITLE
EZP-29889: Cannot set property 'disabled' of null error in console in Trash

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.trash.list.js
+++ b/src/bundle/Resources/public/js/scripts/admin.trash.list.js
@@ -55,9 +55,17 @@
         const isEmptySelection = checkboxes.every((el) => !el.checked);
         const isMissingParent = checkboxes.some((el) => el.checked && parseInt(el.dataset.isParentInTrash, 10) === 1);
 
-        buttonRestore.disabled = isEmptySelection || isMissingParent;
-        buttonDelete.disabled = isEmptySelection;
-        buttonRestoreUnderNewParent.disabled = isEmptySelection;
+        if (buttonRestore) {
+            buttonRestore.disabled = isEmptySelection || isMissingParent;
+        }
+
+        if (buttonDelete) {
+            buttonDelete.disabled = isEmptySelection;
+        }
+
+        if (buttonRestoreUnderNewParent) {
+            buttonRestoreUnderNewParent.disabled = isEmptySelection;
+        }
     };
     const updateTrashForm = (checkboxes) => {
         checkboxes.forEach((checkbox) => {
@@ -71,11 +79,11 @@
         });
     };
     const handleCheckboxChange = (event) => {
-        updateTrashForm([event.target])
+        updateTrashForm([event.target]);
         enableButtons();
-    }; 
+    };
 
     updateTrashForm(checkboxes);
-    enableButtons()
+    enableButtons();
     checkboxes.forEach((checkbox) => checkbox.addEventListener('change', handleCheckboxChange, false));
 })(window, document, window.eZ, window.React, window.ReactDOM, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/button.state.radio.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.radio.toggle.js
@@ -3,8 +3,13 @@
 
     toggleForms.forEach((toggleForm) => {
         const radioInputs = [...toggleForm.querySelectorAll('input[type="radio"]')];
+        const button = doc.querySelector(toggleForm.dataset.toggleButtonId);
+
+        if (!button) {
+            return;
+        }
+
         const toggleButtonState = () => {
-            const button = doc.querySelector(toggleForm.dataset.toggleButtonId);
             const isAnythingSelected = radioInputs.some((el) => el.checked);
 
             button.disabled = !isAnythingSelected;

--- a/src/bundle/Resources/public/js/scripts/button.state.toggle.js
+++ b/src/bundle/Resources/public/js/scripts/button.state.toggle.js
@@ -3,9 +3,14 @@
 
     toggleForms.forEach((toggleForm) => {
         const checkboxes = [...toggleForm.querySelectorAll('.ez-table__cell.ez-table__cell--has-checkbox input[type="checkbox"]')];
+        const buttonRemove = doc.querySelector(toggleForm.dataset.toggleButtonId);
+
+        if (!buttonRemove) {
+            return;
+        }
+
         const toggleButtonState = () => {
             const isAnythingSelected = checkboxes.some((el) => el.checked);
-            const buttonRemove = doc.querySelector(toggleForm.dataset.toggleButtonId);
 
             buttonRemove.disabled = !isAnythingSelected;
         };


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29889
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

In this fix: https://github.com/ezsystems/ezplatform-admin-ui/pull/739 I added functions executions, which set _disabled_ status of buttons just after page has been loaded. Previous code assumed that buttons are always present, but in case of Trash, when there are no items, there are no buttons:

![screen shot 2018-12-13 at 15 25 30](https://user-images.githubusercontent.com/10233057/49945175-88766e80-feec-11e8-9857-f1ffc532501f.png)

it seems that the problem does not exist in other places because buttons are always present, e.g. in Bookmarks or always at least one item is present or table is not displayed when there are no items (e.g. _Draft under edit_ table):

![screen shot 2018-12-13 at 14 48 32](https://user-images.githubusercontent.com/10233057/49945207-a0e68900-feec-11e8-8fd3-0d22866fa289.png)

but I added `if`s also in other places to make code more bullet-proof. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
