### PR TITLE
EZEE-2692: Buttons are in different order while user doesn't have Content/Publish policy

### DIFF
--- a/src/lib/Menu/Admin/ReorderMenuListener.php
+++ b/src/lib/Menu/Admin/ReorderMenuListener.php
@@ -27,4 +27,61 @@ class ReorderMenuListener
         $manipulator = new MenuManipulator();
         $manipulator->moveToLastPosition($menu[MainMenuBuilder::ITEM_ADMIN]);
     }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent $event
+     */
+    public function reorderMenuItems(ConfigureMenuEvent $event): void
+    {
+        $menu = $event->getMenu();
+        $menuOrderArray = [];
+        $addLast = [];
+        $alreadyTaken = [];
+
+        foreach ($menu->getChildren() as $key => $menuItem) {
+            if ($menuItem->hasChildren()) {
+                $this->reorderMenuItems($menuItem);
+            }
+            $orderNumber = $menuItem->getExtra('orderNumber');
+
+            if ($orderNumber != null) {
+                if (!isset($menuOrderArray[$orderNumber])) {
+                    $menuOrderArray[$orderNumber] = $menuItem->getName();
+                } else {
+                    $alreadyTaken[$orderNumber] = $menuItem->getName();
+                }
+            } else {
+                $addLast[] = $menuItem->getName();
+            }
+        }
+        ksort($menuOrderArray);
+
+        if (count($alreadyTaken)) {
+            foreach ($alreadyTaken as $key => $value) {
+                $keysArray = array_keys($menuOrderArray);
+                $position = array_search($key, $keysArray);
+
+                if ($position === false) {
+                    continue;
+                }
+
+                $menuOrderArray = array_merge(
+                    array_slice($menuOrderArray, 0, $position),
+                    [$value],
+                    array_slice($menuOrderArray, $position)
+                );
+            }
+        }
+        ksort($menuOrderArray);
+
+        if (count($addLast)) {
+            foreach ($addLast as $key => $value) {
+                $menuOrderArray[] = $value;
+            }
+        }
+
+        if (count($menuOrderArray)) {
+            $menu->reorderChildren($menuOrderArray);
+        }
+    }
 }

--- a/src/lib/Menu/ContentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentCreateRightSidebarBuilder.php
@@ -130,7 +130,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
                     'extras' => [
                         'icon' => 'publish',
-                        'orderNumber' => 1,
+                        'orderNumber' => 10,
                     ],
                 ]
             ),
@@ -142,7 +142,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                         : array_merge($createAttributes, self::BTN_DISABLED_ATTR),
                     'extras' => [
                         'icon' => 'save',
-                        'orderNumber' => 40,
+                        'orderNumber' => 50,
                     ],
                 ]
             ),
@@ -154,7 +154,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                         : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
                     'extras' => [
                         'icon' => 'view-desktop',
-                        'orderNumber' => 50,
+                        'orderNumber' => 60,
                     ],
                 ]
             ),
@@ -167,7 +167,7 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                     ],
                     'extras' => [
                         'icon' => 'circle-close',
-                        'orderNumber' => 60,
+                        'orderNumber' => 70,
                     ],
                 ]
             ),

--- a/src/lib/Menu/ContentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentCreateRightSidebarBuilder.php
@@ -128,7 +128,10 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                     'attributes' => $canCreate && $canPublish
                         ? $publishAttributes
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
-                    'extras' => ['icon' => 'publish'],
+                    'extras' => [
+                        'icon' => 'publish',
+                        'orderNumber' => 1,
+                    ],
                 ]
             ),
             self::ITEM__SAVE_DRAFT => $this->createMenuItem(
@@ -137,7 +140,10 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                     'attributes' => $canCreate
                         ? $createAttributes
                         : array_merge($createAttributes, self::BTN_DISABLED_ATTR),
-                    'extras' => ['icon' => 'save'],
+                    'extras' => [
+                        'icon' => 'save',
+                        'orderNumber' => 40,
+                    ],
                 ]
             ),
             self::ITEM__PREVIEW => $this->createMenuItem(
@@ -146,7 +152,10 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                     'attributes' => $canPreview
                         ? $previewAttributes
                         : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
-                    'extras' => ['icon' => 'view-desktop'],
+                    'extras' => [
+                        'icon' => 'view-desktop',
+                        'orderNumber' => 50,
+                    ],
                 ]
             ),
             self::ITEM__CANCEL => $this->createMenuItem(
@@ -156,7 +165,10 @@ class ContentCreateRightSidebarBuilder extends AbstractBuilder implements Transl
                         'class' => self::BTN_TRIGGER_CLASS,
                         'data-click' => '#ezrepoforms_content_edit_cancel',
                     ],
