### PR TITLE
EZP-30184: As an Editor I want to collapse/expand content preview

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -166,6 +166,7 @@ module.exports = (Encore) => {
             path.resolve(__dirname, '../public/js/scripts/admin.location.tab.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.location.visibility.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.location.update.js'),
+            path.resolve(__dirname, '../public/js/scripts/admin.location.tooglecontentpreview.js'),
             path.resolve(__dirname, '../public/js/scripts/button.content.edit.js'),
             path.resolve(__dirname, '../public/js/scripts/udw/move.js'),
             path.resolve(__dirname, '../public/js/scripts/udw/copy.js'),

--- a/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
@@ -1,0 +1,24 @@
+(function(doc, localStorage, $) {
+    const CONTENT_PREVIEW_COLLAPSE_SELECTOR = '.ez-content-preview-collapse';
+    const CONTENT_PREVIEW_TOGGLE_STATE_KEY = 'ez-content-preview-collapsed';
+    const getContentPreviewToggleState = () => {
+        const value = localStorage.getItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY);
+        if (value !== null) {
+            return JSON.parse(value);
+        }
+
+        return false;
+    };
+    const setContentPreviewToggleState = (value) => {
+        localStorage.setItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY, value);
+    };
+
+    doc.querySelectorAll(CONTENT_PREVIEW_COLLAPSE_SELECTOR).forEach((collapsable) => {
+        collapsable = $(collapsable).collapse({
+            toggle: getContentPreviewToggleState(),
+        });
+
+        collapsable.on('hide.bs.collapse', () => setContentPreviewToggleState(true));
+        collapsable.on('show.bs.collapse', () => setContentPreviewToggleState(false));
+    });
+})(document, window.localStorage, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
@@ -3,11 +3,8 @@
     const CONTENT_PREVIEW_TOGGLE_STATE_KEY = 'ez-content-preview-collapsed';
     const getContentPreviewToggleState = () => {
         const value = localStorage.getItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY);
-        if (value !== null) {
-            return JSON.parse(value);
-        }
 
-        return false;
+        return value !== null ? JSON.parse(value) : false;
     };
     const setContentPreviewToggleState = (value) => {
         localStorage.setItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY, value);

--- a/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
@@ -4,7 +4,7 @@
     const getContentPreviewToggleState = () => {
         const value = localStorage.getItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY);
 
-        return value !== null ? JSON.parse(value) : false;
+        return !!JSON.parse(value);
     };
     const setContentPreviewToggleState = (value) => {
         localStorage.setItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY, value);

