### PR TITLE
Missing getChoiceList method declaration in BaseChoiceLoader

### DIFF
--- a/src/lib/Form/Type/ChoiceList/Loader/BaseChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/BaseChoiceLoader.php
@@ -14,13 +14,20 @@ use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 abstract class BaseChoiceLoader implements ChoiceLoaderInterface
 {
     /**
+     * Returns list of available choices.
+     *
+     * Introduced for simplify decoration.
+     *
+     * @return array
+     */
+    abstract public function getChoiceList(): array;
+
+    /**
      * {@inheritdoc}
      */
     public function loadChoiceList($value = null)
     {
-        $choices = $this->getChoiceList();
-
-        return new ArrayChoiceList($choices, $value);
+        return new ArrayChoiceList($this->getChoiceList(), $value);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added missing getChoiceList method declaration in BaseChoiceLoader. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
