### PR TITLE
EZP-29982: The IsContainer method does not need arguments after the developer has access to ContentType on Content

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -315,7 +315,7 @@ class ContentViewController extends Controller
             ]);
         }
 
-        $isContainer = new IsContainer($this->contentTypeService);
+        $isContainer = new IsContainer();
         $hasChildren = new HasChildren($this->locationService);
 
         if ($isContainer->and($hasChildren)->isSatisfiedBy($location)) {

--- a/src/lib/Form/Type/Location/LocationTrashContainerType.php
+++ b/src/lib/Form/Type/Location/LocationTrashContainerType.php
@@ -118,7 +118,7 @@ class LocationTrashContainerType extends AbstractType
             return;
         }
 
-        $isContainer = new IsContainer($this->contentTypeService);
+        $isContainer = new IsContainer();
         $hasChildren = new HasChildren($this->locationService);
 
         if (!$isContainer->and($hasChildren)->isSatisfiedBy($location)) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29982
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
