### PR TITLE
EZP-29410: As an Editor I want to be informed that I can't edit CI because of missing policies.

### DIFF
--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -45,7 +45,7 @@
             if (response.status === 409) {
                 response.text().then(showModal);
             } else if (response.status === 403) {
-                response.text().then((error) => showErrorNotification(error));
+                response.text().then(showErrorNotification);
             } else if (response.status === 200) {
                 submitVersionEditForm();
             }

--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -1,5 +1,6 @@
-(function (global, doc, $) {
+(function (global, doc, $, eZ) {
     const FORM_EDIT = 'form.ez-edit-content-form';
+    const showErrorNotification = eZ.helpers.notification.showErrorNotification;
     const editVersion = (event) => {
         const versionEditForm = doc.querySelector(FORM_EDIT);
         const versionEditFormName = versionEditForm.name;
@@ -43,6 +44,8 @@
             // Otherwise we can go to Content Item edit page.
             if (response.status === 409) {
                 response.text().then(showModal);
+            } else if (response.status === 403) {
+                response.text().then((error) => showErrorNotification(error));
             } else if (response.status === 200) {
                 submitVersionEditForm();
             }
@@ -50,4 +53,4 @@
     };
 
     [...doc.querySelectorAll('.ez-btn--content-edit')].forEach(button => button.addEventListener('click', editVersion, false));
-})(window, document, window.jQuery);
+})(window, document, window.jQuery, window.eZ);

--- a/src/bundle/Resources/translations/content.en.xliff
+++ b/src/bundle/Resources/translations/content.en.xliff
@@ -11,6 +11,11 @@
         <target state="new">New Version Draft for '%name%' created.</target>
         <note>key: content.create_draft.success</note>
       </trans-unit>
+      <trans-unit id="1ea2690f8ebd8fc99115a6f94ac56b8b93e46afe" resname="content.draft.conflict.error">
+        <source>Cannot check if the draft has no conflict with other drafts. %error%. </source>
+        <target state="new">Cannot check if the draft has no conflict with other drafts. %error%. </target>
+        <note>key: content.draft.conflict.error</note>
+      </trans-unit>
       <trans-unit id="5f36fd5bb4e6938a731079f403467900e0396ed2" resname="content.main_location_update.success">
         <source>Main location for '%name%' updated.</source>
         <target state="new">Main location for '%name%' updated.</target>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://jira.ez.no/browse/EZP-29410](https://jira.ez.no/browse/EZP-29410)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


To perform a conflict check action content/versionread permission is needed. If the user has no policy, he will be informed in the notification.

![screen shot 2019-02-07 at 3 59 49 pm](https://user-images.githubusercontent.com/1654712/52420473-6e26ce80-2af2-11e9-861a-48fa14f299c7.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
