### PR TITLE
EZP-30103: Missing asterisks from obligatory fields in Admin menu

### DIFF
--- a/src/bundle/Resources/public/scss/_labels.scss
+++ b/src/bundle/Resources/public/scss/_labels.scss
@@ -2,9 +2,7 @@
     margin-bottom: 0;
     font-weight: 700;
 
-    &:after {
-        content: ': ';
-    }
+    @include label-required();
 
     &.checkbox-inline,
     &.form-check-label {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30103
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


![screen shot 2019-02-04 at 10 41 37 am](https://user-images.githubusercontent.com/1654712/52200602-833cfc80-2869-11e9-8e66-4eea2e4f1c13.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
