### PR TITLE
EZP-30235: Editor can't add location if content/create limitations on ContentType of Parent are set

### DIFF
--- a/src/lib/Tab/LocationView/LocationsTab.php
+++ b/src/lib/Tab/LocationView/LocationsTab.php
@@ -128,9 +128,9 @@ class LocationsTab extends AbstractEventDispatchingTab implements OrderedTabInte
         $canManageLocations = $this->permissionResolver->canUser(
             'content', 'manage_locations', $location->getContentInfo()
         );
-        $canCreate = $this->permissionResolver->canUser(
-            'content', 'create', $location->getContentInfo()
-        );
+        // We grant access to choose a valid Location from UDW. Now it is not possible to filter locations
+        // and show only those which user has access to
+        $canCreate = false !== $this->permissionResolver->hasAccess('content', 'create');
         $canEdit = $this->permissionResolver->canUser(
             'content', 'edit', $location->getContentInfo()
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30235
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This fix implies that if a user will choose Location to which has no access for, red notification will be shown with information about missing permission.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
