### PR TITLE
EZP-30024: Simplifies object states table

### DIFF
--- a/src/bundle/Resources/public/scss/_forms.scss
+++ b/src/bundle/Resources/public/scss/_forms.scss
@@ -43,6 +43,10 @@ form:not(.form-inline) {
     flex-flow: row wrap;
     justify-content: flex-end;
 
+    &--align-left {
+        justify-content: flex-start;
+    }
+
     .col-form-label,
     .form-control,
     .ez-field-edit__label {

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -132,12 +132,12 @@
         <note>key: tab.details.state_group_name</note>
       </trans-unit>
       <trans-unit id="69dea878e2926e6a40b3d4e79b1f723d0aa801c7" resname="tab.details.state_name">
-        <source>Name</source>
+        <source>Current object state</source>
         <target state="new">Current object state</target>
         <note>key: tab.details.state_name</note>
       </trans-unit>
       <trans-unit id="5c08278a7b80c4aae97e5683688b5b55b5f5b37e" resname="tab.details.change_state">
-        <source>Name</source>
+        <source>Change state</source>
         <target state="new">Change state</target>
         <note>key: tab.details.change_state</note>
       </trans-unit>

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -111,55 +111,35 @@
         <target state="new">Section details</target>
         <note>key: tab.details.section_details</note>
       </trans-unit>
-      <trans-unit id="67ff5cca435b058142e77b820d5d72090fa26346" resname="tab.details.section_id">
-        <source>Section ID</source>
-        <target state="new">Section ID</target>
-        <note>key: tab.details.section_id</note>
-      </trans-unit>
-      <trans-unit id="0ab2029f0a194849d3f90531f03e37780491d1a6" resname="tab.details.section_identifier">
-        <source>Section identifier</source>
-        <target state="new">Section identifier</target>
-        <note>key: tab.details.section_identifier</note>
-      </trans-unit>
       <trans-unit id="30775f4a9e0512f181cf857fb0f0ea23fe79320d" resname="tab.details.section_name">
         <source>Section name</source>
         <target state="new">Section name</target>
         <note>key: tab.details.section_name</note>
+      </trans-unit>
+      <trans-unit id="a054d7cf662185bfc90a799a19758f4ce7b6e33d" resname="tab.details.change_section">
+        <source>Change section</source>
+        <target state="new">Change section</target>
+        <note>key: tab.details.change_section</note>
       </trans-unit>
       <trans-unit id="6ba61ac8194e021eb1515cc2d3d33ff006e2d55d" resname="tab.details.state_details">
         <source>State details</source>
         <target state="new">State details</target>
         <note>key: tab.details.state_details</note>
       </trans-unit>
-      <trans-unit id="bbbd7d6b2d1c59cedd3012f3d4375ade8cc50c15" resname="tab.details.state_group_id">
-        <source>Group ID</source>
-        <target state="new">Group ID</target>
-        <note>key: tab.details.state_group_id</note>
-      </trans-unit>
-      <trans-unit id="b4e137dd1267dc4e70e23e289313c9340f065634" resname="tab.details.state_group_identifier">
-        <source>Group identifier</source>
-        <target state="new">Group identifier</target>
-        <note>key: tab.details.state_group_identifier</note>
-      </trans-unit>
       <trans-unit id="131730e5ecef276336a53300cdd891e0689023f4" resname="tab.details.state_group_name">
         <source>Group name</source>
         <target state="new">Group name</target>
         <note>key: tab.details.state_group_name</note>
       </trans-unit>
-      <trans-unit id="0ae393a967d866426ebdb62c810ea218c011ea5f" resname="tab.details.state_id">
-        <source>State ID</source>
-        <target state="new">State ID</target>
-        <note>key: tab.details.state_id</note>
-      </trans-unit>
-      <trans-unit id="e185e68f61ce9867e2cafcf406650e12c3a81d05" resname="tab.details.state_identifier">
-        <source>Identifier</source>
-        <target state="new">Identifier</target>
-        <note>key: tab.details.state_identifier</note>
-      </trans-unit>
       <trans-unit id="69dea878e2926e6a40b3d4e79b1f723d0aa801c7" resname="tab.details.state_name">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target state="new">Current object state</target>
         <note>key: tab.details.state_name</note>
+      </trans-unit>
+      <trans-unit id="5c08278a7b80c4aae97e5683688b5b55b5f5b37e" resname="tab.details.change_state">
+        <source>Name</source>
+        <target state="new">Change state</target>
+        <note>key: tab.details.change_state</note>
       </trans-unit>
       <trans-unit id="8ddd1c9e60bd352b4395e1753ede6534db2aac8b" resname="tab.details.sub_items_listing_by.in">
         <source>in</source>

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -68,16 +68,12 @@
         <thead>
         <tr>
             <th>{{ 'tab.details.section_name'|trans()|desc('Section name') }}</th>
-            <th>{{ 'tab.details.section_identifier'|trans()|desc('Section identifier') }}</th>
-            <th>{{ 'tab.details.section_id'|trans()|desc('Section ID') }}</th>
-            <th></th>
+            <th>{{ 'tab.details.change_section '|trans()|desc('Change section') }}</th>
         </tr>
         </thead>
         <tbody>
         <tr>
             <td>{{ section.name }}</td>
-            <td>{{ section.identifier }}</td>
-            <td>{{ section.id }}</td>
             <td>
                 {% if form_assign_section %}
                     {% form_theme form_assign_section '@ezdesign/form_fields.html.twig' %}
@@ -85,7 +81,7 @@
                     {{ form_start(form_assign_section, {
                         'action': path('ezplatform.location.assign_section'),
                         'attr': {
-                            'class': 'form-inline ez-form-inline'
+                            'class': 'form-inline ez-form-inline ez-form-inline--align-left'
                         }
                     }) }}
                         {{ form_row(form_assign_section.section) }}
@@ -108,23 +104,15 @@
     <thead>
     <tr>
         <th>{{ 'tab.details.state_group_name'|trans()|desc('Group name') }}</th>
-        <th>{{ 'tab.details.state_group_identifier'|trans()|desc('Group identifier') }}</th>
-        <th>{{ 'tab.details.state_group_id'|trans()|desc('Group ID') }}</th>
-        <th>{{ 'tab.details.state_name'|trans()|desc('Name') }}</th>
-        <th>{{ 'tab.details.state_identifier'|trans()|desc('Identifier') }}</th>
-        <th>{{ 'tab.details.state_id'|trans()|desc('State ID') }}</th>
-        <th></th>
+        <th>{{ 'tab.details.state_name'|trans()|desc('Current object state') }}</th>
+        <th>{{ 'tab.details.change_state'|trans()|desc('Change state') }}</th>
     </tr>
     </thead>
     <tbody>
     {% for objectState in objectStates %}
         <tr>
             <td>{{ objectState.objectStateGroup.name }}</td>
-            <td>{{ objectState.objectStateGroup.identifier }}</td>
-            <td>{{ objectState.objectStateGroup.id }}</td>
             <td>{{ objectState.name }}</td>
-            <td>{{ objectState.identifier }}</td>
-            <td>{{ objectState.id }}</td>
             <td>
                 {% if can_assign and form_state_update[objectState.objectStateGroup.id].objectState.vars.choices|length != 0 %}
                     {% form_theme form_state_update[objectState.objectStateGroup.id] '@ezdesign/form_fields.html.twig' %}
@@ -134,7 +122,7 @@
                             'contentInfoId': contentInfo.id,
                             'objectStateGroupId': objectState.objectStateGroup.id
                         }),
