### PR TITLE
EZP-29970: As a Developer I'd like to order components & tabs in Admin UI

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -11,20 +11,22 @@ namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
 use EzSystems\EzPlatformAdminUi\Component\Registry;
 use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception;
 
 class ComponentPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
     const TAG_NAME = 'ezplatform.admin_ui.component';
 
     /**
      * @param ContainerBuilder $container
      *
-     * @throws Exception\InvalidArgumentException
-     * @throws Exception\ServiceNotFoundException
-     * @throws InvalidArgumentException
+     * @throws Exception\InvalidArgumentException When a tag is missing 'group' attribute.
+     * @throws InvalidArgumentException In ContainerBuilder::findTaggedServiceIds() when a service is abstract.
      */
     public function process(ContainerBuilder $container)
     {
@@ -33,15 +35,18 @@ class ComponentPass implements CompilerPassInterface
         }
 
         $registryDefinition = $container->getDefinition(Registry::class);
-        $taggedServiceIds = $container->findTaggedServiceIds(self::TAG_NAME);
+        $services = $this->findAndSortTaggedServices(self::TAG_NAME, $container);
 
-        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+        foreach ($services as $serviceReference) {
+            $id = (string)$serviceReference;
+            $definition = $container->getDefinition($id);
+            $tags = $definition->getTag(static::TAG_NAME);
+
             foreach ($tags as $tag) {
                 if (!isset($tag['group'])) {
                     throw new InvalidArgumentException($taggedServiceId, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
                 }
-
-                $registryDefinition->addMethodCall('addComponent', [$tag['group'], $taggedServiceId, new Reference($taggedServiceId)]);
+                $registryDefinition->addMethodCall('addComponent', [$tag['group'], $id, $serviceReference]);
             }
         }
     }

--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -13,8 +13,6 @@ use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Exception;
 
 class ComponentPass implements CompilerPassInterface
 {
@@ -25,10 +23,10 @@ class ComponentPass implements CompilerPassInterface
     /**
      * @param ContainerBuilder $container
      *
-     * @throws Exception\InvalidArgumentException When a tag is missing 'group' attribute.
-     * @throws InvalidArgumentException In ContainerBuilder::findTaggedServiceIds() when a service is abstract.
+     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException When a service is abstract
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException When a tag is missing 'group' attribute
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(Registry::class)) {
             return;

--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -42,7 +42,7 @@ class ComponentPass implements CompilerPassInterface
 
             foreach ($tags as $tag) {
                 if (!isset($tag['group'])) {
-                    throw new InvalidArgumentException($taggedServiceId, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
+                    throw new InvalidArgumentException($id, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
                 }
                 $registryDefinition->addMethodCall('addComponent', [$tag['group'], $id, $serviceReference]);
             }

--- a/src/bundle/DependencyInjection/Compiler/TabPass.php
+++ b/src/bundle/DependencyInjection/Compiler/TabPass.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabRegistry;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -16,10 +17,15 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TabPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
     const TAG_TAB = 'ezplatform.tab';
 
     /**
      * @param ContainerBuilder $container
+     *
+     * @throws Exception\InvalidArgumentException When a tag is missing 'group' attribute.
+     * @throws InvalidArgumentException In ContainerBuilder::findTaggedServiceIds() when a service is abstract.
      */
     public function process(ContainerBuilder $container): void
     {
@@ -28,14 +34,18 @@ class TabPass implements CompilerPassInterface
         }
 
         $tabRegistryDefinition = $container->getDefinition(TabRegistry::class);
-        $tabIds = $container->findTaggedServiceIds(static::TAG_TAB);
+        $services = $this->findAndSortTaggedServices(static::TAG_TAB, $container);
 
-        foreach ($tabIds as $id => $tab) {
-            $tabDefinition = $container->getDefinition($id);
-            $tag = $tabDefinition->getTag(static::TAG_TAB);
+        foreach ($services as $serviceReference) {
+            $id = (string)$serviceReference;
+            $definition = $container->getDefinition($id);
+            $tags = $definition->getTag(static::TAG_TAB);
 
-            foreach (array_column($tag, 'group') as $group) {
-                $tabRegistryDefinition->addMethodCall('addTab', [new Reference($id), $group]);
+            foreach ($tags as $tag) {
+                if (!isset($tag['group'])) {
+                    throw new InvalidArgumentException($taggedServiceId, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
+                }
+                $tabRegistryDefinition->addMethodCall('addTab', [$serviceReference, $tag['group']]);
             }
         }
     }

--- a/src/bundle/DependencyInjection/Compiler/TabPass.php
+++ b/src/bundle/DependencyInjection/Compiler/TabPass.php
@@ -42,7 +42,7 @@ class TabPass implements CompilerPassInterface
 
             foreach ($tags as $tag) {
                 if (!isset($tag['group'])) {
-                    throw new InvalidArgumentException($taggedServiceId, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
+                    throw new InvalidArgumentException($id, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
                 }
                 $tabRegistryDefinition->addMethodCall('addTab', [$serviceReference, $tag['group']]);
             }

--- a/src/bundle/DependencyInjection/Compiler/TabPass.php
+++ b/src/bundle/DependencyInjection/Compiler/TabPass.php
@@ -4,17 +4,16 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabRegistry;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * {@inheritdoc}
- */
 class TabPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
@@ -24,8 +23,8 @@ class TabPass implements CompilerPassInterface
     /**
      * @param ContainerBuilder $container
      *
-     * @throws Exception\InvalidArgumentException When a tag is missing 'group' attribute.
-     * @throws InvalidArgumentException In ContainerBuilder::findTaggedServiceIds() when a service is abstract.
+     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException When a service is abstract
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException When a tag is missing 'group' attribute
      */
     public function process(ContainerBuilder $container): void
     {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29970 Also fixes #501
| Improvment     | yes
| BC breaks?    |  no
| Tests pass?   | ? (maybe)
| Doc needed?   | yes
| Branch   | 1.4
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Avoids having to mess around with event listener, and fight `ezplatform-workflow`, allows to use priority for sorting.

On the nitpick side, ideally the PriorityTaggedServiceTrait should have had method giving plain id /tags structure back like `findTaggedServiceIds` does, to avoid the `getDefinition()` and `getTag()` call. But unless we try to contribute that...


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
