### PR TITLE
EZP-30251: Display the rendering of time & date when editing the Short/Long Date & Time format

### DIFF
--- a/src/bundle/Controller/User/UserSettingsController.php
+++ b/src/bundle/Controller/User/UserSettingsController.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller\User;
 use EzSystems\EzPlatformUserBundle\Controller\UserSettingsController as BaseUserSettingsController;
 use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @deprecated Deprecated in 1.5 and will be removed in 2.0. Please use \EzSystems\EzPlatformUserBundle\Controller\UserSettingsController instead.
@@ -24,7 +25,7 @@ class UserSettingsController extends Controller
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function listAction(int $page = 1)
+    public function listAction(int $page = 1): Response
     {
         return $this->forward(BaseUserSettingsController::class . '::listAction', [
             'page' => $page,
@@ -37,7 +38,7 @@ class UserSettingsController extends Controller
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function updateAction(Request $request, string $identifier)
+    public function updateAction(Request $request, string $identifier): Response
     {
         return $this->forward(BaseUserSettingsController::class . '::updateAction', [
             'identifier' => $identifier,

--- a/src/bundle/Controller/User/UserSettingsController.php
+++ b/src/bundle/Controller/User/UserSettingsController.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUiBundle\Controller\User;
 
-use EzSystems\EzPlatformUser\View\UserSettings\ListView;
 use EzSystems\EzPlatformUserBundle\Controller\UserSettingsController as BaseUserSettingsController;
 use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,41 +17,30 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class UserSettingsController extends Controller
 {
-    /** @var \EzSystems\EzPlatformUserBundle\Controller\UserSettingsController */
-    private $userSettingsController;
-
-    /**
-     * @param \EzSystems\EzPlatformUserBundle\Controller\UserSettingsController $userSettingsController
-     */
-    public function __construct(BaseUserSettingsController $userSettingsController)
-    {
-        $this->userSettingsController = $userSettingsController;
-    }
-
     /**
      * @param int $page
      *
-     * @return \EzSystems\EzPlatformUser\View\UserSettings\ListView
+     * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function listAction(int $page = 1): ListView
+    public function listAction(int $page = 1)
     {
-        return $this->userSettingsController->listAction($page);
+        return $this->forward(BaseUserSettingsController::class . '::listAction', [
+            'page' => $page,
+        ]);
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $identifier
      *
-     * @return \EzSystems\EzPlatformUser\View\UserSettings\UpdateView|null|\Symfony\Component\HttpFoundation\Response
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function updateAction(Request $request, string $identifier)
     {
-        return $this->userSettingsController->updateAction($request, $identifier);
+        return $this->forward(BaseUserSettingsController::class . '::updateAction', [
+            'identifier' => $identifier,
+        ]);
     }
 }

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -44,5 +44,15 @@ system:
                     params:
                         viewbaseLayout: '@ezdesign/layout.html.twig'
 
+        user_settings_update_view:
+            full:
+                ezplatform_admin_ui_datetime_format:
+                    template: '@ezdesign/user/settings/update_datetime_format.html.twig'
+                    match:
+                        Identifier: [full_datetime_format, short_datetime_format]
+                ezplatform_admin_ui:
+                    template: '@ezdesign/user/settings/update.html.twig'
+                    match: true
+
         fielddefinition_edit_templates:
             - { template: '@ezdesign/admin/content_type/field_types.html.twig', priority: 10 }

--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -222,5 +222,8 @@ module.exports = (Encore) => {
             path.resolve(__dirname, '../public/js/scripts/fieldType/base/base-preview-field.js'),
             ...fieldTypes,
             path.resolve(__dirname, '../public/js/scripts/sidebar/extra.actions.js'),
+        ])
+        .addEntry('ezplatform-admin-ui-settings-datetime-format-update', [
+            path.resolve(__dirname, '../public/js/scripts/admin.settings.datetimeformat.update.js'),
         ]);
 };

--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -223,7 +223,7 @@ module.exports = (Encore) => {
             ...fieldTypes,
             path.resolve(__dirname, '../public/js/scripts/sidebar/extra.actions.js'),
         ])
-        .addEntry('ezplatform-admin-ui-settings-datetime-format-update', [
+        .addEntry('ezplatform-admin-ui-settings-datetime-format-update-js', [
             path.resolve(__dirname, '../public/js/scripts/admin.settings.datetimeformat.update.js'),
         ]);
 };

--- a/src/bundle/Resources/public/js/scripts/admin.settings.datetimeformat.update.js
+++ b/src/bundle/Resources/public/js/scripts/admin.settings.datetimeformat.update.js
@@ -1,0 +1,18 @@
+(function(global, doc, moment) {
+    const DATE_FORMAT_SELECTOR = '#user_setting_update_value_date_format';
+    const TIME_FORMAT_SELECTOR = '#user_setting_update_value_time_format';
+    const VALUE_PREVIEW_SELECTOR = '.ez-datetime-format-preview-value';
+    const valuePreview = doc.querySelector(VALUE_PREVIEW_SELECTOR);
+    const dateFormatSelect = doc.querySelector(DATE_FORMAT_SELECTOR);
+    const timeFormatSelect = doc.querySelector(TIME_FORMAT_SELECTOR);
+    const updateDateTimeFormatPreview = () => {
+        valuePreview.innerHTML = moment().formatICU(
+            dateFormatSelect.value + ' ' + timeFormatSelect.value
+        );
+    };
+
+    dateFormatSelect.addEventListener('change', updateDateTimeFormatPreview);
+    timeFormatSelect.addEventListener('change', updateDateTimeFormatPreview);
+
+    updateDateTimeFormatPreview();
+}) (window, window.document, window.moment);

--- a/src/bundle/Resources/public/js/scripts/admin.settings.datetimeformat.update.js
+++ b/src/bundle/Resources/public/js/scripts/admin.settings.datetimeformat.update.js
@@ -1,10 +1,10 @@
 (function(global, doc, moment) {
-    const DATE_FORMAT_SELECTOR = '#user_setting_update_value_date_format';
-    const TIME_FORMAT_SELECTOR = '#user_setting_update_value_time_format';
-    const VALUE_PREVIEW_SELECTOR = '.ez-datetime-format-preview-value';
-    const valuePreview = doc.querySelector(VALUE_PREVIEW_SELECTOR);
-    const dateFormatSelect = doc.querySelector(DATE_FORMAT_SELECTOR);
-    const timeFormatSelect = doc.querySelector(TIME_FORMAT_SELECTOR);
+    const SELECTOR_DATE_FORMAT = '#user_setting_update_value_date_format';
+    const SELECTOR_TIME_FORMAT = '#user_setting_update_value_time_format';
+    const SELECTOR_VALUE_PREVIEW = '.ez-datetime-format-preview-value';
+    const valuePreview = doc.querySelector(SELECTOR_VALUE_PREVIEW);
+    const dateFormatSelect = doc.querySelector(SELECTOR_DATE_FORMAT);
+    const timeFormatSelect = doc.querySelector(SELECTOR_TIME_FORMAT);
     const updateDateTimeFormatPreview = () => {
         valuePreview.innerHTML = moment().formatICU(
             dateFormatSelect.value + ' ' + timeFormatSelect.value

--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -41,70 +41,10 @@
         <target state="new">My Preferences</target>
         <note>key: section.my_preferences</note>
       </trans-unit>
-      <trans-unit id="3a4946ea2a7aaa360112cf1e657617e7ce7c7d9b" resname="settings.language.value.description">
-        <source>The language of the administration panel</source>
-        <target state="new">The language of the administration panel</target>
-        <note>key: settings.language.value.description</note>
-      </trans-unit>
-      <trans-unit id="593fb98cf76c44e48e00ce4ee027a6e54b6625fd" resname="settings.language.value.title">
-        <source>Language</source>
-        <target state="new">Language</target>
-        <note>key: settings.language.value.title</note>
-      </trans-unit>
-      <trans-unit id="18f788ade37f54e5d52f0e3ddacb39a5558190b5" resname="settings.subitems_limit.value.description">
-        <source>Number of items displayed in the table</source>
-        <target state="new">Number of items displayed in the table</target>
-        <note>key: settings.subitems_limit.value.description</note>
-      </trans-unit>
-      <trans-unit id="67329191003095f24d2ca7d2182ecb00d5a85e36" resname="settings.subitems_limit.value.title">
-        <source>Sub-items</source>
-        <target state="new">Sub-items</target>
-        <note>key: settings.subitems_limit.value.title</note>
-      </trans-unit>
-      <trans-unit id="98400a7e546231a994f6fea03dce3ebd52c1c33d" resname="settings.character_counter.value.description">
-        <source><![CDATA[Display character count for Online Editor]]></source>
-        <target state="new"><![CDATA[Display character count for Online Editor]]></target>
-        <note>key: settings.character_counter.value.description</note>
-      </trans-unit>
-      <trans-unit id="fd6ba122727aeacdb3e8c1c02d3e9ae023ca2174" resname="settings.character_counter.value.enabled">
-        <source>enabled</source>
-        <target state="new">Enabled</target>
-        <note>key: settings.character_counter.value.enabled</note>
-      </trans-unit>
-      <trans-unit id="3d03b64f879f2c57cb9395f31c7691ecb7cc2807" resname="settings.character_counter.value.disabled">
-        <source>disabled</source>
-        <target state="new">Disabled</target>
-        <note>key: settings.character_counter.value.disabled</note>
-      </trans-unit>
-      <trans-unit id="ca8c3eac8ffed6fed1ee9e028be185741f33bfec" resname="settings.character_counter.value.title">
-        <source>character counter</source>
-        <target state="new">Character counter</target>
-        <note>key: settings.character_counter.value.title</note>
-      </trans-unit>
-      <trans-unit id="4e0e12004096ce400ace603bc7177c044159b57b" resname="character_counter.words">
-        <source>words</source>
-        <target state="new">words</target>
-        <note>key: character_counter.words</note>
-      </trans-unit>
-      <trans-unit id="d69d746270269a4b3ff2a3ddca0a74086ef48ae6" resname="character_counter.characters">
-        <source>characters</source>
-        <target state="new">characters</target>
-        <note>key: character_counter.characters</note>
-      </trans-unit>
-      <trans-unit id="dac7ffb84bac8bc5a682388098bded0f8f49d841" resname="settings.timezone.value.description">
-        <source><![CDATA[Time Zone in use for displaying Date & Time]]></source>
-        <target state="new"><![CDATA[Time Zone in use for displaying Date & Time]]></target>
-        <note>key: settings.timezone.value.description</note>
-      </trans-unit>
-      <trans-unit id="eb891d0f4283045b518a04aa757810f1ba0b90c9" resname="settings.timezone.value.title">
-        <source>Time Zone</source>
-        <target state="new">Time Zone</target>
-        <note>key: settings.timezone.value.title</note>
-      </trans-unit>
-      <trans-unit id="7f90e23e086f56c5f7b4a82c6e4b8f40732e6e6a" resname="user_setting.update.success">
-        <source>User setting '%identifier%' updated.</source>
-        <target state="new">User setting '%identifier%' updated.</target>
-        <note>key: user_setting.update.success</note>
+      <trans-unit id="befc3e49a7bee4547f8c720a0fbb9d03d0d3e265" resname="settings.datetime_format.preview_label">
+        <source><![CDATA[Date & Time will be displayed in this format:]]></source>
+        <target state="new"><![CDATA[Date & Time will be displayed in this format:]]></target>
+        <note>key: settings.datetime_format.preview_label</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/views/user/settings/update_datetime_format.html.twig
+++ b/src/bundle/Resources/views/user/settings/update_datetime_format.html.twig
@@ -1,0 +1,16 @@
+{% extends '@ezdesign/user/settings/update.html.twig' %}
+
+{% trans_default_domain 'user_settings' %}
+
+{% block form %}
+    {{ parent() }}
+
+    <div id="ez-datetime-format-preview" class="alert ez-alert--info mt-4" role="alert">
+        {{ 'settings.datetime_format.preview_label'|trans|desc('Date & Time will be displayed in this format:') }}
+        <span class="ez-datetime-format-preview-value" />
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-settings-datetime-format-update', null, 'ezplatform') }}
+{% endblock %}

--- a/src/bundle/Resources/views/user/settings/update_datetime_format.html.twig
+++ b/src/bundle/Resources/views/user/settings/update_datetime_format.html.twig
@@ -4,7 +4,6 @@
 
 {% block form %}
     {{ parent() }}
-
     <div id="ez-datetime-format-preview" class="alert ez-alert--info mt-4" role="alert">
         {{ 'settings.datetime_format.preview_label'|trans|desc('Date & Time will be displayed in this format:') }}
         <span class="ez-datetime-format-preview-value" />
@@ -12,5 +11,6 @@
 {% endblock %}
 
 {% block javascripts %}
-    {{ encore_entry_script_tags('ezplatform-admin-ui-settings-datetime-format-update', null, 'ezplatform') }}
+    {{ parent() }}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-settings-datetime-format-update-js', null, 'ezplatform') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30251
| **Depends on**|https://github.com/ezsystems/ezplatform-user/pull/21
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added missing preview for date/time format. 

## Screenshot

![image](https://user-images.githubusercontent.com/211967/54025624-61ea6b80-419b-11e9-8ee0-462952c7b7ed.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
