### PR TITLE
EZP-29935: Add Sub items limit value to User Preferences

### DIFF
--- a/src/bundle/Resources/config/services/modules/subitems.yml
+++ b/src/bundle/Resources/config/services/modules/subitems.yml
@@ -24,4 +24,3 @@ services:
         $outputVisitor: '@ezpublish_rest.output.visitor.json'
         $outputGenerator: '@ezpublish_rest.output.generator.json'
         $contentTypeInfoListValueObjectVisitor: '@ezpublish_rest.output.value_object_visitor.ContentTypeInfoList'
-        $subitemsLimit: '$subitems_module.limit$'

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -15,3 +15,10 @@ services:
         tags:
             - { name: ezplatform.admin_ui.user_setting.value, identifier: timezone }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: timezone }
+
+    EzSystems\EzPlatformAdminUi\UserSetting\Setting\SubitemsLimit:
+        arguments:
+            $subitemsLimit: '$subitems_module.limit$'
+        tags:
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: subitems_limit }
+            - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: subitems_limit }

--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -41,6 +41,16 @@
         <target state="new">My Preferences</target>
         <note>key: section.my_preferences</note>
       </trans-unit>
+      <trans-unit id="18f788ade37f54e5d52f0e3ddacb39a5558190b5" resname="settings.subitems_limit.value.description">
+        <source>Number of items displayed in the table</source>
+        <target state="new">Number of items displayed in the table</target>
+        <note>key: settings.subitems_limit.value.description</note>
+      </trans-unit>
+      <trans-unit id="67329191003095f24d2ca7d2182ecb00d5a85e36" resname="settings.subitems_limit.value.title">
+        <source>Sub-items</source>
+        <target state="new">Sub-items</target>
+        <note>key: settings.subitems_limit.value.title</note>
+      </trans-unit>
       <trans-unit id="dac7ffb84bac8bc5a682388098bded0f8f49d841" resname="settings.timezone.value.description">
         <source><![CDATA[Time Zone in use for displaying Date & Time]]></source>
         <target state="new"><![CDATA[Time Zone in use for displaying Date & Time]]></target>

--- a/src/lib/UI/Config/Provider/Module/SubItemsList.php
+++ b/src/lib/UI/Config/Provider/Module/SubItemsList.php
@@ -8,42 +8,35 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module;
 
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+use EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService;
 
 /**
  * Provides information about current setting for sub-items list.
  */
 class SubItemsList implements ProviderInterface
 {
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
-    private $configResolver;
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService */
+    private $userSettingService;
 
     /**
-     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param \EzSystems\EzPlatformAdminUi\UserSetting\UserSettingService $userSettingService
      */
-    public function __construct(ConfigResolverInterface $configResolver)
+    public function __construct(UserSettingService $userSettingService)
     {
-        $this->configResolver = $configResolver;
+        $this->userSettingService = $userSettingService;
     }
 
     /**
      * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function getConfig(): array
     {
         return [
-            'limit' => $this->getSubItemsListLimit(),
+            'limit' => (int)$this->userSettingService->getUserSetting('subitems_limit')->value,
         ];
-    }
-
-    /**
-     * @return int
-     */
-    protected function getSubItemsListLimit(): int
-    {
-        return $this->configResolver->getParameter(
-            'subitems_module.limit'
-        );
     }
 }

--- a/src/lib/UserSetting/Setting/SubitemsLimit.php
+++ b/src/lib/UserSetting/Setting/SubitemsLimit.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting\Setting;
+
+use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class SubitemsLimit implements ValueDefinitionInterface, FormMapperInterface
+{
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    /** @var int */
+    private $subitemsLimit;
+
+    /**
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param int $subitemsLimit
+     */
+    public function __construct(TranslatorInterface $translator, int $subitemsLimit)
+    {
+        $this->translator = $translator;
+        $this->subitemsLimit = $subitemsLimit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->getTranslatedName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): string
+    {
+        return $this->getTranslatedDescription();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDisplayValue(string $storageValue): string
+    {
+        return $storageValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValue(): string
+    {
+        return (string)$this->subitemsLimit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFieldForm(FormBuilderInterface $formBuilder, ValueDefinitionInterface $value): FormBuilderInterface
+    {
+        return $formBuilder->create(
+            'value',
+            NumberType::class,
+            [
+                'attr' => ['min' => 1],
+                'required' => true,
+                'label' => $this->getTranslatedDescription(),
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedName(): string
+    {
+        return $this->translator->trans(
+            /** @Desc("Sub-items") */
+            'settings.subitems_limit.value.title',
+            [],
+            'user_settings'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedDescription(): string
+    {
+        return $this->translator->trans(
+            /** @Desc("Number of items displayed in the table") */
+            'settings.subitems_limit.value.description',
+            [],
+            'user_settings'
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29935
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds new User Setting in Admin panel to set number of elements displayed on subitems list. A design will be changed in another PR.


![screen shot 2018-12-19 at 1 21 35 pm](https://user-images.githubusercontent.com/1654712/50219964-2c4e9700-0391-11e9-8288-f53616b6733a.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
