### PR TITLE
EZP-29694: Draft conflict does not work as expected for a content item with multiple translations

### DIFF
--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException as AdminInvalidArgumentException;
@@ -190,6 +191,7 @@ class ContentController extends Controller
 
                 if (!$versionInfo->isDraft()) {
                     $contentDraft = $this->contentService->createContentDraft($contentInfo, $versionInfo);
+                    $this->updateDraftInitialLanguage($contentDraft, $language);
                     $versionNo = $contentDraft->getVersionInfo()->versionNo;
 
                     $this->notificationHandler->success(
@@ -455,5 +457,31 @@ class ContentController extends Controller
         }
 
         return $result instanceof Response ? $result : $this->redirectToRoute('ezplatform.dashboard');
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $contentDraft
+     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function updateDraftInitialLanguage(
+        Content $contentDraft,
+        Language $language
+    ): void {
+        if ($language->languageCode === $contentDraft->versionInfo->initialLanguageCode) {
+            return;
+        }
+
+        $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
+
+        $contentUpdateStruct->initialLanguageCode = $language->languageCode;
+        $contentUpdateStruct->creatorId = $contentDraft->versionInfo->creatorId;
+
+        $this->contentService->updateContent($contentDraft->versionInfo, $contentUpdateStruct);
     }
 }

--- a/src/bundle/Controller/Version/VersionConflictController.php
+++ b/src/bundle/Controller/Version/VersionConflictController.php
@@ -36,15 +36,15 @@ class VersionConflictController extends Controller
      *
      * @param int $contentId
      * @param int $versionNo
+     * @param string $languageCode
      *
      * @return Response
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
      */
-    public function versionHasNoConflictAction(int $contentId, int $versionNo): Response
+    public function versionHasNoConflictAction(int $contentId, int $versionNo, string $languageCode): Response
     {
         $versionInfo = $this->contentService->loadVersionInfoById($contentId, $versionNo);
 
@@ -52,7 +52,7 @@ class VersionConflictController extends Controller
             throw new BadStateException('Version status', 'status is not draft');
         }
 
-        if ((new VersionHasConflict($this->contentService))->isSatisfiedBy($versionInfo)) {
+        if ((new VersionHasConflict($this->contentService, $languageCode))->isSatisfiedBy($versionInfo)) {
             return new Response('', Response::HTTP_CONFLICT);
         }
 

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -486,7 +486,7 @@ ezplatform.version.has_no_conflict:
         languageCode: ~
 
 ezplatform.version_draft.has_no_conflict:
-    path: /version-draft/has-no-conflict/{contentId}
+    path: /version-draft/has-no-conflict/{contentId}/{languageCode}
     options:
         expose: true
     defaults:

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -22,13 +22,14 @@
     };
     const handleEditItem = (content) => {
         const contentId = content._id;
-        const checkVersionDraftLink = Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId });
+        const languageCode = content.mainLanguageCode;
+        const checkVersionDraftLink = Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
         const submitVersionEditForm = () => {
             doc.querySelector('#form_subitems_content_edit_content_info').value = contentId;
             doc.querySelector('#form_subitems_content_edit_version_info_content_info').value = contentId;
             doc.querySelector('#form_subitems_content_edit_version_info_version_no').value =
                 content.CurrentVersion.Version.VersionInfo.versionNo;
-            doc.querySelector(`#form_subitems_content_edit_language_${content.mainLanguageCode}`).checked = true;
+            doc.querySelector(`#form_subitems_content_edit_language_${languageCode}`).checked = true;
             doc.querySelector('#form_subitems_content_edit_create').click();
         };
         const addDraft = () => {

--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -15,7 +15,7 @@
             'input[name="' + versionEditFormName + '[version_info][version_no]"]'
         );
         const languageInput = versionEditForm.querySelector('#' + versionEditFormName + '_language_' + languageCode);
-        const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId });
+        const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
         const submitVersionEditForm = () => {
             contentInfoInput.value = contentId;
             versionInfoContentInfoInput.value = contentId;

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -12,12 +12,10 @@
         form.submit();
         $('#version-draft-conflict-modal').modal('hide');
     };
-    const redirectToUserEdit = () => {
+    const redirectToUserEdit = (languageCode) => {
         const versionNo = form.querySelector('#user_edit_version_info_version_no').value;
-        const checkedBtn = btns.find((btn) => btn.checked);
-        const language = checkedBtn.value;
 
-        window.location.href = global.Routing.generate('ez_user_update', { contentId, versionNo, language });
+        window.location.href = global.Routing.generate('ez_user_update', { contentId, versionNo, language: languageCode });
     };
     const onModalHidden = () => {
         resetRadioButtons();
@@ -47,8 +45,8 @@
         wrapper.innerHTML = modalHtml;
         attachModalListeners(wrapper);
     };
-    const changeHandler = () => {
-        const checkedBtn = btns.find((btn) => btn.checked);
+    const changeHandler = (event) => {
+        const checkedBtn = event.currentTarget;
         const languageCode = checkedBtn.value;
         const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
 
@@ -59,7 +57,7 @@
                 response.text().then(showModal);
             } else if (response.status === 200) {
                 if (form.querySelector('#user_edit_version_info')) {
-                    redirectToUserEdit();
+                    redirectToUserEdit(languageCode);
 
                     return;
                 }

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -4,7 +4,6 @@
     const form = editActions.querySelector('form');
     const contentIdInput = form.querySelector('#content_edit_content_info') || form.querySelector('#user_edit_content_info');
     const contentId = contentIdInput.value;
-    const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId });
     const resetRadioButtons = () =>
         btns.forEach((btn) => {
             btn.checked = false;
@@ -49,6 +48,10 @@
         attachModalListeners(wrapper);
     };
     const changeHandler = () => {
+        const checkedBtn = btns.find((btn) => btn.checked);
+        const languageCode = checkedBtn.value;
+        const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
+
         fetch(checkVersionDraftLink, {
             credentials: 'same-origin',
         }).then((response) => {

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -31,11 +31,11 @@
                 path('ez_user_update', {
                 'contentId': version.contentInfo.id,
                 'versionNo': version.versionNo,
-                'language': version.translations[0].languageCode,
+                'language': version.initialLanguageCode,
             }) : path('ez_content_draft_edit', {
                 'contentId': version.contentInfo.id,
                 'versionNo': version.versionNo,
-                'language': version.translations[0].languageCode,
+                'language': version.initialLanguageCode,
                 'locationId': location.id
             })
             %}
@@ -85,7 +85,7 @@
                             data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
                                 'contentId': version.contentInfo.id,
                                 'versionNo': version.versionNo,
-                                'languageCode': version.translations[0].languageCode
+                                'languageCode': version.initialLanguageCode
                             }) }}"
                             class="btn btn-icon mx-2 ez-btn--content-draft-edit"
                             title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}">

