### PR TITLE
EZP-30269: [Content Tree] Collapse all button jumps a little bit when scrolling

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.tree.js
@@ -2,14 +2,13 @@
     const KEY_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
     const CLASS_CONTENT_TREE_EXPANDED = 'ez-content-tree-container--expanded';
     const CLASS_BTN_CONTENT_TREE_EXPANDED = 'ez-btn--content-tree-expanded';
-    const VIEWPORT_CHANGE_TIMEOUT = 50;
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
     const contentTreeContainer = doc.querySelector('.ez-content-tree-container');
     const contentTreeWrapper = doc.querySelector('.ez-content-tree-container__wrapper');
     const btn = doc.querySelector('.ez-btn--toggle-content-tree');
     const { currentLocationPath, userId, treeRootLocationId } = contentTreeContainer.dataset;
-    let onViewportChangeTimeout = null;
+    let frame = null;
     const toggleContentTreePanel = () => {
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);
@@ -23,15 +22,13 @@
         const height = Math.min(window.innerHeight - contentTreeContainer.getBoundingClientRect().top, window.innerHeight);
 
         contentTreeWrapper.style.height = `${height}px`;
-        onViewportChangeTimeout = null;
     };
     const handleViewportChange = () => {
-        if (onViewportChangeTimeout) {
-            return;
+        if (frame) {
+            cancelAnimationFrame(frame);
         }
 
-        window.clearTimeout(onViewportChangeTimeout);
-        onViewportChangeTimeout = window.setTimeout(updateContentTreeWrapperHeight, VIEWPORT_CHANGE_TIMEOUT);
+        frame = requestAnimationFrame(updateContentTreeWrapperHeight);
     };
     const saveContentTreeExpandedState = (userId, isExpanded) => {
         let expandedState = JSON.parse(localStorage.getItem(KEY_CONTENT_TREE_EXPANDED));
@@ -69,6 +66,6 @@
 
     updateContentTreeWrapperHeight();
 
-    doc.addEventListener('scroll', handleViewportChange, false);
-    window.addEventListener('resize', handleViewportChange, false);
+    doc.addEventListener('scroll', handleViewportChange, { capture: false, passive: true });
+    window.addEventListener('resize', handleViewportChange, { capture: false, passive: true });
 })(window.document, window.React, window.ReactDOM, window.eZ, window.localStorage);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30269
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

I was inspired by: https://css-tricks.com/styling-based-on-scroll-position/

Previously we were afraid of poor performance because of frequent updates of DOM element and use of `getBoundingClientRect`. Current solution should be performant.

## Before
![ndupy70uqx](https://user-images.githubusercontent.com/10233057/54018261-7c671980-4188-11e9-9491-fa3eac6849df.gif)

## After
![8rim84byo5](https://user-images.githubusercontent.com/10233057/54018278-86891800-4188-11e9-8af1-43aed689d7a5.gif)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
