### PR TITLE
EZP-30119: Fix database error on cache clear command when database is not configured

### DIFF
--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -21,8 +21,8 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
     /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
 
-    /** @var string */
-    private $preferredLocale;
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
+    private $userLanguagePreferenceProvider;
 
     /** @var \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader */
     private $availableLocaleChoiceLoader;
@@ -38,8 +38,7 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
         AvailableLocaleChoiceLoader $availableLocaleChoiceLoader
     ) {
         $this->translator = $translator;
-        $preferredLocales = $userLanguagePreferenceProvider->getPreferredLocales();
-        $this->preferredLocale = reset($preferredLocales);
+        $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->availableLocaleChoiceLoader = $availableLocaleChoiceLoader;
     }
 
@@ -72,7 +71,9 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
      */
     public function getDefaultValue(): string
     {
-        return $this->preferredLocale;
+        $preferredLocales = $this->userLanguagePreferenceProvider->getPreferredLocales();
+
+        return reset($preferredLocales);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://jira.ez.no/browse/EZP-30119](https://jira.ez.no/browse/EZP-30119)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
