### PR TITLE
EZP-29890: Wrong translation form is opened after using browser back button

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.add.translation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.add.translation.js
@@ -1,22 +1,28 @@
-(function (global, doc) {
+(function(global, doc) {
     const CLASS_SELECTED = 'ez-translation__label--selected';
     const SELECTOR_WRAPPER = '.ez-translation__language-wrapper';
     const SELECTOR_LABEL = '.ez-translation__label';
     const SELECTOR_MODAL = '.ez-modal';
+    const resetSelection = () => {
+        doc.querySelectorAll(`${SELECTOR_LABEL} .ez-translation__input`).forEach((input) => {
+            input.checked = false;
+        });
+    };
     const updateSelection = (event) => {
         event.preventDefault();
 
         const radio = event.currentTarget.querySelector('input[type="radio"]');
         const checked = !(radio.checked && radio.name === 'add-translation[base_language]');
-        const methodName = checked ? 'setAttribute' : 'removeAttribute';
 
-        [...event.target.closest(SELECTOR_WRAPPER).querySelectorAll(SELECTOR_LABEL)].forEach(label => label.classList.remove(CLASS_SELECTED));
+        [...event.target.closest(SELECTOR_WRAPPER).querySelectorAll(SELECTOR_LABEL)].forEach((label) =>
+            label.classList.remove(CLASS_SELECTED)
+        );
 
         if (checked) {
             event.currentTarget.classList.add(CLASS_SELECTED);
         }
 
-        radio[methodName]('checked', checked);
+        radio.checked = checked;
 
         if (radio.name === 'add-translation[language]') {
             const modal = event.target.closest(SELECTOR_MODAL);
@@ -25,5 +31,6 @@
         }
     };
 
-    [...doc.querySelectorAll(SELECTOR_LABEL)].forEach(input => input.addEventListener('click', updateSelection, false));
+    resetSelection();
+    [...doc.querySelectorAll(SELECTOR_LABEL)].forEach((input) => input.addEventListener('click', updateSelection, false));
 })(window, document);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29890
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


How problem worked under the hood:
1. user starts adding a new content translation (by clicking (+) button)
2. modal, where the user can select language and base translation, shows up
3. user selects language _A_ and base translation _B_
4. then user closes modal and changes pages
5. user goes back to the previous page using back button; 
because he used back button, browser re-fills previously filled forms including the form with translation language and base translation
5. user starts adding a new content translation, **again**
6. modal shows up, **again**, but now `input.checked` values were already set by the browser. When the user selects some language _C_ we were setting `checked` property using `setAttribute` but this sets only default property, which does not override value from `input.checked` property set by the browser.
8. draft for content of language _A_ based on translation _B_ shows up.

Fixed by changing `input.setAttribute` to `input.checked` and resetting selection at the beginning. 

Conclusion, we should prefer `input.checked = isChecked`, `element.disabled = isDisabled` etc. over `input.setAttribute('checked', isChecked)`, `element.setAttribute('disabled', isChecked)` etc. because `setAttribute` sets default value which is always overwritten by element property if set.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
