### PR TITLE
EZP-29056: [Object States] Update notification for Object State Group and Object State contains Identifiers instead of Names

### DIFF
--- a/features/ObjectStates.feature
+++ b/features/ObjectStates.feature
@@ -61,7 +61,7 @@ Feature: Object States management
         | Name  | Test Object State Group edited |
       And I click on the edit action bar button "Save"
     Then I should be on "Object State Group" "Test Object State Group edited" page
-      And notification that "Object state group" "TestObjectStateGroupIdentifier" is updated appears
+      And notification that "Object state group" "Test Object State Group edited" is updated appears
 
   @javascript @common
   Scenario: Changes can be discarded while editing Object State Group from group details
@@ -84,7 +84,7 @@ Feature: Object States management
         | Name  | Test Object State Group edited2 |
       And I click on the edit action bar button "Save"
     Then I should be on "Object State Group" "Test Object State Group edited2" page
-      And notification that "Object state group" "TestObjectStateGroupIdentifier" is updated appears
+      And notification that "Object state group" "Test Object State Group edited2" is updated appears
 
   @javascript @common
   Scenario: Object State creation can be discarded
@@ -142,7 +142,7 @@ Feature: Object States management
         | Name  | Test Object State edited |
       And I click on the edit action bar button "Save"
     Then I should be on "Object State" "Test Object State edited" page
-      And notification that "Object state" "TestObjectStateIdentifier" is updated appears
+      And notification that "Object state" "Test Object State edited" is updated appears
       And "Object State" "Test Object State edited" has proper attributes
         | label             | value                     |
         | Object state name | Test Object State edited  |
@@ -171,7 +171,7 @@ Feature: Object States management
         | Name  | Test Object State edited2 |
       And I click on the edit action bar button "Save"
     Then I should be on "Object State" "Test Object State edited2" page
-      And notification that "Object state" "TestObjectStateIdentifier" is updated appears
+      And notification that "Object state" "Test Object State edited2" is updated appears
       And "Object State" "Test Object State edited" has proper attributes
         | label             | value                     |
         | Object state name | Test Object State edited2 |
@@ -199,7 +199,7 @@ Feature: Object States management
     When  I delete Object State from "Test Object State Group edited2"
         | item                |
         | Test Object State 2 |
-    Then notification that "Object state" "TestObjectStateIdentifier2" is deleted appears
+    Then notification that "Object state" "Test Object State edited2" is deleted appears
       And there's no "Test Object State 2" on "Test Object State Group edited2" Object States list
 
   @javascript @common
@@ -208,5 +208,5 @@ Feature: Object States management
     When I delete "Object State Group"
       | item                            |
       | Test Object State Group edited2 |
-    Then notification that "Object state type group" "TestObjectStateGroupIdentifier" is deleted appears
+    Then notification that "Object state type group" "Test Object State Group edited2" is deleted appears
       And there's no "Test Object State Group edited2" on "Object State Groups" list

--- a/features/ObjectStates.feature
+++ b/features/ObjectStates.feature
@@ -32,7 +32,7 @@ Feature: Object States management
         | label                   | value                          |
         | Object state group name | Test Object State Group        |
         | Identifier              | TestObjectStateGroupIdentifier |
-      And notification that "Object state type group" "Test Object State Group" is created appears
+      And notification that "Object state group" "Test Object State Group" is created appears
 
   @javascript @common
   Scenario: I can navigate to Admin / Object State Groups through breadcrumb
@@ -208,5 +208,5 @@ Feature: Object States management
     When I delete "Object State Group"
       | item                            |
       | Test Object State Group edited2 |
-    Then notification that "Object state type group" "Test Object State Group edited2" is deleted appears
+    Then notification that "Object state group" "Test Object State Group edited2" is deleted appears
       And there's no "Test Object State Group edited2" on "Object State Groups" list

--- a/features/ObjectStates.feature
+++ b/features/ObjectStates.feature
@@ -199,7 +199,7 @@ Feature: Object States management
     When  I delete Object State from "Test Object State Group edited2"
         | item                |
         | Test Object State 2 |
-    Then notification that "Object state" "Test Object State edited2" is deleted appears
+    Then notification that "Object state" "Test Object State 2" is deleted appears
       And there's no "Test Object State 2" on "Test Object State Group edited2" Object States list
 
   @javascript @common

--- a/src/bundle/Controller/ObjectStateController.php
+++ b/src/bundle/Controller/ObjectStateController.php
@@ -197,7 +197,7 @@ class ObjectStateController extends Controller
                     $this->translator->trans(
                         /** @Desc("Object state '%name%' deleted.") */
                         'object_state.delete.success',
-                        ['%name%' => $objectState->identifier],
+                        ['%name%' => $objectState->getName()],
                         'object_state'
                     )
                 );
@@ -239,7 +239,7 @@ class ObjectStateController extends Controller
                         $this->translator->trans(
                             /** @Desc("Object state '%name%' deleted.") */
                             'object_state.delete.success',
-                            ['%name%' => $objectState->identifier],
+                            ['%name%' => $objectState->getName()],
                             'object_state'
                         )
                     );
