### PR TITLE
EZP-29754: Embed block is overwritten by Table in RichText Editor

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -89,6 +89,7 @@ const alloyEditor = [
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-custom-tag.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-inline-custom-tag.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-custom-style.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/core/table.js'),
 ];
 const fieldTypes = [];
 


### PR DESCRIPTION
Follow up after merging up https://github.com/ezsystems/ezplatform-admin-ui/pull/937
