### PR TITLE
[WIP] Wait until DraftConflict dialog is visible

### DIFF
--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -176,6 +176,7 @@ class ContentViewContext extends BusinessContext
     public function startCreatingNewDraftFromDraftConflictModal(): void
     {
         $draftConflictModal = ElementFactory::createElement($this->utilityContext, DraftConflictDialog::ELEMENT_NAME);
+        $draftConflictModal->verifyVisibility();
         $draftConflictModal->createNewDraft();
     }
 
@@ -185,6 +186,7 @@ class ContentViewContext extends BusinessContext
     public function startEditingDraftFromDraftConflictModal(string $draftID): void
     {
         $draftConflictModal = ElementFactory::createElement($this->utilityContext, DraftConflictDialog::ELEMENT_NAME);
+        $draftConflictModal->verifyVisibility();
         $draftConflictModal->dashboardTable->clickEditButton($draftID);
     }
 


### PR DESCRIPTION
Trying to fix an error from build: https://travis-ci.com/ezsystems/ezplatform-form-builder/jobs/172979252

```
   And I start creating new draft from draft conflict modal                           # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\ContentViewContext::startCreatingNewDraftFromDraftConflictModal()
      WebDriver\Exception\ElementNotVisible: element not interactable
        (Session info: chrome=71.0.3578.98)
        (Driver info: chromedriver=2.45.615279 (12b89733300bd268cff3b78fc76cb8f3a7cc44e5),platform=Linux 4.4.0-101-generic x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:155
```

Screen: https://res.cloudinary.com/ezplatformtravis/image/upload/v1548415191/screenshots/vendor_ezsystems_ezplatform-form-builder_features_formcontentitemadministration_feature_123_zavl4r.png

Looks like we're trying to interact with the popup before it's ready.