### PR TITLE
ezdatetime displays selected date and timeon calendar after clearing the field

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -1,11 +1,11 @@
-(function (global) {
+(function(global, doc, eZ, flatpickr) {
     const SELECTOR_FIELD = '.ez-field-edit--ezdate';
     const SELECTOR_INPUT = '.ez-data-source__input:not(.flatpickr-input)';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
     const SELECTOR_FLATPICKR_INPUT = '.flatpickr-input';
     const EVENT_VALUE_CHANGED = 'valueChanged';
 
-    class EzDateValidator extends global.eZ.BaseFieldValidator {
+    class EzDateValidator extends eZ.BaseFieldValidator {
         /**
          * Validates the input
          *
@@ -24,12 +24,12 @@
 
             if (isRequired && isEmpty) {
                 isError = true;
-                errorMessage = window.eZ.errors.emptyField.replace('{fieldName}', label);
+                errorMessage = eZ.errors.emptyField.replace('{fieldName}', label);
             }
 
             return {
                 isError,
-                errorMessage
+                errorMessage,
             };
         }
     }
@@ -52,18 +52,16 @@
                 errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 invalidStateSelectors: [SELECTOR_FLATPICKR_INPUT],
             },
-        ]
+        ],
     });
 
     validator.init();
 
-    global.eZ.fieldTypeValidators = global.eZ.fieldTypeValidators ?
-        [...global.eZ.fieldTypeValidators, validator] :
-        [validator];
+    eZ.fieldTypeValidators = eZ.fieldTypeValidators ? [...eZ.fieldTypeValidators, validator] : [validator];
 
-    const dateFields = [...document.querySelectorAll(SELECTOR_FIELD)];
+    const dateFields = [...doc.querySelectorAll(SELECTOR_FIELD)];
     const dateConfig = {
-        formatDate: (date) => (new Date(date)).toLocaleDateString()
+        formatDate: (date) => new Date(date).toLocaleDateString(),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);
@@ -91,19 +89,25 @@
             defaultDate = new Date(sourceInput.value * 1000);
         }
 
-        btnClear.addEventListener('click', (event) => {
-            event.preventDefault();
+        btnClear.addEventListener(
+            'click',
+            (event) => {
+                event.preventDefault();
 
-            flatPickrInput.value = '';
-            sourceInput.value = '';
+                flatPickrInput._flatpickr.clear();
 
-            sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
-        }, false);
+                sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
+            },
+            false
+        );
 
-        window.flatpickr(flatPickrInput, Object.assign({}, dateConfig, {
-            onChange: updateInputValue.bind(null, sourceInput),
-            defaultDate
-        }));
+        flatpickr(
+            flatPickrInput,
+            Object.assign({}, dateConfig, {
+                onChange: updateInputValue.bind(null, sourceInput),
+                defaultDate,
+            })
+        );
 
         if (sourceInput.hasAttribute('required')) {
             flatPickrInput.setAttribute('required', true);
@@ -111,4 +115,4 @@
     };
 
     dateFields.forEach(initFlatPickr);
-})(window);
+})(window, window.document, window.eZ, window.flatpickr);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -79,40 +79,27 @@
         sourceInput.value = Math.floor(date.getTime() / 1000);
         sourceInput.dispatchEvent(event);
     };
+    const clearValue = (sourceInput, flatpickrInstance, event) => {
+        event.preventDefault();
+
+        flatpickrInstance.clear();
+
+        sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
+    };
     const initFlatPickr = (field) => {
         const sourceInput = field.querySelector(SELECTOR_INPUT);
         const flatPickrInput = field.querySelector(SELECTOR_FLATPICKR_INPUT);
         const btnClear = field.querySelector('.ez-data-source__btn--clear-input');
-        let flatpickrInstance = null;
-        let defaultDate;
-
-        if (sourceInput.value) {
-            defaultDate = new Date(sourceInput.value * 1000);
-        }
-
-        btnClear.addEventListener(
-            'click',
-            (event) => {
-                event.preventDefault();
-
-                if (!flatpickrInstance) {
-                    return;
-                }
-
-                flatpickrInstance.clear();
-
-                sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
-            },
-            false
-        );
-
-        flatpickrInstance = flatpickr(
+        const defaultDate = sourceInput.value ? new Date(sourceInput.value * 1000) : null;
+        const flatpickrInstance = flatpickr(
             flatPickrInput,
             Object.assign({}, dateConfig, {
                 onChange: updateInputValue.bind(null, sourceInput),
                 defaultDate,
             })
         );
+
+        btnClear.addEventListener('click', clearValue.bind(null, sourceInput, flatpickrInstance), false);
 
         if (sourceInput.hasAttribute('required')) {
             flatPickrInput.setAttribute('required', true);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -83,6 +83,7 @@
         const sourceInput = field.querySelector(SELECTOR_INPUT);
         const flatPickrInput = field.querySelector(SELECTOR_FLATPICKR_INPUT);
         const btnClear = field.querySelector('.ez-data-source__btn--clear-input');
+        let flatpickrInstance = null;
         let defaultDate;
 
         if (sourceInput.value) {
@@ -94,14 +95,18 @@
             (event) => {
                 event.preventDefault();
 
-                flatPickrInput._flatpickr.clear();
+                if (!flatpickrInstance) {
+                    return;
+                }
+
+                flatpickrInstance.clear();
 
                 sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
             },
             false
         );
 
-        flatpickr(
+        flatpickrInstance = flatpickr(
             flatPickrInput,
             Object.assign({}, dateConfig, {
                 onChange: updateInputValue.bind(null, sourceInput),

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -1,11 +1,11 @@
-(function (global) {
+(function(global, doc, eZ, flatpickr) {
     const SELECTOR_FIELD = '.ez-field-edit--ezdatetime';
     const SELECTOR_INPUT = '.ez-data-source__input[data-seconds]';
     const SELECTOR_FLATPICKR_INPUT = '.flatpickr-input';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
     const EVENT_VALUE_CHANGED = 'valueChanged';
 
-    class EzDateTimeValidator extends global.eZ.BaseFieldValidator {
+    class EzDateTimeValidator extends eZ.BaseFieldValidator {
         /**
          * Validates the input
          *
@@ -24,15 +24,15 @@
 
             if (isRequired && isEmpty) {
                 isError = true;
-                errorMessage = window.eZ.errors.emptyField.replace('{fieldName}', label);
+                errorMessage = eZ.errors.emptyField.replace('{fieldName}', label);
             }
 
             return {
                 isError,
-                errorMessage
+                errorMessage,
             };
         }
-    };
+    }
 
     const validator = new EzDateTimeValidator({
         classInvalid: 'is-invalid',
@@ -57,15 +57,13 @@
 
     validator.init();
 
-    global.eZ.fieldTypeValidators = global.eZ.fieldTypeValidators ?
-        [...global.eZ.fieldTypeValidators, validator] :
-        [validator];
+    eZ.fieldTypeValidators = eZ.fieldTypeValidators ? [...eZ.fieldTypeValidators, validator] : [validator];
 
-    const datetimeFields = [...document.querySelectorAll(SELECTOR_FIELD)];
+    const datetimeFields = [...doc.querySelectorAll(SELECTOR_FIELD)];
     const datetimeConfig = {
         enableTime: true,
         time_24hr: true,
-        formatDate: (date) => (new Date(date)).toLocaleString()
+        formatDate: (date) => new Date(date).toLocaleString(),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);
@@ -92,20 +90,26 @@
             defaultDate = new Date(sourceInput.value * 1000);
         }
 
-        btnClear.addEventListener('click', (event) => {
-            event.preventDefault();
+        btnClear.addEventListener(
+            'click',
+            (event) => {
+                event.preventDefault();
 
-            flatPickrInput.value = '';
-            sourceInput.value = '';
+                flatPickrInput._flatpickr.clear();
 
-            sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
-        }, false);
+                sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
+            },
+            false
+        );
 
-        window.flatpickr(flatPickrInput, Object.assign({}, datetimeConfig, {
-            onChange: updateInputValue.bind(null, sourceInput),
-            defaultDate,
-            enableSeconds: !!parseInt(sourceInput.dataset.seconds, 10),
-        }));
+        flatpickr(
+            flatPickrInput,
+            Object.assign({}, datetimeConfig, {
+                onChange: updateInputValue.bind(null, sourceInput),
+                defaultDate,
+                enableSeconds: !!parseInt(sourceInput.dataset.seconds, 10),
+            })
+        );
 
         if (sourceInput.hasAttribute('required')) {
             flatPickrInput.setAttribute('required', true);
@@ -113,4 +117,4 @@
     };
 
     datetimeFields.forEach(initFlatPickr);
-})(window);
+})(window, window.document, window.eZ, window.flatpickr);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -80,34 +80,19 @@
 
         sourceInput.dispatchEvent(event);
     };
+    const clearValue = (sourceInput, flatpickrInstance, event) => {
+        event.preventDefault();
+
+        flatpickrInstance.clear();
+
+        sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
+    };
     const initFlatPickr = (field) => {
         const sourceInput = field.querySelector(SELECTOR_INPUT);
         const flatPickrInput = field.querySelector(SELECTOR_FLATPICKR_INPUT);
         const btnClear = field.querySelector('.ez-data-source__btn--clear-input');
-        let flatpickrInstance = null;
-        let defaultDate;
-
-        if (sourceInput.value) {
-            defaultDate = new Date(sourceInput.value * 1000);
-        }
-
-        btnClear.addEventListener(
-            'click',
-            (event) => {
-                event.preventDefault();
-
-                if (!flatpickrInstance) {
-                    return;
-                }
-
-                flatpickrInstance.clear();
-
-                sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
-            },
-            false
-        );
-
-        flatpickrInstance = flatpickr(
+        const defaultDate = sourceInput.value ? new Date(sourceInput.value * 1000) : null;
+        const flatpickrInstance = flatpickr(
             flatPickrInput,
             Object.assign({}, datetimeConfig, {
                 onChange: updateInputValue.bind(null, sourceInput),
@@ -115,6 +100,8 @@
                 enableSeconds: !!parseInt(sourceInput.dataset.seconds, 10),
             })
         );
+
+        btnClear.addEventListener('click', clearValue.bind(null, sourceInput, flatpickrInstance), false);
 
         if (sourceInput.hasAttribute('required')) {
             flatPickrInput.setAttribute('required', true);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -84,6 +84,7 @@
         const sourceInput = field.querySelector(SELECTOR_INPUT);
         const flatPickrInput = field.querySelector(SELECTOR_FLATPICKR_INPUT);
         const btnClear = field.querySelector('.ez-data-source__btn--clear-input');
+        let flatpickrInstance = null;
         let defaultDate;
 
         if (sourceInput.value) {
@@ -95,14 +96,18 @@
             (event) => {
                 event.preventDefault();
 
-                flatPickrInput._flatpickr.clear();
+                if (!flatpickrInstance) {
+                    return;
+                }
+
+                flatpickrInstance.clear();
 
                 sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
             },
             false
         );
 
-        flatpickr(
+        flatpickrInstance = flatpickr(
             flatPickrInput,
             Object.assign({}, datetimeConfig, {
                 onChange: updateInputValue.bind(null, sourceInput),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29783
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fix clearing of date/datetime in ezdate & ezdatetime. Clear should clear both input element and date selected in calendar view.

Most of the changes were caused by formatting files with Prettier + changes in IIFE parameters.
The Problem was fixed by changing:
```js
flatPickrInput.value = '';	                 
sourceInput.value = '';
```
to
```js
flatPickrInput._flatpickr.clear();
```
in both files.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
