### PR TITLE
EZP-30258: [Content tree] After reloading tree is partially collapsed

### DIFF
--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -110,7 +110,7 @@ final class NodeFactory
                     $childLocation,
                     $childLoadSubtreeRequestNode,
                     null !== $childLoadSubtreeRequestNode,
-                    $depth++
+                    $depth + 1
                 );
             }
         } else {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30258
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Fixing my huge programmer mistake...


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
