### PR TITLE
EZP-30098 bringing back Mareks redirection fix, and extend timeout for waiting for SIL

### DIFF
--- a/features/ContentManagement.feature
+++ b/features/ContentManagement.feature
@@ -176,6 +176,6 @@ Scenario: Content can be moved to trash from non-root location
 Scenario: Content can be moved to trash from root location
   Given I navigate to content "Test Article edited" of type "Article" in root path
   When I send content to trash
-  Then there's no "Article" "Test Article edited" on Sub-items list of root
+  Then I should be redirected to root in default view
     And going to trash there is "Article" "Test Article edited" on list
 

--- a/src/lib/Behat/PageElement/Pagination.php
+++ b/src/lib/Behat/PageElement/Pagination.php
@@ -30,6 +30,6 @@ class Pagination extends Element
     public function clickNextButton(): void
     {
         $this->context->findElement($this->fields['nextButton'])->click();
-        $this->context->waitUntilElementDisappears($this->fields['spinner'], 5);
+        $this->context->waitUntilElementDisappears($this->fields['spinner'], 10);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30098
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR is bringing back fix for redirection after removing an item in Content structure, that was lost by merging Fastest. Additionally, it extends behat timeout for SIL spinner to disappear.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
