### PR TITLE
EZP-30090: As an editor I would like content tree panel staying opened until clicking on a Content Tree button again

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
@@ -1,5 +1,5 @@
 (function(doc, React, ReactDOM, eZ, localStorage) {
-    const PROP_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
+    const KEY_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
     const CLASS_CONTENT_TREE_EXPANDED = 'ez-content-tree-container--expanded';
     const CLASS_BTN_CONTENT_TREE_EXPANDED = 'ez-btn--content-tree-expanded';
     const contentTreeContainer = doc.querySelector('.ez-content-tree-container');
@@ -8,14 +8,14 @@
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);
 
-        localStorage.setItem(PROP_CONTENT_TREE_EXPANDED, contentTreeContainer.classList.contains(CLASS_CONTENT_TREE_EXPANDED));
+        localStorage.setItem(KEY_CONTENT_TREE_EXPANDED, contentTreeContainer.classList.contains(CLASS_CONTENT_TREE_EXPANDED));
     };
 
     ReactDOM.render(React.createElement(eZ.modules.ContentTree, {}), contentTreeContainer);
 
     btn.addEventListener('click', toggleContentTreePanel, false);
 
-    if (localStorage.getItem(PROP_CONTENT_TREE_EXPANDED) === 'true') {
+    if (localStorage.getItem(KEY_CONTENT_TREE_EXPANDED) === 'true') {
         contentTreeContainer.classList.add(CLASS_CONTENT_TREE_EXPANDED);
         btn.classList.add(CLASS_BTN_CONTENT_TREE_EXPANDED);
     }

--- a/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
@@ -1,5 +1,22 @@
-(function(doc, React, ReactDOM, eZ) {
+(function(doc, React, ReactDOM, eZ, localStorage) {
+    const PROP_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
+    const CLASS_CONTENT_TREE_EXPANDED = 'ez-content-tree-container--expanded';
+    const CLASS_BTN_CONTENT_TREE_EXPANDED = 'ez-btn--content-tree-expanded';
     const contentTreeContainer = doc.querySelector('.ez-content-tree-container');
+    const btn = doc.querySelector('.ez-btn--toggle-content-tree');
+    const toggleContentTreePanel = () => {
+        contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
+        btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);
+
+        localStorage.setItem(PROP_CONTENT_TREE_EXPANDED, contentTreeContainer.classList.contains(CLASS_CONTENT_TREE_EXPANDED));
+    };
 
     ReactDOM.render(React.createElement(eZ.modules.ContentTree, {}), contentTreeContainer);
-})(window.document, window.React, window.ReactDOM, window.eZ);
+
+    btn.addEventListener('click', toggleContentTreePanel, false);
+
+    if (localStorage.getItem(PROP_CONTENT_TREE_EXPANDED) === 'true') {
+        contentTreeContainer.classList.add(CLASS_CONTENT_TREE_EXPANDED);
+        btn.classList.add(CLASS_BTN_CONTENT_TREE_EXPANDED);
+    }
+})(window.document, window.React, window.ReactDOM, window.eZ, window.localStorage);

--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -181,3 +181,9 @@
         }
     }
 }
+
+.ez-btn--content-tree-expanded {
+    background: $ez-white;
+    border-color: $ez-white;
+    color: $ez-black;
+}

--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -228,3 +228,15 @@
         }
     }
 }
+
+.ez-btn--content-tree-expanded {
+    .ez-icon {
+        fill: $ez-black;
+    }
+
+    &:hover {
+        .ez-icon {
+            fill: $ez-white;
+        }
+    }
+}

--- a/src/bundle/Resources/public/scss/_view-content.scss
+++ b/src/bundle/Resources/public/scss/_view-content.scss
@@ -4,10 +4,17 @@
     }
 
     .ez-content-tree-container {
-        min-width: calculateRem(250px);
-        max-width: 33vw;
+        max-width: 0;
         position: relative;
         background: $ez-white;
+        overflow: auto;
+        color: inherit;
+        transition: max-width 0.2s $ez-admin-transition;
+
+        &--expanded {
+            min-width: calculateRem(250px);
+            max-width: 33vw;
+        }
     }
 
     .ez-location-view-container {

--- a/src/lib/Menu/LeftSidebarBuilder.php
+++ b/src/lib/Menu/LeftSidebarBuilder.php
@@ -110,7 +110,7 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
                     'extras' => ['icon' => 'content-tree'],
                     'attributes' => [
                         'type' => 'button',
-                        'class' => 'btn--toggle-content-tree',
+                        'class' => 'ez-btn ez-btn--toggle-content-tree',
                     ],
                 ]
             ),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30090
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->
