### PR TITLE
EZP-30124: Right sidebar menu is broken when editing link in Link manager

### DIFF
--- a/src/bundle/Resources/views/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/link_manager/edit.html.twig
@@ -6,7 +6,7 @@
 
 {%- block content -%}
     <div class="row align-items-stretch ez-main-row">
-        <div class="col-sm-11 px-0 pb-4">
+        <div class="px-0 pb-4 ez-content-container">
             <div class="ez-header">
                 <div class="container">
                     {% include '@ezdesign/parts/breadcrumbs.html.twig' with { items: [
@@ -36,7 +36,7 @@
                 {{ form_end(form) }}
             </div>
         </div>
-        <div class="col-sm-1 pt-4 px-0 bg-secondary ez-context-menu">
+        <div class="pt-4 px-0 bg-secondary ez-context-menu">
             {% set url_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.url_edit.sidebar_right', [], {'url': url}) %}
 
             {{ knp_menu_render(url_create_sidebar_right, {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30124
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->