### PR TITLE
EZP-30120 Update table.php to avoid crach

### DIFF
--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -41,7 +41,18 @@
 
         <tr>
             {% if form is defined %}
-                <td class="ez-table__cell ez-table__cell--has-checkbox">{{ form_widget(form.versions[version.versionNo], {'attr': {'disabled': not version.canDelete}}) }}</td>
+                <td class="ez-table__cell ez-table__cell--has-checkbox">
+                    {# https://jira.ez.no/browse/EZP-30135 #}
+                    {# 
+                    # If form.versions[version.versionNo] is not defined :
+                    # > Type error: Argument 1 passed to Symfony\Component\Form\FormRenderer::searchAndRenderBlock() must be an instance of Symfony\Component\Form\FormView, null given, called in .../cache/.../twig/.../....php on line 131
+                    #}
+                    {% if form.versions[version.versionNo] is defined %}
+                        {{  form_widget(form.versions[version.versionNo], {'a ttr': {'disabled': not version.canDelete}}) }}
+                    {% else %}
+                        <span style="color:red">La version {{ version.versionNo }} est buguée</span>
+                    {% endif %}
+                </td>
             {% endif %}
             <td class="ez-table__cell">
                 {{ version.versionNo }}


### PR DESCRIPTION
Update table.php to avoid crach if form.versions[version.versionNo] is not defined
https://jira.ez.no/browse/EZP-30135

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30135
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