--- a/src/lib/Specification/Content/ContentDraftHasConflict.php
+++ b/src/lib/Specification/Content/ContentDraftHasConflict.php
@@ -10,26 +10,30 @@ namespace EzSystems\EzPlatformAdminUi\Specification\Content;
 
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
 
 class ContentDraftHasConflict extends AbstractSpecification
 {
-    /** @var ContentService */
+    /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
+    /** @var string */
+    private $languageCode;
+
     /**
-     * @param ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param string $languageCode
      */
-    public function __construct(ContentService $contentService)
+    public function __construct(ContentService $contentService, string $languageCode)
     {
         $this->contentService = $contentService;
+        $this->languageCode = $languageCode;
     }
 
     /**
      * Checks if Content has draft conflict.
      *
-     * @param ContentInfo $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      *
      * @return bool
      *
@@ -40,7 +44,10 @@ class ContentDraftHasConflict extends AbstractSpecification
         $versions = $this->contentService->loadVersions($contentInfo);
 
         foreach ($versions as $checkedVersionInfo) {
-            if ($checkedVersionInfo->isDraft() && $checkedVersionInfo->versionNo > $contentInfo->currentVersionNo) {
+            if ($checkedVersionInfo->isDraft()
+                && $checkedVersionInfo->versionNo > $contentInfo->currentVersionNo
+                && $checkedVersionInfo->initialLanguageCode === $this->languageCode
+            ) {
                 return true;
             }
         }

--- a/src/lib/Specification/Version/VersionHasConflict.php
+++ b/src/lib/Specification/Version/VersionHasConflict.php
@@ -15,15 +15,20 @@ use EzSystems\EzPlatformAdminUi\Specification\AbstractSpecification;
 
 class VersionHasConflict extends AbstractSpecification
 {
-    /** @var ContentService */
+    /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
+    /** @var string */
+    private $languageCode;
+
     /**
-     * @param ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param string $languageCode
      */
-    public function __construct(ContentService $contentService)
+    public function __construct(ContentService $contentService, string $languageCode)
     {
         $this->contentService = $contentService;
+        $this->languageCode = $languageCode;
     }
 
     /**
@@ -40,7 +45,10 @@ class VersionHasConflict extends AbstractSpecification
         $versions = $this->contentService->loadVersions($versionInfo->getContentInfo());
 
         foreach ($versions as $checkedVersionInfo) {
-            if ($checkedVersionInfo->versionNo > $versionInfo->versionNo && $checkedVersionInfo->isPublished()) {
+            if ($checkedVersionInfo->versionNo > $versionInfo->versionNo
+                && $checkedVersionInfo->isPublished()
+                && $checkedVersionInfo->initialLanguageCode === $this->languageCode
+            ) {
                 return true;
             }
         }

--- a/src/lib/UI/Config/Provider/FieldType/RichText/AlloyEditor.php
+++ b/src/lib/UI/Config/Provider/FieldType/RichText/AlloyEditor.php
@@ -50,7 +50,7 @@ class AlloyEditor implements ProviderInterface
      */
     protected function getExtraButtons(): array
     {
-        trigger_error(
+        @trigger_error(
             '"ezrichtext.alloy_editor.extra_buttons" is deprecated since v2.5.1. There will be new and more flexible solution to manage buttons in Online Editor in 3.0.0',
             E_USER_DEPRECATED
         );

--- a/src/lib/UI/Dataset/VersionsDataset.php
+++ b/src/lib/UI/Dataset/VersionsDataset.php
@@ -73,15 +73,18 @@ class VersionsDataset
 
     /**
      * @param int $currentVersionNo
+     * @param string $languageCode
      *
      * @return array
      */
-    public function getConflictedDraftVersions(int $currentVersionNo): array
+    public function getConflictedDraftVersions(int $currentVersionNo, string $languageCode): array
     {
         return $this->filterVersions(
             $this->data,
-            function (VersionInfo $versionInfo) use ($currentVersionNo) {
-                return $versionInfo->isDraft() && $versionInfo->versionNo > $currentVersionNo;
+            function (VersionInfo $versionInfo) use ($currentVersionNo, $languageCode) {
+                return $versionInfo->isDraft()
+                    && $versionInfo->versionNo > $currentVersionNo
+                    && $versionInfo->initialLanguageCode === $languageCode;
             }
         );
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29694
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | **yes**
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This, together with https://github.com/ezsystems/ezpublish-kernel/pull/2598 should align how adminUI behaves comparing to ezPublish. 
This ticket should also be solved by this:
https://jira.ez.no/browse/EZP-29691

BC:
Additional route parameter was needed.
not sure if `Specifications` are under BC though

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
