### PR TITLE
EZP-30263 : User date format don't apply to date fields in content item update and preview

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -61,7 +61,7 @@
 
     const dateFields = [...doc.querySelectorAll(SELECTOR_FIELD)];
     const dateConfig = {
-        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.full_date),
+        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.fullDate),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -61,7 +61,7 @@
 
     const dateFields = [...doc.querySelectorAll(SELECTOR_FIELD)];
     const dateConfig = {
-        formatDate: (date) => new Date(date).toLocaleDateString(),
+        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.full_date),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdatetime.js
@@ -65,6 +65,7 @@
     const datetimeConfig = {
         enableTime: true,
         time_24hr: true,
+        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null),
     };
     const updateInputValue = (sourceInput, dates) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);
@@ -95,7 +96,6 @@
         const flatPickrInput = field.querySelector(SELECTOR_FLATPICKR_INPUT);
         const btnClear = field.querySelector('.ez-data-source__btn--clear-input');
         const secondsEnabled = sourceInput.dataset.seconds === '1';
-        const formatDate = secondsEnabled ? (date) => date.toLocaleString() : (date) => eZ.helpers.timezone.formatDate(date);
         let defaultDate = null;
 
         if (sourceInput.value) {
@@ -111,7 +111,6 @@
                 onChange: updateInputValue.bind(null, sourceInput),
                 defaultDate,
                 enableSeconds: secondsEnabled,
-                formatDate,
             })
         );
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
@@ -64,7 +64,7 @@
         enableTime: true,
         noCalendar: true,
         time_24hr: true,
-        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.full_time),
+        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.fullTime),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);

--- a/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
@@ -1,4 +1,4 @@
-(function (global) {
+(function(global) {
     const SELECTOR_FIELD = '.ez-field-edit--eztime';
     const SELECTOR_INPUT = '.ez-data-source__input:not(.flatpickr-input)';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
@@ -29,7 +29,7 @@
 
             return {
                 isError,
-                errorMessage
+                errorMessage,
             };
         }
     }
@@ -57,15 +57,14 @@
 
     validator.init();
 
-    global.eZ.fieldTypeValidators = global.eZ.fieldTypeValidators ?
-        [...global.eZ.fieldTypeValidators, validator] :
-        [validator];
+    global.eZ.fieldTypeValidators = global.eZ.fieldTypeValidators ? [...global.eZ.fieldTypeValidators, validator] : [validator];
 
     const timeFields = [...document.querySelectorAll(SELECTOR_FIELD)];
     const timeConfig = {
         enableTime: true,
         noCalendar: true,
-        time_24hr: true
+        time_24hr: true,
+        formatDate: (date) => eZ.helpers.timezone.formatFullDateTime(date, null, eZ.adminUiConfig.dateFormat.full_time),
     };
     const updateInputValue = (sourceInput, date) => {
         const event = new CustomEvent(EVENT_VALUE_CHANGED);
@@ -78,7 +77,7 @@
         }
 
         date = new Date(date[0]);
-        sourceInput.value = (date.getHours() * 3600) + (date.getMinutes() * 60) + date.getSeconds();
+        sourceInput.value = date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
 
         sourceInput.dispatchEvent(event);
     };
@@ -94,27 +93,33 @@
             const date = new Date();
 
             date.setHours(Math.floor(value / 3600));
-            date.setMinutes(Math.floor(value % 3600 / 60));
-            date.setSeconds(Math.floor(value % 3600 % 60));
+            date.setMinutes(Math.floor((value % 3600) / 60));
+            date.setSeconds(Math.floor((value % 3600) % 60));
 
             defaultDate = date;
         }
 
-        btnClear.addEventListener('click', (event) => {
-            event.preventDefault();
+        btnClear.addEventListener(
+            'click',
+            (event) => {
+                event.preventDefault();
 
-            flatPickrInput.value = '';
-            sourceInput.value = '';
+                flatPickrInput.value = '';
+                sourceInput.value = '';
 
-            sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
-        }, false);
+                sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
+            },
+            false
+        );
 
