### PR TITLE
EZP-29999: As an editor, I want to see custom icons for content types

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -127,6 +127,7 @@
                         attrs: Object.assign({}, mfuAttrs, {
                             onPopupClose: (itemsUploaded) => itemsUploaded.length && global.location.reload(true),
                             contentCreatePermissionsConfig: JSON.parse(container.dataset.mfuCreatePermissionsConfig),
+                            contentTypesMap,
                         }),
                     },
                 ],

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -113,6 +113,13 @@
             return total;
         }, {});
         const udwConfigBulkMoveItems = JSON.parse(container.dataset.udwConfigBulkMoveItems);
+        const mfuContentTypesMap = Object.values(eZ.adminUiConfig.contentTypes).reduce((contentTypeDataMap, contentTypeGroup) => {
+            for (const contentTypeData of contentTypeGroup) {
+                contentTypeDataMap[contentTypeData.href] = contentTypeData;
+            }
+
+            return contentTypeDataMap;
+        }, {});
 
         ReactDOM.render(
             React.createElement(eZ.modules.SubItems, {
@@ -127,7 +134,7 @@
                         attrs: Object.assign({}, mfuAttrs, {
                             onPopupClose: (itemsUploaded) => itemsUploaded.length && global.location.reload(true),
                             contentCreatePermissionsConfig: JSON.parse(container.dataset.mfuCreatePermissionsConfig),
-                            contentTypesMap,
+                            contentTypesMap: mfuContentTypesMap,
                         }),
                     },
                 ],

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -1,9 +1,9 @@
 .ez-extra-actions {
     $block: '.ez-extra-actions';
 
-    border-radius: 8px;
-    border: 6px solid $ez-color-secondary;
-    width: 300px;
+    border-radius: calculateRem(8px);
+    border: calculateRem(6px) solid $ez-color-secondary;
+    width: calculateRem(300px);
 
     &__action {
         display: block;
@@ -11,9 +11,9 @@
         border: 0 none;
         width: 100%;
         text-align: left;
-        border-radius: 4px;
-        padding: 0 16px;
-        line-height: 45px;
+        border-radius: calculateRem(4px);
+        padding: 0 calculateRem(16px);
+        line-height: calculateRem(45px);
         background: $ez-white;
         color: $ez-color-secondary;
         text-decoration: none;
@@ -38,19 +38,19 @@
     }
 
     &__action + &__action {
-        margin-top: 8px;
+        margin-top: calculateRem(8px);
     }
 
     &__header {
-        line-height: 45px;
+        line-height: calculateRem(45px);
         color: $ez-white;
-        padding: 0 8px;
+        padding: 0 calculateRem(8px);
         font-weight: 700;
     }
 
     &__content {
         background: $ez-ground-base-dark;
-        max-height: 300px;
+        max-height: calculateRem(300px);
         overflow: auto;
 
         .form-group {
@@ -61,11 +61,11 @@
     &--edit-user,
     &--edit {
         #{$block}__content {
-            padding: 8px;
+            padding: calculateRem(8px);
         }
 
         #{$block}__form-values {
-            max-height: 150px;
+            max-height: calculateRem(150px);
             overflow: auto;
         }
 
@@ -75,15 +75,15 @@
             border: 0 none;
             width: 100%;
             text-align: left;
-            border-radius: 4px;
-            padding: 0 16px;
-            line-height: 45px;
+            border-radius: calculateRem(4px);
+            padding: 0 calculateRem(16px);
+            line-height: calculateRem(45px);
             background: $ez-white;
             text-decoration: none;
             cursor: pointer;
             transition: all 0.2s $ez-admin-transition;
             margin-bottom: 0;
-            font-size: 0.9375rem;
+            font-size: calculateRem(15px);
 
             &:hover,
             &:focus {
@@ -97,7 +97,7 @@
             }
 
             &:not(:last-child) {
-                margin-bottom: 0.5rem;
+                margin-bottom: calculateRem(8px);
             }
 
             &-label {
@@ -115,15 +115,15 @@
 
     &__section-header {
         background: $ez-ground-base-dark;
-        padding: 0.25rem 0 0.25rem 0.5rem;
-        font-size: 0.9375rem;
+        padding: calculateRem(4px) 0 calculateRem(4px) calculateRem(8px);
+        font-size: calculateRem(15px);
         font-weight: 700;
     }
 
     &__section-content {
         background: $ez-white;
-        padding: 1rem 0.5rem;
-        font-size: 0.9375rem;
+        padding: 1rem calculateRem(8px);
+        font-size: calculateRem(15px);
 
         select {
             display: inline-block;
@@ -160,7 +160,7 @@
             &-label {
                 margin: 0;
                 display: block;
-                padding-left: 1.5rem;
+                padding-left: calculateRem(40px);
             }
 
             &-input[type='radio'] {
@@ -178,10 +178,10 @@
     &::after {
         content: '';
         position: absolute;
-        height: 40px;
-        width: 10px;
-        top: 30px;
-        right: -6px;
+        height: calculateRem(40px);
+        width: calculateRem(10px);
+        top: calculateRem(30px);
+        right: calculateRem(-6px);
         transform: translate(100%, -50%);
         z-index: 0;
         background: $ez-color-secondary;
@@ -194,13 +194,13 @@
         left: 0;
         z-index: 2;
         opacity: 1;
-        transform: translate(calc(-100% - 10px), 0) scaleX(1);
+        transform: translate(calc(-100% - #{calculateRem(10px)}), 0) scaleX(1);
         transform-origin: right center;
         transition: all 0.2s $ez-admin-transition;
 
         &--hidden {
             opacity: 0;
-            transform: translate(calc(-100% - 15px), 0) scaleX(0);
+            transform: translate(calc(-100% - #{calculateRem(15px)}), 0) scaleX(0);
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_instant-filter.scss
+++ b/src/bundle/Resources/public/scss/_instant-filter.scss
@@ -8,21 +8,33 @@
 .ez-extra-actions--create {
     .ez-instant-filter {
         &__group-name {
-            padding-left: .5rem;
+            padding-left: calculateRem(8px);
         }
 
         &__input-wrapper {
-            padding: 1rem .5rem;
+            padding: calculateRem(16px) calculateRem(8px);
         }
 
         &__group-item {
+            position: relative;
+
             label {
                 cursor: pointer;
+            }
+
+            .ez-icon {
+                fill: $ez-black;
+                position: absolute;
+                top: 0;
+                left: calculateRem(20px);
+                width: calculateRem(16px);
+                height: calculateRem(16px);
+                margin-top: calculateRem(3px);
             }
         }
 
         &__items {
-            max-height: 200px;
+            max-height: calculateRem(200px);
             overflow: auto;
         }
     }

--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -4,16 +4,26 @@
         justify-content: space-between;
         background-color: $ez-ground-primary;
         align-items: center;
-        padding: 0 1.25rem;
-        min-height: 50px;
-        border-radius: .25rem .25rem 0 0;
+        padding: 0 calculateRem(20px);
+        min-height: calculateRem(50px);
+        border-radius: calculateRem(4px) calculateRem(4px) 0 0;
     }
 
     &__headline {
-        font-size: 1.0625rem;
+        font-size: calculateRem(17px);
         margin-bottom: 0;
         font-weight: bold;
         color: $ez-black;
+    }
+
+    &__header-cell {
+        .table &--has-icon {
+            padding: 0;
+        }
+
+        .table &--after-icon {
+            padding-left: 0;
+        }
     }
 
     &__cell {
@@ -22,16 +32,28 @@
         }
 
         .table &--has-action-btns {
-            padding-right: 1.25rem;
+            padding-right: calculateRem(20px);
         }
 
         &--has-checkbox {
             width: 5%;
         }
 
+        .table &--has-icon {
+            padding: 0 calculateRem(8px);
+            width: calculateRem(24px);
+            text-align: right;
+            vertical-align: middle;
+            line-height: 0;
+        }
+
+        .table &--after-icon {
+            padding-left: 0;
+        }
+
         &--no-content {
-            margin-bottom: 3rem;
-            padding: 0.75rem 1rem;
+            margin-bottom: calculateRem(48px);
+            padding: calculateRem(12px) calculateRem(16px);
             background-color: $ez-white;
             font-style: italic;
             color: $ez-color-base-dark;
@@ -48,12 +70,12 @@
     justify-content: space-between;
     background-color: $ez-ground-primary;
     align-items: center;
-    padding: 0 1.25rem;
-    min-height: 50px;
-    border-radius: .25rem .25rem 0 0;
+    padding: 0 calculateRem(20px);
+    min-height: calculateRem(50px);
+    border-radius: calculateRem(4px) calculateRem(4px) 0 0;
 
     &__headline {
-        font-size: 1.0625rem;
+        font-size: calculateRem(17px);
         margin-bottom: 0;
         font-weight: bold;
         color: $ez-black;
@@ -65,20 +87,21 @@
 }
 
 .table {
-    margin-bottom: 3rem;
+    margin-bottom: calculateRem(48px);
 
-    th, td {
-        padding: .7rem 1.4rem;
-        line-height: 20px;
+    th,
+    td {
+        padding: calculateRem(11px) calculateRem(22px);
+        line-height: calculateRem(20px);
     }
 
     thead th {
-        font-size: .9375rem;
+        font-size: calculateRem(15px);
         vertical-align: top;
     }
 
     td {
-        font-size: .875rem;
+        font-size: calculateRem(14px);
         vertical-align: middle;
 
         .checkbox label {
@@ -109,11 +132,11 @@
 }
 
 .ez-table-no-content {
-    margin-bottom: 3rem;
-    padding: 0.75rem 1rem;
+    margin-bottom: calculateRem(48px);
+    padding: calculateRem(12px) calculateRem(16px);
     background-color: $ez-white;
     font-style: italic;
-    font-size: .875rem;
+    font-size: calculateRem(14px);
     color: $ez-color-base-dark;
 }
 

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -29,11 +29,12 @@
                     <table class="ez-table table">
                         <thead>
                         <tr>
-                            <th></th>
-                            <th>{{ 'bookmark.list.name'|trans|desc('Name') }}</th>
-                            <th>{{ 'bookmark.list.content_type'|trans|desc('Content Type') }}</th>
-                            <th>{{ 'bookmark.list.path'|trans|desc('Path') }}</th>
-                            <th></th>
+                            <th class="ez-table__header-cell"></th>
+                            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'bookmark.list.name'|trans|desc('Name') }}</th>
+                            <th class="ez-table__header-cell">{{ 'bookmark.list.content_type'|trans|desc('Content Type') }}</th>
+                            <th class="ez-table__header-cell">{{ 'bookmark.list.path'|trans|desc('Path') }}</th>
+                            <th class="ez-table__header-cell"></th>
                         </tr>
                         </thead>
                         <tbody>
@@ -47,7 +48,12 @@
                         {% for bookmark in pager.currentPageResults %}
                             <tr>
                                 <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form_remove.bookmarks[bookmark.id]) }}</td>
-                                <td class="ez-table__cell"><a href="{{ path('_ezpublishLocation', { 'locationId': bookmark.id }) }}">{{ ez_content_name(bookmark.contentInfo) }}</a></td>
+                                <td class="ez-table__cell ez-table__cell--has-icon">
+                                    <svg class="ez-icon ez-icon--medium">
+                                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(bookmark.contentType) }}"></use>
+                                    </svg>
+                                </td>
+                                <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ path('_ezpublishLocation', { 'locationId': bookmark.id }) }}">{{ ez_content_name(bookmark.contentInfo) }}</a></td>
                                 <td class="ez-table__cell">{{ bookmark.contentType.name }}</td>
                                 <td class="ez-table__cell">
                                     {% if bookmark.pathLocations|length > 1 %}

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -50,7 +50,7 @@
                                 <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form_remove.bookmarks[bookmark.id]) }}</td>
                                 <td class="ez-table__cell ez-table__cell--has-icon">
                                     <svg class="ez-icon ez-icon--medium">
-                                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(bookmark.contentType) }}"></use>
+                                        <use xlink:href="{{ ez_content_type_icon(bookmark.contentType.identifier) }}"></use>
                                     </svg>
                                 </td>
                                 <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ path('_ezpublishLocation', { 'locationId': bookmark.id }) }}">{{ ez_content_name(bookmark.contentInfo) }}</a></td>

--- a/src/bundle/Resources/views/admin/content_draft/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_draft/list.html.twig
@@ -68,7 +68,7 @@
                                     </td>
                                     <td class="ez-table__cell ez-table__cell--has-icon">
                                         <svg class="ez-icon ez-icon--medium">
-                                            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                                            <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                                         </svg>
                                     </td>
                                     <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>

--- a/src/bundle/Resources/views/admin/content_draft/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_draft/list.html.twig
@@ -40,13 +40,14 @@
                     <table class="ez-table table">
                         <thead>
                             <tr>
-                                <th></th>
-                                <th>{{ 'drafts.list.name'|trans|desc('Name') }}</th>
-                                <th>{{ 'drafts.list.content_type'|trans|desc('Content Type') }}</th>
-                                <th>{{ 'drafts.list.modified_language'|trans|desc('Modified Language') }}</th>
-                                <th>{{ 'drafts.list.version'|trans|desc('Version') }}</th>
-                                <th>{{ 'drafts.list.last_saved'|trans|desc('Last Saved') }}</th>
-                                <th></th>
+                                <th class="ez-table__header-cell"></th>
+                                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'drafts.list.name'|trans|desc('Name') }}</th>
+                                <th class="ez-table__header-cell">{{ 'drafts.list.content_type'|trans|desc('Content Type') }}</th>
+                                <th class="ez-table__header-cell">{{ 'drafts.list.modified_language'|trans|desc('Modified Language') }}</th>
+                                <th class="ez-table__header-cell">{{ 'drafts.list.version'|trans|desc('Version') }}</th>
+                                <th class="ez-table__header-cell">{{ 'drafts.list.last_saved'|trans|desc('Last Saved') }}</th>
+                                <th class="ez-table__header-cell"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -65,8 +66,13 @@
                                     <td class="ez-table__cell ez-table__cell--has-checkbox">
                                          {{ form_widget(form_remove.versions[row.id ~ '']) }}
                                     </td>
