### PR TITLE
EZEE-2716: Richtext block: tooltip for links can render in way that part of it won't be visible

### DIFF
--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -1045,6 +1045,6 @@
   line-height: 1;
 }
 
-.ae-toolbar-styles {
+.alloy-editor-visible {
   z-index: 1;
 }

--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -1044,3 +1044,7 @@
   font-size: 14px;
   line-height: 1;
 }
+
+.ae-toolbar-styles {
+  z-index: 1;
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2716
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
