### PR TITLE
EZP-30397: Unify JavaScript event names

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
@@ -97,7 +97,7 @@
          * @method showFileSizeError
          */
         showFileSizeError() {
-            this.inputField.dispatchEvent(new CustomEvent('invalidFileSize'));
+            this.inputField.dispatchEvent(new CustomEvent('ez-invalid-file-size'));
         }
 
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
@@ -64,7 +64,7 @@
                 {
                     isValueValidator: false,
                     selector: `input[type="file"]`,
-                    eventName: 'invalidFileSize',
+                    eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 },

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -9,6 +9,7 @@
     const EVENT_BLUR = 'blur';
     const EVENT_KEYUP = 'keyup';
     const EVENT_CANCEL_ERRORS = 'ez-cancel-errors';
+    const EVENT_ADDRESS_NOT_FOUND = 'ez-address-not-found';
     const POSITION_TYPE_LONGITUDE = 'longitude';
     const POSITION_TYPE_LATITUDE = 'latitude';
     const VALIDATE_LONGITUDE = 'validateLongitude';
@@ -357,7 +358,7 @@
             {
                 isValueValidator: false,
                 selector: `${SELECTOR_FIELD} ${SELECTOR_ADDRESS_INPUT}`,
-                eventName: 'ez-address-not-found',
+                eventName: EVENT_ADDRESS_NOT_FOUND,
                 callback: 'showNotFoundError',
                 errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
             },
@@ -529,7 +530,7 @@
          *
          * @function showAddressNotFoundError
          */
-        const showAddressNotFoundError = () => addressInput.dispatchEvent(new CustomEvent('ez-address-not-found'));
+        const showAddressNotFoundError = () => addressInput.dispatchEvent(new CustomEvent(EVENT_ADDRESS_NOT_FOUND));
 
         /**
          * Handles address input actions

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -8,7 +8,7 @@
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
     const EVENT_BLUR = 'blur';
     const EVENT_KEYUP = 'keyup';
-    const EVENT_CANCEL_ERRORS = 'cancelErrors';
+    const EVENT_CANCEL_ERRORS = 'ez-cancel-errors';
     const POSITION_TYPE_LONGITUDE = 'longitude';
     const POSITION_TYPE_LATITUDE = 'latitude';
     const VALIDATE_LONGITUDE = 'validateLongitude';
@@ -357,7 +357,7 @@
             {
                 isValueValidator: false,
                 selector: `${SELECTOR_FIELD} ${SELECTOR_ADDRESS_INPUT}`,
-                eventName: 'addressNotFound',
+                eventName: 'ez-address-not-found',
                 callback: 'showNotFoundError',
                 errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
             },
@@ -529,7 +529,7 @@
          *
          * @function showAddressNotFoundError
          */
-        const showAddressNotFoundError = () => addressInput.dispatchEvent(new CustomEvent('addressNotFound'));
+        const showAddressNotFoundError = () => addressInput.dispatchEvent(new CustomEvent('ez-address-not-found'));
 
         /**
          * Handles address input actions

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -43,7 +43,7 @@
             sizeContainer.title = fileSize;
 
             preview.querySelector('.ez-field-edit-preview__action--preview').href = URL.createObjectURL(files[0]);
-            this.fieldContainer.querySelector(SELECTOR_INPUT_ALT).dispatchEvent(new CustomEvent('cancelErrors'));
+            this.fieldContainer.querySelector(SELECTOR_INPUT_ALT).dispatchEvent(new CustomEvent('ez-cancel-errors'));
         }
     }
 
@@ -92,14 +92,14 @@
                 {
                     isValueValidator: false,
                     selector: `${SELECTOR_INPUT_FILE}`,
-                    eventName: 'invalidFileSize',
+                    eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 },
                 {
                     isValueValidator: false,
                     selector: SELECTOR_INPUT_ALT,
-                    eventName: 'cancelErrors',
+                    eventName: 'ez-cancel-errors',
                     callback: 'cancelErrors',
                     invalidStateSelectors: ['.ez-data-source__field--alternativeText'],
                     errorNodeSelectors: [`${SELECTOR_ALT_WRAPPER} .ez-data-source__label-wrapper`],

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -4,6 +4,7 @@
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
     const SELECTOR_ALT_WRAPPER = '.ez-field-edit-preview__image-alt';
     const SELECTOR_INPUT_ALT = '.ez-field-edit-preview__image-alt .ez-data-source__input';
+    const EVENT_CANCEL_ERROR = 'ez-cancel-errors';
 
     class EzImageFilePreviewField extends global.eZ.BasePreviewField {
         /**
@@ -43,7 +44,7 @@
             sizeContainer.title = fileSize;
 
             preview.querySelector('.ez-field-edit-preview__action--preview').href = URL.createObjectURL(files[0]);
-            this.fieldContainer.querySelector(SELECTOR_INPUT_ALT).dispatchEvent(new CustomEvent('ez-cancel-errors'));
+            this.fieldContainer.querySelector(SELECTOR_INPUT_ALT).dispatchEvent(new CustomEvent(EVENT_CANCEL_ERROR));
         }
     }
 
@@ -99,7 +100,7 @@
                 {
                     isValueValidator: false,
                     selector: SELECTOR_INPUT_ALT,
-                    eventName: 'ez-cancel-errors',
+                    eventName: EVENT_CANCEL_ERROR,
                     callback: 'cancelErrors',
                     invalidStateSelectors: ['.ez-data-source__field--alternativeText'],
                     errorNodeSelectors: [`${SELECTOR_ALT_WRAPPER} .ez-data-source__label-wrapper`],

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -258,7 +258,7 @@
                 {
                     isValueValidator: false,
                     selector: `${SELECTOR_INPUT_FILE}`,
-                    eventName: 'invalidFileSize',
+                    eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 },

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -167,7 +167,7 @@
                 }, {
                     isValueValidator: false,
                     selector: SELECTOR_INPUT_FILE,
-                    eventName: 'invalidFileSize',
+                    eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
                     errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
                 }, {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30397
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

## New names

**Admin UI** (this PR)

| old name      | new name
| ------------- | ---
| invalidFileSize       | ez-invalid-file-size
| addressNotFound       | ez-address-not-found
| cancelErrors       | ez-cancel-errors

**Page builder** (https://github.com/ezsystems/ezplatform-page-builder/pull/334)

| old name      | new name
| ------------- | ---
| openUdw       | ez-open-udw
| openAirtimePopup       | ez-open-airtime-popup
| postUpdateBlocksPreview       | ez-post-update-blocks-preview
| pbIframeLoaded       | ez-page-builder-iframe-loaded
| pbHideTools       | ez-page-builder-hide-tools

**Form Builder** (https://github.com/ezsystems/ezplatform-form-builder/pull/156 + https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/180)

| old name      | new name
| ------------- | ---
| openUdw       | ez-open-udw
| updateFieldName       | ez-update-field-name
| fbFormBuilderLoaded       | ez-form-builder-loaded
| fbFormBuilderUnloaded       | ez-form-builder-unloaded

## Deleted event listener for:
- pbPreviewReloaded (https://github.com/ezsystems/ezplatform-page-builder/pull/334)

## Names that does not change

**Admin UI**

| name |   
| ------------- | 
| ez-notify       |
| ez-bookmark-change       |
| ez-draft-conflict-modal-hidden       |

**Admin UI Modules**

| name |   
| ------------- | 
| ez-content-tree-refresh       |