-                                    <td class="ez-table__cell">{{ row.name }}</td>
-                                    <td class="ez-table__cell">{{ row.type }}</td>
+                                    <td class="ez-table__cell ez-table__cell--has-icon">
+                                        <svg class="ez-icon ez-icon--medium">
+                                            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                                        </svg>
+                                    </td>
+                                    <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
+                                    <td class="ez-table__cell">{{ row.content_type.name }}</td>
                                     <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
                                     <td class="ez-table__cell">{{ row.version }}</td>
                                     <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -17,7 +17,7 @@
 {% block page_title_admin %}
     {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type.view.edit.title'|trans({ '%name%': content_type.name })|desc('Editing Content Type: %name%'),
-        contentType: content_type.identifier
+        content_type_identifier: content_type.identifier
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -17,7 +17,7 @@
 {% block page_title_admin %}
     {% include '@ezdesign/parts/page_title.html.twig' with {
         title: 'content_type.view.edit.title'|trans({ '%name%': content_type.name })|desc('Editing Content Type: %name%'),
-        iconName: 'content-type'
+        contentType: content_type.identifier
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -48,12 +48,13 @@
     <table class="ez-table table">
         <thead>
             <tr>
-                <th></th>
-                <th>{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>
-                <th>{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
-                <th>{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
-                <th>{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
-                <th></th>
+                <th class="ez-table__header-cell"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
+                <th class="ez-table__header-cell"></th>
             </tr>
         </thead>
         <tbody>
@@ -66,7 +67,12 @@
                         {% do form_content_types_delete.content_types.setRendered %}
                     {% endif %}
                 </td>
-                <td class="ez-table__cell">
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(content_type) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon">
                 {% set view_url = path('ezplatform.content_type.view', {
                         'contentTypeGroupId': content_type_group.id,
                         'contentTypeId': content_type.id

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -69,7 +69,7 @@
                 </td>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(content_type) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon">

--- a/src/bundle/Resources/views/admin/search/search.html.twig
+++ b/src/bundle/Resources/views/admin/search/search.html.twig
@@ -48,10 +48,11 @@
                             <table class="table mx-4">
                                 <thead>
                                 <tr>
-                                    <th>{{ 'search.name'|trans|desc('Name') }}</th>
-                                    <th>{{ 'search.modified'|trans|desc('Modified') }}</th>
-                                    <th>{{ 'search.type'|trans|desc('Content Type') }}</th>
-                                    <th></th>
+                                    <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                                    <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'search.name'|trans|desc('Name') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'search.modified'|trans|desc('Modified') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'search.type'|trans|desc('Content Type') }}</th>
+                                    <th class="ez-table__header-cell"></th>
                                 </tr>
                                 </thead>
                                 <tbody>

--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -1,5 +1,10 @@
 <tr>
-    <td class="ez-table__cell">
+    <td class="ez-table__cell ez-table__cell--has-icon">
+        <svg class="ez-icon ez-icon--medium">
+            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+        </svg>
+    </td>   
+    <td class="ez-table__cell ez-table__cell--after-icon">
         <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a>
     </td>
     <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>

--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -1,7 +1,7 @@
 <tr>
     <td class="ez-table__cell ez-table__cell--has-icon">
         <svg class="ez-icon ez-icon--medium">
-            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+            <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
         </svg>
     </td>   
     <td class="ez-table__cell ez-table__cell--after-icon">

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -65,10 +65,11 @@
                     <table class="ez-table table">
                         <thead>
                         <tr>
-                            <th></th>
-                            <th>{{ 'trash.name'|trans|desc('Name') }}</th>
-                            <th>{{ 'trash.type'|trans|desc('Type') }}</th>
-                            <th>{{ 'trash.original_location'|trans|desc('Original location') }}</th>
+                            <th class="ez-table__header-cell"></th>
+                            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'trash.name'|trans|desc('Name') }}</th>
+                            <th class="ez-table__header-cell">{{ 'trash.type'|trans|desc('Type') }}</th>
+                            <th class="ez-table__header-cell">{{ 'trash.original_location'|trans|desc('Original location') }}</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -90,7 +91,12 @@
                                             'data-is-parent-in-trash': is_parent_in_trash ? '1': '0'
                                         }}) }}
                                     </td>
-                                    <td class="ez-table__cell">{{ ez_content_name(trash_item.location.contentInfo) }}</td>
+                                    <td class="ez-table__cell ez-table__cell--has-icon">
+                                        <svg class="ez-icon ez-icon--medium">
+                                            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(trash_item.contentType) }}"></use>
+                                        </svg>
+                                    </td>
+                                    <td class="ez-table__cell ez-table__cell--after-icon">{{ ez_content_name(trash_item.location.contentInfo) }}</td>
                                     <td class="ez-table__cell">{{ trash_item.contentType.name }}</td>
                                     <td class="ez-table__cell">
                                         {% if not is_parent_in_trash %}