-                    'extras' => ['icon' => 'circle-close'],
+                    'extras' => [
+                        'icon' => 'circle-close',
+                        'orderNumber' => 60,
+                    ],
                 ]
             ),
         ]);

--- a/src/lib/Menu/ContentEditRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentEditRightSidebarBuilder.php
@@ -123,7 +123,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
                     'extras' => [
                         'icon' => 'publish',
-                        'orderNumber' => 1,
+                        'orderNumber' => 10,
                     ],
                 ]
             ),
@@ -135,7 +135,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                         : array_merge($editAttributes, self::BTN_DISABLED_ATTR),
                     'extras' => [
                         'icon' => 'save',
-                        'orderNumber' => 40,
+                        'orderNumber' => 50,
                     ],
                 ]
             ),
@@ -156,7 +156,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                     : array_merge($deleteAttributes, self::BTN_DISABLED_ATTR),
                 'extras' => [
                     'icon' => 'circle-close',
-                    'orderNumber' => 60,
+                    'orderNumber' => 70,
                 ],
             ]
         );
@@ -230,7 +230,7 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                     : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
                 'extras' => [
                     'icon' => 'view-desktop',
-                    'orderNumber' => 50,
+                    'orderNumber' => 60,
                 ],
             ]
         );

--- a/src/lib/Menu/ContentEditRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentEditRightSidebarBuilder.php
@@ -121,7 +121,10 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                     'attributes' => $canEdit && $canPublish
                         ? $publishAttributes
                         : array_merge($publishAttributes, self::BTN_DISABLED_ATTR),
-                    'extras' => ['icon' => 'publish'],
+                    'extras' => [
+                        'icon' => 'publish',
+                        'orderNumber' => 1,
+                    ],
                 ]
             ),
             self::ITEM__SAVE_DRAFT => $this->createMenuItem(
@@ -130,7 +133,10 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                     'attributes' => $canEdit
                         ? $editAttributes
                         : array_merge($editAttributes, self::BTN_DISABLED_ATTR),
-                    'extras' => ['icon' => 'save'],
+                    'extras' => [
+                        'icon' => 'save',
+                        'orderNumber' => 40,
+                    ],
                 ]
             ),
         ];
@@ -148,7 +154,10 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                 'attributes' => $canDelete
                     ? $deleteAttributes
                     : array_merge($deleteAttributes, self::BTN_DISABLED_ATTR),
-                'extras' => ['icon' => 'circle-close'],
+                'extras' => [
+                    'icon' => 'circle-close',
+                    'orderNumber' => 60,
+                ],
             ]
         );
 
@@ -219,7 +228,10 @@ class ContentEditRightSidebarBuilder extends AbstractBuilder implements Translat
                 'attributes' => $canPreview && !empty($siteaccesses)
                     ? $previewAttributes
                     : array_merge($previewAttributes, self::BTN_DISABLED_ATTR),
-                'extras' => ['icon' => 'view-desktop'],
+                'extras' => [
+                    'icon' => 'view-desktop',
+                    'orderNumber' => 50,
+                ],
             ]
         );
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2692
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Ordering of menu items in Admin UI relies now on orderNumber which is necessary for repositories which add new items to the dropdown.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
