### PR TITLE
EZP-30107: Name of Content Item is not updated after changing the main language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "white-october/pagerfanta-bundle": "^1.1",
         "knplabs/knp-menu-bundle": "^2.1",
         "mck89/peast": "^1.8",
-        "willdurand/js-translation-bundle": "^2.6.6",
-        "ezsystems/ezplatform-user": "^1.0@dev"
+        "willdurand/js-translation-bundle": "^2.6.6"
     },
     "require-dev": {
         "behat/behat": "^3.5.0",

--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -349,7 +349,8 @@ class ContentController extends Controller
 
         if ($form->isSubmitted()) {
             $result = $this->submitHandler->handle($form, function (MainTranslationUpdateData $data) {
-                $contentInfo = $data->getContentInfo();
+                $content = $data->getContent();
+                $contentInfo = $content->contentInfo;
                 $mapper = new MainTranslationUpdateMapper();
                 $contentMetadataUpdateStruct = $mapper->reverseMap($data);
                 $this->contentService->updateContentMetadata($contentInfo, $contentMetadataUpdateStruct);

--- a/src/lib/Form/Data/Content/Translation/MainTranslationUpdateData.php
+++ b/src/lib/Form/Data/Content/Translation/MainTranslationUpdateData.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation;
 
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class MainTranslationUpdateData
@@ -16,9 +16,9 @@ class MainTranslationUpdateData
     /**
      * @Assert\NotBlank()
      *
-     * @var \eZ\Publish\API\Repository\Values\Content\ContentInfo|null
+     * @var \eZ\Publish\API\Repository\Values\Content\Content|null
      */
-    public $contentInfo;
+    public $content;
 
     /**
      * @Assert\NotBlank()
@@ -28,31 +28,31 @@ class MainTranslationUpdateData
     public $languageCode;
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo|null $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Content|null $content
      * @param string|null $languageCode
      */
     public function __construct(
-        ?ContentInfo $contentInfo = null,
+        ?Content $content = null,
         ?string $languageCode = null
     ) {
-        $this->contentInfo = $contentInfo;
+        $this->content = $content;
         $this->languageCode = $languageCode;
     }
 
     /**
-     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo|null
+     * @return \eZ\Publish\API\Repository\Values\Content\Content|null
      */
-    public function getContentInfo(): ?ContentInfo
+    public function getContent(): ?Content
     {
-        return $this->contentInfo;
+        return $this->content;
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo|null $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Content|null $contentInfo
      */
-    public function setContentInfo(?ContentInfo $contentInfo = null)
+    public function setContent(?Content $contentInfo = null)
     {
-        $this->contentInfo = $contentInfo;
+        $this->content = $contentInfo;
     }
 
     /**

--- a/src/lib/Form/DataMapper/MainTranslationUpdateMapper.php
+++ b/src/lib/Form/DataMapper/MainTranslationUpdateMapper.php
@@ -43,6 +43,7 @@ class MainTranslationUpdateMapper implements DataMapperInterface
 
         return new ContentMetadataUpdateStruct([
             'mainLanguageCode' => $data->getLanguageCode(),
+            'name' => $data->getContent()->getName($data->getLanguageCode()),
         ]);
     }
 }

--- a/src/lib/Form/DataTransformer/ContentTransformer.php
+++ b/src/lib/Form/DataTransformer/ContentTransformer.php
@@ -28,13 +28,13 @@ class ContentTransformer implements DataTransformerInterface
     }
 
     /**
-     * Transforms a domain specific ContentInfo object into a Content's ID.
+     * Transforms a domain specific Content object into a Content's ID.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Content|null $value
      *
      * @return int|null
      */
-    public function transform($value)
+    public function transform($value): ?int
     {
         if (null === $value) {
             return null;
@@ -62,7 +62,7 @@ class ContentTransformer implements DataTransformerInterface
             return null;
         }
 
-        if (!is_numeric($value)) {
+        if (!filter_var($value, FILTER_VALIDATE_INT)) {
             throw new TransformationFailedException('Expected a numeric string.');
         }
 

--- a/src/lib/Form/DataTransformer/ContentTransformer.php
+++ b/src/lib/Form/DataTransformer/ContentTransformer.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\DataTransformer;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class ContentTransformer implements DataTransformerInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    protected $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Transforms a domain specific ContentInfo object into a Content's ID.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content|null $value
+     *
+     * @return int|null
+     */
+    public function transform($value)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof Content) {
+            throw new TransformationFailedException('Expected a ' . Content::class . ' object.');
+        }
+
+        return $value->id;
+    }
+
+    /**
+     * Transforms a Content's ID integer into a domain specific Content object.
+     *
+     * @param string|null $value
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function reverseTransform($value): ?Content
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if (!is_numeric($value)) {
+            throw new TransformationFailedException('Expected a numeric string.');
+        }
+
+        try {
+            return $this->contentService->loadContent($value);
+        } catch (NotFoundException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/lib/Form/Type/Content/ContentType.php
+++ b/src/lib/Form/Type/Content/ContentType.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\Content;
+
+use eZ\Publish\API\Repository\ContentService;
+use EzSystems\EzPlatformAdminUi\Form\DataTransformer\ContentTransformer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ContentType extends AbstractType
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    protected $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addViewTransformer(new ContentTransformer($this->contentService));
+    }
+
+    public function getParent(): ?string
+    {
+        return HiddenType::class;
+    }
+}

--- a/src/lib/Form/Type/Content/ContentType.php
+++ b/src/lib/Form/Type/Content/ContentType.php
@@ -27,11 +27,17 @@ class ContentType extends AbstractType
         $this->contentService = $contentService;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addViewTransformer(new ContentTransformer($this->contentService));
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getParent(): ?string
     {
         return HiddenType::class;

--- a/src/lib/Form/Type/Content/Translation/MainTranslationUpdateType.php
+++ b/src/lib/Form/Type/Content/Translation/MainTranslationUpdateType.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation;
 
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\MainTranslationUpdateData;
-use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentInfoType;
+use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -26,8 +26,8 @@ class MainTranslationUpdateType extends AbstractType
     {
         $builder
             ->add(
-                'content_info',
-                ContentInfoType::class,
+                'content',
+                ContentType::class,
                 ['label' => false]
             )
             ->add(

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Tab\LocationView;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\MainTranslationUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
@@ -109,14 +108,13 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
         );
 
         $mainTranslationUpdateForm = $this->createMainLanguageUpdateForm(
-            $versionInfo->contentInfo,
+            $content,
             $versionInfo->contentInfo->mainLanguageCode
         );
 
         $viewParameters = [
             'translations' => $translationsDataset->getTranslations(),
             'form_translation_add' => $translationAddForm->createView(),
-            'form_translation_remove' => $translationDeleteForm->createView(),
             'form_translation_remove' => $translationDeleteForm->createView(),
             'form_main_translation_update' => $mainTranslationUpdateForm->createView(),
             'main_translation_switch' => true,
@@ -158,16 +156,14 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
     }
 
     /**
-     * @param ContentInfo $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $languageCode
      *
-     * @return FormInterface
-     *
-     * @throws InvalidOptionsException
+     * @return \Symfony\Component\Form\FormInterface
      */
-    private function createMainLanguageUpdateForm(ContentInfo $contentInfo, string $languageCode): FormInterface
+    private function createMainLanguageUpdateForm(Content $content, string $languageCode): FormInterface
     {
-        $data = new MainTranslationUpdateData($contentInfo, $languageCode);
+        $data = new MainTranslationUpdateData($content, $languageCode);
 
         return $this->formFactory->create(MainTranslationUpdateType::class, $data);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30107
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (as this was not released yet)
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Following changes in https://github.com/ezsystems/ezpublish-kernel/pull/2563 were needed.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
