### PR TITLE
EZP-30162: Revert BC broken in EZP-30100

### DIFF
--- a/src/bundle/Resources/translations/object_state.en.xliff
+++ b/src/bundle/Resources/translations/object_state.en.xliff
@@ -31,6 +31,11 @@
         <target state="new">Delete Object State </target>
         <note>key: object_state.bulk_delete.delete</note>
       </trans-unit>
+      <trans-unit id="3f83af98ac201931eaf0055972d467c386ab72ef" resname="object_state.button.set">
+        <source>Set</source>
+        <target state="new">Set</target>
+        <note>key: object_state.button.set</note>
+      </trans-unit>
       <trans-unit id="ba36d98066b4d157d8c91e3d642a2b54442f4846" resname="object_state.create.identifier">
         <source>Identifier</source>
         <target state="new">Identifier</target>

--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -127,6 +127,7 @@
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].contentInfo) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].objectStateGroup) }}
                         {{ form_row(form_state_update[objectState.objectStateGroup.id].objectState, { 'attr': {'class': 'ez-form-autosubmit'} }) }}
+                        {% do form_state_update[objectState.objectStateGroup.id].set.setRendered %}
                     {{ form_end(form_state_update[objectState.objectStateGroup.id]) }}
                 {% endif %}
             </td>

--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -15,6 +15,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\ObjectState\ContentObjectStateUpdateDa
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -49,6 +50,9 @@ class ContentObjectStateUpdateType extends AbstractType
             ])
             ->add('objectStateGroup', ObjectStateGroupType::class, [
                 'label' => false,
+            ])
+            ->add('set', SubmitType::class, [
+                'label' => /** @Desc("Set") */ 'object_state.button.set',
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30162](https://jira.ez.no/browse/EZP-30162)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Adds submit button to the form removed in EZP-30100

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