-        window.flatpickr(flatPickrInput, Object.assign({}, timeConfig, {
-            enableSeconds,
-            onChange: updateInputValue.bind(null, sourceInput),
-            dateFormat: enableSeconds ? 'H:i:S' : 'H:i',
-            defaultDate
-        }));
+        window.flatpickr(
+            flatPickrInput,
+            Object.assign({}, timeConfig, {
+                enableSeconds,
+                onChange: updateInputValue.bind(null, sourceInput),
+                defaultDate,
+            })
+        );
 
         if (sourceInput.hasAttribute('required')) {
             flatPickrInput.setAttribute('required', true);

--- a/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
@@ -13,10 +13,10 @@
 
         return moment(date).formatICU(format);
     };
-    const formatFullDateTime = (date, timezone = null, format = userPreferedFullDateTimeFormat) => {
+    const formatFullDateTime = (date, timezone = userPreferedTimezone, format = userPreferedFullDateTimeFormat) => {
         return formatDate(date, timezone, format);
     };
-    const formatShortDateTime = (date, timezone = null, format = userPreferedShortDateTimeFormat) => {
+    const formatShortDateTime = (date, timezone = userPreferedTimezone, format = userPreferedShortDateTimeFormat) => {
         return formatDate(date, timezone, format);
     };
 

--- a/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
@@ -1,29 +1,77 @@
 (function(global, doc, eZ, moment) {
     const userPreferedTimezone = eZ.adminUiConfig.timezone;
-    const userPreferedFullDateFormat = eZ.adminUiConfig.dateFormat.full;
-    const userPreferedShortDateFormat = eZ.adminUiConfig.dateFormat.short;
+    const userPreferedFullDateTimeFormat = eZ.adminUiConfig.dateFormat.full_datetime;
+    const userPreferedFullDateFormat = eZ.adminUiConfig.dateFormat.full_date;
+    const userPreferedFullTimeFormat = eZ.adminUiConfig.dateFormat.full_time;
+    const userPreferedShortDateTimeFormat = eZ.adminUiConfig.dateFormat.short_datetime;
+    const userPreferedShortDateFormat = eZ.adminUiConfig.dateFormat.short_date;
+    const userPreferedShortTimeFormat = eZ.adminUiConfig.dateFormat.short_time;
 
     const convertDateToTimezone = (date, timezone = userPreferedTimezone, forceSameTime = false) => {
         return moment(date).tz(timezone, forceSameTime);
     };
-    const formatDate = (date, format = userPreferedFullDateFormat) => {
+    const formatDate = (date, format, timezone = null) => {
+        if (timezone) {
+            date = convertDateToTimezone(date, timezone);
+        }
+
         return moment(date).formatICU(format);
     };
-    const formatDateWithTimezone = (date, timezone = userPreferedTimezone, format = userPreferedFullDateFormat) => {
-        return formatDate(convertDateToTimezone(date, timezone), format);
+    const formatFullDateTime = (date, timezone = null, format = userPreferedFullDateTimeFormat) => {
+        return formatDate(date, format, timezone);
     };
-    const formatShortDate = (date, format = userPreferedShortDateFormat) => {
-        return formatDate(date, format);
+    const formatFullDate = (date, timezone = null, format = userPreferedFullDateFormat) => {
+        return formatDate(date, format, timezone);
     };
-    const formatShortDateWithTimezone = (date, timezone = userPreferedTimezone, format = userPreferedShortDateFormat) => {
-        return formatDateWithTimezone(date, timezone, format);
+    const formatFullTime = (date, timezone = null, format = userPreferedFullTimeFormat) => {
+        return formatDate(date, format, timezone);
+    };
+    const formatShortDateTime = (date, timezone = null, format = userPreferedShortDateTimeFormat) => {
+        return formatDate(date, format, timezone);
+    };
+    const formatShortDate = (date, timezone = null, format = userPreferedShortDateFormat) => {
+        return formatDate(date, format, timezone);
+    };
+    const formatShortTime = (date, timezone = null, format = userPreferedShortimeFormat) => {
+        return formatDate(date, format, timezone);
+    };
+
+    const deprecatedFormatDate = (date, format = userPreferedFullDateTimeFormat) => {
+        console.warn('[DEPRECATED] formatDate function is deprecated');
+        console.warn('[DEPRECATED] it will change behaviour from ezplatform-admin-ui 2.0');
+        console.warn('[DEPRECATED] use formatFullDateTime instead');
+
+        return formatFullDateTime(date, null, format);
+    };
+    const deprecatedFormatShortDate = (date, format = userPreferedShortDateTimeFormat) => {
+        console.warn('[DEPRECATED] formatShortDate function is deprecated');
+        console.warn('[DEPRECATED] it will change behaviour from ezplatform-admin-ui 2.0');
+        console.warn('[DEPRECATED] use formatShortDateTime instead');
+
+        return formatShortDateTime(date, null, format);
+    };
+    const deprecatedFormatDateWithTimezone = (date, timezone, format) => {
+        console.warn('[DEPRECATED] formatDateWithTimezone function is deprecated');
+        console.warn('[DEPRECATED] it will be removed from ezplatform-admin-ui 2.0');
+        console.warn('[DEPRECATED] use formatFullDateTime instead');
+
+        return formatFullDateTime(date, timezone, format);
+    };
+    const deprecatedFormatShortDateWithTimezone = (date, timezone, format) => {
+        console.warn('[DEPRECATED] formatShortDateWithTimezone function is deprecated');
+        console.warn('[DEPRECATED] it will be removed from ezplatform-admin-ui 2.0');
+        console.warn('[DEPRECATED] use formatShortDateTime instead');
+
+        return formatShortDateTime(date, timezone, format);
     };
 
     eZ.addConfig('helpers.timezone', {
         convertDateToTimezone,
-        formatDate,
-        formatShortDate,
-        formatDateWithTimezone,
-        formatShortDateWithTimezone,
+        formatFullDateTime,
+        formatShortDateTime,
+        formatDate: deprecatedFormatDate,
+        formatShortDate: deprecatedFormatShortDate,
+        formatDateWithTimezone: deprecatedFormatDateWithTimezone,
+        formatShortDateWithTimezone: deprecatedFormatShortDateWithTimezone,
     });
 })(window, document, window.eZ, window.moment);

--- a/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/timezone.helper.js
@@ -1,16 +1,12 @@
 (function(global, doc, eZ, moment) {
     const userPreferedTimezone = eZ.adminUiConfig.timezone;
-    const userPreferedFullDateTimeFormat = eZ.adminUiConfig.dateFormat.full_datetime;
-    const userPreferedFullDateFormat = eZ.adminUiConfig.dateFormat.full_date;
-    const userPreferedFullTimeFormat = eZ.adminUiConfig.dateFormat.full_time;
-    const userPreferedShortDateTimeFormat = eZ.adminUiConfig.dateFormat.short_datetime;
-    const userPreferedShortDateFormat = eZ.adminUiConfig.dateFormat.short_date;
-    const userPreferedShortTimeFormat = eZ.adminUiConfig.dateFormat.short_time;
+    const userPreferedFullDateTimeFormat = eZ.adminUiConfig.dateFormat.fullDateTime;
+    const userPreferedShortDateTimeFormat = eZ.adminUiConfig.dateFormat.shortDateTime;
 
     const convertDateToTimezone = (date, timezone = userPreferedTimezone, forceSameTime = false) => {
         return moment(date).tz(timezone, forceSameTime);
     };
-    const formatDate = (date, format, timezone = null) => {
+    const formatDate = (date, timezone = null, format) => {
         if (timezone) {
             date = convertDateToTimezone(date, timezone);
         }
@@ -18,22 +14,10 @@
         return moment(date).formatICU(format);
     };
     const formatFullDateTime = (date, timezone = null, format = userPreferedFullDateTimeFormat) => {
-        return formatDate(date, format, timezone);
-    };
-    const formatFullDate = (date, timezone = null, format = userPreferedFullDateFormat) => {
-        return formatDate(date, format, timezone);
-    };
-    const formatFullTime = (date, timezone = null, format = userPreferedFullTimeFormat) => {
-        return formatDate(date, format, timezone);
+        return formatDate(date, timezone, format);
     };
     const formatShortDateTime = (date, timezone = null, format = userPreferedShortDateTimeFormat) => {
-        return formatDate(date, format, timezone);
-    };
-    const formatShortDate = (date, timezone = null, format = userPreferedShortDateFormat) => {
-        return formatDate(date, format, timezone);
-    };
-    const formatShortTime = (date, timezone = null, format = userPreferedShortimeFormat) => {
-        return formatDate(date, format, timezone);
+        return formatDate(date, timezone, format);
     };
 
     const deprecatedFormatDate = (date, format = userPreferedFullDateTimeFormat) => {
@@ -50,14 +34,14 @@
 
         return formatShortDateTime(date, null, format);
     };
-    const deprecatedFormatDateWithTimezone = (date, timezone, format) => {
+    const deprecatedFormatDateWithTimezone = (date, timezone = userPreferedTimezone, format = userPreferedFullDateTimeFormat) => {
         console.warn('[DEPRECATED] formatDateWithTimezone function is deprecated');
         console.warn('[DEPRECATED] it will be removed from ezplatform-admin-ui 2.0');
         console.warn('[DEPRECATED] use formatFullDateTime instead');
 
         return formatFullDateTime(date, timezone, format);
     };
-    const deprecatedFormatShortDateWithTimezone = (date, timezone, format) => {
+    const deprecatedFormatShortDateWithTimezone = (date, timezone = userPreferedTimezone, format = userPreferedShortDateTimeFormat) => {
         console.warn('[DEPRECATED] formatShortDateWithTimezone function is deprecated');
         console.warn('[DEPRECATED] it will be removed from ezplatform-admin-ui 2.0');
         console.warn('[DEPRECATED] use formatShortDateTime instead');

--- a/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
+++ b/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">yes</target>
         <note>key: ezboolean.yes</note>
       </trans-unit>
+      <trans-unit id="a871dec7f18c06b9061bc2aae9af1aafe1ad1600" resname="ezdatetime.useseconds.enabled">
+        <source>`The date format is based on your user preferences and does not include seconds even if the field allows it`</source>
+        <target state="new">`The date format is based on your user preferences and does not include seconds even if the field allows it`</target>
+        <note>key: ezdatetime.useseconds.enabled</note>
+      </trans-unit>
       <trans-unit id="bf1525899659fa5ea6c18aa4bf63d596fecbf97e" resname="ezgmaplocation.address">
         <source>Address</source>
         <target state="new">Address</target>

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -67,11 +67,7 @@
 {% block ezdatetime_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% if fieldSettings.useSeconds %}
-            {% set field_value = field.value.value|localizeddate('short', 'medium', null, ez_user_settings['timezone']) %}
-        {% else %}
-            {% set field_value = field.value.value|localizeddate('short', 'short', null, ez_user_settings['timezone']) %}
-        {% endif %}
+        {% set field_value = field.value.value|ez_full_datetime %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}
@@ -80,7 +76,7 @@
 {% block ezdate_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set field_value = field.value.date|localizeddate( 'short', 'none', parameters.locale, 'UTC' ) %}
+        {% set field_value = field.value.date|ez_full_date %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}
@@ -89,11 +85,7 @@
 {% block eztime_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% if fieldSettings.useSeconds %}
-            {% set field_value = field.value.time|localizeddate( 'none', 'medium', parameters.locale, 'UTC' ) %}
-        {% else %}
-            {% set field_value = field.value.time|localizeddate( 'none', 'short', parameters.locale, 'UTC' ) %}
-        {% endif %}
+        {% set field_value = field.value.time|ez_full_time %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}

--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -69,6 +69,11 @@
     {% if not ez_is_field_empty( content, field ) %}
         {% set field_value = field.value.value|ez_full_datetime %}
         {{ block( 'simple_block_field' ) }}
+        {% if fieldSettings.useSeconds %}
+            <div class="ez-alert ez-alert--info mt-2">
+                {{ 'ezdatetime.useseconds.enabled'|trans()|desc('`The date format is based on your user preferences and does not include seconds even if the field allows it`') }}
+            </div>
+        {% endif %}
     {% endif %}
 {% endspaceless %}
 {% endblock %}
@@ -76,7 +81,7 @@
 {% block ezdate_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set field_value = field.value.date|ez_full_date %}
+        {% set field_value = field.value.date|ez_full_date('UTC') %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}
@@ -85,8 +90,13 @@
 {% block eztime_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set field_value = field.value.time|ez_full_time %}
+        {% set field_value = field.value.time|ez_full_time('UTC') %}
         {{ block( 'simple_block_field' ) }}
+        {% if fieldSettings.useSeconds %}
+            <div class="ez-alert ez-alert--info mt-2">
+                {{ 'ezdatetime.useseconds.enabled'|trans()|desc('`The date format is based on your user preferences and does not include seconds even if the field allows it`') }}
+            </div>
+        {% endif %}
     {% endif %}
 {% endspaceless %}
 {% endblock %}

--- a/src/lib/UI/Config/Provider/DateFormat.php
+++ b/src/lib/UI/Config/Provider/DateFormat.php
@@ -46,12 +46,12 @@ class DateFormat implements ProviderInterface
         );
 
         return [
-            'full_datetime' => (string)$fullDateTimeFormat,
-            'full_date' => $fullDateTimeFormat->getDateFormat(),
-            'full_time' => $fullDateTimeFormat->getTimeFormat(),
-            'short_datetime' => (string)$shortDateTimeFormat,
-            'short_date' => $shortDateTimeFormat->getDateFormat(),
-            'short_time' => $shortDateTimeFormat->getTimeFormat(),
+            'fullDateTime' => (string)$fullDateTimeFormat,
+            'fullDate' => $fullDateTimeFormat->getDateFormat(),
+            'fullTime' => $fullDateTimeFormat->getTimeFormat(),
+            'shortDateTime' => (string)$shortDateTimeFormat,
+            'shortDate' => $shortDateTimeFormat->getDateFormat(),
+            'shortTime' => $shortDateTimeFormat->getTimeFormat(),
             /** @deprecated  */
             'full' => (string)$fullDateTimeFormat,
             /** @deprecated  */

--- a/src/lib/UI/Config/Provider/DateFormat.php
+++ b/src/lib/UI/Config/Provider/DateFormat.php
@@ -46,7 +46,15 @@ class DateFormat implements ProviderInterface
         );
 
         return [
+            'full_datetime' => (string)$fullDateTimeFormat,
+            'full_date' => $fullDateTimeFormat->getDateFormat(),
+            'full_time' => $fullDateTimeFormat->getTimeFormat(),
+            'short_datetime' => (string)$shortDateTimeFormat,
+            'short_date' => $shortDateTimeFormat->getDateFormat(),
+            'short_time' => $shortDateTimeFormat->getTimeFormat(),
+            /** @deprecated  */
             'full' => (string)$fullDateTimeFormat,
+            /** @deprecated  */
             'short' => (string)$shortDateTimeFormat,
         ];
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30263](https://jira.ez.no/browse/EZP-30263)
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Adds into ez_full_datetime, ez_full_date, ez_full_time in ezdate_fields.

Warning, this PR can be merged only if https://github.com/ezsystems/ezplatform-user/pull/26 is merged 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
