### PR TITLE
EZP-30220: CustomTagTest::testMapConfig fails in phpunit

### DIFF
--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -57,6 +57,7 @@ class CustomTagTest extends TestCase
                     'ezyoutube' => [
                         'template' => '@ezdesign/fields/ezrichtext/custom_tags/ezyoutube.html.twig',
                         'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#video',
+                        'is_inline' => false,
                         'attributes' => [
                             'width' => [
                                 'type' => 'number',
@@ -78,6 +79,7 @@ class CustomTagTest extends TestCase
                     'eztwitter' => [
                         'template' => '@ezdesign/fields/ezrichtext/custom_tags/eztwitter.html.twig',
                         'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#twitter',
+                        'is_inline' => false,
                         'attributes' => [
                             'tweet_url' => [
                                 'type' => 'string',
@@ -102,6 +104,7 @@ class CustomTagTest extends TestCase
                         'label' => 'ezrichtext.custom_tags.ezyoutube.label',
                         'description' => 'ezrichtext.custom_tags.ezyoutube.description',
                         'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#video',
+                        'isInline' => false,
                         'attributes' => [
                             'width' => [
                                 'label' => 'ezrichtext.custom_tags.ezyoutube.attributes.width.label',
@@ -127,6 +130,7 @@ class CustomTagTest extends TestCase
                         'label' => 'ezrichtext.custom_tags.eztwitter.label',
                         'description' => 'ezrichtext.custom_tags.eztwitter.description',
                         'icon' => '/bundles/ezplatformadminui/img/ez-icons.svg#twitter',
+                        'isInline' => false,
                         'attributes' => [
                             'tweet_url' => [
                                 'label' => 'ezrichtext.custom_tags.eztwitter.attributes.tweet_url.label',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Due to configuration change in #869 dataProvider should have been updated to return `is_inline` configuration parameter. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
