### PR TITLE
EZP-30223: Collapse all button is not always displayed in Content Tree

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.content.tree.js
@@ -13,6 +13,7 @@
     const toggleContentTreePanel = () => {
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);
+        updateContentTreeWrapperHeight();
 
         localStorage.setItem(KEY_CONTENT_TREE_EXPANDED, contentTreeContainer.classList.contains(CLASS_CONTENT_TREE_EXPANDED));
     };


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30223
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
