### PR TITLE
EZP-30197: Missing default value for content_tree_module.tree_root_location_id setting

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -24,6 +24,9 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  *              load_more_limit: 30
  *              children_load_max_limit: 200
  *              tree_max_depth: 10
+ *              tree_root_location_id: ~ # use tree root location from SA
+ *              allowed_content_types: '*'
+ *              ignored_content_types: [article, post]
  * ```
  */
 class ContentTree extends AbstractParser

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -70,4 +70,5 @@ parameters:
     ezsettings.default.content_tree_module.tree_max_depth: 10
     ezsettings.default.content_tree_module.allowed_content_types: []
     ezsettings.default.content_tree_module.ignored_content_types: []
+    ezsettings.default.content_tree_module.tree_root_location_id: ~
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30197
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
