### PR TITLE
EZP-29967: Content Type name is not translated in AdminUI tables

### DIFF
--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\Tab\Dashboard;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\ContentIsUser;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use Pagerfanta\Pagerfanta;
@@ -26,47 +27,74 @@ class PagerContentToDataMapper
     /** @var UserService */
     protected $userService;
 
+    /** @var UserLanguagePreferenceProviderInterface */
+    private $userLanguagePreferenceProvider;
+
     /**
      * @param ContentService $contentService
      * @param ContentTypeService $contentTypeService
      * @param UserService $userService
+     * @param UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
      */
     public function __construct(
         ContentService $contentService,
         ContentTypeService $contentTypeService,
-        UserService $userService
+        UserService $userService,
+        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
     ) {
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->userService = $userService;
+        $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
     }
 
     /**
      * @param Pagerfanta $pager
      *
      * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function map(Pagerfanta $pager): array
     {
         $data = [];
+        $contentTypeIds = [];
 
         foreach ($pager as $content) {
+            /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
             $contentInfo = $content->getVersionInfo()->getContentInfo();
 
             $contributor = (new UserExists($this->userService))->isSatisfiedBy($contentInfo->ownerId)
                 ? $this->userService->loadUser($contentInfo->ownerId) : null;
 
+            $contentTypeIds[] = $contentInfo->contentTypeId;
             $data[] = [
+                'content' => $content,
+                'contentTypeId' => $contentInfo->contentTypeId,
                 'contentId' => $content->id,
                 'name' => $contentInfo->name,
                 'language' => $contentInfo->mainLanguageCode,
                 'contributor' => $contributor,
                 'version' => $content->versionInfo->versionNo,
-                'type' => $content->getContentType()->getName(),
                 'modified' => $content->versionInfo->modificationDate,
                 'initialLanguageCode' => $content->versionInfo->initialLanguageCode,
                 'content_is_user' => (new ContentIsUser($this->userService))->isSatisfiedBy($content),
             ];
+        }
+
+        // load list of Content Types with proper translated names
+        $contentTypes = $this->contentTypeService->loadContentTypeList(
+            array_unique($contentTypeIds),
+            $this->userLanguagePreferenceProvider->getPreferredLanguages()
+        );
+        foreach ($data as $idx => $item) {
+            /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
+            // get content type from bulk-loaded list or fallback to lazy loaded one if not present
+            $contentType = isset($contentTypes[$item['contentTypeId']])
+                ? $contentTypes[$item['contentTypeId']]
+                : $item['content']->getContentType();
+            $data[$idx]['type'] = $contentType->getName();
+            unset($data[$idx]['content'], $data[$idx]['contentTypeId']);
         }
 
         return $data;

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -26,6 +26,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
@@ -60,6 +61,9 @@ class ValueFactory
     /** @var \EzSystems\EzPlatformAdminUi\UI\Service\PathService */
     protected $pathService;
 
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
+    private $userLanguagePreferenceProvider;
+
     /**
      * @param \eZ\Publish\API\Repository\UserService $userService
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
@@ -70,6 +74,7 @@ class ValueFactory
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      * @param \EzSystems\EzPlatformAdminUi\UI\Service\PathService $pathService
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
+     * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
      */
     public function __construct(
         UserService $userService,
@@ -80,7 +85,8 @@ class ValueFactory
         ObjectStateService $objectStateService,
         PermissionResolver $permissionResolver,
         PathService $pathService,
-        DatasetFactory $datasetFactory
+        DatasetFactory $datasetFactory,
+        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
     ) {
         $this->userService = $userService;
         $this->languageService = $languageService;
@@ -91,6 +97,7 @@ class ValueFactory
         $this->permissionResolver = $permissionResolver;
         $this->pathService = $pathService;
         $this->datasetFactory = $datasetFactory;
+        $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
     }
 
     /**
@@ -250,7 +257,10 @@ class ValueFactory
         return new UIValue\Location\Bookmark(
             $location,
             [
-                'contentType' => $location->getContent()->getContentType(),
+                'contentType' => $this->contentTypeService->loadContentType(
+                    $location->getContentInfo()->contentTypeId,
+                    $this->userLanguagePreferenceProvider->getPreferredLanguages()
+                ),
                 'pathLocations' => $this->pathService->loadPathLocations($location),
                 'userCanEdit' => $this->permissionResolver->canUser('content', 'edit', $location->contentInfo),
             ]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29967
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes several issues of missing Content Type translation in various tables / data grids found in the AdminUI.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Inject translated Content Type into Search results table
- [x]  Inject translated Content Type into Bookmarks table
- [x]  Inject translated Content Type into Trash table
- [x] Ready for Code Review
