### PR TITLE
EZP-30242: Characters counter does not work properly with embed inline

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -292,7 +292,9 @@
         }
 
         cleanWhiteCharacters(text) {
-            return text.replace(/\s\r?\n/g, ' ').trim();
+            return text
+                .replace(/[\u200B-\u200D\uFEFF]/g, '')  //zero-width characters
+                .replace(/\s\r?\n/g, ' ').trim();       //white characters
         }
     };
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30242
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Output from the Editor isn't cleaned from zero-width characters which are treated like regular ones and corrupt the counter.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
