### PR TITLE
EZP-30182: ContentTree/loadSubitems action is not respecting offset value

### DIFF
--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -79,11 +79,15 @@ final class NodeFactory
         $content = $location->getContent();
         $contentType = $content->getContentType();
 
-        $numberOfSubitemsToLoad = $this->resolveLoadLimit($loadSubtreeRequestNode);
+        $limit = $this->resolveLoadLimit($loadSubtreeRequestNode);
+        $offset = null !== $loadSubtreeRequestNode
+            ? $loadSubtreeRequestNode->offset
+            : 0;
+
 
         $children = [];
         if ($depth < $this->maxDepth && $loadChildren) {
-            $searchResult = $this->findSubitems($location, $numberOfSubitemsToLoad);
+            $searchResult = $this->findSubitems($location, $limit, $offset);
             $totalChildrenCount = $searchResult->totalCount;
 
             /** @var \eZ\Publish\API\Repository\Values\Content\Location $childLocation */
@@ -111,7 +115,7 @@ final class NodeFactory
             $contentType->identifier,
             $contentType->isContainer,
             $location->invisible,
-            $numberOfSubitemsToLoad,
+            $limit,
             $totalChildrenCount,
             $children
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30182
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
