### PR TITLE
EZP-28413: Empty username field after copying a user

### DIFF
--- a/src/bundle/Resources/config/services/menu.yml
+++ b/src/bundle/Resources/config/services/menu.yml
@@ -31,6 +31,9 @@ services:
 
     EzSystems\EzPlatformAdminUi\Menu\ContentRightSidebarBuilder:
         public: true
+        arguments:
+            $userContentTypeIdentifier: '$user_content_type_identifier$'
+            $userGroupContentTypeIdentifier: '$user_group_content_type_identifier$'
         tags:
             - { name: knp_menu.menu_builder, method: build, alias: ezplatform_admin_ui.menu.content.sidebar_right }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28413
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Copying user as content skips `account_user` data (`externalData`). In result we end with invalid entity in database. As copying user should be handled by specific method in UserService instead of Content/Location Service - copying (and copySubtree) of users and users groups is now disabled in adminUI.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
