### PR TITLE
EZP-29808: Newly created content via Multi Upload has wrong language set

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -18,6 +18,7 @@
             locationPath: mfuContainer.dataset.parentLocationPath,
             language: mfuContainer.dataset.parentContentLanguage,
         },
+        currentLanguage: mfuContainer.dataset.currentLanguage,
     };
     const handleEditItem = (content) => {
         const contentId = content._id;

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -15,10 +15,11 @@
 
 {% block content %}
     <div id="ez-mfu"
-         data-parent-content-language="{{ content.versionInfo.initialLanguageCode }}"
-         data-parent-location-path="{{ location.pathString }}"
-         data-parent-content-type-identifier="{{ contentType.identifier }}"
-         data-parent-content-type-id="{{ contentType.id }}"></div>
+        data-parent-content-language="{{ content.versionInfo.initialLanguageCode }}"
+        data-parent-location-path="{{ location.pathString }}"
+        data-parent-content-type-identifier="{{ contentType.identifier }}"
+        data-parent-content-type-id="{{ contentType.id }}"
+        data-current-language="{{ app.request.get('languageCode') ?: content.prioritizedFieldLanguageCode }}"></div>
     <div class="row align-items-stretch ez-main-row">
 
         {% block left_sidebar %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29808
| Requires     | https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/177
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
