### PR TITLE
EZP-30454: Broken table in notifications modal when notification list is empty

### DIFF
--- a/src/bundle/Resources/views/notifications/notifications_modal_body.html.twig
+++ b/src/bundle/Resources/views/notifications/notifications_modal_body.html.twig
@@ -15,7 +15,7 @@
     <tbody class="n-table__body">
     {% if pager.count is same as(0) %}
         <tr>
-            <td colspan="4">
+            <td colspan="3">
                 <span class="ez-table-no-content mb-0 py-1 pl-0">
                     {{ 'bookmark.list.empty'|trans|desc('The notification list is empty.') }}
                 </span>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30454
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
