### PR TITLE
EZP-30285: Focus is set to inline custom tag toolbar in edit mode

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-custom-tag.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-custom-tag.js
@@ -42,7 +42,7 @@ CKEDITOR.dtd.$editable.span = 1;
 
                 init: function() {
                     this.on('focus', this.fireEditorInteraction);
-                    this.syncAlignment();
+                    this.syncAlignment(true);
                     this.getEzConfigElement();
                     this.cancelEditEvents();
                     this.renderIcon();

--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
@@ -66,7 +66,7 @@ const customTagBaseDefinition = {
 
     init: function() {
         this.on('focus', this.fireEditorInteraction);
-        this.syncAlignment();
+        this.syncAlignment(true);
         this.renderAttributes();
         this.renderHeader();
         this.getEzContentElement();
@@ -229,14 +229,15 @@ const customTagBaseDefinition = {
      * is aligned.
      *
      * @method syncAlignment
+     * @param {Boolean} fireEditorInteractionPrevented
      */
-    syncAlignment: function() {
+    syncAlignment: function(fireEditorInteractionPrevented) {
         const align = this.element.data(DATA_ALIGNMENT_ATTR);
 
         if (align) {
-            this.setAlignment(align);
+            this.setAlignment(align, fireEditorInteractionPrevented);
         } else {
-            this.unsetAlignment();
+            this.unsetAlignment(fireEditorInteractionPrevented);
         }
     },
 
@@ -246,13 +247,16 @@ const customTagBaseDefinition = {
      *
      * @method setAlignment
      * @param {String} type
+     * @param {Boolean} fireEditorInteractionPrevented
      */
-    setAlignment: function(type) {
+    setAlignment: function(type, fireEditorInteractionPrevented) {
         this.wrapper.data(DATA_ALIGNMENT_ATTR, type);
         this.element.data(DATA_ALIGNMENT_ATTR, type);
 
-        window.clearTimeout(this.setAlignmentFireEditorInteractionTimeout);
-        this.setAlignmentFireEditorInteractionTimeout = window.setTimeout(this.fireEditorInteraction.bind(this, 'aligmentUpdated'), 50);
+        if (!fireEditorInteractionPrevented) {
+            window.clearTimeout(this.setAlignmentFireEditorInteractionTimeout);
+            this.setAlignmentFireEditorInteractionTimeout = window.setTimeout(this.fireEditorInteraction.bind(this, 'aligmentUpdated'), 50);
+        }
     },
 
     /**
@@ -260,13 +264,19 @@ const customTagBaseDefinition = {
      * corresponding `editorInteraction` event.
      *
      * @method unsetAlignment
+     * @param {Boolean} fireEditorInteractionPrevented
      */
-    unsetAlignment: function() {
+    unsetAlignment: function(fireEditorInteractionPrevented) {
         this.wrapper.data(DATA_ALIGNMENT_ATTR, false);
         this.element.data(DATA_ALIGNMENT_ATTR, false);
 
-        window.clearTimeout(this.unsetAlignmentFireEditorInteractionTimeout);
-        this.unsetAlignmentFireEditorInteractionTimeout = window.setTimeout(this.fireEditorInteraction.bind(this, 'aligmentRemoved'), 50);
+        if (!fireEditorInteractionPrevented) {
+            window.clearTimeout(this.unsetAlignmentFireEditorInteractionTimeout);
+            this.unsetAlignmentFireEditorInteractionTimeout = window.setTimeout(
+                this.fireEditorInteraction.bind(this, 'aligmentRemoved'),
+                50
+            );
+        }
     },
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30285
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
