### PR TITLE
EZP-29200: Admin menu disappear when user is redirected from policy to limitations

### DIFF
--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -179,6 +179,7 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
                         'policy_update' => 'ezplatform.policy.update',
                         'policy_list' => 'ezplatform.policy.list',
                         'policy_create' => 'ezplatform.policy.create',
+                        'policy_create_with_limitation' => 'ezplatform.policy.create_with_limitation',
                     ],
                 ]]
             );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://jira.ez.no/browse/EZP-29200](https://jira.ez.no/browse/EZP-29200)
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2019-01-22 at 11 18 05 am](https://user-images.githubusercontent.com/1654712/51528741-a3b39280-1e37-11e9-807c-710bcbd8ff47.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
