### PR TITLE
[Travis] Move Varnish/Redis jobs to nightly jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ matrix:
           - BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction -vv"
           - SYMFONY_ENV=behat
           - SYMFONY_DEBUG=1
-        - php: 7.1
-          env:
-          - WEB_HOST="varnish"
-          - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
-          - BEHAT_OPTS="--profile=adminui --suite=adminui --no-interaction --tags=~@EZP-29291-excluded"
-          - SYMFONY_ENV=behat
-          - SYMFONY_DEBUG=1
 
 cache:
     directories:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | http://jira.ez.no/browse/ezp-30097
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Our current experience with the Varnish/Redis job shows that it does not have to be run every time a PR is issued (but I still believe that having this job is valuable). Removing it from here, is it's also run in ezplatform: https://github.com/ezsystems/ezplatform/blob/master/.travis.yml#L28 (meaning it gets run every night as part of the cron builds).