--- a/src/bundle/Resources/public/scss/_field-group.scss
+++ b/src/bundle/Resources/public/scss/_field-group.scss
@@ -1,31 +1,76 @@
 .ez-view-rawcontentview {
-
     .ez-raw-content-title {
-        border-bottom: 1px solid $ez-color-secondary;
+        border-bottom: calculateRem(1px) solid $ez-color-secondary;
         color: $ez-color-secondary;
 
         h2 {
-            margin-top: 1rem;
+            margin-top: calculateRem(16px);
             margin-bottom: 0;
-            padding-bottom: .5rem;
-            font-size: 1.125rem;
-            font-weight: 400;  
+            padding-bottom: calculateRem(8px);
+            font-size: calculateRem(18px);
+            font-weight: 400;
+        }
+
+        .ez-content-preview-toggle {
+            color: $ez-color-secondary;
+            position: relative;
+            padding-right: calculateRem(24px);
+            display: inline-block;
+
+            &:hover {
+                text-decoration: none;
+            }
+
+            &:before,
+            &:after {
+                content: '';
+                width: calculateRem(1px);
+                height: calculateRem(7px);
+                background-color: $ez-color-secondary;
+                position: absolute;
+                top: 50%;
+                right: calculateRem(-16px);
+                transition: all 0.2s $ez-admin-transition;
+            }
+
+            &:before {
+                transform: translate(calculateRem(-27px), -50%) rotate(135deg);
+            }
+
+            &:after {
+                transform: translate(calculateRem(-22px), -50%) rotate(45deg);
+            }
+
+            &.collapsed {
+                &:before {
+                    transform: translate(calculateRem(-27px), -20%) rotate(45deg);
+                }
+
+                &:after {
+                    transform: translate(calculateRem(-27px), -80%) rotate(-45deg);
+                }
+            }
         }
 
         .form-inline {
-            padding-bottom: .25rem;
+            padding-bottom: calculateRem(4px);
+
+            &.collapsing {
+                -webkit-transition: none;
+                transition: none;
+                display: none;
+            }
         }
-    }    
+    }
 }
 
 .ez-fieldgroup {
-
     &__name {
         color: $ez-color-secondary;
-        border-bottom: 1px solid $ez-color-secondary;
-        padding-bottom: .5rem;
+        border-bottom: calculateRem(1px) solid $ez-color-secondary;
+        padding-bottom: calculateRem(8px);
         font-weight: 400;
-        font-size: 1.125rem;
+        font-size: calculateRem(18px);
     }
 
     .ez-content-field-name {
@@ -33,21 +78,21 @@
     }
 
     .ez-content-field {
-        padding: 0 1rem;
-        margin-bottom: 1.5rem;
+        padding: 0 calculateRem(16px);
+        margin-bottom: calculateRem(24px);
 
         .ez-content-field-name {
             background-color: $ez-color-base-pale;
             margin-bottom: 0;
-            padding: .5rem 1.5rem;
-            border-radius: 5px 5px 0 0;
+            padding: calculateRem(8px) calculateRem(24px);
+            border-radius: calculateRem(5px) calculateRem(5px) 0 0;
             font-weight: 700;
         }
 
         .ez-content-field-value {
             background-color: $ez-white;
-            padding: 1rem 1.5rem;
-            border-radius: 0 0 5px 5px;
+            padding: calculateRem(16px) calculateRem(24px);
+            border-radius: 0 0 calculateRem(5px) calculateRem(5px);
         }
     }
 

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -249,6 +249,11 @@
         <target state="new">Content</target>
         <note>key: tab.view.content</note>
       </trans-unit>
+      <trans-unit id="fd2350c1f97fb7a3bd77d158fcf6dfbd5845a9a0" resname="tab.view.preview">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note>key: tab.view.preview</note>
+      </trans-unit>
       <trans-unit id="4e7901a215220faba4d546cd3fb63f3e2a64e849" resname="trash.delete.all.confirm">
         <source>Are you sure you want to permanently delete %trashItemsCount% item(s)?</source>
         <target state="new">Are you sure you want to permanently delete %trashItemsCount% item(s)?</target>

--- a/src/bundle/Resources/views/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/content/content_view_fields.html.twig
@@ -1,32 +1,36 @@
 <section class="ez-view-rawcontentview">
     <div class="ez-raw-content-title d-flex justify-content-between mb-3">
         <h2>
-            {{ 'tab.view.content'|trans()|desc('Content') }}
+            <a data-toggle="collapse" href=".ez-content-preview-collapse" class="ez-content-preview-toggle">
+                {{ 'tab.view.preview'|trans()|desc('Preview') }}
+            </a>
         </h2>
         {% block extras %}{% endblock %}
     </div>
 
     {% block fields %}
-        {% for group in field_definitions_by_group if group.fieldDefinitions|length > 0 %}
-            <section class="ez-fieldgroup container">
-                <h3 class="ez-fieldgroup__name">{{ group.name|capitalize }}</h3>
-                {% for fieldDefinition in group.fieldDefinitions %}
-                    {% block field %}
-                        <div class="ez-content-field">
-                            <p class="ez-content-field-name">{{ fieldDefinition.name }}:</p>
-                            <div class="ez-content-field-value">
-                                {% if ez_is_field_empty(content, fieldDefinition.identifier) %}
-                                    <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
-                                {% else %}
-                                    {{ ez_render_field(content, fieldDefinition.identifier, {
-                                        'template': '@ezdesign/fieldtypes/preview/content_fields.html.twig'
-                                    }) }}
-                                {% endif %}
+        <div class="ez-content-preview-collapse collapse show">
+            {% for group in field_definitions_by_group if group.fieldDefinitions|length > 0 %}
+                <section class="ez-fieldgroup container">
+                    <h3 class="ez-fieldgroup__name">{{ group.name|capitalize }}</h3>
+                    {% for fieldDefinition in group.fieldDefinitions %}
+                        {% block field %}
+                            <div class="ez-content-field">
+                                <p class="ez-content-field-name">{{ fieldDefinition.name }}:</p>
+                                <div class="ez-content-field-value">
+                                    {% if ez_is_field_empty(content, fieldDefinition.identifier) %}
+                                        <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
+                                    {% else %}
+                                        {{ ez_render_field(content, fieldDefinition.identifier, {
+                                            'template': '@ezdesign/fieldtypes/preview/content_fields.html.twig'
+                                        }) }}
+                                    {% endif %}
+                                </div>
                             </div>
-                        </div>
-                    {% endblock %}
-                {% endfor %}
-            </section>
-        {% endfor %}
+                        {% endblock %}
+                    {% endfor %}
+                </section>
+            {% endfor %}
+        </div>
     {% endblock %}
 </section>

--- a/src/bundle/Resources/views/content/tab/content.html.twig
+++ b/src/bundle/Resources/views/content/tab/content.html.twig
@@ -2,8 +2,9 @@
 
 {% block extras %}
     {% set current_language = app.request.get('languageCode') ?: content.prioritizedFieldLanguageCode %}
+
     {% if languages|length > 1  %}
-    <form class="form-inline">
+    <form class="form-inline ez-content-preview-collapse collapse show">
         <select class="form-control ez-location-language-change">
             {% for language in languages %}
                 <option value="{{ path('_ezpublishLocation', {'locationId': location.id, 'languageCode': language.languageCode}) }}"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30184
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Description

This PR introduces a feature which allows editors to collapse/expand content preview. Default state is configurable via User Setting. 

Front-end implementation based on  https://getbootstrap.com/docs/4.1/components/collapse/ with some CSS tweaks.

## Demo

![collapse_content_preview](https://user-images.githubusercontent.com/211967/53553031-fec65c80-3b3c-11e9-9cf7-03e264bbe428.gif)

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [x] Move `EzSystems\EzPlatformAdminUi\UserSetting\Setting\CollapseContentPreview` to `ezplatform-user` package (https://github.com/ezsystems/ezplatform-user/pull/5)
- [x] Ready for Code Review
