### PR TITLE
EZP-30323: Copy Subtree does not use data-udw-config

### DIFF
--- a/src/bundle/Resources/public/js/scripts/udw/copy_subtree.js
+++ b/src/bundle/Resources/public/js/scripts/udw/copy_subtree.js
@@ -17,17 +17,24 @@
         event.preventDefault();
 
         const title = Translator.trans(/*@Desc("Select location")*/ 'subtree.title', {}, 'universal_discovery_widget');
+        const config = JSON.parse(event.currentTarget.dataset.udwConfig);
 
         ReactDOM.render(
-            React.createElement(global.eZ.modules.UniversalDiscovery, {
-                onConfirm,
-                onCancel,
-                title,
-                multiple: false,
-                startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
-                restInfo: { token, siteaccess },
-                allowContainersOnly: true,
-            }),
+            React.createElement(
+                global.eZ.modules.UniversalDiscovery,
+                Object.assign(
+                    {
+                        onConfirm,
+                        onCancel,
+                        title,
+                        multiple: false,
+                        startingLocationId: parseInt(event.currentTarget.dataset.rootLocation, 10),
+                        restInfo: {token, siteaccess},
+                        allowContainersOnly: true,
+                    },
+                    config
+                ),
+            ),
             udwContainer
         );
     };

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -178,6 +178,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         ];
         $copySubtreeAttributes = [
             'class' => 'ez-btn--udw-copy-subtree',
+            'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
             'data-root-location' => $this->configResolver->getParameter(
                 'universal_discovery_widget_module.default_location_id'
             ),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30323
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
