### PR TITLE
EZP-30179: Anchor to image not displayed when returning to editor

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -426,9 +426,15 @@ const embedBaseDefinition = {
 
         while (element) {
             next = element.getNext();
-            if (!element.data || !element.data('ezelement')) {
+
+            const isEzElement = element.data && element.data('ezelement');
+            const isAnchorIcon = element.$.classList && element.$.classList.contains('ez-icon--anchor');
+            const shouldRemove = !(isEzElement || isAnchorIcon);
+
+            if (shouldRemove) {
                 element.remove();
             }
+
             element = next;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30179
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