--- a/src/bundle/Resources/views/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/admin/trash/list.html.twig
@@ -93,7 +93,7 @@
                                     </td>
                                     <td class="ez-table__cell ez-table__cell--has-icon">
                                         <svg class="ez-icon ez-icon--medium">
-                                            <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(trash_item.contentType) }}"></use>
+                                            <use xlink:href="{{ ez_content_type_icon(trash_item.contentType.identifier) }}"></use>
                                         </svg>
                                     </td>
                                     <td class="ez-table__cell ez-table__cell--after-icon">{{ ez_content_name(trash_item.location.contentInfo) }}</td>

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -11,7 +11,7 @@
         <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/content_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_create.html.twig
@@ -11,7 +11,7 @@
         <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': contentType.name, '%languageName%': language.name})|desc('Creating - %contentTypeName% in %languageName%') }}</h2>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
+                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -15,7 +15,7 @@
         {% endif %}
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
+                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ content.name }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/content_edit.html.twig
@@ -15,7 +15,7 @@
         {% endif %}
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ content.name }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/user_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_create.html.twig
@@ -7,7 +7,7 @@
         <h4 class="ez-content-item-status">{{ 'creating'|trans({'%contentType%': contentType.name})|desc('Creating - %contentType%') }}</h4>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
+                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/user_create.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_create.html.twig
@@ -7,7 +7,7 @@
         <h4 class="ez-content-item-status">{{ 'creating'|trans({'%contentType%': contentType.name})|desc('Creating - %contentType%') }}</h4>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ 'new_content_item'|trans({'%contentType%': contentType.name})|desc('New %contentType%') }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -7,7 +7,7 @@
         <h4 class="ez-content-item-status">{{ 'editing'|trans({'%contentType%': contentType.name})|desc('Editing - %contentType%') }}</h4>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
