### PR TITLE
EZP-29904: Unable to select Base translation for a Content Item

### DIFF
--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -152,7 +152,6 @@
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.tab.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.visibility.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.update.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.add.translation.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.content.edit.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/move.js'
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/udw/copy.js'

--- a/src/bundle/Resources/views/content/tab/translations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/translations/tab.html.twig
@@ -73,7 +73,6 @@
 {% block javascripts %}
     {% javascripts
         '@EzPlatformAdminUiBundle/Resources/public/js/scripts/button.state.toggle.js'
-        '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.add.translation.js'
     %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -159,6 +159,7 @@
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.prevent.click.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.picker.js'
             '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.notifications.modal.js'
+            '@EzPlatformAdminUiBundle/Resources/public/js/scripts/admin.location.add.translation.js'
         %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29904
| Requires     | https://github.com/ezsystems/ezplatform-page-builder/pull/281
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