-                        'attr': {'class': 'form-inline ez-form-inline'}
+                        'attr': {'class': 'form-inline ez-form-inline ez-form-inline--align-left'}
                     }) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -127,7 +127,7 @@
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].objectState) }}
-                        {{ form_row(form_state_update[objectState.objectStateGroup.id].set) }}
+                        {{ form_row(form_state_update[objectState.objectStateGroup.id].set, { 'attr': {'class': 'btn-secondary'} }) }}
                     {{ form_end(form_state_update[objectState.objectStateGroup.id]) }}
                 {% endif %}
             </td>

--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -70,7 +70,7 @@ class ContentObjectStateUpdateType extends AbstractType
                     return array_filter(
                         $this->objectStateService->loadObjectStates($objectStateGroup),
                         function (ObjectState $objectState) use ($contentInfo, $contentState) {
-                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]) && $contentState->id !== $objectState->id;
+                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]);
                         }
                     );
                 }),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30024](https://jira.ez.no/browse/EZP-30024) [EZP-30055](https://jira.ez.no/browse/EZP-30055)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Simplifies object states table
<img width="1412" alt="ez platform 2019-01-30 10-59-02" src="https://user-images.githubusercontent.com/6184173/51973866-e9e3a400-247e-11e9-9328-f20b59995bd9.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
