### PR TITLE
EZP-29902: Admin UI - Locale is not correctly set

### DIFF
--- a/src/lib/Behat/PageElement/Fields/Date.php
+++ b/src/lib/Behat/PageElement/Fields/Date.php
@@ -52,8 +52,8 @@ class Date extends EzFieldElement
 
     public function verifyValueInItemView(array $values): void
     {
-        $expectedDateTime = date_format(date_create($values['value']), self::VIEW_DATE_FORMAT);
-        $actualDateTime = $this->context->findElement($this->fields['fieldContainer'])->getText();
+        $expectedDateTime = date_create($values['value']);
+        $actualDateTime = date_create($this->context->findElement($this->fields['fieldContainer'])->getText());
         Assert::assertEquals(
             $expectedDateTime,
             $actualDateTime,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29902
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2018-12-17 at 12 56 16 pm](https://user-images.githubusercontent.com/1654712/50085827-6e45d480-01fb-11e9-9ff7-19fe560db062.png)



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
