### PR TITLE
EZP-29539 : Deleting object will remove all subtree items even when user does not have permission to delete them

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -354,7 +354,7 @@ class LocationController extends Controller
             }
         }
 
-        return $this->redirect($this->generateUrl('ezplatform.trash.list'));
+        return $this->redirectToLocation($form->getData()->getLocation());
     }
 
     /**

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -354,6 +354,7 @@ class LocationController extends Controller
             }
         }
 
+        // in case of error when processing form ($result === null) redirect to the same Location
         return $this->redirectToLocation($form->getData()->getLocation());
     }
 

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Translation\TranslatorInterface;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as APIRepositoryUnauthorizedException;
 
@@ -352,6 +353,10 @@ class LocationController extends Controller
             if ($result instanceof Response) {
                 return $result;
             }
+        }
+
+        if (empty($form->getData()->getLocation())) {
+            throw new BadRequestHttpException();
         }
 
         // in case of error when processing form ($result === null) redirect to the same Location


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29539](https://jira.ez.no/browse/EZP-29539)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

returns to the same page on error


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
