### PR TITLE
EZEE-2749: Long message not displayed correctly on Notifications pop-up

### DIFF
--- a/src/bundle/Resources/public/scss/_notifications-modal.scss
+++ b/src/bundle/Resources/public/scss/_notifications-modal.scss
@@ -28,6 +28,8 @@
     }
 
     .table {
+        table-layout: fixed;
+        white-space: normal;
         margin-bottom: 0;
 
         th {
@@ -41,6 +43,7 @@
             cursor: pointer;
 
             td {
+                vertical-align: top;
                 border-top: 1px solid $ez-color-base-dark;
             }
         }
@@ -95,12 +98,17 @@
         }
 
         .description__text {
+            width: 100%;
             margin-bottom: 0;
             max-width: 50ch;
             float: left;
 
             + .description__read-more {
                 display: none;
+
+                &::after {
+                    content: ' \00BB';
+                }
             }
 
             &--ellipsis {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2749
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

## Screenshots:
![Screen Shot 2019-04-08 at 14 34 09](https://user-images.githubusercontent.com/10233057/55726969-43cd9080-5a11-11e9-954e-6a0c7bb4cb8e.png)
![Screen Shot 2019-04-08 at 14 34 34](https://user-images.githubusercontent.com/10233057/55726995-5051e900-5a11-11e9-974a-c9fe998ebc1e.png)

### Bigger screen:
![Screen Shot 2019-04-08 at 14 34 18](https://user-images.githubusercontent.com/10233057/55726964-429c6380-5a11-11e9-8585-6f8c72c60386.png)
![Screen Shot 2019-04-08 at 14 34 27](https://user-images.githubusercontent.com/10233057/55726976-47611780-5a11-11e9-8f4b-a5c6e6532bd2.png)



