### PR TITLE
EZEE-2652: Cannot add Landing page translation via action bar button

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.add.translation.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.add.translation.js
@@ -5,6 +5,10 @@
     const SELECTOR_MODAL = '.ez-modal';
     const resetSelection = () => {
         doc.querySelectorAll(`${SELECTOR_LABEL} .ez-translation__input`).forEach((input) => {
+            if (input.closest('[hidden]')) {
+                return;
+            }
+
             input.checked = false;
         });
     };


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2652
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
