### PR TITLE
EZP-29779: [Safari] Nothing responds after using web browser back button

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -5,9 +5,9 @@
         <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
         <script>
-            const ua = navigator.userAgent.toLowerCase();
+            const userAgent = navigator.userAgent.toLowerCase();
 
-            if (ua.indexOf('chrome') < 0 && ua.indexOf('safari') >= 0) {
+            if (userAgent.indexOf('chrome') < 0 && userAgent.indexOf('safari') >= 0) {
                 window.onpageshow = (event) => {
                     if (event.persisted) {
                         document.body.classList.remove('ez-prevent-click');

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -5,6 +5,17 @@
         <meta name="CSRF-Token" content="{{ csrf_token('authenticate') }}" />
         <meta name="SiteAccess" content="{{ app.request.get('siteaccess').name }}" />
         <script>
+            const ua = navigator.userAgent.toLowerCase();
+
+            if (ua.indexOf('chrome') < 0 && ua.indexOf('safari') >= 0) {
+                window.onpageshow = (event) => {
+                    if (event.persisted) {
+                        document.body.classList.remove('ez-prevent-click');
+                    }
+                };
+            }
+        </script>
+        <script>
             window.eZ = {
                 addConfig: (path, value, shouldMerge = false) => {
                     const keys = path.split('.');


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29779
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When the back button is used in Safari, the `onload` event isn't called and the whole UI freezes. This PR contains workaround which is just about removing `ez-prevent-click` class from the `<body>` element.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
