### PR TITLE
EZP-30205: As an editor I would like content tree to hold separate state for different users

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
@@ -8,6 +8,7 @@
     const contentTreeContainer = doc.querySelector('.ez-content-tree-container');
     const contentTreeWrapper = doc.querySelector('.ez-content-tree-container__wrapper');
     const btn = doc.querySelector('.ez-btn--toggle-content-tree');
+    const { currentLocationPath, userId } = contentTreeContainer.dataset;
     let onViewportChangeTimeout = null;
     const toggleContentTreePanel = () => {
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
@@ -32,7 +33,8 @@
 
     ReactDOM.render(
         React.createElement(eZ.modules.ContentTree, {
-            currentLocationPath: contentTreeContainer.dataset.currentLocationPath,
+            userId,
+            currentLocationPath,
             restInfo: { token, siteaccess },
         }),
         contentTreeWrapper


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30205
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
