### PR TITLE
EZP-30172: Cannot edit Content Type with ezobjectrelation/ezobjectrelationlist with deleted starting location

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -139,7 +139,7 @@
                 |desc("Select item") }}</button>
         </div>
         <div id="{{ form.selectionRoot.vars.id }}-selected-root-name">
-            {% if form.selectionRoot.vars.value is not empty %}
+            {% if form.selectionRoot.vars.destination_location is not null %}
                 {{ render( controller( "ez_content:viewLocation", {'locationId': form.selectionRoot.vars.value, 'viewType': '_platformui_content_name'} ) ) }}
             {% endif %}
         </div>
@@ -169,7 +169,7 @@
                 |desc("Select location") }}</button>
         </div>
         <div id="{{ form.selectionDefaultLocation.vars.id }}-selected-root-name">
-            {% if form.selectionDefaultLocation.vars.value is not empty %}
+            {% if form.selectionDefaultLocation.vars.destination_location is not null %}
                 {{ render( controller( "ez_content:viewLocation", {'locationId': form.selectionDefaultLocation.vars.value, 'viewType': '_platformui_content_name'} ) ) }}
             {% endif %}
         </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30172
| **Depends on**| https://github.com/ezsystems/repository-forms/pull/279 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
