### PR TITLE
EZP-30297: Error when I try to add a translation for a user object

### DIFF
--- a/src/lib/RepositoryForms/Data/ContentTranslationData.php
+++ b/src/lib/RepositoryForms/Data/ContentTranslationData.php
@@ -7,8 +7,8 @@
 namespace EzSystems\EzPlatformAdminUi\RepositoryForms\Data;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
+use EzSystems\RepositoryForms\Data\ContentTranslationData as BaseContentTranslationData;
 use EzSystems\RepositoryForms\Data\NewnessCheckable;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @property FieldData[] $fieldsData
  * @property Content $content
  */
-class ContentTranslationData extends ContentUpdateStruct implements NewnessCheckable
+class ContentTranslationData extends BaseContentTranslationData implements NewnessCheckable
 {
     /**
      * @var \EzSystems\RepositoryForms\Data\Content\FieldData[]
@@ -31,6 +31,8 @@ class ContentTranslationData extends ContentUpdateStruct implements NewnessCheck
     }
 
     protected $content;
+
+    protected $contentType;
 
     public function isNew()
     {

--- a/src/lib/RepositoryForms/Data/Mapper/ContentTranslationMapper.php
+++ b/src/lib/RepositoryForms/Data/Mapper/ContentTranslationMapper.php
@@ -50,7 +50,7 @@ class ContentTranslationMapper implements FormDataMapperInterface
         /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
         $contentType = $params['contentType'];
 
-        $data = new ContentTranslationData(['content' => $content]);
+        $data = new ContentTranslationData(['content' => $content, 'contentType' => $contentType]);
         $data->initialLanguageCode = $language->languageCode;
 
         foreach ($content->getFieldsByLanguage() as $field) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30297](https://jira.ez.no/browse/EZP-30297)
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

[https://github.com/ezsystems/repository-forms/pull/282](https://github.com/ezsystems/repository-forms/pull/282)
<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
