### PR TITLE
EZP-29921: Add possibility to use icons with custom path in Sidebar menu

### DIFF
--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -36,7 +36,7 @@
 {% block label %}
     {% set icon_path = null %}
     {% set icon_class = (item_class|default('ez-icon ') ~ item.extras.icon_class|default(''))|trim %}
-    {% if item.extras.icon_path is defined and item.extras.icon_path is not empty %}
+    {% if item.extras.icon_path|default %}
         {% set icon_path = item.extras.icon_path %}
     {% elseif item.extras.icon is defined and item.extras.icon is not empty %}
         {% set icon_path = asset('bundles/ezplatformadminui/img/ez-icons.svg') ~ '#' ~ item.extras.icon %}

--- a/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
+++ b/src/bundle/Resources/views/parts/menu/sidebar_base.html.twig
@@ -34,9 +34,18 @@
 {% endblock %}
 
 {% block label %}
-    {% if item.extras.icon is defined and item.extras.icon != '' %}
-        <svg class="ez-icon ez-icon-{{ item.extras.icon }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ item.extras.icon }}"></use>
+    {% set icon_path = null %}
+    {% set icon_class = (item_class|default('ez-icon ') ~ item.extras.icon_class|default(''))|trim %}
+    {% if item.extras.icon_path is defined and item.extras.icon_path is not empty %}
+        {% set icon_path = item.extras.icon_path %}
+    {% elseif item.extras.icon is defined and item.extras.icon is not empty %}
+        {% set icon_path = asset('bundles/ezplatformadminui/img/ez-icons.svg') ~ '#' ~ item.extras.icon %}
+        {% set icon_class = (icon_class ~ ' ez-icon-' ~ item.extras.icon)|trim %}
+    {% endif %}
+
+    {% if icon_path is not empty %}
+        <svg class="{{ icon_class }}">
+            <use xlink:href="{{ icon_path }}"></use>
         </svg>
     {% endif %}
     {{ parent() }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29921
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


1. Introduces new `icon_path` parameter in menu item extras to be used instead of existing `icon` parameter if menu items need custom svg icons.
2. `icon_class` was added for adding custom classes to `<svg></svg>` element.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
