### PR TITLE
EZP-29897: Workflow state panel becomes unusable in the Content Edit, when its container is displayed below the fold

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -1,35 +1,53 @@
-(function () {
+(function (global, doc) {
     const CLASS_HIDDEN = 'ez-extra-actions--hidden';
     const CLASS_PREVENT_SHOW = 'ez-extra-actions--prevent-show';
-    const btns = [...document.querySelectorAll('.ez-btn--extra-actions')];
+    const btns = doc.querySelectorAll('.ez-btn--extra-actions');
+    const haveHiddenPart = (element) => element.classList.contains(CLASS_HIDDEN) && !element.classList.contains(CLASS_PREVENT_SHOW);
 
     btns.forEach(btn => {
         btn.addEventListener('click', () => {
-            const actions = document.querySelector(`.ez-extra-actions[data-actions="${btn.dataset.actions}"]`);
-            const haveHiddenPart = (element) => {
-                return element.classList.contains(CLASS_HIDDEN) && !element.classList.contains(CLASS_PREVENT_SHOW)
-            };
+            const actions = doc.querySelector(`.ez-extra-actions[data-actions="${btn.dataset.actions}"]`);
+
             const methodName = haveHiddenPart(actions) ? 'remove' : 'add';
-            const clickOutsideMethodName = actions.classList.contains(CLASS_HIDDEN) ? 'addEventListener' : 'removeEventListener';
             const focusElement = actions.querySelector(btn.dataset.focusElement);
             const detectClickOutside = (event) => {
-                const isNotButton = !event.target.contains(btn);
+                const isNotButton = event.target !== btn || !btn.contains(event.target);
                 const isNotExtraActions = !event.target.closest('.ez-extra-actions');
                 const isNotCalendar = !event.target.closest('.flatpickr-calendar');
 
                 if (isNotButton && isNotExtraActions && isNotCalendar) {
                     actions.classList.add(CLASS_HIDDEN);
-                    document.body.removeEventListener('click', detectClickOutside, false);
+                    doc.body.removeEventListener('click', detectClickOutside, false);
                 }
             };
 
-            actions.style.top = btn.offsetTop + 'px';
             actions.classList[methodName](CLASS_HIDDEN);
-            document.body[clickOutsideMethodName]('click', detectClickOutside, false);
+
+            const actionsRect = actions.getBoundingClientRect();
+
+            actions.style.opacity = 0;
+
+            const fitsViewport = actionsRect.height + btn.offsetTop <= global.innerHeight;
+
+            if (!fitsViewport) {
+                actions.style.bottom = `0px`;
+                actions.style.top = 'auto';
+            } else {
+                actions.style.top = `${btn.offsetTop}px`;
+                actions.style.bottom = 'auto';
+            }
+
+            if (!actions.classList.contains(CLASS_HIDDEN)) {
+                doc.body.addEventListener('click', detectClickOutside, false);
+            } else {
+                doc.body.removeEventListener('click', detectClickOutside);
+            }
 
             if (focusElement) {
                 focusElement.focus();
             }
+
+            actions.style.opacity = 1;
         }, false);
     });
-})();
+})(window, window.document);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29897
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Issues fixed
- [x] panel hiding below the fold so user is not able to submit the content of a panel (test it with workflow feature and small window height),
- [x] click outside of a panel detection