@@ -277,13 +277,13 @@ class ObjectStateController extends Controller
                 $updateStruct->identifier = $data->getIdentifier();
                 $updateStruct->names[$objectState->mainLanguageCode] = $data->getName();
 
-                $this->objectStateService->updateObjectState($objectState, $updateStruct);
+                $updatedObjectState = $this->objectStateService->updateObjectState($objectState, $updateStruct);
 
                 $this->notificationHandler->success(
                     $this->translator->trans(
                         /** @Desc("Object state '%name%' updated.") */
                         'object_state.update.success',
-                        ['%name%' => $objectState->identifier],
+                        ['%name%' => $updatedObjectState->getName()],
                         'object_state'
                     )
                 );
@@ -343,7 +343,7 @@ class ObjectStateController extends Controller
                     $this->translator->trans(
                         /** @Desc("Content object state '%name%' updated.") */
                         'content_object_state.update.success',
-                        ['%name%' => $objectState->identifier],
+                        ['%name%' => $objectState->getName()],
                         'object_state'
                     )
                 );

--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -181,7 +181,7 @@ class ObjectStateGroupController extends Controller
                     $this->translator->trans(
                         /** @Desc("Object state type group '%name%' deleted.") */
                         'object_state_group.delete.success',
-                        ['%name%' => $group->identifier],
+                        ['%name%' => $group->getName()],
                         'object_state'
                     )
                 );
@@ -220,7 +220,7 @@ class ObjectStateGroupController extends Controller
                         $this->translator->trans(
                             /** @Desc("Object state type group '%name%' deleted.") */
                             'object_state_group.delete.success',
-                            ['%name%' => $objectStateGroup->identifier],
+                            ['%name%' => $objectStateGroup->getName()],
                             'object_state'
                         )
                     );
@@ -256,13 +256,13 @@ class ObjectStateGroupController extends Controller
                 $updateStruct->identifier = $data->getIdentifier();
                 $updateStruct->names[$group->mainLanguageCode] = $data->getName();
 
-                $this->objectStateService->updateObjectStateGroup($group, $updateStruct);
+                $updatedGroup = $this->objectStateService->updateObjectStateGroup($group, $updateStruct);
 
                 $this->notificationHandler->success(
                     $this->translator->trans(
                         /** @Desc("Object state group '%name%' updated.") */
                         'object_state_group.update.success',
-                        ['%name%' => $group->identifier],
+                        ['%name%' => $updatedGroup->getName()],
                         'object_state'
                     )
                 );

--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -136,7 +136,7 @@ class ObjectStateGroupController extends Controller
 
                     $this->notificationHandler->success(
                         $this->translator->trans(
-                            /** @Desc("Object state type group '%name%' created.") */
+                            /** @Desc("Object state group '%name%' created.") */
                             'object_state_group.create.success',
                             ['%name%' => $data->getName()],
                             'object_state'
@@ -179,7 +179,7 @@ class ObjectStateGroupController extends Controller
 
                 $this->notificationHandler->success(
                     $this->translator->trans(
-                        /** @Desc("Object state type group '%name%' deleted.") */
+                        /** @Desc("Object state group '%name%' deleted.") */
                         'object_state_group.delete.success',
                         ['%name%' => $group->getName()],
                         'object_state'
@@ -218,7 +218,7 @@ class ObjectStateGroupController extends Controller
 
                     $this->notificationHandler->success(
                         $this->translator->trans(
-                            /** @Desc("Object state type group '%name%' deleted.") */
+                            /** @Desc("Object state group '%name%' deleted.") */
                             'object_state_group.delete.success',
                             ['%name%' => $objectStateGroup->getName()],
                             'object_state'

--- a/src/bundle/Resources/translations/object_state.en.xliff
+++ b/src/bundle/Resources/translations/object_state.en.xliff
@@ -192,8 +192,8 @@
         <note>key: object_state_group.create.submit</note>
       </trans-unit>
       <trans-unit id="0b3303ec319a0c482f87d38b1a422288d9f1712b" resname="object_state_group.create.success">
-        <source>Object state type group '%name%' created.</source>
-        <target state="new">Object state type group '%name%' created.</target>
+        <source>Object state group '%name%' created.</source>
+        <target state="new">Object state group '%name%' created.</target>
         <note>key: object_state_group.create.success</note>
       </trans-unit>
       <trans-unit id="0f857d4dff9c8232ede300a39010d289d31c2937" resname="object_state_group.delete.bulk_delete.submit">
@@ -207,8 +207,8 @@
         <note>key: object_state_group.delete.submit</note>
       </trans-unit>
       <trans-unit id="f33647d41b6e4ddd150317c9ef8cf2b3bd8d8b4b" resname="object_state_group.delete.success">
-        <source>Object state type group '%name%' deleted.</source>
-        <target state="new">Object state type group '%name%' deleted.</target>
+        <source>Object state group '%name%' deleted.</source>
+        <target state="new">Object state group '%name%' deleted.</target>
         <note>key: object_state_group.delete.success</note>
       </trans-unit>
       <trans-unit id="940f19a907923467a0fc0084f21dc689a18ab804" resname="object_state_group.id">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29056
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Update Behat tests
- [x] Ready for Code Review
