### PR TITLE
EZP-30307: After removing option from ezauthor it is not possible to add more

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
@@ -62,7 +62,7 @@
          * @memberof EzAuthorValidator
          */
         setIndex(parentNode, template) {
-            return template.replace(/__index__/g, parentNode.querySelectorAll(SELECTOR_AUTHOR).length);
+            return template.replace(/__index__/g, parentNode.dataset.nextAuthorId);
         }
 
         /**
@@ -113,6 +113,7 @@
             const node = event.target.closest('.ez-field-edit__data .ez-data-source');
 
             node.insertAdjacentHTML('beforeend', this.setIndex(authorNode, template));
+            authorNode.dataset.nextAuthorId++;
 
             this.reinit();
             this.updateDisabledState(authorNode);

--- a/src/bundle/Resources/views/fieldtypes/edit/ezauthor.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezauthor.html.twig
@@ -1,6 +1,9 @@
 {% block ezplatform_fieldtype_ezauthor_row %}
     {% if form.authors.vars.prototype is defined %}
-        {%- set wrapper_attr = attr|merge({'data-template': form_row(form.authors.vars.prototype) }) -%}
+        {%- set wrapper_attr = attr|merge({
+            'data-template': form_row(form.authors.vars.prototype),
+            'data-next-author-id': form.authors.vars.value is empty ? 0 : max(form.authors.vars.value|keys) + 1
+        }) -%}
     {% endif %}
     {{ block('form_row_fieldtype') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30307
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
