### PR TITLE
EZP-30231: When resizing Content Tree text is accidentally selected

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -156,3 +156,7 @@ select {
 .ez-prevent-click * {
     pointer-events: none !important;
 }
+
+.ez-is-tree-resizing {
+    user-select: none;
+}

--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -158,5 +158,8 @@ select {
 }
 
 .ez-is-tree-resizing {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }

--- a/src/bundle/Resources/public/scss/_view-content.scss
+++ b/src/bundle/Resources/public/scss/_view-content.scss
@@ -32,7 +32,3 @@
         min-width: 0;
     }
 }
-
-.ez-is-tree-resizing {
-    user-select: none;
-}

--- a/src/bundle/Resources/public/scss/_view-content.scss
+++ b/src/bundle/Resources/public/scss/_view-content.scss
@@ -31,10 +31,8 @@
         flex: 1 1 auto;
         min-width: 0;
     }
+}
 
-    &.ez-is-tree-resizing {
-        .ez-location-view-container {
-            pointer-events: none;
-        }
-    }
+.ez-is-tree-resizing {
+    user-select: none;
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30231
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


### Problem:
![tbrsdrvftb](https://user-images.githubusercontent.com/10233057/53867700-b30c2b00-3ff4-11e9-9f2b-274ea2939dc1.gif)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
