### PR TITLE
Removed extra space from the end of the 'tab.details.change_section' translation key

### DIFF
--- a/src/bundle/Resources/views/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/content/tab/details.html.twig
@@ -68,7 +68,7 @@
         <thead>
         <tr>
             <th>{{ 'tab.details.section_name'|trans()|desc('Section name') }}</th>
-            <th>{{ 'tab.details.change_section '|trans()|desc('Change section') }}</th>
+            <th>{{ 'tab.details.change_section'|trans()|desc('Change section') }}</th>
         </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