+                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ user.name }}
         </h1>

--- a/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
+++ b/src/bundle/Resources/views/content/content_edit/user_edit.html.twig
@@ -7,7 +7,7 @@
         <h4 class="ez-content-item-status">{{ 'editing'|trans({'%contentType%': contentType.name})|desc('Editing - %contentType%') }}</h4>
         <h1>
             <svg class="ez-icon ez-icon-{{ contentType.identifier }}">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ contentType.identifier }}"></use>
+                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType.identifier) }}"></use>
             </svg>
             {{ user.name }}
         </h1>

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -17,7 +17,7 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>

--- a/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_content.html.twig
@@ -4,17 +4,23 @@
     <table class="ez-table table">
         <thead>
         <tr>
-            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
-            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
-            <th>{{ 'dashboard.table.contributor'|trans|desc('Contributor') }}</th>
-            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
-            <th></th>
+            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.contributor'|trans|desc('Contributor') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th class="ez-table__header-cell"></th>
         </tr>
         </thead>
         <tbody>
         {% for row in data %}
             <tr>
-                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td class="ez-table__cell">{{ row.type }}</td>
                 <td class="ez-table__cell">
                     {% if row.contributor is not null %}

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -17,7 +17,7 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>

--- a/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/all_media.html.twig
@@ -4,17 +4,23 @@
     <table class="ez-table table">
         <thead>
         <tr>
