### PR TITLE
EZP-29821: Reduce API/SPI lookups in Admin UI

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -56,6 +56,7 @@ services:
             - { name: ezplatform.admin_ui.config_provider, key: 'contentTypes' }
 
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypeNames:
+        deprecated: 'The "%service_id%" service is deprecated. Use "EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypes" instead'
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'contentTypeNames' }
 

--- a/src/lib/Specification/ContentIsUser.php
+++ b/src/lib/Specification/ContentIsUser.php
@@ -34,11 +34,6 @@ class ContentIsUser implements ContentSpecification
      */
     public function isSatisfiedBy(Content $content): bool
     {
-        if (method_exists($this->userService, 'isUser')) {
-            return $this->userService->isUser($content);
-        }
-
-        // @deprecated As of 2.4 UserService should be able to tell us this above
-        return $content->getVersionInfo()->getContentInfo()->contentTypeId === 4;
+        return $this->userService->isUser($content);
     }
 }

--- a/src/lib/Specification/ContentIsUser.php
+++ b/src/lib/Specification/ContentIsUser.php
@@ -10,7 +10,6 @@ namespace EzSystems\EzPlatformAdminUi\Specification;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\UserService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 
 class ContentIsUser implements ContentSpecification
 {

--- a/src/lib/Specification/ContentIsUser.php
+++ b/src/lib/Specification/ContentIsUser.php
@@ -34,12 +34,11 @@ class ContentIsUser implements ContentSpecification
      */
     public function isSatisfiedBy(Content $content): bool
     {
-        try {
-            $this->userService->loadUser($content->id);
-
-            return true;
-        } catch (NotFoundException $e) {
-            return false;
+        if (method_exists($this->userService, 'isUser')) {
+            return $this->userService->isUser($content);
         }
+
+        // @deprecated As of 2.4 UserService should be able to tell us this above
+        return $content->getVersionInfo()->getContentInfo()->contentTypeId === 4;
     }
 }

--- a/src/lib/UI/Config/Provider/ContentTypeNames.php
+++ b/src/lib/UI/Config/Provider/ContentTypeNames.php
@@ -11,7 +11,7 @@ use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 
 /**
- * @deprecated Please move to use ContentTypes so we don't have to load the same data several times.
+ * @deprecated please move to use ContentTypes so we don't have to load the same data several times
  */
 class ContentTypeNames implements ProviderInterface
 {

--- a/src/lib/UI/Config/Provider/ContentTypeNames.php
+++ b/src/lib/UI/Config/Provider/ContentTypeNames.php
@@ -10,6 +10,9 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 
+/**
+ * @deprecated Please move to use ContentTypes so we don't have to load the same data several times.
+ */
 class ContentTypeNames implements ProviderInterface
 {
     /** @var \eZ\Publish\API\Repository\ContentTypeService */

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -33,7 +33,7 @@ class ContentTypes implements ProviderInterface
      */
     public function getConfig()
     {
-        $contentTypeGroups = ['_types' => []];
+        $contentTypeGroups = [];
 
         $preferredLanguages = $this->userLanguagePreferenceProvider->getPreferredLanguages();
         $loadedContentTypeGroups = $this->contentTypeService->loadContentTypeGroups(
@@ -49,7 +49,6 @@ class ContentTypes implements ProviderInterface
                     'identifier' => $contentType->identifier,
                     'name' => $contentType->getName(),
                 ];
-                $contentTypeGroups['_types'][$contentType->identifier] = $contentType->getName();
             }
         }
 

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -33,7 +33,7 @@ class ContentTypes implements ProviderInterface
      */
     public function getConfig()
     {
-        $contentTypeGroups = [];
+        $contentTypeGroups = ['_types' => []];
 
         $preferredLanguages = $this->userLanguagePreferenceProvider->getPreferredLanguages();
         $loadedContentTypeGroups = $this->contentTypeService->loadContentTypeGroups(
@@ -49,6 +49,7 @@ class ContentTypes implements ProviderInterface
                     'identifier' => $contentType->identifier,
                     'name' => $contentType->getName(),
                 ];
+                $contentTypeGroups['_types'][$contentType->identifier] = $contentType->getName();
             }
         }
 

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -41,8 +41,8 @@ class Languages implements ProviderInterface
     public function getConfig(): array
     {
         return [
-            'mappings' => $this->getLanguagesMap(),
-            'priority' => $this->getLanguagesPriority(),
+            'mappings' => $languagesMap = $this->getLanguagesMap(),
+            'priority' => $this->getLanguagesPriority($languagesMap),
         ];
     }
 
@@ -72,9 +72,11 @@ class Languages implements ProviderInterface
      * Next: fallback languages of siteaccesses.
      * Last: languages defined but not used in siteaccesses.
      *
+     * @param array $languagesMap Data from call to getLanguagesMap().
+     *
      * @return array
      */
-    protected function getLanguagesPriority(): array
+    protected function getLanguagesPriority(array $languagesMap): array
     {
         $priority = [];
         $fallback = [];
@@ -88,7 +90,6 @@ class Languages implements ProviderInterface
 
         // Append fallback languages at the end of priority language list
         $languageCodes = array_unique(array_merge($priority, $fallback));
-        $languagesMap = $this->getLanguagesMap();
 
         $languages = array_filter(array_values($languageCodes), function ($languageCode) use ($languagesMap) {
             // Get only Languages defined and enabled in Admin

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -72,7 +72,7 @@ class Languages implements ProviderInterface
      * Next: fallback languages of siteaccesses.
      * Last: languages defined but not used in siteaccesses.
      *
-     * @param array $languagesMap Data from call to getLanguagesMap().
+     * @param array $languagesMap data from call to getLanguagesMap()
      *
      * @return array
      */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29821
| Improvment     | yes
| BC breaks?    | no
| Tests pass?   | ??
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

##### Before:
<img width="697" alt="dashboard_before" src="https://user-images.githubusercontent.com/289757/50356838-ee4da080-0553-11e9-89f1-cbb6c1b7e507.png">

##### After:
<img width="689" alt="dashboard_after" src="https://user-images.githubusercontent.com/289757/50356840-f1489100-0553-11e9-8394-d31f4304638d.png">


##### Done:
- Take advantage of `isUser[Group]()` API's added in 2.4
- Avoid loading language map twice
- Deprecate content type config to just use one
  - Possible todo or followup: Find a way to share the data between the two, could be done on JS side too, once that is done ContentTypeNames can be removed


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
