### PR TITLE
EZP-30065: As an editor I would like content tree to use real data

### DIFF
--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -77,7 +77,7 @@ class ContentTreeController extends RestController
         );
 
         $elements = [];
-        foreach ($loadSubtreeRequest->elements as $childLoadSubtreeRequestNode) {
+        foreach ($loadSubtreeRequest->nodes as $childLoadSubtreeRequestNode) {
             $location = $this->locationService->loadLocation($childLoadSubtreeRequestNode->locationId);
             $elements[] = $this->contentTreeNodeFactory->createNode(
                 $location,

--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -76,9 +76,12 @@ class ContentTreeController extends RestController
             )
         );
 
+        $locationIdList = array_column($loadSubtreeRequest->nodes, 'locationId');
+        $locations = $this->locationService->loadLocationList($locationIdList);
+
         $elements = [];
         foreach ($loadSubtreeRequest->nodes as $childLoadSubtreeRequestNode) {
-            $location = $this->locationService->loadLocation($childLoadSubtreeRequestNode->locationId);
+            $location = $locations[$childLoadSubtreeRequestNode->locationId];
             $elements[] = $this->contentTreeNodeFactory->createNode(
                 $location,
                 $childLoadSubtreeRequestNode,

--- a/src/bundle/Controller/Content/ContentTreeController.php
+++ b/src/bundle/Controller/Content/ContentTreeController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Controller\Content;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\REST\Common\Message;
+use eZ\Publish\Core\REST\Server\Controller as RestController;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root;
+use EzSystems\EzPlatformAdminUi\UI\Module\ContentTree\NodeFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentTreeController extends RestController
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Module\ContentTree\NodeFactory */
+    private $contentTreeNodeFactory;
+
+    /**
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Module\ContentTree\NodeFactory $contentTreeNodeFactory
+     */
+    public function __construct(
+        LocationService $locationService,
+        NodeFactory $contentTreeNodeFactory
+    ) {
+        $this->locationService = $locationService;
+        $this->contentTreeNodeFactory = $contentTreeNodeFactory;
+    }
+
+    /**
+     * @param int $parentLocationId
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function loadChildrenAction(int $parentLocationId, int $limit, int $offset): Node
+    {
+        $location = $this->locationService->loadLocation($parentLocationId);
+
+        $loadSubtreeRequestNode = new LoadSubtreeRequestNode($parentLocationId, $limit, $offset);
+
+        return $this->contentTreeNodeFactory->createNode($location, $loadSubtreeRequestNode, true);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function loadSubtreeAction(Request $request): Root
+    {
+        /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequest $loadSubtreeRequest */
+        $loadSubtreeRequest = $this->inputDispatcher->parse(
+            new Message(
+                ['Content-Type' => $request->headers->get('Content-Type')],
+                $request->getContent()
+            )
+        );
+
+        $elements = [];
+        foreach ($loadSubtreeRequest->elements as $childLoadSubtreeRequestNode) {
+            $location = $this->locationService->loadLocation($childLoadSubtreeRequestNode->locationId);
+            $elements[] = $this->contentTreeNodeFactory->createNode(
+                $location,
+                $childLoadSubtreeRequestNode,
+                true
+            );
+        }
+
+        return new Root($elements);
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\Module;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for Subitems module.
+ *
+ * Example configuration:
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          content_tree_module:
+ *              load_more_limit: 30
+ *              children_load_max_limit: 200
+ *              tree_max_depth: 10
+ * ```
+ */
+class ContentTree extends AbstractParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('content_tree_module')
+                ->info('Content Tree module configuration')
+                ->children()
+                    ->integerNode('load_more_limit')
+                        ->info('Number of children to load in expand and load more operations')
+                        ->isRequired()
+                        ->defaultValue(30)
+                    ->end()
+                    ->integerNode('children_load_max_limit')
+                        ->info('Total limit of loaded children in single node')
+                        ->isRequired()
+                        ->defaultValue(200)
+                    ->end()
+                    ->integerNode('tree_max_depth')
+                        ->info('Max depth of expanded tree')
+                        ->isRequired()
+                        ->defaultValue(10)
+                    ->end()
+                    ->arrayNode('content_type_ignore_list')
+                        ->info('List of content type identifiers to ignore in Content Tree')
+                        ->arrayPrototype()
+                            ->children()
+                                ->scalarNode('content_type_identifier')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings['content_tree_module'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['content_tree_module'];
+
+        if (array_key_exists('load_more_limit', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.load_more_limit',
+                $currentScope,
+                $settings['load_more_limit']
+            );
+        }
+
+        if (array_key_exists('children_load_max_limit', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.children_load_max_limit',
+                $currentScope,
+                $settings['children_load_max_limit']
+            );
+        }
+
+        if (array_key_exists('tree_max_depth', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.tree_max_depth',
+                $currentScope,
+                $settings['tree_max_depth']
+            );
+        }
+
+        if (array_key_exists('content_type_ignore_list', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.content_type_ignore_list',
+                $currentScope,
+                $settings['content_type_ignore_list']
+            );
+        }
+    }
+}

--- a/src/bundle/EzPlatformAdminUiBundle.php
+++ b/src/bundle/EzPlatformAdminUiBundle.php
@@ -66,6 +66,7 @@ class EzPlatformAdminUiBundle extends Bundle
             new Parser\LocationIds(),
             new Parser\Module\Subitems(),
             new Parser\Module\UniversalDiscoveryWidget(),
+            new Parser\Module\ContentTree(),
             new Parser\Pagination(),
             new Parser\Security(),
             new Parser\UserIdentifier(),

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -53,3 +53,10 @@ parameters:
 
     # Additional translations e.g. ['en_US', 'nb_NO']
     ezsettings.default.user_preferences.additional_translations: []
+
+    # Content Tree Module
+    ezsettings.default.content_tree_module.load_more_limit: 30
+    ezsettings.default.content_tree_module.children_load_max_limit: 200
+    ezsettings.default.content_tree_module.tree_max_depth: 10
+    ezsettings.default.content_tree_module.content_type_ignore_list: []
+

--- a/src/bundle/Resources/config/routing_rest.yml
+++ b/src/bundle/Resources/config/routing_rest.yml
@@ -1,7 +1,37 @@
+#
+# Bulk Operation
+#
+
 ezplatform.bulk_operation:
     path: /bulk
     options:
-      expose: true
+        expose: true
     defaults:
-      _controller: 'EzPlatformAdminUiBundle:BulkOperation\BulkOperation:bulk'
-    methods: [POST]
+        _controller: 'EzPlatformAdminUiBundle:BulkOperation\BulkOperation:bulk'
+    methods: ['POST']
+
+#
+# Location Tree
+#
+
+ezplatform.location.tree.load_children:
+    # @todo change name to content tree
+    path: /location/tree/load-subitems/{parentLocationId}/{limit}/{offset}
+    methods: ['GET']
+    options:
+        expose: true
+    requirements:
+        parentLocationId: \d+
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Content/ContentTree:loadChildren'
+        limit: 10
+        offset: 0
+
+ezplatform.location.tree.load_subtree:
+    # @todo change name to content tree
+    path: /location/tree/load-subtree
+    methods: ['POST']
+    options:
+        expose: true
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:Content/ContentTree:loadSubtree'

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ imports:
     - { resource: services/components.yml }
     - { resource: services/dashboard.yml }
     - { resource: services/modules/subitems.yml }
+    - { resource: services/modules/content_tree.yml }
     - { resource: services/form_processors.yml }
     - { resource: services/validators.yml }
     - { resource: services/siteaccess.yml }

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -109,3 +109,13 @@ services:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
             $defaultPaginationLimit: '$pagination.content_draft_limit$'
+
+    #
+    # REST
+    #
+
+    EzSystems\EzPlatformAdminUiBundle\Controller\Content\ContentTreeController:
+        parent: ezpublish_rest.controller.base
+        tags: ['controller.service_arguments']
+        autowire: true
+        autoconfigure: false

--- a/src/bundle/Resources/config/services/modules/content_tree.yml
+++ b/src/bundle/Resources/config/services/modules/content_tree.yml
@@ -1,0 +1,12 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
+    EzSystems\EzPlatformAdminUi\UI\Module\ContentTree\NodeFactory:
+        arguments:
+            $displayLimit: '$content_tree_module.load_more_limit$'
+            $childrenLoadMaxLimit: '$content_tree_module.children_load_max_limit$'
+            $maxDepth: '$content_tree_module.tree_max_depth$'
+            $contentTypeIdentifierIgnoreList: '$content_tree_module.content_type_ignore_list$'

--- a/src/bundle/Resources/config/services/rest.yml
+++ b/src/bundle/Resources/config/services/rest.yml
@@ -9,21 +9,25 @@ services:
       tags:
         - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.Operation }
 
-  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequestNode:
-      parent: ezpublish_rest.input.parser
-      tags:
-          - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode }
-
-  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequest:
-      parent: ezpublish_rest.input.parser
-      tags:
-          - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequest }
-
   EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\BulkOperationResponse:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
         - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\BulkOperationResponse }
 
+  #
+  # Content Tree
+  #
+
+  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequestNode:
+    parent: ezpublish_rest.input.parser
+    tags:
+      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTree.LoadSubtreeRequestNode }
+
+  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequest:
+    parent: ezpublish_rest.input.parser
+    tags:
+      - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTree.LoadSubtreeRequest }
+      -
   EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\ContentTree\Node:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:

--- a/src/bundle/Resources/config/services/rest.yml
+++ b/src/bundle/Resources/config/services/rest.yml
@@ -9,7 +9,27 @@ services:
       tags:
         - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.Operation }
 
+  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequestNode:
+      parent: ezpublish_rest.input.parser
+      tags:
+          - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode }
+
+  EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree\LoadSubtreeRequest:
+      parent: ezpublish_rest.input.parser
+      tags:
+          - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequest }
+
   EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\BulkOperationResponse:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
         - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\BulkOperationResponse }
+
+  EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\ContentTree\Node:
+      parent: ezpublish_rest.output.value_object_visitor.base
+      tags:
+          - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node }
+
+  EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\ContentTree\Root:
+      parent: ezpublish_rest.output.value_object_visitor.base
+      tags:
+          - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root }

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
@@ -28,7 +28,7 @@ class LoadSubtreeRequest extends BaseParser
 
         $nodes = [];
         foreach ($data['nodes'] as $node) {
-            $nodes[] = $parsingDispatcher->parse($node, $data['_media-type']);
+            $nodes[] = $parsingDispatcher->parse($node, $node['_media-type']);
         }
 
         return new LoadSubtreeRequestValue($nodes);

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
@@ -20,20 +20,17 @@ class LoadSubtreeRequest extends BaseParser
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher): LoadSubtreeRequestValue
     {
-        if (!array_key_exists('elements', $data) || !is_array($data['elements'])) {
+        if (!array_key_exists('nodes', $data) || !is_array($data['nodes'])) {
             throw new Exceptions\Parser(
-                sprintf("Missing or invalid 'elements' property for %s.", self::class)
+                sprintf("Missing or invalid 'nodes' property for %s.", self::class)
             );
         }
 
-        $elements = [];
-        foreach ($data['elements'] as $element) {
-            $elements[] = $parsingDispatcher->parse(
-                $element,
-                'application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode'
-            );
+        $nodes = [];
+        foreach ($data['nodes'] as $node) {
+            $nodes[] = $parsingDispatcher->parse($node, $data['_media-type']);
         }
 
-        return new LoadSubtreeRequestValue($elements);
+        return new LoadSubtreeRequestValue($nodes);
     }
 }

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequest as LoadSubtreeRequestValue;
+
+class LoadSubtreeRequest extends BaseParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): LoadSubtreeRequestValue
+    {
+        if (!array_key_exists('elements', $data) || !is_array($data['elements'])) {
+            throw new Exceptions\Parser(
+                sprintf("Missing or invalid 'elements' property for %s.", self::class)
+            );
+        }
+
+        $elements = [];
+        foreach ($data['elements'] as $element) {
+            $elements[] = $parsingDispatcher->parse(
+                $element,
+                'application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode'
+            );
+        }
+
+        return new LoadSubtreeRequestValue($elements);
+    }
+}

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
@@ -39,12 +39,10 @@ class LoadSubtreeRequestNode extends BaseParser
                 self::class));
         }
 
-        $children = array_map(
-            function (array $child) use ($parsingDispatcher): LoadSubtreeRequestNodeValue {
-                return $parsingDispatcher->parse($child, $child['_media-type']);
-            },
-            $data['children']
-        );
+        $children = [];
+        foreach ($data['children'] as $child) {
+            $children[] = $parsingDispatcher->parse($child, $child['_media-type']);
+        }
 
         return new LoadSubtreeRequestNodeValue(
             (int) $data['locationId'],

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
@@ -41,7 +41,7 @@ class LoadSubtreeRequestNode extends BaseParser
 
         $children = array_map(
             function (array $child) use ($parsingDispatcher): LoadSubtreeRequestNodeValue {
-                return $parsingDispatcher->parse($child, 'application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode');
+                return $parsingDispatcher->parse($child, $child['_media-type']);
             },
             $data['children']
         );

--- a/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
+++ b/src/lib/REST/Input/Parser/ContentTree/LoadSubtreeRequestNode.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Input\Parser\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode as LoadSubtreeRequestNodeValue;
+
+class LoadSubtreeRequestNode extends BaseParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): LoadSubtreeRequestNodeValue
+    {
+        if (!array_key_exists('locationId', $data) || !is_numeric($data['locationId'])) {
+            throw new Exceptions\Parser(sprintf("Missing or invalid 'locationId' property for %s.", self::class));
+        }
+
+        if (!array_key_exists('limit', $data) || !is_numeric($data['limit'])) {
+            throw new Exceptions\Parser(sprintf("Missing or invalid 'limit' property for %s.",
+                self::class));
+        }
+
+        if (!array_key_exists('offset', $data) || !is_numeric($data['offset'])) {
+            throw new Exceptions\Parser(sprintf("Missing or invalid 'offset' property for %s.",
+                self::class));
+        }
+
+        if (!array_key_exists('children', $data) || !is_array($data['children'])) {
+            throw new Exceptions\Parser(sprintf("Missing or invalid 'children' property for %s.",
+                self::class));
+        }
+
+        $children = array_map(
+            function (array $child) use ($parsingDispatcher): LoadSubtreeRequestNodeValue {
+                return $parsingDispatcher->parse($child, 'application/vnd.ez.api.internal.ContentTree.LoadSubtreeRequestNode');
+            },
+            $data['children']
+        );
+
+        return new LoadSubtreeRequestNodeValue(
+            (int) $data['locationId'],
+            (int) $data['limit'],
+            (int) $data['offset'],
+            $children
+        );
+    }
+}

--- a/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Node.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Node.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use Symfony\Component\HttpFoundation\Response;
+
+class Node extends ValueObjectVisitor
+{
+    /**
+     * Visit struct returned by controllers.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $generator->startObjectElement('ContentTreeNode');
+        $visitor->setHeader('Content-Type', $generator->getMediaType('ContentTreeNode'));
+        $visitor->setStatus(Response::HTTP_OK);
+
+        $generator->startValueElement('locationId', $data->locationId);
+        $generator->endValueElement('locationId');
+
+        $generator->startValueElement('contentId', $data->contentId);
+        $generator->endValueElement('contentId');
+
+        $generator->startValueElement('name', $data->name);
+        $generator->endValueElement('name');
+
+        $generator->startValueElement('contentTypeIdentifier', $data->contentTypeIdentifier);
+        $generator->endValueElement('contentTypeIdentifier');
+
+        $generator->startValueElement('isContainer', $data->isContainer);
+        $generator->endValueElement('isContainer');
+
+        $generator->startValueElement('isInvisible', $data->isInvisible);
+        $generator->endValueElement('isInvisible');
+
+        $generator->startValueElement('displayLimit', $data->displayLimit);
+        $generator->endValueElement('displayLimit');
+
+        $generator->startValueElement('totalChildrenCount', $data->totalChildrenCount);
+        $generator->endValueElement('totalChildrenCount');
+
+        $generator->startList('children');
+
+        foreach ($data->children as $child) {
+            $visitor->visitValueObject($child);
+        }
+
+        $generator->endList('children');
+
+        $generator->endObjectElement('ContentTreeNode');
+    }
+}

--- a/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Root.php
+++ b/src/lib/REST/Output/ValueObjectVisitor/ContentTree/Root.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Output\ValueObjectVisitor\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use Symfony\Component\HttpFoundation\Response;
+
+class Root extends ValueObjectVisitor
+{
+    /**
+     * Visit struct returned by controllers.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $generator->startObjectElement('ContentTreeRoot');
+        $visitor->setHeader('Content-Type', $generator->getMediaType('ContentTreeRoot'));
+        $visitor->setStatus(Response::HTTP_OK);
+
+        $generator->startList('ContentTreeNodeList');
+
+        foreach ($data->elements as $element) {
+            $visitor->visitValueObject($element);
+        }
+
+        $generator->endList('ContentTreeNodeList');
+
+        $generator->endObjectElement('ContentTreeRoot');
+    }
+}

--- a/src/lib/REST/Value/ContentTree/LoadSubtreeRequest.php
+++ b/src/lib/REST/Value/ContentTree/LoadSubtreeRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Value\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+class LoadSubtreeRequest extends RestValue
+{
+    /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode[] */
+    public $elements;
+
+    /**
+     * @param array $elements
+     */
+    public function __construct(array $elements = [])
+    {
+        $this->elements = $elements;
+    }
+}

--- a/src/lib/REST/Value/ContentTree/LoadSubtreeRequest.php
+++ b/src/lib/REST/Value/ContentTree/LoadSubtreeRequest.php
@@ -13,13 +13,13 @@ use eZ\Publish\Core\REST\Common\Value as RestValue;
 class LoadSubtreeRequest extends RestValue
 {
     /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode[] */
-    public $elements;
+    public $nodes;
 
     /**
-     * @param array $elements
+     * @param array $nodes
      */
-    public function __construct(array $elements = [])
+    public function __construct(array $nodes = [])
     {
-        $this->elements = $elements;
+        $this->nodes = $nodes;
     }
 }

--- a/src/lib/REST/Value/ContentTree/LoadSubtreeRequestNode.php
+++ b/src/lib/REST/Value/ContentTree/LoadSubtreeRequestNode.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Value\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+class LoadSubtreeRequestNode extends RestValue
+{
+    /** @var int */
+    public $locationId;
+
+    /** @var int */
+    public $limit;
+
+    /** @var int */
+    public $offset;
+
+    /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode[] */
+    public $children;
+
+    /**
+     * @param int $locationId
+     * @param int $limit
+     * @param int $offset
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode[] $children
+     */
+    public function __construct(
+        int $locationId,
+        int $limit = 20,
+        int $offset = 0,
+        array $children = []
+    ) {
+        $this->locationId = $locationId;
+        $this->children = $children;
+        $this->limit = $limit;
+        $this->offset = $offset;
+    }
+}

--- a/src/lib/REST/Value/ContentTree/Node.php
+++ b/src/lib/REST/Value/ContentTree/Node.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Value\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+class Node extends RestValue
+{
+    /** @var int */
+    private $depth;
+
+    /** @var int */
+    public $locationId;
+
+    /** @var int */
+    public $contentId;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $contentTypeIdentifier;
+
+    /** @var bool */
+    public $isContainer;
+
+    /** @var bool */
+    public $isInvisible;
+
+    /** @var int */
+    public $displayLimit;
+
+    /** @var int */
+    public $totalChildrenCount;
+
+    /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node[] */
+    public $children;
+
+    /**
+     * @param int $depth
+     * @param int $locationId
+     * @param int $contentId
+     * @param string $name
+     * @param string $contentTypeIdentifier
+     * @param bool $isContainer
+     * @param bool $isInvisible
+     * @param int $displayLimit
+     * @param int $totalChildrenCount
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node[] $children
+     */
+    public function __construct(
+        int $depth,
+        int $locationId,
+        int $contentId,
+        string $name,
+        string $contentTypeIdentifier,
+        bool $isContainer,
+        bool $isInvisible,
+        int $displayLimit,
+        int $totalChildrenCount,
+        array $children = []
+    ) {
+        $this->depth = $depth;
+        $this->locationId = $locationId;
+        $this->contentId = $contentId;
+        $this->name = $name;
+        $this->isInvisible = $isInvisible;
+        $this->contentTypeIdentifier = $contentTypeIdentifier;
+        $this->isContainer = $isContainer;
+        $this->totalChildrenCount = $totalChildrenCount;
+        $this->displayLimit = $displayLimit;
+        $this->children = $children;
+    }
+}

--- a/src/lib/REST/Value/ContentTree/Root.php
+++ b/src/lib/REST/Value/ContentTree/Root.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\REST\Value\ContentTree;
+
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+class Root extends RestValue
+{
+    /** @var \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node[] */
+    public $elements;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node[] $elements
+     */
+    public function __construct(array $elements = [])
+    {
+        $this->elements = $elements;
+    }
+}

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Module\ContentTree;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode;
+use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node;
+
+/**
+ * @internal
+ */
+final class NodeFactory
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    /** @var int */
+    private $displayLimit;
+
+    /** @var int */
+    private $childrenLoadMaxLimit;
+
+    /** @var int */
+    private $maxDepth;
+
+    /** @var string[] */
+    private $contentTypeIdentifierIgnoreList;
+
+    /**
+     * @param \eZ\Publish\API\Repository\SearchService $searchService
+     * @param int $displayLimit
+     * @param int $childrenLoadMaxLimit
+     * @param int $maxDepth
+     * @param array $contentTypeIdentifierIgnoreList
+     */
+    public function __construct(
+        SearchService $searchService,
+        int $displayLimit = 20,
+        int $childrenLoadMaxLimit = 100,
+        int $maxDepth = 10,
+        array $contentTypeIdentifierIgnoreList = []
+    ) {
+        $this->searchService = $searchService;
+        $this->displayLimit = $displayLimit;
+        $this->childrenLoadMaxLimit = $childrenLoadMaxLimit;
+        $this->maxDepth = $maxDepth;
+        $this->contentTypeIdentifierIgnoreList = $contentTypeIdentifierIgnoreList;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode $loadSubtreeRequestNode
+     * @param bool $loadChildren
+     * @param int $depth
+     *
+     * @return \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function createNode(
+        Location $location,
+        ?LoadSubtreeRequestNode $loadSubtreeRequestNode = null,
+        bool $loadChildren = false,
+        int $depth = 0
+    ): Node {
+        $content = $location->getContent();
+        $contentType = $content->getContentType();
+
+        $numberOfSubitemsToLoad = $this->resolveLoadLimit($loadSubtreeRequestNode);
+
+        $children = [];
+        if ($depth < $this->maxDepth && $loadChildren) {
+            $searchResult = $this->findSubitems($location, $numberOfSubitemsToLoad);
+            $totalChildrenCount = $searchResult->totalCount;
+
+            /** @var \eZ\Publish\API\Repository\Values\Content\Location $childLocation */
+            foreach (array_column($searchResult->searchHits, 'valueObject') as $childLocation) {
+                $childLoadSubtreeRequestNode = null !== $loadSubtreeRequestNode
+                    ? $this->findChild($childLocation->id, $loadSubtreeRequestNode)
+                    : null;
+
+                $children[] = $this->createNode(
+                    $childLocation,
+                    $childLoadSubtreeRequestNode,
+                    null !== $childLoadSubtreeRequestNode,
+                    $depth++
+                );
+            }
+        } else {
+            $totalChildrenCount = $this->countSubitems($location);
+        }
+
+        return new Node(
+            $depth,
+            $location->id,
+            $location->contentId,
+            $content->getName(),
+            $contentType->identifier,
+            $contentType->isContainer,
+            $location->invisible,
+            $totalChildrenCount,
+            $numberOfSubitemsToLoad,
+            $children
+        );
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode|null $loadSubtreeRequestNode
+     *
+     * @return int
+     */
+    private function resolveLoadLimit(?LoadSubtreeRequestNode $loadSubtreeRequestNode): int
+    {
+        $limit = $this->displayLimit;
+
+        if (null !== $loadSubtreeRequestNode) {
+            $limit = $loadSubtreeRequestNode->limit;
+        }
+
+        if ($limit > $this->childrenLoadMaxLimit) {
+            $limit = $this->childrenLoadMaxLimit;
+        }
+
+        return $limit;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function findSubitems(Location $parentLocation, int $limit = 10, int $offset = 0): SearchResult
+    {
+        $searchQuery = $this->getSearchQuery($parentLocation);
+
+        $searchQuery->limit = $limit;
+        $searchQuery->offset = $offset;
+
+        return $this->searchService->findLocations($searchQuery);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\LocationQuery
+     */
+    private function getSearchQuery(Location $parentLocation): LocationQuery
+    {
+        $searchQuery = new LocationQuery();
+        $searchQuery->filter = new Criterion\ParentLocationId($parentLocation->id);
+
+        if (!empty($this->contentTypeIdentifierIgnoreList)) {
+            $searchQuery->filter = new Criterion\LogicalAnd([
+                $searchQuery->filter,
+                new Criterion\LogicalNot(
+                    new Criterion\ContentTypeIdentifier($this->contentTypeIdentifierIgnoreList)
+                ),
+            ]);
+        }
+
+        return $searchQuery;
+    }
+
+    /**
+     * @param int $locationId
+     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode $loadSubtreeRequestNode
+     *
+     * @return \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\LoadSubtreeRequestNode|null
+     */
+    private function findChild(int $locationId, LoadSubtreeRequestNode $loadSubtreeRequestNode): ?LoadSubtreeRequestNode
+    {
+        foreach ($loadSubtreeRequestNode->children as $child) {
+            if ($child->locationId === $locationId) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
+     *
+     * @return int
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function countSubitems(Location $parentLocation): int
+    {
+        $searchQuery = $this->getSearchQuery($parentLocation);
+
+        $searchQuery->limit = 0;
+        $searchQuery->offset = 0;
+        $searchQuery->performCount = true;
+
+        return $this->searchService->findLocations($searchQuery)->totalCount;
+    }
+}

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Module\ContentTree;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
@@ -110,8 +111,8 @@ final class NodeFactory
             $contentType->identifier,
             $contentType->isContainer,
             $location->invisible,
-            $totalChildrenCount,
             $numberOfSubitemsToLoad,
+            $totalChildrenCount,
             $children
         );
     }
@@ -151,6 +152,12 @@ final class NodeFactory
 
         $searchQuery->limit = $limit;
         $searchQuery->offset = $offset;
+
+        try {
+            $searchQuery->sortClauses = $parentLocation->getSortClauses();
+        } catch (NotImplementedException $e) {
+            $searchQuery->sortClauses = []; // rely on storage engine default sorting
+        }
 
         return $this->searchService->findLocations($searchQuery);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30065
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


# Description
This PR adds backend part for Content Tree feature. Content Tree uses two REST (based on REST Server from `ezpublish-kernel`) endpoints:
- `ezplatform.location.tree.load_children` for consecutive loading of given location subitems
-  `ezplatform.location.tree.load_subtree` for loading larger subtrees in single request

My implementation uses `SearchService`  to possibly speed up serving responses and offload database.

# Configuration
Content Tree is configurable:
```yaml
ezpublish:
    system:
        admin_group: # any siteaccess or siteaccess group
            content_tree_module:
                load_more_limit: 15 # defines how many children will be shown after expanding parent
                children_load_max_limit: 200 # users won't be able to load more children than that
                tree_max_depth: 10 # maximum depth of expanded tree
                content_type_ignore_list: # Content Tree won't display these content types
                   - post
                   - article
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
