### PR TITLE
EZP-30233: Messages for content item visibility are not displayed for all scenarios

### DIFF
--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -37,8 +37,8 @@
         <note>key: content.edit.select_language</note>
       </trans-unit>
       <trans-unit id="e136be672df8eb27dc4eb2f1ce0650096090bf81" resname="content.hidden.message">
-        <source>This content item is hidden and is not publicly available</source>
-        <target state="new">This content item is hidden and is not publicly available</target>
+        <source>The content item or its location is hidden. It will no longer be publicly available.</source>
+        <target state="new">The content item or its location is hidden. It will no longer be publicly available.</target>
         <note>key: content.hidden.message</note>
       </trans-unit>
       <trans-unit id="9c91d85bc7658ec7dc6bbb07b720979177c0846a" resname="content.view.subitems">

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -48,12 +48,12 @@
                             contentTypeName: contentType.name
                         } %}
 
-                        {% if location.contentInfo.isHidden %}
+                        {% if location.hidden or location.invisible %}
                             <div class="ez-alert ez-alert--info mb-4">
                                 <svg class="ez-icon ez-icon--small">
                                     <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#hide"></use>
                                 </svg>
-                                {{ 'content.hidden.message'|trans()|desc('This content item is hidden and is not publicly available') }}
+                                {{ 'content.hidden.message'|trans()|desc('The content item or its location is hidden. It will no longer be publicly available.') }}
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30233](https://jira.ez.no/browse/EZP-30233)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Adds one generic message for all scenarios when content is not publicly visible


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
