### PR TITLE
EZP-30185: Expose ContentTree configuration to AdminUI

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -54,11 +54,7 @@ class ContentTree extends AbstractParser
                     ->end()
                     ->arrayNode('content_type_ignore_list')
                         ->info('List of content type identifiers to ignore in Content Tree')
-                        ->arrayPrototype()
-                            ->children()
-                                ->scalarNode('content_type_identifier')
-                            ->end()
-                        ->end()
+                        ->scalarPrototype()->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -52,6 +52,13 @@ class ContentTree extends AbstractParser
                         ->isRequired()
                         ->defaultValue(10)
                     ->end()
+                    ->integerNode('tree_root_location_id')
+                        ->info(
+                            'Location that will be used as a tree root. User won\'t be able to see ancestors of this location.' . "\n\n"
+                            . 'When set to \'null\' SiteAccess \'content.tree_root.location_id\' setting will be used.'
+                        )
+                        ->defaultValue(null)
+                    ->end()
                     ->arrayNode('allowed_content_types')
                         ->beforeNormalization()
                             ->ifString()
@@ -110,11 +117,11 @@ class ContentTree extends AbstractParser
             );
         }
 
-        if (array_key_exists('ignored_content_types', $settings)) {
+        if (array_key_exists('tree_root_location_id', $settings)) {
             $contextualizer->setContextualParameter(
-                'content_tree_module.ignored_content_types',
+                'content_tree_module.tree_root_location_id',
                 $currentScope,
-                $settings['ignored_content_types']
+                $settings['tree_root_location_id']
             );
         }
 
@@ -123,6 +130,14 @@ class ContentTree extends AbstractParser
                 'content_tree_module.allowed_content_types',
                 $currentScope,
                 $settings['allowed_content_types']
+            );
+        }
+
+        if (array_key_exists('ignored_content_types', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.ignored_content_types',
+                $currentScope,
+                $settings['ignored_content_types']
             );
         }
     }

--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -52,8 +52,23 @@ class ContentTree extends AbstractParser
                         ->isRequired()
                         ->defaultValue(10)
                     ->end()
-                    ->arrayNode('content_type_ignore_list')
-                        ->info('List of content type identifiers to ignore in Content Tree')
+                    ->arrayNode('allowed_content_types')
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->thenEmptyArray()
+                        ->end()
+                        ->info(
+                            'List of content type identifiers to show in Content Tree. ' . "\n\n"
+                            . 'Use string value \'*\' to display all content types. '
+                            . 'Empty array also means all content types will be displayed.'
+                        )
+                        ->scalarPrototype()->end()
+                    ->end()
+                    ->arrayNode('ignored_content_types')
+                        ->info(
+                            'List of content type identifiers to ignore in Content Tree.' . "\n\n"
+                            . 'This option is only useful when used with \'allowed_content_types = *\'.'
+                        )
                         ->scalarPrototype()->end()
                     ->end()
                 ->end()
@@ -95,11 +110,19 @@ class ContentTree extends AbstractParser
             );
         }
 
-        if (array_key_exists('content_type_ignore_list', $settings)) {
+        if (array_key_exists('ignored_content_types', $settings)) {
             $contextualizer->setContextualParameter(
-                'content_tree_module.content_type_ignore_list',
+                'content_tree_module.ignored_content_types',
                 $currentScope,
-                $settings['content_type_ignore_list']
+                $settings['ignored_content_types']
+            );
+        }
+
+        if (array_key_exists('allowed_content_types', $settings)) {
+            $contextualizer->setContextualParameter(
+                'content_tree_module.allowed_content_types',
+                $currentScope,
+                $settings['allowed_content_types']
             );
         }
     }

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -68,5 +68,6 @@ parameters:
     ezsettings.default.content_tree_module.load_more_limit: 30
     ezsettings.default.content_tree_module.children_load_max_limit: 200
     ezsettings.default.content_tree_module.tree_max_depth: 10
-    ezsettings.default.content_tree_module.content_type_ignore_list: []
+    ezsettings.default.content_tree_module.allowed_content_types: []
+    ezsettings.default.content_tree_module.ignored_content_types: []
 

--- a/src/bundle/Resources/config/services/modules/content_tree.yml
+++ b/src/bundle/Resources/config/services/modules/content_tree.yml
@@ -9,7 +9,8 @@ services:
             $displayLimit: '$content_tree_module.load_more_limit$'
             $childrenLoadMaxLimit: '$content_tree_module.children_load_max_limit$'
             $maxDepth: '$content_tree_module.tree_max_depth$'
-            $contentTypeIdentifierIgnoreList: '$content_tree_module.content_type_ignore_list$'
+            $allowedContentTypes: '$content_tree_module.allowed_content_types$'
+            $ignoredContentTypes: '$content_tree_module.ignored_content_types$'
 
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module\ContentTree:
         tags:

--- a/src/bundle/Resources/config/services/modules/content_tree.yml
+++ b/src/bundle/Resources/config/services/modules/content_tree.yml
@@ -10,3 +10,7 @@ services:
             $childrenLoadMaxLimit: '$content_tree_module.children_load_max_limit$'
             $maxDepth: '$content_tree_module.tree_max_depth$'
             $contentTypeIdentifierIgnoreList: '$content_tree_module.content_type_ignore_list$'
+
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module\ContentTree:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'contentTree' }

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -26,7 +26,7 @@
         {% endblock left_sidebar %}
 
         <div class="px-0 pb-4 ez-content-container">
-            <div class="ez-content-tree-container" data-current-location-id="{{ location.id }}">
+            <div class="ez-content-tree-container" data-tree-root-location-id="{{ admin_ui_config['contentTree']['treeRootLocationId'] }}" data-current-location-id="{{ location.id }}">
                 <div class="ez-content-tree-container__wrapper"></div>
             </div>
             <div class="ez-location-view-container">

--- a/src/lib/UI/Config/Provider/Module/ContentTree.php
+++ b/src/lib/UI/Config/Provider/Module/ContentTree.php
@@ -32,7 +32,8 @@ class ContentTree implements ProviderInterface
             'loadMoreLimit' => $this->configResolver->getParameter('content_tree_module.load_more_limit'),
             'childrenLoadMaxLimit' => $this->configResolver->getParameter('content_tree_module.children_load_max_limit'),
             'treeMaxDepth' => $this->configResolver->getParameter('content_tree_module.tree_max_depth'),
-            'contentTypeIgnoreList' => $this->configResolver->getParameter('content_tree_module.content_type_ignore_list'),
+            'allowedContentTypes' => $this->configResolver->getParameter('content_tree_module.allowed_content_types'),
+            'ignoredContentTypes' => $this->configResolver->getParameter('content_tree_module.ignored_content_types'),
         ];
     }
 }

--- a/src/lib/UI/Config/Provider/Module/ContentTree.php
+++ b/src/lib/UI/Config/Provider/Module/ContentTree.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+class ContentTree implements ProviderInterface
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     */
+    public function __construct(
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return [
+            'loadMoreLimit' => $this->configResolver->getParameter('content_tree_module.load_more_limit'),
+            'childrenLoadMaxLimit' => $this->configResolver->getParameter('content_tree_module.children_load_max_limit'),
+            'treeMaxDepth' => $this->configResolver->getParameter('content_tree_module.tree_max_depth'),
+            'contentTypeIgnoreList' => $this->configResolver->getParameter('content_tree_module.content_type_ignore_list'),
+        ];
+    }
+}

--- a/src/lib/UI/Config/Provider/Module/ContentTree.php
+++ b/src/lib/UI/Config/Provider/Module/ContentTree.php
@@ -28,12 +28,15 @@ class ContentTree implements ProviderInterface
      */
     public function getConfig(): array
     {
+        $rootLocationId = $this->configResolver->getParameter('content_tree_module.tree_root_location_id');
+
         return [
             'loadMoreLimit' => $this->configResolver->getParameter('content_tree_module.load_more_limit'),
             'childrenLoadMaxLimit' => $this->configResolver->getParameter('content_tree_module.children_load_max_limit'),
             'treeMaxDepth' => $this->configResolver->getParameter('content_tree_module.tree_max_depth'),
             'allowedContentTypes' => $this->configResolver->getParameter('content_tree_module.allowed_content_types'),
             'ignoredContentTypes' => $this->configResolver->getParameter('content_tree_module.ignored_content_types'),
+            'treeRootLocationId' => $rootLocationId ?? $this->configResolver->getParameter('content.tree_root.location_id'),
         ];
     }
 }

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -83,7 +83,12 @@ final class NodeFactory
         int $depth = 0
     ): Node {
         $content = $location->getContent();
-        $contentType = $content->getContentType();
+        $contentInfo = $location->getContentInfo();
+
+        // Top Level Location (id = 1) does not have a Content Type
+        $contentType = $location->depth > 0
+            ? $content->getContentType()
+            : null;
 
         $limit = $this->resolveLoadLimit($loadSubtreeRequestNode);
         $offset = null !== $loadSubtreeRequestNode
@@ -116,9 +121,9 @@ final class NodeFactory
             $depth,
             $location->id,
             $location->contentId,
-            $content->getName(),
-            $contentType->identifier,
-            $contentType->isContainer,
+            $contentInfo->name,
+            $contentType ? $contentType->identifier : '',
+            $contentType ? $contentType->isContainer : true,
             $location->invisible,
             $limit,
             $totalChildrenCount,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30185
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->





#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