-            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
-            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
-            <th>{{ 'dashboard.table.contributor'|trans|desc('Contributor') }}</th>
-            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
-            <th></th>
+            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.contributor'|trans|desc('Contributor') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th class="ez-table__header-cell"></th>
         </tr>
         </thead>
         <tbody>
         {% for row in data %}
             <tr>
-                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td class="ez-table__cell">{{ row.type }}</td>
                 <td class="ez-table__cell">
                     {% if row.contributor is not null %}

--- a/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
@@ -16,7 +16,7 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>

--- a/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_content.html.twig
@@ -4,16 +4,22 @@
     <table class="ez-table table">
         <thead>
         <tr>
-            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
-            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
-            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
-            <th></th>
+            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th class="ez-table__header-cell"></th>
         </tr>
         </thead>
         <tbody>
         {% for row in data %}
             <tr>
-                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td class="ez-table__cell">{{ row.type }}</td>
                 <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>
                 <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -4,20 +4,26 @@
     <table class="ez-table table">
         <thead>
             <tr>
-                <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
-                <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
-                <th>{{ 'dashboard.table.modified_language'|trans|desc('Modified Language') }}</th>
-                <th>{{ 'dashboard.table.version'|trans|desc('Version') }}</th>
-                <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
-                <th></th>
+                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.modified_language'|trans|desc('Modified Language') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.version'|trans|desc('Version') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+                <th class="ez-table__header-cell"></th>
             </tr>
         </thead>
         <tbody>
         {% for row in data %}
             {% set content_draft_edit_url = content_is_user|default(false) ? 'ez_user_update' : 'ez_content_draft_edit' %}
             <tr>
