### PR TITLE
EZP-30096: Solr scoring is not taken into account in the backend search results list order

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
 use eZ\Publish\API\Repository\SearchService;
@@ -142,9 +143,8 @@ class SearchController extends Controller
                 $fullText = null;
                 $criteria = [];
 
-                if (null !== $queryString) {
-                    $fullText = new Criterion\FullText($queryString);
-                }
+                $query->query = new Criterion\FullText($queryString);
+
                 if (null !== $section) {
                     $criteria[] = new Criterion\SectionId($section->id);
                 }
@@ -175,8 +175,9 @@ class SearchController extends Controller
                 if (!empty($criteria)) {
                     $query->filter = new Criterion\LogicalAnd($criteria);
                 }
-                if (null !== $fullText) {
-                    $query->query = $fullText;
+
+                if (!$this->searchService->supports(SearchService::CAPABILITY_SCORING)) {
+                    $query->sortClauses[] = new SortClause\DateModified(Query::SORT_ASC);
                 }
 
                 $pagerfanta = new Pagerfanta(

--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -8,7 +8,6 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
 use eZ\Publish\API\Repository\SearchService;
@@ -140,10 +139,11 @@ class SearchController extends Controller
                 $created = $data->getCreated();
                 $creator = $data->getCreator();
                 $query = new Query();
+                $fullText = null;
                 $criteria = [];
 
                 if (null !== $queryString) {
-                    $criteria[] = new Criterion\FullText($queryString);
+                    $fullText = new Criterion\FullText($queryString);
                 }
                 if (null !== $section) {
                     $criteria[] = new Criterion\SectionId($section->id);
@@ -175,8 +175,9 @@ class SearchController extends Controller
                 if (!empty($criteria)) {
                     $query->filter = new Criterion\LogicalAnd($criteria);
                 }
-
-                $query->sortClauses[] = new SortClause\DateModified(Query::SORT_ASC);
+                if (null !== $fullText) {
+                    $query->query = $fullText;
+                }
 
                 $pagerfanta = new Pagerfanta(
                     new ContentSearchAdapter($query, $this->searchService)

--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -140,11 +140,11 @@ class SearchController extends Controller
                 $created = $data->getCreated();
                 $creator = $data->getCreator();
                 $query = new Query();
-                $fullText = null;
                 $criteria = [];
 
-                $query->query = new Criterion\FullText($queryString);
-
+                if (null !== $queryString) {
+                    $query->query = new Criterion\FullText($queryString);
+                }
                 if (null !== $section) {
                     $criteria[] = new Criterion\SectionId($section->id);
                 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30096](https://jira.ez.no/browse/EZP-30096)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As mentioned in the JIRA ticket, Solr scoring is not taken in the search results list order. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
