### PR TITLE
Set correct branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "extra": {
         "_ezplatform_branch_for_behat_tests": "master",
         "branch-alias": {
-            "dev-tmp_ci_branch": "2.5.x-dev",
+            "dev-tmp_ci_branch": "1.5.x-dev",
             "dev-master": "1.5.x-dev"
         }
     }


### PR DESCRIPTION
Currently builds are failing: https://travis-ci.org/ezsystems/ezplatform-admin-ui/builds/500215494

This is caused by incorrectly set branch alias for tmp_ci_branch - it should be equal to master alias.