### PR TITLE
EZP-29811: Content field definitions is misaligned while creating Content Type

### DIFF
--- a/src/bundle/Resources/public/scss/_card.scss
+++ b/src/bundle/Resources/public/scss/_card.scss
@@ -34,15 +34,12 @@
             padding: .25rem 1.25rem;
             justify-content: space-between;
             z-index: 1040;
+        }
 
-            .form-inline {
-                .btn-danger {
-                    .ez-icon {
-                        width: 1.5rem;
-                        height: 1.5rem;
-                        margin-top: 5px;
-                    }
-                }
+        .form-inline {
+            .btn-danger {
+                display: flex;
+                height: calculateRem(48px);
             }
         }
     }

--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -69,18 +69,6 @@
     }
 }
 
-.ez-card__header {
-    .form-inline {
-        .btn-danger {
-            .ez-icon {
-                width: 1.2rem;
-                height: 1.2rem;
-                fill: $white;
-            }
-        }
-    }
-}
-
 .ez-btn--extra-actions {
     .ez-icon {
         pointer-events: none;

--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -6,7 +6,7 @@
 
 {% block _ezrepoforms_contenttype_update_removeFieldDefinition_widget %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
-        <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-trash">
+        <svg class="ez-icon ez-icon--medium ez-icon--light">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>

--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -6,7 +6,7 @@
 
 {% block _ezrepoforms_contenttype_update_removeFieldDefinition_widget %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
-        <svg class="ez-icon ez-icon-trash">
+        <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-trash">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
         </svg>
     </button>
@@ -53,7 +53,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="ez-card__header ez-card__header--secondary d-flex justify-content-between">
-                <div class="p-2">
+                <div class="p-3">
                     {{ 'content_type.view.create.content_field_definitions'|trans|desc('Content field definitions') }}
                 </div>
                 <div class="form-inline">

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -60,7 +60,7 @@
                             class="btn btn-danger"
                             data-toggle="modal"
                             data-target="#delete-content-type-modal">
-                        <svg class="ez-icon">
+                        <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-trash">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -60,7 +60,7 @@
                             class="btn btn-danger"
                             data-toggle="modal"
                             data-target="#delete-content-type-modal">
-                        <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-trash">
+                        <svg class="ez-icon ez-icon--medium ez-icon--light">
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
                         </svg>
                     </button>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29811
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


## Fixes button styling. After changes:
![screen shot 2019-01-07 at 08 38 43](https://user-images.githubusercontent.com/10233057/50755612-d5363680-1259-11e9-8f03-3b70b16ef198.png)

![screen shot 2019-01-07 at 08 45 22](https://user-images.githubusercontent.com/10233057/50755613-d5363680-1259-11e9-9734-c681c61b8f7e.png)
