### PR TITLE
EZP-29925: Content Type Translate in Edit mode is not based on browser's settings

### DIFF
--- a/src/lib/View/Builder/ContentTranslateViewBuilder.php
+++ b/src/lib/View/Builder/ContentTranslateViewBuilder.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
@@ -39,16 +40,21 @@ class ContentTranslateViewBuilder implements ViewBuilder
     /** @var \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface */
     private $contentActionDispatcher;
 
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider */
+    private $languagePreferenceProvider;
+
     public function __construct(
         Repository $repository,
         Configurator $viewConfigurator,
         ParametersInjector $viewParametersInjector,
-        ActionDispatcherInterface $contentActionDispatcher
+        ActionDispatcherInterface $contentActionDispatcher,
+        UserLanguagePreferenceProvider $languagePreferenceProvider
     ) {
         $this->repository = $repository;
         $this->viewConfigurator = $viewConfigurator;
         $this->viewParametersInjector = $viewParametersInjector;
         $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->languagePreferenceProvider = $languagePreferenceProvider;
     }
 
     /**
@@ -81,7 +87,10 @@ class ContentTranslateViewBuilder implements ViewBuilder
         $location = $this->resolveLocation($parameters, $fromLanguage);
         $content = $this->resolveContent($parameters, $location, $fromLanguage);
         $contentInfo = $content->contentInfo;
-        $contentType = $content->getContentType();
+        $contentType = $this->repository->getContentTypeService()->loadContentType(
+            $content->getContentType()->id,
+            $this->languagePreferenceProvider->getPreferredLanguages()
+        );
         /** @var \Symfony\Component\Form\FormInterface $form */
         $form = $parameters['form'];
 

--- a/src/lib/View/Builder/ContentTranslateViewBuilder.php
+++ b/src/lib/View/Builder/ContentTranslateViewBuilder.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
@@ -40,15 +40,22 @@ class ContentTranslateViewBuilder implements ViewBuilder
     /** @var \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface */
     private $contentActionDispatcher;
 
-    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider */
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
     private $languagePreferenceProvider;
 
+    /**
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\Core\MVC\Symfony\View\Configurator $viewConfigurator
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector $viewParametersInjector
+     * @param \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface $contentActionDispatcher
+     * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $languagePreferenceProvider
+     */
     public function __construct(
         Repository $repository,
         Configurator $viewConfigurator,
         ParametersInjector $viewParametersInjector,
         ActionDispatcherInterface $contentActionDispatcher,
-        UserLanguagePreferenceProvider $languagePreferenceProvider
+        UserLanguagePreferenceProviderInterface $languagePreferenceProvider
     ) {
         $this->repository = $repository;
         $this->viewConfigurator = $viewConfigurator;

--- a/src/lib/View/Filter/ContentTranslateViewFilter.php
+++ b/src/lib/View/Filter/ContentTranslateViewFilter.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
 use EzSystems\EzPlatformAdminUi\RepositoryForms\Data\ContentTranslationData;
@@ -41,7 +41,7 @@ class ContentTranslateViewFilter implements EventSubscriberInterface
     /** @var \Symfony\Component\Form\FormFactoryInterface */
     private $formFactory;
 
-    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider */
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
     private $languagePreferenceProvider;
 
     /**
@@ -49,14 +49,14 @@ class ContentTranslateViewFilter implements EventSubscriberInterface
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
-     * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider $languagePreferenceProvider
+     * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $languagePreferenceProvider
      */
     public function __construct(
         ContentService $contentService,
         LanguageService $languageService,
         ContentTypeService $contentTypeService,
         FormFactoryInterface $formFactory,
-        UserLanguagePreferenceProvider $languagePreferenceProvider
+        UserLanguagePreferenceProviderInterface $languagePreferenceProvider
     ) {
         $this->contentService = $contentService;
         $this->languageService = $languageService;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29925
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