-                <td class="ez-table__cell">{{ row.name }}</td>
-                <td class="ez-table__cell">{{ row.type }}</td>
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
+                <td class="ez-table__cell">{{ row.content_type.name }}</td>
                 <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
                 <td class="ez-table__cell">{{ row.version }}</td>
                 <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>

--- a/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_drafts.html.twig
@@ -19,7 +19,7 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>

--- a/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
@@ -16,7 +16,7 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-icon">
                     <svg class="ez-icon ez-icon--medium">
-                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                        <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>

--- a/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/dashboard/tab/my_media.html.twig
@@ -4,16 +4,22 @@
     <table class="ez-table table">
         <thead>
         <tr>
-            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
-            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
-            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
-            <th></th>
+            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th class="ez-table__header-cell"></th>
         </tr>
         </thead>
         <tbody>
         {% for row in data %}
             <tr>
-                <td class="ez-table__cell"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td class="ez-table__cell ez-table__cell--has-icon">
+                    <svg class="ez-icon ez-icon--medium">
+                        <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(row.content_type.identifier) }}"></use>
+                    </svg>
+                </td>
+                <td class="ez-table__cell ez-table__cell--after-icon"><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
                 <td class="ez-table__cell">{{ row.type }}</td>
                 <td class="ez-table__cell">{{ row.modified|localizeddate('medium', 'short', null, ez_user_settings['timezone']) }}</td>
                 <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -32,7 +32,7 @@
             <div class="ez-instant-filter__group-item">
                 {{ form_widget(form[choice.value]) }}
                 <svg class="ez-icon ez-icon--medium">
-                    <use xlink:href="{{ ez_content_type_icon(choice.value.identifier) }}"></use>
+                    <use xlink:href="{{ ez_content_type_icon(choice.value) }}"></use>
                 </svg>
             </div>
         {%- endif -%}

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -32,7 +32,7 @@
             <div class="ez-instant-filter__group-item">
                 {{ form_widget(form[choice.value]) }}
                 <svg class="ez-icon ez-icon--medium">
-                    <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(choice.value) }}"></use>
+                    <use xlink:href="{{ ez_content_type_icon(choice.value.identifier) }}"></use>
                 </svg>
             </div>
         {%- endif -%}

--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -31,6 +31,9 @@
         {%- else -%}
             <div class="ez-instant-filter__group-item">
                 {{ form_widget(form[choice.value]) }}
