### PR TITLE
EZP-30109: Add autofocus attribute to creation forms in the Admin section

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/create.html.twig
@@ -37,7 +37,7 @@
                 {{ 'content_type.view.create.global_properties'|trans|desc('Global properties') }}
             </div>
             <div class="card-body">
-                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
                 {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}}) }}
                 {{ form_row(form.description, {'label_attr': {'class': 'ez-label'}}) }}
                 {{ form_row(form.nameSchema, {'label_attr': {'class': 'ez-label'}}) }}

--- a/src/bundle/Resources/views/admin/content_type_group/create.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/create.html.twig
@@ -25,7 +25,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
             </div>
         </div>
     </section>

--- a/src/bundle/Resources/views/admin/language/create.html.twig
+++ b/src/bundle/Resources/views/admin/language/create.html.twig
@@ -27,7 +27,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
                 {{ form_row(form.languageCode, {'label_attr': {'class': 'ez-label'}}) }}
                 {{ form_row(form.enabled, {'label_attr': {'class': 'checkbox-inline ez-label'}}) }}
             </div>

--- a/src/bundle/Resources/views/admin/object_state/add.html.twig
+++ b/src/bundle/Resources/views/admin/object_state/add.html.twig
@@ -26,7 +26,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
                 {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}}) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/admin/object_state_group/add.html.twig
+++ b/src/bundle/Resources/views/admin/object_state_group/add.html.twig
@@ -25,7 +25,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.name, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
                 {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}}) }}
             </div>
         </div>

--- a/src/bundle/Resources/views/admin/policy/add.html.twig
+++ b/src/bundle/Resources/views/admin/policy/add.html.twig
@@ -26,7 +26,7 @@
     <section class="container mt-4">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_widget(form.policy) }}
+                {{ form_widget(form.policy, {'attr': {'autofocus': 'autofocus'}}) }}
             </div>
         </div>
     </section>

--- a/src/bundle/Resources/views/admin/role/add.html.twig
+++ b/src/bundle/Resources/views/admin/role/add.html.twig
@@ -25,7 +25,7 @@
     <section class="container mt-4 px-5">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form.identifier, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
             </div>
         </div>
     </section>

--- a/src/bundle/Resources/views/admin/section/create.html.twig
+++ b/src/bundle/Resources/views/admin/section/create.html.twig
@@ -25,7 +25,7 @@
     <section class="container mt-4">
         <div class="card ez-card">
             <div class="card-body">
-                {{ form_row(form_section_create.name, {'label_attr': {'class': 'ez-label'}}) }}
+                {{ form_row(form_section_create.name, {'label_attr': {'class': 'ez-label'}, 'attr': {'autofocus': 'autofocus'}}) }}
                 {{ form_row(form_section_create.identifier, {'label_attr': {'class': 'ez-label'}}) }}
             </div>
         </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30109
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
![screen shot 2019-02-04 at 11 44 12 am](https://user-images.githubusercontent.com/1654712/52203777-7375e600-2872-11e9-849c-bc284eeec89b.png)



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
