### PR TITLE
EZP-30192: Content Tree panel is partially visible when toggled

### DIFF
--- a/src/bundle/Resources/public/scss/_view-content.scss
+++ b/src/bundle/Resources/public/scss/_view-content.scss
@@ -5,6 +5,7 @@
     }
 
     .ez-content-tree-container {
+        display: none;
         flex: 0 0 auto;
         max-width: 0;
         position: relative;
@@ -14,6 +15,7 @@
         margin-bottom: calculateRem(-24px);
 
         &--expanded {
+            display: initial;
             min-width: calculateRem(250px);
             max-width: 33vw;
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30192
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