+                <svg class="ez-icon ez-icon--medium">
+                    <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(choice.value) }}"></use>
+                </svg>
             </div>
         {%- endif -%}
     {%- endfor -%}

--- a/src/bundle/Resources/views/parts/page_title.html.twig
+++ b/src/bundle/Resources/views/parts/page_title.html.twig
@@ -5,6 +5,10 @@
             <svg class="ez-icon ez-icon-{{ iconName }}">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ iconName }}"></use>
             </svg>
+        {% elseif contentType is defined %}
+            <svg class="ez-icon ez-icon-{{ contentType }}">
+                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType) }}"></use>
+            </svg>
         {% endif %}
         {{ title }}
         </h1>

--- a/src/bundle/Resources/views/parts/page_title.html.twig
+++ b/src/bundle/Resources/views/parts/page_title.html.twig
@@ -7,7 +7,7 @@
             </svg>
         {% elseif contentType is defined %}
             <svg class="ez-icon ez-icon-{{ contentType }}">
-                <use xlink:href="{{ ezplatform_admin_ui_content_type_icon(contentType) }}"></use>
+                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
             </svg>
         {% endif %}
         {{ title }}

--- a/src/bundle/Resources/views/parts/page_title.html.twig
+++ b/src/bundle/Resources/views/parts/page_title.html.twig
@@ -5,9 +5,9 @@
             <svg class="ez-icon ez-icon-{{ iconName }}">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ iconName }}"></use>
             </svg>
-        {% elseif contentType is defined %}
-            <svg class="ez-icon ez-icon-{{ contentType }}">
-                <use xlink:href="{{ ez_content_type_icon(contentType.identifier) }}"></use>
+        {% elseif content_type_identifier is defined %}
+            <svg class="ez-icon ez-icon-{{ content_type_identifier }}">
+                <use xlink:href="{{ ez_content_type_icon(content_type_identifier) }}"></use>
             </svg>
         {% endif %}
         {{ title }}

--- a/src/bundle/Resources/views/parts/tab/content_type.html.twig
+++ b/src/bundle/Resources/views/parts/tab/content_type.html.twig
@@ -17,7 +17,7 @@
                 {% block page_title %}
                     {% include '@ezdesign/parts/page_title.html.twig' with {
                         title: 'content_type.view.view.title'|trans({ '%name%': content_type.name })|desc('%name%'),
-                        contentType: content_type.identifier
+                        content_type_identifier: content_type.identifier
                     } %}
                 {% endblock %}
             </div>

--- a/src/bundle/Resources/views/parts/tab/content_type.html.twig
+++ b/src/bundle/Resources/views/parts/tab/content_type.html.twig
@@ -17,7 +17,7 @@
                 {% block page_title %}
                     {% include '@ezdesign/parts/page_title.html.twig' with {
                         title: 'content_type.view.view.title'|trans({ '%name%': content_type.name })|desc('%name%'),
-                        iconName: 'content-type'
+                        contentType: content_type.identifier
                     } %}
                 {% endblock %}
             </div>

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -76,6 +76,8 @@ class PagerContentToDataMapper
                 'language' => $contentInfo->mainLanguageCode,
                 'contributor' => $contributor,
                 'version' => $content->versionInfo->versionNo,
+                'type' => $content->getContentType()->getName(),
+                'content_type' => $content->getContentType(),
                 'modified' => $content->versionInfo->modificationDate,
                 'initialLanguageCode' => $content->versionInfo->initialLanguageCode,
                 'content_is_user' => (new ContentIsUser($this->userService))->isSatisfiedBy($content),

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -76,7 +76,6 @@ class PagerContentToDataMapper
                 'language' => $contentInfo->mainLanguageCode,
                 'contributor' => $contributor,
                 'version' => $content->versionInfo->versionNo,
