### PR TITLE
EZP-29914: When translating the Content Type disable 'Select item' button for Content Relation (Single and Multi)

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -24,8 +24,8 @@
 {% block form %}
     {{ form_start(form) }}
     {% set language_code = language_code|default(content_type.mainLanguageCode) %}
-
-    {% if language_code != content_type.mainLanguageCode %}
+    {% set is_translation = form.vars.data.languageCode != content_type.mainLanguageCode %}
+    {% if is_translation %}
         {% include '@ezdesign/admin/content_type/parts/nontranslatable_fields_disabled.html.twig' %}
     {% endif %}
     <section class="container mt-4 px-5">
@@ -110,7 +110,8 @@
                             {{ ez_render_fielddefinition_edit(value, {
                                 'languageCode': language_code,
                                 'form': field_definition,
-                                'group_class': value.group_class|default('')
+                                'group_class': value.group_class|default(''),
+                                'is_translation': is_translation,
                             }) }}
 
                             {# Default rendering #}

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -121,9 +121,9 @@
 {% endblock %}
 
 {% block ezobjectrelation_field_definition_edit %}
+    {% set is_translation = is_translation ?? false %}
     <div class="ezobjectrelation-settings selection-root">
         {{- form_row(form.selectionRoot) -}}
-
         <div class="mt-1">
             <button
                 data-universaldiscovery-title="{{ "field_definition.ezobjectrelation.selection_root_udw_title"
@@ -134,6 +134,7 @@
                 data-relation-selected-root-name-selector="#{{ form.selectionRoot.vars.id }}-selected-root-name"
                 data-starting-location-id="{{ admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single', {}) }}"
+                {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelation.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select item") }}</button>
@@ -151,6 +152,7 @@
 {% endblock %}
 
 {% block ezobjectrelationlist_field_definition_edit %}
+    {% set is_translation = is_translation ?? false %}
     <div class="ezobjectrelationlist-settings selection-default-location">
         {{- form_row(form.selectionDefaultLocation) -}}
 
@@ -164,6 +166,7 @@
                 data-relation-selected-root-name-selector="#{{ form.selectionDefaultLocation.vars.id }}-selected-root-name"
                 data-starting-location-id="{{ admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+                {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelationlist.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select location") }}</button>

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -194,6 +194,7 @@
 {% endblock %}
 
 {% block ezselection_field_definition_edit %}
+    {% set is_translation = is_translation ?? false %}
     <div class="ezselection-settings is-multiple{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_row(form.isMultiple, {'label_attr': {'class': 'checkbox-inline ez-label'}}) -}}
     </div>
@@ -206,7 +207,10 @@
             data-selection-buttons=".ezselection-settings-option-remove">
             {% for option in form.options %}
                 <li class="ezselection-settings-option-value ez-selection-table-row mb-2 d-flex align-items-center">
-                    <input type="checkbox" class="ezselection-settings-option-checkbox ez-selection-table-checkbox">
+                    <input
+                        type="checkbox"
+                        class="ezselection-settings-option-checkbox ez-selection-table-checkbox"
+                        {{ is_translation ? 'disabled' : '' }}>
                     {{ form_errors(option) }}
                     {{ form_widget(option, { 'attr': { 'class': 'form-control ml-1 mb-0'}}) }}
                 </li>
@@ -225,7 +229,8 @@
         <div class="ezselection-settings-toolbar">
             <button
                 type="button"
-                class="ezselection-settings-option-add ez-font-icon ez-button btn btn-secondary ez-button-add pure-button">
+                class="ezselection-settings-option-add ez-font-icon ez-button btn btn-secondary ez-button-add pure-button"
+                {{ is_translation ? 'disabled' : '' }}>
                 {{ "field_definition.ezselection.add_option"|trans({}, "ezrepoforms_content_type")|desc("Add an option") }}
             </button>
             <button


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29914
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
