### PR TITLE
EZP-29871: Error 500 after creating Content Item based on Content Type with ezuser

### DIFF
--- a/src/lib/Specification/ContentType/ContentTypeIsUser.php
+++ b/src/lib/Specification/ContentType/ContentTypeIsUser.php
@@ -14,6 +14,8 @@ use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
 
 class ContentTypeIsUser extends AbstractSpecification
 {
+    private const EZUSER_FIELD_TYPE_IDENTIFIER = 'ezuser';
+
     /** @var array */
     private $userContentTypeIdentifier;
 
@@ -40,6 +42,16 @@ class ContentTypeIsUser extends AbstractSpecification
             throw new InvalidArgumentException($contentType, sprintf('Must be instance of %s', ContentType::class));
         }
 
-        return in_array($contentType->identifier, $this->userContentTypeIdentifier, true);
+        if (in_array($contentType->identifier, $this->userContentTypeIdentifier, true)) {
+            return true;
+        }
+
+        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+            if ($fieldDefinition->fieldTypeIdentifier === self::EZUSER_FIELD_TYPE_IDENTIFIER) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29871
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

IMHO we can assume that if a content type contains `ezuser` field then it is "User" content type (and skip adding it to YAML configuration).

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
