### PR TITLE
EZP-20181: Editor is not able to select any item in the ezobjectrelation/ezobjectrelationlist FTs if starting location is not accessible

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelation.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelation.html.twig
@@ -4,7 +4,7 @@
 
 {% block ezplatform_fieldtype_ezobjectrelation_widget %}
     {% set limit = 1 %}
-    {% set default_location = form.parent.vars.value.fieldDefinition.fieldSettings.selectionRoot %}
+    {% set default_location = form.vars.default_location ? form.vars.default_location.id : null %}
     {% set allowed_content_type_identifiers = form.parent.vars.value.fieldDefinition.fieldSettings.selectionContentTypes %}
     {{ block('ezobjectrelation_base_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelationlist.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezobjectrelationlist.html.twig
@@ -4,7 +4,7 @@
 
 {% block ezplatform_fieldtype_ezobjectrelationlist_widget %}
     {% set limit = form.parent.vars.value.fieldDefinition.validatorConfiguration.RelationListValueValidator.selectionLimit %}
-    {% set default_location = form.parent.vars.value.fieldDefinition.fieldSettings.selectionDefaultLocation %}
+    {% set default_location = form.vars.default_location ? form.vars.default_location.id : null %}
     {% set allowed_content_type_identifiers = form.parent.vars.value.fieldDefinition.fieldSettings.selectionContentTypes %}
     {{ block('ezobjectrelation_base_widget') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30181
| **Depends on**| https://github.com/ezsystems/repository-forms/pull/280
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
