### PR TITLE
EZP-30177: Validation of XML content failed when adding two anchors w…

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-anchoredit.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-anchoredit.js
@@ -90,6 +90,8 @@ export default class EzBtnAnchorEdit extends Component {
                 [...container.querySelectorAll(`#${value}`)].every((element) => {
                     const ckeditorElement = new CKEDITOR.dom.element(element);
 
+                    block.removeClass('is-block-focused');
+
                     return ckeditorElement.isIdentical(block);
                 })
             );

--- a/src/bundle/Resources/public/scss/_alloyeditor-anchor-edit.scss
+++ b/src/bundle/Resources/public/scss/_alloyeditor-anchor-edit.scss
@@ -1,6 +1,8 @@
 .ez-ae-anchor-edit {
     display: flex;
     padding: calculateRem(8px) 0 calculateRem(8px) calculateRem(8px);
+    flex-wrap: wrap;
+    max-width: calculateRem(528px);
 
     &__input-wrapper {
         margin-right: calculateRem(10px);
@@ -19,6 +21,11 @@
         align-items: flex-end;
         justify-content: space-around;
         width: calculateRem(110px);
+    }
+
+    & &__error {
+        color: $ez-color-warning-dark;
+        margin-top: calculateRem(8px);
     }
 
     &__btn {

--- a/src/bundle/Resources/translations/alloy_editor.en.xliff
+++ b/src/bundle/Resources/translations/alloy_editor.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="a31bc2d766bef988d3d4e2e0892c79b64d2aadd9" resname="anchor_btn.error.unique">
+        <source>This anchor already exists on the page. Anchor name must be unique.</source>
+        <target state="new">This anchor already exists on the page. Anchor name must be unique.</target>
+        <note>key: anchor_btn.error.unique</note>
+      </trans-unit>
       <trans-unit id="2fec67b71cd77563c4e494477e691ba9661d95fe" resname="anchor_btn.label">
         <source>Anchor</source>
         <target state="new">Anchor</target>


### PR DESCRIPTION
…ith the same name

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30177
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
