### PR TITLE
Wait after clicking Edit

### DIFF
--- a/features/ContentCreation.feature
+++ b/features/ContentCreation.feature
@@ -163,6 +163,7 @@ Scenario: Content draft can be created and published through draft list modal
 Scenario: Content can be previewed during edition
   Given I navigate to content "Test Article edited3" of type "Article" in root path
   When I click on the edit action bar button "Edit"
+    And I should be on "Content Update" "Test Article edited3" page
     And I click on the edit action bar button "Preview"
     And I go to "tablet" view in "Test Article edited3" preview
     And I go to "mobile" view in "Test Article edited3" preview


### PR DESCRIPTION
This should fix the failure from: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/186035384

```
    When I click on the edit action bar button "Edit"                                 # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\RightMenuContext::clickEditActionBar()
    And I click on the edit action bar button "Preview"                               # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\RightMenuContext::clickEditActionBar()
      WebDriver\Exception\StaleElementReference: stale element reference: element is not attached to the page document
```

I guess we're trying to click the "Preview" a bit too fast, added waiting that the Content Edit page is properly loaded.