### PR TITLE
EZEE-2718: Adjust tests for redirects

### DIFF
--- a/features/ContentCreation.feature
+++ b/features/ContentCreation.feature
@@ -256,7 +256,7 @@ Scenario: Content can be moved to trash from non-root location
   Scenario Outline: Content can be moved to trash from root location
     Given I navigate to content "<itemName>" of type "<itemType>" in root path
     When I send content to trash
-    Then there's no "<itemType>" "<itemName>" on Sub-items list of root
+    Then I should be redirected to root in default view
     And going to trash there is "<itemType>" "<itemName>" on list
 
     Examples:

--- a/src/lib/Behat/BusinessContext/NavigationContext.php
+++ b/src/lib/Behat/BusinessContext/NavigationContext.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformAdminUi\Behat\BusinessContext;
 
 use EzSystems\EzPlatformAdminUi\Behat\Helper\EzEnvironmentConstants;
+use EzSystems\EzPlatformPageBuilder\Tests\Behat\PageObject\PageBuilderEditor;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Breadcrumb;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\UpperMenu;
@@ -120,5 +121,22 @@ class NavigationContext extends BusinessContext
     {
         $path = sprintf('%s/%s', EzEnvironmentConstants::get('ROOT_CONTENT_NAME'), $path);
         $this->verifyIfBreadcrumbShowsPath($path);
+    }
+
+    /**
+     * @Then I should be redirected to root in default view
+     */
+    public function iShouldBeRedirectedToRootInDefaultView(): void
+    {
+        if (EzEnvironmentConstants::get('ROOT_CONTENT_TYPE') === 'Landing page') {
+            $previewType = PageObjectFactory::getPreviewType(EzEnvironmentConstants::get('ROOT_CONTENT_TYPE'));
+            $pageEditor = PageObjectFactory::createPage($this->utilityContext, PageBuilderEditor::PAGE_NAME, $previewType);
+            $pageEditor->pagePreview->setTitle(EzEnvironmentConstants::get('ROOT_CONTENT_NAME'));
+            $pageEditor->waitUntilLoaded();
+            $pageEditor->verifyIsLoaded();
+        } else {
+            $contentItemPage = PageObjectFactory::createPage($this->utilityContext, ContentItemPage::PAGE_NAME, EzEnvironmentConstants::get('ROOT_CONTENT_NAME'));
+            $contentItemPage->verifyIsLoaded();
+        }
     }
 }

--- a/src/lib/Behat/BusinessContext/TrashContext.php
+++ b/src/lib/Behat/BusinessContext/TrashContext.php
@@ -10,8 +10,11 @@ use EzSystems\EzPlatformAdminUi\Behat\PageElement\Dialog;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\LeftMenu;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\RightMenu;
+use EzSystems\EzPlatformAdminUi\Behat\Helper\EzEnvironmentConstants;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\UpperMenu;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\PageObjectFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\TrashPage;
+use EzSystems\EzPlatformAdminUi\Behat\PageObject\ContentItemPage;
 use PHPUnit\Framework\Assert;
 
 class TrashContext extends BusinessContext
@@ -45,6 +48,17 @@ class TrashContext extends BusinessContext
     public function goingToTrashThereIsItemOnList(string $itemType, string $itemName): void
     {
         $leftMenu = ElementFactory::createElement($this->utilityContext, LeftMenu::ELEMENT_NAME);
+
+        if (!$leftMenu->isVisible()) {
+            // we're not in Content View
+            $upperMenu = ElementFactory::createElement($this->utilityContext, UpperMenu::ELEMENT_NAME);
+            $upperMenu->goToTab('Content');
+            $upperMenu->goToSubTab('Content structure');
+
+            $contentPage = PageObjectFactory::createPage($this->utilityContext, ContentItemPage::PAGE_NAME, EzEnvironmentConstants::get('ROOT_CONTENT_NAME'));
+            $contentPage->verifyIsLoaded();
+        }
+
         $leftMenu->clickButton('Trash');
 
         $trash = PageObjectFactory::createPage($this->utilityContext, TrashPage::PAGE_NAME);

--- a/src/lib/Behat/Helper/Hooks.php
+++ b/src/lib/Behat/Helper/Hooks.php
@@ -17,13 +17,6 @@ class Hooks extends RawMinkContext
 
     /** @BeforeScenario
      */
-    public function restartSessionBeforeScenario()
-    {
-        $this->getSession()->restart();
-    }
-
-    /** @BeforeScenario
-     */
     public function setInstallTypeBeforeScenario()
     {
         $env = new Environment($this->getContainer());

--- a/src/lib/Behat/PageElement/LeftMenu.php
+++ b/src/lib/Behat/PageElement/LeftMenu.php
@@ -37,4 +37,9 @@ class LeftMenu extends Element
     {
         Assert::assertTrue($this->context->findElement($this->fields['menuSelector'])->isVisible());
     }
+
+    public function isVisible(): bool
+    {
+        return $this->context->isElementVisible($this->fields['menuSelector']);
+    }
 }


### PR DESCRIPTION
After https://jira.ez.no/browse/EZEE-2718 the behaviour after Trashing a content item has changed:
Before:
Trashing a Content Item that has a Landing Page as a parent redirects to the Parent in Content View
After:
Trashing a Content Item that has a Landing Page as a parent redirects to the Parent:
- ezplatform: in Content View
- ezplatform-ee: in Page Builder

This is a bit tricky, as we don't have a mechanism right now to deal with logic like this.

Possible solutions:
1) the proposed one - adding an IF based on environment

I'm not a fan of this, but it works - we need to think of a better approach for future uses.

2) Defining the same step definition in two Contexts and specifying the correct one in behat_suites.yml

I've decided against at as it does not work for use cases like "I want to run AdminUI suite on ezplatform-ee (we would have to define the suite twice, with the different Context being the only difference)

3) Creating two scenarios, tagging it with `ezplatform` and `ezplatform-ee` and filtering it in suites: 

Again, this does not work for use case "I want to run AdminUI suite on ezplatform-ee"

4) Creating two scenarios, tagging it with `ezplatform` and `ezplatform-ee` and filtering in an BeforeScenario hook

This works, but only partially - the ezplatform-ee scenario might require steps that are not defined in any AdminUI Context, so it will fail when running with --strict flag because of undefined steps

5) Create a Behat extension that will allow to skip tests marked with a certain tag (for example "ezplatform" when running on "ezplatform-ee") and will not mark undefined steps in these Scenarios as missing

I've an idea how to do it, but it's not something I can do right now.