### PR TITLE
[2.5] EZP-29961: Add preferred language value to User Preferences

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/UserPreferences.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserPreferences.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for user preferences.
+ *
+ * Example configuration:
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          user_preferences:
+ *              additional_translations: ['en_US', 'en_GB']
+ * ```
+ */
+class UserPreferences extends AbstractParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode('user_preferences')
+                ->info('User Preferences configuration.')
+                ->children()
+                    ->arrayNode('additional_translations')
+                        ->info('Additional translations to display on the preferred language list.')
+                        ->example(['en_US', 'en_GB'])
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings['user_preferences']['additional_translations'])) {
+            return;
+        }
+
+        $contextualizer->setContextualParameter(
+            'user_preferences.additional_translations',
+            $currentScope,
+            $scopeSettings['user_preferences']['additional_translations']
+        );
+    }
+}

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -14,17 +14,7 @@ use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SystemInfoTab
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\TabPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UiConfigProviderPass;
 use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ViewBuilderRegistryPass;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\AdminUiForms;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\ContentTranslateView;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\ContentType;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\LocationIds;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Module;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Notifications;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Pagination;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Security;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\UserGroupIdentifier;
-use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\UserIdentifier;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -73,18 +63,19 @@ class EzPlatformAdminUiBundle extends Bundle
     private function getConfigParsers(): array
     {
         return [
-            new LocationIds(),
-            new Module\Subitems(),
-            new Module\UniversalDiscoveryWidget(),
-            new Pagination(),
-            new Security(),
-            new UserIdentifier(),
-            new UserGroupIdentifier(),
-            new SubtreeOperations(),
-            new Notifications(),
-            new ContentTranslateView(),
-            new AdminUiForms(),
-            new ContentType(),
+            new Parser\LocationIds(),
+            new Parser\Module\Subitems(),
+            new Parser\Module\UniversalDiscoveryWidget(),
+            new Parser\Pagination(),
+            new Parser\Security(),
+            new Parser\UserIdentifier(),
+            new Parser\UserGroupIdentifier(),
+            new Parser\SubtreeOperations(),
+            new Parser\Notifications(),
+            new Parser\ContentTranslateView(),
+            new Parser\AdminUiForms(),
+            new Parser\UserPreferences(),
+            new Parser\ContentType(),
         ];
     }
 }

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -50,3 +50,6 @@ parameters:
 
     # Views
     ezsettings.default.content_translate_view: {}
+
+    # Additional translations e.g. ['en_US', 'nb_NO']
+    ezsettings.default.user_preferences.additional_translations: []

--- a/src/bundle/Resources/config/services/forms.yml
+++ b/src/bundle/Resources/config/services/forms.yml
@@ -33,6 +33,10 @@ services:
 
     EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader: ~
 
+    EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader:
+        arguments:
+            $availableTranslations: '%available_translations%'
+
     EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\LanguageChoiceLoader:
         arguments:
             $siteAccessLanguages: '$languages$'

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -22,3 +22,10 @@ services:
         tags:
             - { name: ezplatform.admin_ui.user_setting.value, identifier: subitems_limit }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: subitems_limit }
+
+    EzSystems\EzPlatformAdminUi\UserSetting\Setting\Language:
+        arguments:
+            $availableLocaleChoiceLoader: '@EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader'
+        tags:
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: language }
+            - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: language }

--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -41,6 +41,16 @@
         <target state="new">My Preferences</target>
         <note>key: section.my_preferences</note>
       </trans-unit>
+      <trans-unit id="3a4946ea2a7aaa360112cf1e657617e7ce7c7d9b" resname="settings.language.value.description">
+        <source>The language of the administration panel</source>
+        <target state="new">The language of the administration panel</target>
+        <note>key: settings.language.value.description</note>
+      </trans-unit>
+      <trans-unit id="593fb98cf76c44e48e00ce4ee027a6e54b6625fd" resname="settings.language.value.title">
+        <source>Language</source>
+        <target state="new">Language</target>
+        <note>key: settings.language.value.title</note>
+      </trans-unit>
       <trans-unit id="18f788ade37f54e5d52f0e3ddacb39a5558190b5" resname="settings.subitems_limit.value.description">
         <source>Number of items displayed in the table</source>
         <target state="new">Number of items displayed in the table</target>

--- a/src/lib/EventListener/RequestLocaleListener.php
+++ b/src/lib/EventListener/RequestLocaleListener.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\EventListener;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -31,22 +32,28 @@ class RequestLocaleListener implements EventSubscriberInterface
     /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
     private $userLanguagePreferenceProvider;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
     /**
      * @param array $siteAccessGroups
      * @param array $availableTranslations
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      */
     public function __construct(
         array $siteAccessGroups,
         array $availableTranslations,
         TranslatorInterface $translator,
-        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
+        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
+        ConfigResolverInterface $configResolver
     ) {
         $this->siteAccessGroups = $siteAccessGroups;
         $this->availableTranslations = $availableTranslations;
         $this->translator = $translator;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -72,11 +79,14 @@ class RequestLocaleListener implements EventSubscriberInterface
             return;
         }
 
+        $additionalTranslations = $this->configResolver->getParameter('user_preferences.additional_translations');
         $preferableLocales = $this->userLanguagePreferenceProvider->getPreferredLocales($request);
         $locale = null;
 
         foreach ($preferableLocales as $preferableLocale) {
-            if (\in_array($preferableLocale, $this->availableTranslations)) {
+            if (\in_array($preferableLocale, $this->availableTranslations, true)
+                || \in_array($preferableLocale, $additionalTranslations, true)
+            ) {
                 $locale = $preferableLocale;
                 break;
             }

--- a/src/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\Validator\Constraints\Locale;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Intl\Intl;
+
+class AvailableLocaleChoiceLoader extends BaseChoiceLoader
+{
+    /** @var \Symfony\Component\Validator\Validator\ValidatorInterface */
+    private $validator;
+
+    /** @var string[] */
+    private $availableTranslations;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /**
+     * @param \Symfony\Component\Validator\Validator\ValidatorInterface $validator
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param string[] $availableTranslations
+     */
+    public function __construct(
+        ValidatorInterface $validator,
+        ConfigResolverInterface $configResolver,
+        array $availableTranslations
+    ) {
+        $this->validator = $validator;
+        $this->availableTranslations = $availableTranslations;
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoiceList(): array
+    {
+        $choices = [];
+
+        $additionalTranslations = $this->configResolver->getParameter('user_preferences.additional_translations');
+        $availableLocales = array_unique(array_merge($this->availableTranslations, $additionalTranslations));
+
+        foreach ($availableLocales as $locale) {
+            if (0 === $this->validator->validate($locale, new Locale())->count()) {
+                $choices[Intl::getLocaleBundle()->getLocaleName($locale)] = $locale;
+            }
+        }
+
+        return $choices;
+    }
+}

--- a/src/lib/Tests/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
+++ b/src/lib/Tests/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Form\Type\ChoiceList\Loader;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Locale;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class AvailableLocaleChoiceLoaderTest extends TestCase
+{
+    /** @var \Symfony\Component\Validator\Validator\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $validator;
+
+    /** @var \Symfony\Component\Validator\Constraints\Locale|\PHPUnit\Framework\MockObject\MockObject */
+    private $localeConstraint;
+
+    /** @var \Symfony\Component\Validator\ConstraintViolationInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $constraintViolation;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->localeConstraint = $this->createMock(Locale::class);
+        $this->validator = $this->createMock(ValidatorInterface::class);
+        $this->constraintViolation = $this->createMock(ConstraintViolationInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+    }
+
+    /**
+     * @dataProvider providerForGetChoiceList
+     *
+     * @param array $availableTranslations
+     * @param array $additionalTranslations
+     * @param array $expectedLocales
+     */
+    public function testGetChoiceList(
+        array $availableTranslations,
+        array $additionalTranslations,
+        array $expectedLocales
+    ): void {
+        $this->validator
+            ->method('validate')
+            ->willReturnCallback(function ($locale) {
+                return $locale === 'foo_BAR' ? new ConstraintViolationList([$this->constraintViolation]) : new ConstraintViolationList();
+            });
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with('user_preferences.additional_translations')
+            ->willReturn($additionalTranslations);
+
+        $availableLocaleChoiceLoader = new AvailableLocaleChoiceLoader(
+            $this->validator,
+            $this->configResolver,
+            $availableTranslations
+        );
+
+        $this->assertSame($expectedLocales, $availableLocaleChoiceLoader->getChoiceList());
+    }
+
+    public function providerForGetChoiceList(): array
+    {
+        return [
+            'available_translations' => [
+                ['en', 'nb_NO'],
+                [],
+                [
+                    'English' => 'en',
+                    'Norwegian Bokmål (Norway)' => 'nb_NO',
+                ],
+            ],
+            'available_and_additional_translations' => [
+                ['en', 'nb_NO'],
+                ['de_DE'],
+                [
+                    'English' => 'en',
+                    'Norwegian Bokmål (Norway)' => 'nb_NO',
+                    'German (Germany)' => 'de_DE',
+                ],
+            ],
+            'unsupported_translation' => [
+                ['en', 'nb_NO'],
+                ['de_DE', 'foo_BAR'],
+                [
+                    'English' => 'en',
+                    'Norwegian Bokmål (Norway)' => 'nb_NO',
+                    'German (Germany)' => 'de_DE',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UserSetting\Setting;
+
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader;
+use EzSystems\EzPlatformAdminUi\UserSetting\FormMapperInterface;
+use EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class Language implements ValueDefinitionInterface, FormMapperInterface
+{
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    /** @var string */
+    private $preferredLocale;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader */
+    private $availableLocaleChoiceLoader;
+
+    /**
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
+     * @param \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader $availableLocaleChoiceLoader
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
+        AvailableLocaleChoiceLoader $availableLocaleChoiceLoader
+    ) {
+        $this->translator = $translator;
+        $preferredLocales = $userLanguagePreferenceProvider->getPreferredLocales();
+        $this->preferredLocale = reset($preferredLocales);
+        $this->availableLocaleChoiceLoader = $availableLocaleChoiceLoader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->getTranslatedName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): string
+    {
+        return $this->getTranslatedDescription();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDisplayValue(string $storageValue): string
+    {
+        return $storageValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValue(): string
+    {
+        return $this->preferredLocale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFieldForm(FormBuilderInterface $formBuilder, ValueDefinitionInterface $value): FormBuilderInterface
+    {
+        return $formBuilder->create(
+            'value',
+            LocaleType::class,
+            [
+                'required' => true,
+                'label' => $this->getTranslatedDescription(),
+                'choice_loader' => $this->availableLocaleChoiceLoader,
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedName(): string
+    {
+        return $this->translator->trans(
+            /** @Desc("Language") */
+            'settings.language.value.title',
+            [],
+            'user_settings'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getTranslatedDescription(): string
+    {
+        return $this->translator->trans(
+            /** @Desc("The language of the administration panel") */
+            'settings.language.value.description',
+            [],
+            'user_settings'
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29961
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


[2.5] This PR adds new User Setting which is used to set the language of the Administration Panel. The default value for setting is gathered from browsers language settings. The list of available languages has available translations on top.

![screen shot 2018-12-21 at 10 10 42 am](https://user-images.githubusercontent.com/1654712/50334498-c6851b00-0508-11e9-9015-34c5a7ee81ce.png)

Depends on [https://github.com/ezsystems/ezpublish-kernel/pull/2516](https://github.com/ezsystems/ezpublish-kernel/pull/2516)
#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
