### PR TITLE
EZP-30164: After removing option from ezselection it it not possible to add more options

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
@@ -20,7 +20,7 @@
                 return 0;
             }
             const lastInput = container.querySelector(SELECTOR_OPTIONS_LIST).lastElementChild.querySelector('input[type="text"]');
-            const lastId = parseInt(lastInput.name.match(/.+\[(\d)]$/)[1]);
+            const lastId = lastInput.dataset.ezselectionOptionId;
 
             return lastId + 1;
         };

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
@@ -15,12 +15,21 @@
 
             container.querySelector(SELECTOR_BTN_REMOVE)[methodName]('disabled', disabledState);
         };
+        const getNextId = () => {
+            if (countExistingOptions() === 0) {
+                return 0;
+            }
+            const lastInput = container.querySelector(SELECTOR_OPTIONS_LIST).lastElementChild.querySelector('input[type="text"]');
+            const lastId = parseInt(lastInput.name.match(/.+\[(\d)]$/)[1]);
+
+            return lastId + 1;
+        };
         const addOption = () => {
             const template = container.querySelector(SELECTOR_TEMPLATE).innerHTML;
 
             container
                 .querySelector(SELECTOR_OPTIONS_LIST)
-                .insertAdjacentHTML('beforeend', template.replace(NUMBER_PLACEHOLDER, countExistingOptions()));
+                .insertAdjacentHTML('beforeend', template.replace(NUMBER_PLACEHOLDER, getNextId()));
         };
         const removeOptions = () => {
             findCheckedOptions().forEach(element => element.closest(SELECTOR_OPTION).remove());

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.selection.js
@@ -7,7 +7,6 @@
     const NUMBER_PLACEHOLDER = /__number__/g;
 
     [...doc.querySelectorAll('.ezselection-settings.options')].forEach(container => {
-        const countExistingOptions = () => container.querySelectorAll(SELECTOR_OPTION).length;
         const findCheckedOptions = () => [...container.querySelectorAll('.ezselection-settings-option-checkbox:checked')];
         const toggleDisableState = () => {
             const disabledState = !!findCheckedOptions().length;
@@ -15,21 +14,13 @@
 
             container.querySelector(SELECTOR_BTN_REMOVE)[methodName]('disabled', disabledState);
         };
-        const getNextId = () => {
-            if (countExistingOptions() === 0) {
-                return 0;
-            }
-            const lastInput = container.querySelector(SELECTOR_OPTIONS_LIST).lastElementChild.querySelector('input[type="text"]');
-            const lastId = lastInput.dataset.ezselectionOptionId;
-
-            return lastId + 1;
-        };
         const addOption = () => {
             const template = container.querySelector(SELECTOR_TEMPLATE).innerHTML;
+            const optionsList = container.querySelector(SELECTOR_OPTIONS_LIST);
+            const nextId = parseInt(optionsList.dataset.nextOptionId, 10);
 
-            container
-                .querySelector(SELECTOR_OPTIONS_LIST)
-                .insertAdjacentHTML('beforeend', template.replace(NUMBER_PLACEHOLDER, getNextId()));
+            optionsList.dataset.nextOptionId = nextId + 1;
+            optionsList.insertAdjacentHTML('beforeend', template.replace(NUMBER_PLACEHOLDER, nextId));
         };
         const removeOptions = () => {
             findCheckedOptions().forEach(element => element.closest(SELECTOR_OPTION).remove());

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -212,7 +212,10 @@
                         class="ezselection-settings-option-checkbox ez-selection-table-checkbox"
                         {{ is_translation ? 'disabled' : '' }}>
                     {{ form_errors(option) }}
-                    {{ form_widget(option, { 'attr': { 'class': 'form-control ml-1 mb-0'}}) }}
+                    {{ form_widget(option, { 'attr': {
+                        'class': 'form-control ml-1 mb-0',
+                        'data-ezselection-option-id': option.vars.name }})
+                    }}
                 </li>
             {% endfor %}
         </ul>
@@ -222,7 +225,10 @@
             data-ezselection-option-input-id="{{ form.options.vars.prototype.vars.id }}">
             <li class="ezselection-settings-option-value ez-selection-table-row mb-2 d-flex align-items-center">
                 <input type="checkbox" class="ezselection-settings-option-checkbox ez-selection-table-checkbox">
-                {{ form_widget(form.options.vars.prototype, { 'attr': { 'class': 'form-control ml-1 mb-0'}}) }}
+                {{ form_widget(form.options.vars.prototype, { 'attr': {
+                    'class': 'form-control ml-1 mb-0',
+                    'data-ezselection-option-id': form.options.vars.prototype.vars.name
+                }}) }}
             </li>
         </script>
 

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -204,7 +204,8 @@
         {{ form_errors(form.options) }}
         <ul
             class="ezselection-settings-option-list ez-selection-table list-unstyled"
-            data-selection-buttons=".ezselection-settings-option-remove">
+            data-selection-buttons=".ezselection-settings-option-remove"
+            data-next-option-id="{{ form.options.vars.value is empty ? 0 : max(form.options.vars.value|keys) + 1 }}">
             {% for option in form.options %}
                 <li class="ezselection-settings-option-value ez-selection-table-row mb-2 d-flex align-items-center">
                     <input
@@ -212,10 +213,7 @@
                         class="ezselection-settings-option-checkbox ez-selection-table-checkbox"
                         {{ is_translation ? 'disabled' : '' }}>
                     {{ form_errors(option) }}
-                    {{ form_widget(option, { 'attr': {
-                        'class': 'form-control ml-1 mb-0',
-                        'data-ezselection-option-id': option.vars.name }})
-                    }}
+                    {{ form_widget(option, { 'attr': { 'class': 'form-control ml-1 mb-0'}}) }}
                 </li>
             {% endfor %}
         </ul>
@@ -225,10 +223,7 @@
             data-ezselection-option-input-id="{{ form.options.vars.prototype.vars.id }}">
             <li class="ezselection-settings-option-value ez-selection-table-row mb-2 d-flex align-items-center">
                 <input type="checkbox" class="ezselection-settings-option-checkbox ez-selection-table-checkbox">
-                {{ form_widget(form.options.vars.prototype, { 'attr': {
-                    'class': 'form-control ml-1 mb-0',
-                    'data-ezselection-option-id': form.options.vars.prototype.vars.name
-                }}) }}
+                {{ form_widget(form.options.vars.prototype, { 'attr': { 'class': 'form-control ml-1 mb-0'}}) }}
             </li>
         </script>
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30164
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Instead of counting options, which creates problem with overlapping ids when prior to add option is removed, we use `id` extracted from `name` from last input.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