-                'type' => $content->getContentType()->getName(),
                 'content_type' => $content->getContentType(),
                 'modified' => $content->versionInfo->modificationDate,
                 'initialLanguageCode' => $content->versionInfo->initialLanguageCode,

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ContentTypes implements ProviderInterface
 {
@@ -22,19 +23,25 @@ class ContentTypes implements ProviderInterface
     /** @var \EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver */
     private $contentTypeIconResolver;
 
+    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
+    private $urlGenerator;
+
     /**
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
      * @param \EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver $contentTypeIconResolver
+     * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $urlGenerator
      */
     public function __construct(
         ContentTypeService $contentTypeService,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
-        ContentTypeIconResolver $contentTypeIconResolver
+        ContentTypeIconResolver $contentTypeIconResolver,
+        UrlGeneratorInterface $urlGenerator
     ) {
         $this->contentTypeService = $contentTypeService;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->contentTypeIconResolver = $contentTypeIconResolver;
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**
@@ -58,6 +65,9 @@ class ContentTypes implements ProviderInterface
                     'identifier' => $contentType->identifier,
                     'name' => $contentType->getName(),
                     'thumbnail' => $this->contentTypeIconResolver->getContentTypeIcon($contentType->identifier),
+                    'href' => $this->urlGenerator->generate('ezpublish_rest_loadContentType', [
+                        'contentTypeId' => $contentType->id,
+                    ]),
                 ];
             }
         }

--- a/src/lib/UI/Dataset/ContentDraftsDataset.php
+++ b/src/lib/UI/Dataset/ContentDraftsDataset.php
@@ -103,10 +103,9 @@ class ContentDraftsDataset
 
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $draft
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      *
      * @return array
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     private function mapContentDraft(VersionInfo $draft, ContentType $contentType): array
     {
@@ -119,7 +118,8 @@ class ContentDraftsDataset
             ),
             'contentId' => $contentInfo->id,
             'name' => $draft->getName(),
-            'type' => $contentType->getName(),
+            'type' => $contentType->identifier,
+            'content_type' => $contentType,
             'language' => $draft->initialLanguageCode,
             'version' => $draft->versionNo,
             'modified' => $draft->modificationDate,

--- a/src/lib/UI/Dataset/ContentDraftsDataset.php
+++ b/src/lib/UI/Dataset/ContentDraftsDataset.php
@@ -118,7 +118,7 @@ class ContentDraftsDataset
             ),
             'contentId' => $contentInfo->id,
             'name' => $draft->getName(),
-            'type' => $contentType->identifier,
+            'type' => $contentType->getName(),
             'content_type' => $contentType,
             'language' => $draft->initialLanguageCode,
             'version' => $draft->versionNo,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29999
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Requires: https://github.com/ezsystems/ezplatform-admin-ui/pull/804
UDW part in: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/132
date-based-publisher: https://github.com/ezsystems/date-based-publisher/pull/89
Workflow: https://github.com/ezsystems/ezplatform-workflow/pull/46

## Views with icons

![screen shot 2019-01-21 at 13 00 55](https://user-images.githubusercontent.com/10233057/51473665-4e1aaf80-1d7d-11e9-8264-f1e8f45a2f10.png)

### Content item view & edit view
![screen shot 2019-01-21 at 13 01 30](https://user-images.githubusercontent.com/10233057/51473670-5115a000-1d7d-11e9-8ea8-5db38cd75194.png)

![screen shot 2019-01-21 at 13 01 42](https://user-images.githubusercontent.com/10233057/51473675-54109080-1d7d-11e9-80f5-666b64201a8c.png)

### Bookmarks
![screen shot 2019-01-28 at 09 22 08](https://user-images.githubusercontent.com/10233057/51823023-5a06f400-22de-11e9-8946-062bd38a0ad2.png)

### Trash
![screen shot 2019-01-28 at 09 22 20](https://user-images.githubusercontent.com/10233057/51823033-612e0200-22de-11e9-90d5-6ca586e7f468.png)

### Drafts
![screen shot 2019-01-30 at 13 09 17](https://user-images.githubusercontent.com/10233057/51980448-5ca94b00-2490-11e9-8512-e52cd20fa63c.png)

### Content type list; content type view; content type edit
![screen shot 2019-01-21 at 13 02 51](https://user-images.githubusercontent.com/10233057/51473681-57a41780-1d7d-11e9-81b0-f1dec96cbe24.png)
![screen shot 2019-01-21 at 13 14 23](https://user-images.githubusercontent.com/10233057/51474202-e1a0b000-1d7e-11e9-932c-4763b330e684.png)
![screen shot 2019-01-21 at 13 14 39](https://user-images.githubusercontent.com/10233057/51474208-e49ba080-1d7e-11e9-8f4b-bb28e32a3d1c.png)

### Dashboard
![screen shot 2019-01-30 at 13 08 45](https://user-images.githubusercontent.com/10233057/51980468-6cc12a80-2490-11e9-95dc-92016f216251.png)


#### Checklist:
- [x] pass content types data to twig templates, which lack them
- [x] add `ez_content_type_icon` where necessary
- [x] ready for Code Review
