### PR TITLE
EZP-30400: Inject TranslationService into NotificationService

### DIFF
--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -30,7 +30,7 @@ use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\ContentVisibilityUpdateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\MainTranslationUpdateType;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer;
 use EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface;
 use EzSystems\EzPlatformAdminUi\Specification\ContentIsUser;
@@ -41,13 +41,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
-use Symfony\Component\Translation\TranslatorInterface;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException as APIRepositoryInvalidArgumentException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
 
 class ContentController extends Controller
 {
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
 
     /** @var ContentService */
@@ -58,9 +57,6 @@ class ContentController extends Controller
 
     /** @var SubmitHandler */
     private $submitHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /** @var ContentMainLocationUpdateMapper */
     private $contentMainLocationUpdateMapper;
@@ -84,11 +80,10 @@ class ContentController extends Controller
     private $userContentTypeIdentifier;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \EzSystems\EzPlatformAdminUi\Form\DataMapper\ContentMainLocationUpdateMapper $contentMetadataUpdateMapper
      * @param \EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface $siteaccessResolver
      * @param \eZ\Publish\API\Repository\LocationService $locationService
@@ -98,11 +93,10 @@ class ContentController extends Controller
      * @param array $userContentTypeIdentifier
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ContentService $contentService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
-        TranslatorInterface $translator,
         ContentMainLocationUpdateMapper $contentMetadataUpdateMapper,
         SiteaccessResolverInterface $siteaccessResolver,
         LocationService $locationService,
@@ -115,7 +109,6 @@ class ContentController extends Controller
         $this->contentService = $contentService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
-        $this->translator = $translator;
         $this->contentMainLocationUpdateMapper = $contentMetadataUpdateMapper;
         $this->siteaccessResolver = $siteaccessResolver;
         $this->locationService = $locationService;
@@ -212,12 +205,10 @@ class ContentController extends Controller
                     $versionNo = $contentDraft->getVersionInfo()->versionNo;
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("New Version Draft for '%name%' created.") */
-                            'content.create_draft.success',
-                            ['%name%' => $contentInfo->name],
-                            'content'
-                        )
+                        /** @Desc("New Version Draft for '%name%' created.") */
+                        'content.create_draft.success',
+                        ['%name%' => $contentInfo->name],
+                        'content'
                     );
                 }
 
@@ -275,12 +266,10 @@ class ContentController extends Controller
                 $this->contentService->updateContentMetadata($contentInfo, $contentMetadataUpdateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Main location for '%name%' updated.") */
-                        'content.main_location_update.success',
-                        ['%name%' => $contentInfo->name],
-                        'content'
-                    )
+                    /** @Desc("Main location for '%name%' updated.") */
+                    'content.main_location_update.success',
+                    ['%name%' => $contentInfo->name],
+                    'content'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -374,12 +363,10 @@ class ContentController extends Controller
                 $contentMetadataUpdateStruct = $mapper->reverseMap($data);
                 $this->contentService->updateContentMetadata($contentInfo, $contentMetadataUpdateStruct);
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Main language for '%name%' updated.") */
-                        'content.main_language_update.success',
-                        ['%name%' => $contentInfo->name],
-                        'content'
-                    )
+                    /** @Desc("Main language for '%name%' updated.") */
+                    'content.main_language_update.success',
+                    ['%name%' => $contentInfo->name],
+                    'content'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -423,23 +410,19 @@ class ContentController extends Controller
 
                 if ($contentInfo->isHidden && $desiredVisibility === false) {
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content '%name%' was already hidden.") */
-                            'content.hide.already_hidden',
-                            ['%name%' => $contentInfo->name],
-                            'content'
-                        )
+                        /** @Desc("Content '%name%' was already hidden.") */
+                        'content.hide.already_hidden',
+                        ['%name%' => $contentInfo->name],
+                        'content'
                     );
                 }
 
                 if (!$contentInfo->isHidden && $desiredVisibility === true) {
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content '%name%' was already visible.") */
-                            'content.reveal.already_visible',
-                            ['%name%' => $contentInfo->name],
-                            'content'
-                        )
+                        /** @Desc("Content '%name%' was already visible.") */
+                        'content.reveal.already_visible',
+                        ['%name%' => $contentInfo->name],
+                        'content'
                     );
                 }
 
@@ -447,12 +430,10 @@ class ContentController extends Controller
                     $this->contentService->hideContent($contentInfo);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content '%name%' has been hidden.") */
-                            'content.hide.success',
-                            ['%name%' => $contentInfo->name],
-                            'content'
-                        )
+                        /** @Desc("Content '%name%' has been hidden.") */
+                        'content.hide.success',
+                        ['%name%' => $contentInfo->name],
+                        'content'
                     );
                 }
 
@@ -460,12 +441,10 @@ class ContentController extends Controller
                     $this->contentService->revealContent($contentInfo);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content '%name%' has been revealed.") */
-                            'content.reveal.success',
-                            ['%name%' => $contentInfo->name],
-                            'content'
-                        )
+                        /** @Desc("Content '%name%' has been revealed.") */
+                        'content.reveal.success',
+                        ['%name%' => $contentInfo->name],
+                        'content'
                     );
                 }
 

--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -21,7 +21,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\ContentType\Translation\TranslationRem
 use EzSystems\EzPlatformAdminUi\Form\Factory\ContentTypeFormFactory;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Tab\ContentType\TranslationsTab;
 use EzSystems\RepositoryForms\Data\Mapper\ContentTypeDraftMapper;
 use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
@@ -42,7 +42,7 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 
 class ContentTypeController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
 
     /** @var \Symfony\Component\Translation\TranslatorInterface */
@@ -79,7 +79,7 @@ class ContentTypeController extends Controller
     private $contentTypeDraftMapper;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface $contentTypeActionDispatcher
@@ -92,7 +92,7 @@ class ContentTypeController extends Controller
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\ContentTypeFormFactory $contentTypeFormFactory
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         TranslatorInterface $translator,
         ContentTypeService $contentTypeService,
         ActionDispatcherInterface $contentTypeActionDispatcher,
@@ -190,12 +190,10 @@ class ContentTypeController extends Controller
             $contentTypeDraft = $this->contentTypeService->createContentType($createStruct, [$group]);
         } catch (NotFoundException $e) {
             $this->notificationHandler->error(
-                $this->translator->trans(
-                    /** @Desc("Cannot create Content Type. Could not find 'Language' with identifier '%languageCode%'") */
-                    'content_type.add.missing_language',
-                    ['%languageCode%' => $mainLanguageCode],
-                    'content_type'
-                )
+                /** @Desc("Cannot create Content Type. Could not find 'Language' with identifier '%languageCode%'") */
+                'content_type.add.missing_language',
+                ['%languageCode%' => $mainLanguageCode],
+                'content_type'
             );
 
             return $this->redirectToRoute('ezplatform.content_type_group.view', [
@@ -241,12 +239,10 @@ class ContentTypeController extends Controller
                 } catch (BadStateException $e) {
                     $userId = $contentType->modifierId;
                     $this->notificationHandler->error(
-                        $this->translator->trans(
-                            /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
-                            'content_type.edit.error.already_exists',
-                            ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
-                            'content_type'
-                        )
+                        /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
+                        'content_type.edit.error.already_exists',
+                        ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
+                        'content_type'
                     );
 
                     return $this->redirectToRoute('ezplatform.content_type.view', [
@@ -301,12 +297,10 @@ class ContentTypeController extends Controller
                 } catch (BadStateException $e) {
                     $userId = $contentType->modifierId;
                     $this->notificationHandler->error(
-                        $this->translator->trans(
-                            /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
-                            'content_type.edit.error.already_exists',
-                            ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
-                            'content_type'
-                        )
+                        /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
+                        'content_type.edit.error.already_exists',
+                        ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
+                        'content_type'
                     );
 
                     return $this->redirectToRoute('ezplatform.content_type.view', [
@@ -361,12 +355,10 @@ class ContentTypeController extends Controller
             } catch (BadStateException $e) {
                 $userId = $contentType->modifierId;
                 $this->notificationHandler->error(
-                    $this->translator->trans(
-                        /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
-                        'content_type.edit.error.already_exists',
-                        ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
-                        'content_type'
-                    )
+                    /** @Desc("Draft of the Content Type '%name%' already exists and is locked by '%userContentName%'") */
+                    'content_type.edit.error.already_exists',
+                    ['%name%' => $contentType->getName(), '%userContentName%' => $this->getUserNameById($userId)],
+                    'content_type'
                 );
 
                 return $this->redirectToRoute('ezplatform.content_type.view', [
@@ -451,12 +443,10 @@ class ContentTypeController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content Type '%name%' updated.") */
-                        'content_type.update.success',
-                        ['%name%' => $contentTypeDraft->getName()],
-                        'content_type'
-                    )
+                    /** @Desc("Content Type '%name%' updated.") */
+                    'content_type.update.success',
+                    ['%name%' => $contentTypeDraft->getName()],
+                    'content_type'
                 );
 
                 if ('publishContentType' === $form->getClickedButton()->getName()) {
@@ -508,12 +498,10 @@ class ContentTypeController extends Controller
                 $this->contentTypeService->deleteContentType($contentType);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content Type '%name%' deleted.") */
-                        'content_type.delete.success',
-                        ['%name%' => $contentType->getName()],
-                        'content_type'
-                    )
+                    /** @Desc("Content Type '%name%' deleted.") */
+                    'content_type.delete.success',
+                    ['%name%' => $contentType->getName()],
+                    'content_type'
                 );
             });
 
@@ -555,12 +543,10 @@ class ContentTypeController extends Controller
                     $this->contentTypeService->deleteContentType($contentType);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content Type '%name%' deleted.") */
-                            'content_type.delete.success',
-                            ['%name%' => $contentType->getName()],
-                            'content_type'
-                        )
+                        /** @Desc("Content Type '%name%' deleted.") */
+                        'content_type.delete.success',
+                        ['%name%' => $contentType->getName()],
+                        'content_type'
                     );
                 }
             });

--- a/src/bundle/Controller/ContentTypeGroupController.php
+++ b/src/bundle/Controller/ContentTypeGroupController.php
@@ -16,22 +16,18 @@ use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupsDele
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 
 class ContentTypeGroupController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
@@ -42,36 +38,27 @@ class ContentTypeGroupController extends Controller
     /** @var \EzSystems\EzPlatformAdminUi\Form\SubmitHandler */
     private $submitHandler;
 
-    /** @var array */
-    private $languages;
-
     /** @var int */
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
-     * @param array $languages
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ContentTypeService $contentTypeService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
-        array $languages,
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->contentTypeService = $contentTypeService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
-        $this->languages = $languages;
         $this->defaultPaginationLimit = $defaultPaginationLimit;
     }
 
@@ -139,12 +126,10 @@ class ContentTypeGroupController extends Controller
                 $group = $this->contentTypeService->createContentTypeGroup($createStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content type group '%name%' created.") */
-                        'content_type_group.create.success',
-                        ['%name%' => $data->getIdentifier()],
-                        'content_type'
-                    )
+                    /** @Desc("Content type group '%name%' created.") */
+                    'content_type_group.create.success',
+                    ['%name%' => $data->getIdentifier()],
+                    'content_type'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.content_type_group.view', [
@@ -185,12 +170,10 @@ class ContentTypeGroupController extends Controller
                 $this->contentTypeService->updateContentTypeGroup($group, $updateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content type group '%name%' updated.") */
-                        'content_type_group.update.success',
-                        ['%name%' => $group->identifier],
-                        'content_type'
-                    )
+                    /** @Desc("Content type group '%name%' updated.") */
+                    'content_type_group.update.success',
+                    ['%name%' => $group->identifier],
+                    'content_type'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.content_type_group.view', [
@@ -229,12 +212,10 @@ class ContentTypeGroupController extends Controller
                 $this->contentTypeService->deleteContentTypeGroup($group);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content type group '%name%' deleted.") */
-                        'content_type_group.delete.success',
-                        ['%name%' => $group->identifier],
-                        'content_type'
-                    )
+                    /** @Desc("Content type group '%name%' deleted.") */
+                    'content_type_group.delete.success',
+                    ['%name%' => $group->identifier],
+                    'content_type'
                 );
             });
 
@@ -268,12 +249,10 @@ class ContentTypeGroupController extends Controller
                     $this->contentTypeService->deleteContentTypeGroup($group);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Content type group '%name%' deleted.") */
-                            'content_type_group.delete.success',
-                            ['%name%' => $group->identifier],
-                            'content_type'
-                        )
+                        /** @Desc("Content type group '%name%' deleted.") */
+                        'content_type_group.delete.success',
+                        ['%name%' => $group->identifier],
+                        'content_type'
                     );
                 }
             });

--- a/src/bundle/Controller/LanguageController.php
+++ b/src/bundle/Controller/LanguageController.php
@@ -16,7 +16,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Language\LanguageUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\DataMapper\LanguageCreateMapper;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -27,15 +27,11 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException as TranslationInvalidArgumentException;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class LanguageController extends Controller
 {
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /** @var LanguageService */
     private $languageService;
@@ -53,8 +49,7 @@ class LanguageController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param NotificationHandlerInterface $notificationHandler
-     * @param TranslatorInterface $translator
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      * @param LanguageService $languageService
      * @param LanguageCreateMapper $languageCreateMapper
      * @param SubmitHandler $submitHandler
@@ -62,8 +57,7 @@ class LanguageController extends Controller
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         LanguageService $languageService,
         LanguageCreateMapper $languageCreateMapper,
         SubmitHandler $submitHandler,
@@ -71,7 +65,6 @@ class LanguageController extends Controller
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->languageService = $languageService;
         $this->languageCreateMapper = $languageCreateMapper;
         $this->submitHandler = $submitHandler;
@@ -160,12 +153,10 @@ class LanguageController extends Controller
                 $this->languageService->deleteLanguage($language);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Language '%name%' removed.") */
-                        'language.delete.success',
-                        ['%name%' => $language->name],
-                        'language'
-                    )
+                    /** @Desc("Language '%name%' removed.") */
+                    'language.delete.success',
+                    ['%name%' => $language->name],
+                    'language'
                 );
             });
 
@@ -205,12 +196,10 @@ class LanguageController extends Controller
                     $this->languageService->deleteLanguage($language);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Language '%name%' removed.") */
-                            'language.delete.success',
-                            ['%name%' => $language->name],
-                            'language'
-                        )
+                        /** @Desc("Language '%name%' removed.") */
+                        'language.delete.success',
+                        ['%name%' => $language->name],
+                        'language'
                     );
                 }
             });
@@ -234,12 +223,10 @@ class LanguageController extends Controller
                 $language = $this->languageService->createLanguage($languageCreateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Language '%name%' created.") */
-                        'language.create.success',
-                        ['%name%' => $language->name],
-                        'language'
-                    )
+                    /** @Desc("Language '%name%' created.") */
+                    'language.create.success',
+                    ['%name%' => $language->name],
+                    'language'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.language.view', [
@@ -274,12 +261,10 @@ class LanguageController extends Controller
                     : $this->languageService->disableLanguage($language);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Language '%name%' updated.") */
-                        'language.update.success',
-                        ['%name%' => $language->name],
-                        'language'
-                    )
+                    /** @Desc("Language '%name%' updated.") */
+                    'language.update.success',
+                    ['%name%' => $language->name],
+                    'language'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.language.view', [

--- a/src/bundle/Controller/LinkManagerController.php
+++ b/src/bundle/Controller/LinkManagerController.php
@@ -9,12 +9,11 @@ namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentEditData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\API\Repository\URLService;
-use eZ\Publish\API\Repository\Values\URL\Query\Criterion as Criterion;
-use eZ\Publish\API\Repository\Values\URL\Query\SortClause as SortClause;
-use eZ\Publish\API\Repository\Values\URL\URL;
+use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+use eZ\Publish\API\Repository\Values\URL\Query\SortClause;
 use eZ\Publish\API\Repository\Values\URL\URLQuery;
 use EzSystems\RepositoryForms\Data\URL\URLListData;
 use EzSystems\RepositoryForms\Data\URL\URLUpdateData;
@@ -24,7 +23,6 @@ use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class LinkManagerController extends Controller
 {
@@ -39,11 +37,8 @@ class LinkManagerController extends Controller
     /** @var SubmitHandler */
     private $submitHandler;
 
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /**
      * EzPlatformLinkManagerController constructor.
@@ -51,21 +46,18 @@ class LinkManagerController extends Controller
      * @param URLService $urlService
      * @param FormFactory $formFactory
      * @param SubmitHandler $submitHandler
-     * @param NotificationHandlerInterface $notificationHandler
-     * @param TranslatorInterface $translator
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      */
     public function __construct(
         URLService $urlService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator)
-    {
+        TranslatableNotificationHandlerInterface $notificationHandler
+    ) {
         $this->urlService = $urlService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
     }
 
     /**
@@ -124,7 +116,10 @@ class LinkManagerController extends Controller
             $result = $this->submitHandler->handle($form, function (URLUpdateData $data) use ($url) {
                 $this->urlService->updateUrl($url, $data);
                 $this->notificationHandler->success(
-                    $this->translator->trans('url.update.success', [], 'linkmanager')
+                    /** @Desc("URL updated") */
+                    'url.update.success',
+                    [],
+                    'linkmanager'
                 );
 
                 return $this->redirectToRoute('ezplatform.link_manager.list');

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -30,7 +30,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Location\LocationAssignSubtreeData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Form\Type\Location\LocationAssignSectionType;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Tab\LocationView\DetailsTab;
 use EzSystems\EzPlatformAdminUi\Tab\LocationView\LocationsTab;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -42,7 +42,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class LocationController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
 
     /** @var \Symfony\Component\Translation\TranslatorInterface */
@@ -73,7 +73,7 @@ class LocationController extends Controller
     private $permissionResolver;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
@@ -85,7 +85,7 @@ class LocationController extends Controller
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         TranslatorInterface $translator,
         LocationService $locationService,
         ContentTypeService $contentTypeService,
@@ -137,12 +137,10 @@ class LocationController extends Controller
                 $this->locationService->moveSubtree($location, $newParentLocation);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("'%name%' moved to '%location%'") */
-                        'location.move.success',
-                        ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
-                        'location'
-                    )
+                    /** @Desc("'%name%' moved to '%location%'") */
+                    'location.move.success',
+                    ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
+                    'location'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -195,12 +193,10 @@ class LocationController extends Controller
                 $newLocation = $this->locationService->loadLocation($copiedContent->contentInfo->mainLocationId);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("'%name%' copied to '%location%'") */
-                        'location.copy.success',
-                        ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
-                        'location'
-                    )
+                    /** @Desc("'%name%' copied to '%location%'") */
+                    'location.copy.success',
+                    ['%name%' => $location->getContentInfo()->name, '%location%' => $newParentLocation->getContentInfo()->name],
+                    'location'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -244,14 +240,13 @@ class LocationController extends Controller
                 $newLocation = $this->locationService->loadLocation($copiedContent->contentInfo->mainLocationId);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Subtree '%name%' copied to location '%location%'") */
-                        'location.copy_subtree.success', [
+                    /** @Desc("Subtree '%name%' copied to location '%location%'") */
+                    'location.copy_subtree.success',
+                    [
                         '%name%' => $location->getContentInfo()->name,
                         '%location%' => $newParentLocation->getContentInfo()->name,
                     ],
-                        'location'
-                    )
+                    'location'
                 );
 
                 return $this->redirectToLocation($newLocation);
@@ -295,12 +290,10 @@ class LocationController extends Controller
                 $this->locationService->swapLocation($currentLocation, $newLocation);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Location '%name%' swaped with location '%location%'") */
-                        'location.swap.success',
-                        ['%name%' => $currentLocation->getContentInfo()->name, '%location%' => $newLocation->getContentInfo()->name],
-                        'location'
-                    )
+                    /** @Desc("Location '%name%' swaped with location '%location%'") */
+                    'location.swap.success',
+                    ['%name%' => $currentLocation->getContentInfo()->name, '%location%' => $newLocation->getContentInfo()->name],
+                    'location'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -392,12 +385,10 @@ class LocationController extends Controller
         $this->trashService->trash($location);
 
         $this->notificationHandler->success(
-            $this->translator->trans(
-                /** @Desc("Location '%name%' moved to trash.") */
-                'location.trash.success',
-                ['%name%' => $location->getContentInfo()->name],
-                'location'
-            )
+            /** @Desc("Location '%name%' moved to trash.") */
+            'location.trash.success',
+            ['%name%' => $location->getContentInfo()->name],
+            'location'
         );
 
         return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -431,12 +422,10 @@ class LocationController extends Controller
                     $this->locationService->deleteLocation($location);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Location '%name%' removed.") */
-                            'location.delete.success',
-                            ['%name%' => $location->getContentInfo()->name],
-                            'location'
-                        )
+                        /** @Desc("Location '%name%' removed.") */
+                        'location.delete.success',
+                        ['%name%' => $location->getContentInfo()->name],
+                        'location'
                     );
                 }
 
@@ -482,12 +471,10 @@ class LocationController extends Controller
                     $this->locationService->createLocation($contentInfo, $locationCreateStruct);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Location '%name%' created.") */
-                            'location.create.success',
-                            ['%name%' => $newLocation->getContentInfo()->name],
-                            'location'
-                        )
+                        /** @Desc("Location '%name%' created.") */
+                        'location.create.success',
+                        ['%name%' => $newLocation->getContentInfo()->name],
+                        'location'
                     );
                 }
 
@@ -585,12 +572,10 @@ class LocationController extends Controller
                 $this->locationService->updateLocation($location, $locationUpdateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Location '%name%' updated.") */
-                        'location.update.success',
-                        ['%name%' => $location->getContentInfo()->name],
-                        'location'
-                    )
+                    /** @Desc("Location '%name%' updated.") */
+                    'location.update.success',
+                    ['%name%' => $location->getContentInfo()->name],
+                    'location'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [
@@ -630,12 +615,10 @@ class LocationController extends Controller
                 $this->sectionService->assignSectionToSubtree($location, $section);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Section '%name%' has been assigned to subtree") */
-                        'location.assign_section.success',
-                        ['%name%' => $section->name],
-                        'location'
-                    )
+                    /** @Desc("Section '%name%' has been assigned to subtree") */
+                    'location.assign_section.success',
+                    ['%name%' => $section->name],
+                    'location'
                 );
 
                 return $this->redirectToLocation($location, DetailsTab::URI_FRAGMENT);

--- a/src/bundle/Controller/ObjectStateController.php
+++ b/src/bundle/Controller/ObjectStateController.php
@@ -25,19 +25,15 @@ use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStateCreateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStateDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStatesDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ObjectState\ObjectStateUpdateType;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ObjectStateController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\ObjectStateService */
     private $objectStateService;
@@ -55,7 +51,7 @@ class ObjectStateController extends Controller
     private $languages;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
@@ -64,8 +60,7 @@ class ObjectStateController extends Controller
      * @param array $languages
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ObjectStateService $objectStateService,
         FormFactoryInterface $formFactory,
         SubmitHandler $submitHandler,
@@ -73,7 +68,6 @@ class ObjectStateController extends Controller
         array $languages
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->objectStateService = $objectStateService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
@@ -159,12 +153,10 @@ class ObjectStateController extends Controller
                     $objectState = $this->objectStateService->createObjectState($objectStateGroup, $createStruct);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
                             /** @Desc("Object state '%name%' created.") */
                             'object_state.create.success',
                             ['%name%' => $data->getName()],
                             'object_state'
-                        )
                     );
 
                     return $this->redirectToRoute('ezplatform.object_state.state.view', [
@@ -203,12 +195,10 @@ class ObjectStateController extends Controller
                 $this->objectStateService->deleteObjectState($objectState);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Object state '%name%' deleted.") */
-                        'object_state.delete.success',
-                        ['%name%' => $objectState->getName()],
-                        'object_state'
-                    )
+                    /** @Desc("Object state '%name%' deleted.") */
+                    'object_state.delete.success',
+                    ['%name%' => $objectState->getName()],
+                    'object_state'
                 );
             });
 
@@ -246,12 +236,10 @@ class ObjectStateController extends Controller
                     $this->objectStateService->deleteObjectState($objectState);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Object state '%name%' deleted.") */
-                            'object_state.delete.success',
-                            ['%name%' => $objectState->getName()],
-                            'object_state'
-                        )
+                        /** @Desc("Object state '%name%' deleted.") */
+                        'object_state.delete.success',
+                        ['%name%' => $objectState->getName()],
+                        'object_state'
                     );
                 }
             });
@@ -291,12 +279,10 @@ class ObjectStateController extends Controller
                 $updatedObjectState = $this->objectStateService->updateObjectState($objectState, $updateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Object state '%name%' updated.") */
-                        'object_state.update.success',
-                        ['%name%' => $updatedObjectState->getName()],
-                        'object_state'
-                    )
+                    /** @Desc("Object state '%name%' updated.") */
+                    'object_state.update.success',
+                    ['%name%' => $updatedObjectState->getName()],
+                    'object_state'
                 );
 
                 return $this->redirectToRoute('ezplatform.object_state.state.view', [
@@ -352,12 +338,10 @@ class ObjectStateController extends Controller
                 $this->objectStateService->setContentState($contentInfo, $objectStateGroup, $objectState);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Content object state '%name%' updated.") */
-                        'content_object_state.update.success',
-                        ['%name%' => $objectState->getName()],
-                        'object_state'
-                    )
+                    /** @Desc("Content object state '%name%' updated.") */
+                    'content_object_state.update.success',
+                    ['%name%' => $objectState->getName()],
+                    'object_state'
                 );
             });
 

--- a/src/bundle/Controller/ObjectStateGroupController.php
+++ b/src/bundle/Controller/ObjectStateGroupController.php
@@ -17,18 +17,14 @@ use EzSystems\EzPlatformAdminUi\Form\Data\ObjectState\ObjectStateGroupsDeleteDat
 use EzSystems\EzPlatformAdminUi\Form\Data\ObjectState\ObjectStateGroupUpdateData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ObjectStateGroupController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\ObjectStateService */
     private $objectStateService;
@@ -43,23 +39,20 @@ class ObjectStateGroupController extends Controller
     private $languages;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
      * @param array $languages
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ObjectStateService $objectStateService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
         array $languages
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->objectStateService = $objectStateService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
@@ -135,12 +128,10 @@ class ObjectStateGroupController extends Controller
                     $group = $this->objectStateService->createObjectStateGroup($createStruct);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Object state group '%name%' created.") */
-                            'object_state_group.create.success',
-                            ['%name%' => $data->getName()],
-                            'object_state'
-                        )
+                        /** @Desc("Object state group '%name%' created.") */
+                        'object_state_group.create.success',
+                        ['%name%' => $data->getName()],
+                        'object_state'
                     );
 
                     return $this->redirectToRoute('ezplatform.object_state.group.view', [
@@ -178,12 +169,10 @@ class ObjectStateGroupController extends Controller
                 $this->objectStateService->deleteObjectStateGroup($group);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Object state group '%name%' deleted.") */
-                        'object_state_group.delete.success',
-                        ['%name%' => $group->getName()],
-                        'object_state'
-                    )
+                    /** @Desc("Object state group '%name%' deleted.") */
+                    'object_state_group.delete.success',
+                    ['%name%' => $group->getName()],
+                    'object_state'
                 );
             });
 
@@ -217,12 +206,10 @@ class ObjectStateGroupController extends Controller
                     $this->objectStateService->deleteObjectStateGroup($objectStateGroup);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Object state group '%name%' deleted.") */
-                            'object_state_group.delete.success',
-                            ['%name%' => $objectStateGroup->getName()],
-                            'object_state'
-                        )
+                        /** @Desc("Object state group '%name%' deleted.") */
+                        'object_state_group.delete.success',
+                        ['%name%' => $objectStateGroup->getName()],
+                        'object_state'
                     );
                 }
             });
@@ -259,12 +246,10 @@ class ObjectStateGroupController extends Controller
                 $updatedGroup = $this->objectStateService->updateObjectStateGroup($group, $updateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Object state group '%name%' updated.") */
-                        'object_state_group.update.success',
-                        ['%name%' => $updatedGroup->getName()],
-                        'object_state'
-                    )
+                    /** @Desc("Object state group '%name%' updated.") */
+                    'object_state_group.update.success',
+                    ['%name%' => $updatedGroup->getName()],
+                    'object_state'
                 );
 
                 return $this->redirectToRoute('ezplatform.object_state.group.view', [

--- a/src/bundle/Controller/PolicyController.php
+++ b/src/bundle/Controller/PolicyController.php
@@ -20,22 +20,18 @@ use EzSystems\EzPlatformAdminUi\Form\DataMapper\PolicyCreateMapper;
 use EzSystems\EzPlatformAdminUi\Form\DataMapper\PolicyUpdateMapper;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 
 class PolicyController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\RoleService */
     private $roleService;
@@ -56,8 +52,7 @@ class PolicyController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\RoleService $roleService
      * @param \EzSystems\EzPlatformAdminUi\Form\DataMapper\PolicyCreateMapper $policyCreateMapper
      * @param \EzSystems\EzPlatformAdminUi\Form\DataMapper\PolicyUpdateMapper $policyUpdateMapper
@@ -66,8 +61,7 @@ class PolicyController extends Controller
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         RoleService $roleService,
         PolicyCreateMapper $policyCreateMapper,
         PolicyUpdateMapper $policyUpdateMapper,
@@ -76,7 +70,6 @@ class PolicyController extends Controller
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->roleService = $roleService;
         $this->policyCreateMapper = $policyCreateMapper;
         $this->policyUpdateMapper = $policyUpdateMapper;
@@ -164,12 +157,10 @@ class PolicyController extends Controller
 
                 if ($isEditable) {
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Now you can set limitations for the policy.") */
-                            'policy.add.set_limitation',
-                            ['%role%' => $role->identifier],
-                            'role'
-                        )
+                        /** @Desc("Now you can set limitations for the policy.") */
+                        'policy.add.set_limitation',
+                        ['%role%' => $role->identifier],
+                        'role'
                     );
 
                     return new RedirectResponse($this->generateUrl('ezplatform.policy.create_with_limitation', [
@@ -189,12 +180,10 @@ class PolicyController extends Controller
                 $this->roleService->publishRoleDraft($roleDraft);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("New policies in role '%role%' created.") */
-                        'policy.add.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("New policies in role '%role%' created.") */
+                    'policy.add.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -235,12 +224,10 @@ class PolicyController extends Controller
 
         if (!$isEditable) {
             $this->notificationHandler->error(
-                $this->translator->trans(
-                    /** @Desc("Policy type '%policy%' does not contain limitations.") */
-                    'policy.edit.no_limitations',
-                    ['%policy%' => $policy->module . '/' . $policy->function],
-                    'role'
-                )
+                /** @Desc("Policy type '%policy%' does not contain limitations.") */
+                'policy.edit.no_limitations',
+                ['%policy%' => $policy->module . '/' . $policy->function],
+                'role'
             );
 
             return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -268,12 +255,10 @@ class PolicyController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Policies in role '%role%' updated.") */
-                        'policy.update.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Policies in role '%role%' updated.") */
+                    'policy.update.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -320,12 +305,10 @@ class PolicyController extends Controller
                 $this->roleService->publishRoleDraft($roleDraft);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("New policies in role '%role%' created.") */
-                        'policy.add.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("New policies in role '%role%' created.") */
+                    'policy.add.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -374,12 +357,10 @@ class PolicyController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Policies in role '%role%' removed.") */
-                        'policy.delete.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Policies in role '%role%' removed.") */
+                    'policy.delete.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -432,12 +413,10 @@ class PolicyController extends Controller
                 $this->roleService->publishRoleDraft($roleDraft);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Policies in role '%role%' removed.") */
-                        'policy.delete.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Policies in role '%role%' removed.") */
+                    'policy.delete.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [

--- a/src/bundle/Controller/RoleAssignmentController.php
+++ b/src/bundle/Controller/RoleAssignmentController.php
@@ -20,21 +20,17 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Role\RoleAssignmentCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Role\RoleAssignmentDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class RoleAssignmentController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\RoleService */
     private $roleService;
@@ -49,23 +45,20 @@ class RoleAssignmentController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\RoleService $roleService
      * @param \EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory $formFactory
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         RoleService $roleService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->roleService = $roleService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
@@ -135,12 +128,10 @@ class RoleAssignmentController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Assignments on role '%role%' created.") */
-                        'role.assignment_create.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Assignments on role '%role%' created.") */
+                    'role.assignment_create.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -180,12 +171,10 @@ class RoleAssignmentController extends Controller
                 $this->roleService->removeRoleAssignment($roleAssignment);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Assignment on role '%role%' removed.") */
-                        'role.assignment_delete.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Assignment on role '%role%' removed.") */
+                    'role.assignment_delete.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -227,12 +216,10 @@ class RoleAssignmentController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Assignment on role '%role%' removed.") */
-                        'role.assignment_delete.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Assignment on role '%role%' removed.") */
+                    'role.assignment_delete.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [

--- a/src/bundle/Controller/RoleController.php
+++ b/src/bundle/Controller/RoleController.php
@@ -19,7 +19,7 @@ use EzSystems\EzPlatformAdminUi\Form\DataMapper\RoleCreateMapper;
 use EzSystems\EzPlatformAdminUi\Form\DataMapper\RoleUpdateMapper;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -28,15 +28,11 @@ use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class RoleController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\RoleService */
     private $roleService;
@@ -57,8 +53,7 @@ class RoleController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\RoleService $roleService
      * @param \EzSystems\EzPlatformAdminUi\Form\DataMapper\RoleCreateMapper $roleCreateMapper
      * @param \EzSystems\EzPlatformAdminUi\Form\DataMapper\RoleUpdateMapper $roleUpdateMapper
@@ -67,8 +62,7 @@ class RoleController extends Controller
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         RoleService $roleService,
         RoleCreateMapper $roleCreateMapper,
         RoleUpdateMapper $roleUpdateMapper,
@@ -77,7 +71,6 @@ class RoleController extends Controller
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->roleService = $roleService;
         $this->roleCreateMapper = $roleCreateMapper;
         $this->roleUpdateMapper = $roleUpdateMapper;
@@ -174,12 +167,10 @@ class RoleController extends Controller
                 $this->roleService->publishRoleDraft($roleDraft);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Role '%role%' created.") */
-                        'role.create.success',
-                        ['%role%' => $roleDraft->identifier],
-                        'role'
-                    )
+                    /** @Desc("Role '%role%' created.") */
+                    'role.create.success',
+                    ['%role%' => $roleDraft->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -222,12 +213,10 @@ class RoleController extends Controller
                 $this->roleService->publishRoleDraft($roleDraft);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Role '%role%' updated.") */
-                        'role.update.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Role '%role%' updated.") */
+                    'role.update.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
@@ -266,12 +255,10 @@ class RoleController extends Controller
                 $this->roleService->deleteRole($role);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Role '%role%' removed.") */
-                        'role.delete.success',
-                        ['%role%' => $role->identifier],
-                        'role'
-                    )
+                    /** @Desc("Role '%role%' removed.") */
+                    'role.delete.success',
+                    ['%role%' => $role->identifier],
+                    'role'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.list'));
@@ -313,12 +300,10 @@ class RoleController extends Controller
                     $this->roleService->deleteRole($role);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Role '%role%' removed.") */
-                            'role.delete.success',
-                            ['%role%' => $role->identifier],
-                            'role'
-                        )
+                        /** @Desc("Role '%role%' removed.") */
+                        'role.delete.success',
+                        ['%role%' => $role->identifier],
+                        'role'
                     );
                 }
 

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -29,7 +29,7 @@ use EzSystems\EzPlatformAdminUi\Form\DataMapper\SectionCreateMapper;
 use EzSystems\EzPlatformAdminUi\Form\DataMapper\SectionUpdateMapper;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
 use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
 use EzSystems\EzPlatformAdminUiBundle\View\EzPagerfantaView;
@@ -44,7 +44,7 @@ use Exception;
 
 class SectionController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
 
     /** @var \Symfony\Component\Translation\TranslatorInterface */
@@ -87,7 +87,7 @@ class SectionController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param \eZ\Publish\API\Repository\SectionService $sectionService
      * @param \eZ\Publish\API\Repository\SearchService $searchService
@@ -103,7 +103,7 @@ class SectionController extends Controller
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         TranslatorInterface $translator,
         SectionService $sectionService,
         SearchService $searchService,
@@ -291,12 +291,10 @@ class SectionController extends Controller
                 $this->sectionService->deleteSection($section);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Section '%name%' removed.") */
-                        'section.delete.success',
-                        ['%name%' => $section->name],
-                        'section'
-                    )
+                    /** @Desc("Section '%name%' removed.") */
+                    'section.delete.success',
+                    ['%name%' => $section->name],
+                    'section'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.section.list'));
@@ -332,12 +330,10 @@ class SectionController extends Controller
                     $this->sectionService->deleteSection($section);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Section '%name%' removed.") */
-                            'section.delete.success',
-                            ['%name%' => $section->name],
-                            'section'
-                        )
+                        /** @Desc("Section '%name%' removed.") */
+                        'section.delete.success',
+                        ['%name%' => $section->name],
+                        'section'
                     );
                 }
             });
@@ -382,12 +378,10 @@ class SectionController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("%contentItemsCount% content items were assigned to '%name%'") */
-                        'section.assign_content.success',
-                        ['%name%' => $section->name, '%contentItemsCount%' => count($contentInfos)],
-                        'section'
-                    )
+                    /** @Desc("%contentItemsCount% content items were assigned to '%name%'") */
+                    'section.assign_content.success',
+                    ['%name%' => $section->name, '%contentItemsCount%' => count($contentInfos)],
+                    'section'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.section.view', [
@@ -425,19 +419,17 @@ class SectionController extends Controller
                 $section = $this->sectionService->createSection($sectionCreateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Section '%name%' created.") */
-                        'section.create.success',
-                        ['%name%' => $section->name],
-                        'section'
-                    )
+                    /** @Desc("Section '%name%' created.") */
+                    'section.create.success',
+                    ['%name%' => $section->name],
+                    'section'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.section.view', [
                     'sectionId' => $section->id,
                 ]));
             } catch (Exception $e) {
-                $this->notificationHandler->error($e->getMessage());
+                $this->notificationHandler->error(/** @Ignore */ $e->getMessage());
             }
         }
 
@@ -467,19 +459,17 @@ class SectionController extends Controller
                 $section = $this->sectionService->updateSection($data->getSection(), $sectionUpdateStruct);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Section '%name%' updated.") */
-                        'section.update.success',
-                        ['%name%' => $section->name],
-                        'section'
-                    )
+                    /** @Desc("Section '%name%' updated.") */
+                    'section.update.success',
+                    ['%name%' => $section->name],
+                    'section'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.section.view', [
                     'sectionId' => $section->id,
                 ]));
             } catch (Exception $e) {
-                $this->notificationHandler->error($e->getMessage());
+                $this->notificationHandler->error(/** @Ignore */ $e->getMessage());
             }
         }
 

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -12,20 +12,16 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Tab\LocationView\TranslationsTab;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class TranslationController extends Controller
 {
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /** @var ContentService */
     private $contentService;
@@ -37,21 +33,18 @@ class TranslationController extends Controller
     private $submitHandler;
 
     /**
-     * @param NotificationHandlerInterface $notificationHandler
-     * @param TranslatorInterface $translator
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      * @param ContentService $contentService
      * @param FormFactory $formFactory
      * @param SubmitHandler $submitHandler
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ContentService $contentService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->contentService = $contentService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
@@ -118,12 +111,10 @@ class TranslationController extends Controller
                     $this->contentService->deleteTranslation($contentInfo, $languageCode);
 
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Translation '%languageCode%' removed from content '%name%'.") */
-                            'translation.remove.success',
-                            ['%languageCode%' => $languageCode, '%name%' => $contentInfo->name],
-                            'translation'
-                        )
+                        /** @Desc("Translation '%languageCode%' removed from content '%name%'.") */
+                        'translation.remove.success',
+                        ['%languageCode%' => $languageCode, '%name%' => $contentInfo->name],
+                        'translation'
                     );
                 }
 

--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -21,23 +21,19 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Trash\TrashItemRestoreData;
 use EzSystems\EzPlatformAdminUi\Form\Data\TrashItemData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta\TrashItemAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use EzSystems\EzPlatformAdminUi\UI\Service\PathService as UiPathService;
 
 class TrashController extends Controller
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \eZ\Publish\API\Repository\TrashService */
     private $trashService;
@@ -70,8 +66,7 @@ class TrashController extends Controller
     private $defaultPaginationLimit;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \eZ\Publish\API\Repository\TrashService $trashService
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
@@ -84,8 +79,7 @@ class TrashController extends Controller
      * @param int $defaultPaginationLimit
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         TrashService $trashService,
         LocationService $locationService,
         ContentService $contentService,
@@ -98,7 +92,6 @@ class TrashController extends Controller
         int $defaultPaginationLimit
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->trashService = $trashService;
         $this->locationService = $locationService;
         $this->contentService = $contentService;
@@ -210,12 +203,10 @@ class TrashController extends Controller
                 $this->trashService->emptyTrash();
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Trash empty.") */
-                        'trash.empty.success',
-                        [],
-                        'trash'
-                    )
+                    /** @Desc("Trash empty.") */
+                    'trash.empty.success',
+                    [],
+                    'trash'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.trash.list'));
@@ -257,21 +248,17 @@ class TrashController extends Controller
 
                 if (null === $newParentLocation) {
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Items restored under their original location.") */
-                            'trash.restore_original_location.success',
-                            [],
-                            'trash'
-                        )
+                        /** @Desc("Items restored under their original location.") */
+                        'trash.restore_original_location.success',
+                        [],
+                        'trash'
                     );
                 } else {
                     $this->notificationHandler->success(
-                        $this->translator->trans(
-                            /** @Desc("Items restored under '%location%' location.") */
-                            'trash.restore_new_location.success',
-                            ['%location%' => $newParentLocation->getContentInfo()->name],
-                            'trash'
-                        )
+                        /** @Desc("Items restored under '%location%' location.") */
+                        'trash.restore_new_location.success',
+                        ['%location%' => $newParentLocation->getContentInfo()->name],
+                        'trash'
                     );
                 }
 
@@ -312,12 +299,10 @@ class TrashController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Deleted selected trash items.") */
-                        'trash.deleted.success',
-                        [],
-                        'trash'
-                    )
+                    /** @Desc("Deleted selected trash items.") */
+                    'trash.deleted.success',
+                    [],
+                    'trash'
                 );
 
                 return new RedirectResponse($this->generateUrl('ezplatform.trash.list'));

--- a/src/bundle/Controller/User/UserDeleteController.php
+++ b/src/bundle/Controller/User/UserDeleteController.php
@@ -11,19 +11,18 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use EzSystems\EzPlatformAdminUi\Form\Data\User\UserDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
-use Symfony\Component\Translation\TranslatorInterface;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\LocationService;
 
 class UserDeleteController extends Controller
 {
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
 
     /** @var FormFactory */
@@ -32,9 +31,6 @@ class UserDeleteController extends Controller
     /** @var SubmitHandler */
     private $submitHandler;
 
-    /** @var TranslatorInterface */
-    private $translator;
-
     /** @var UserService */
     private $userService;
 
@@ -42,25 +38,22 @@ class UserDeleteController extends Controller
     private $locationService;
 
     /**
-     * @param NotificationHandlerInterface $notificationHandler
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      * @param FormFactory $formFactory
      * @param SubmitHandler $submitHandler
-     * @param TranslatorInterface $translator
      * @param UserService $userService
      * @param LocationService $locationService
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         FormFactory $formFactory,
         SubmitHandler $submitHandler,
-        TranslatorInterface $translator,
         UserService $userService,
         LocationService $locationService
     ) {
         $this->notificationHandler = $notificationHandler;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
-        $this->translator = $translator;
         $this->userService = $userService;
         $this->locationService = $locationService;
     }
@@ -92,12 +85,10 @@ class UserDeleteController extends Controller
                 $this->userService->deleteUser($user);
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("User with login '%login%' deleted.") */
-                        'user.delete.success',
-                        ['%login%' => $user->login],
-                        'content'
-                    )
+                    /** @Desc("User with login '%login%' deleted.") */
+                    'user.delete.success',
+                    ['%login%' => $user->login],
+                    'content'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [

--- a/src/bundle/Controller/VersionController.php
+++ b/src/bundle/Controller/VersionController.php
@@ -14,22 +14,18 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\EzPlatformAdminUi\Form\Data\Version\VersionRemoveData;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\EzPlatformAdminUi\Tab\LocationView\VersionsTab;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class VersionController extends Controller
 {
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /** @var ContentService */
     private $contentService;
@@ -41,21 +37,18 @@ class VersionController extends Controller
     private $submitHandler;
 
     /**
-     * @param NotificationHandlerInterface $notificationHandler
-     * @param TranslatorInterface $translator
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      * @param ContentService $contentService
      * @param FormFactory $formFactory
      * @param SubmitHandler $submitHandler
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         ContentService $contentService,
         FormFactory $formFactory,
         SubmitHandler $submitHandler
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->contentService = $contentService;
         $this->formFactory = $formFactory;
         $this->submitHandler = $submitHandler;
@@ -101,12 +94,10 @@ class VersionController extends Controller
                 }
 
                 $this->notificationHandler->success(
-                    $this->translator->trans(
-                        /** @Desc("Versions removed from '%name%' content.") */
-                        'version.delete.success',
-                        ['%name%' => $contentInfo->name],
-                        'version'
-                    )
+                    /** @Desc("Versions removed from '%name%' content.") */
+                    'version.delete.success',
+                    ['%name%' => $contentInfo->name],
+                    'version'
                 );
 
                 return new RedirectResponse($this->generateUrl('_ezpublishLocation', [

--- a/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
@@ -49,6 +49,7 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $this->prependEzDesignConfiguration($container);
         $this->prependAdminUiFormsConfiguration($container);
         $this->prependBazingaJsTranslationConfiguration($container);
+        $this->prependJMSTranslation($container);
     }
 
     /**
@@ -116,5 +117,25 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $config = Yaml::parseFile($configFile);
         $container->prependExtensionConfig('bazinga_js_translation', $config);
         $container->addResource(new FileResource($configFile));
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function prependJMSTranslation(ContainerBuilder $container): void
+    {
+        $container->prependExtensionConfig('jms_translation', [
+            'configs' => [
+                'ezplatform_admin_ui' => [
+                    'dirs' => [
+                        __DIR__ . '/../../../src/',
+                    ],
+                    'output_dir' => __DIR__ . '/../Resources/translations/',
+                    'output_format' => 'xliff',
+                    'excluded_dirs' => ['Behat', 'Tests', 'node_modules'],
+                    'extractors' => ['ez_policy'],
+                ],
+            ],
+        ]);
     }
 }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -84,10 +84,10 @@ services:
             - { name: form.type }
 
     EzSystems\EzPlatformAdminUi\Notification\FlashBagNotificationHandler: ~
-    EzSystems\EzPlatformAdminUi\Notification\TranslatableFlashBagNotificationHandler: ~
+    EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandler: ~
 
     EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface: '@EzSystems\EzPlatformAdminUi\Notification\FlashBagNotificationHandler'
-    EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface: '@EzSystems\EzPlatformAdminUi\Notification\TranslatableFlashBagNotificationHandler'
+    EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface: '@EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandler'
 
     EzSystems\EzPlatformAdminUi\RepositoryForms\View\ViewParametersListener:
         public: true

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -84,8 +84,10 @@ services:
             - { name: form.type }
 
     EzSystems\EzPlatformAdminUi\Notification\FlashBagNotificationHandler: ~
+    EzSystems\EzPlatformAdminUi\Notification\TranslatableFlashBagNotificationHandler: ~
 
     EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface: '@EzSystems\EzPlatformAdminUi\Notification\FlashBagNotificationHandler'
+    EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface: '@EzSystems\EzPlatformAdminUi\Notification\TranslatableFlashBagNotificationHandler'
 
     EzSystems\EzPlatformAdminUi\RepositoryForms\View\ViewParametersListener:
         public: true

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -37,7 +37,6 @@ services:
     EzSystems\EzPlatformAdminUiBundle\Controller\ContentTypeGroupController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
-            $languages: '$languages$'
             $defaultPaginationLimit: '$pagination.content_type_group_limit$'
 
     EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:

--- a/src/bundle/Resources/config/services/translation.yml
+++ b/src/bundle/Resources/config/services/translation.yml
@@ -13,3 +13,7 @@ services:
             - '%ezpublish.api.role.policy_map%'
         tags:
             - { name: jms_translation.extractor, alias: ez_policy }
+
+    EzSystems\EzPlatformAdminUi\Translation\Extractor\NotificationTranslationExtractor:
+        tags:
+            - { name: jms_translation.file_visitor }

--- a/src/bundle/Resources/translations/content.en.xliff
+++ b/src/bundle/Resources/translations/content.en.xliff
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="fbc24757e92f52997d730762e004765425845995" resname="content.hide.already_hidden">
         <source>Content '%name%' was already hidden.</source>
-        <target state="new">Content '%name%' has been hidden.</target>
+        <target state="new">Content '%name%' was already hidden.</target>
         <note>key: content.hide.already_hidden</note>
       </trans-unit>
       <trans-unit id="7a80db58ea3f3bef5b9f07c4565d715efdacda99" resname="content.hide.success">

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -67,8 +67,8 @@
         <note>key: content_type.default_sort</note>
       </trans-unit>
       <trans-unit id="5ecc210ad42274409db7ec4e56ba286b487639c6" resname="content_type.delete.success">
-        <source>Content type '%name%' deleted.</source>
-        <target state="new">Content type '%name%' deleted.</target>
+        <source>Content Type '%name%' deleted.</source>
+        <target state="new">Content Type '%name%' deleted.</target>
         <note>key: content_type.delete.success</note>
       </trans-unit>
       <trans-unit id="f2a3cc77cdadcff8883b0022e006e24918307687" resname="content_type.description">
@@ -172,8 +172,8 @@
         <note>key: content_type.sort_field.section_identifier</note>
       </trans-unit>
       <trans-unit id="48d3eb66c0f8928777189eab11eae254866852b2" resname="content_type.update.success">
-        <source>Content type '%name%' updated.</source>
-        <target state="new">Content type '%name%' updated.</target>
+        <source>Content Type '%name%' updated.</source>
+        <target state="new">Content Type '%name%' updated.</target>
         <note>key: content_type.update.success</note>
       </trans-unit>
       <trans-unit id="6ab7362c77b22ff8bc0d14eeaae8514b0a683473" resname="content_type.url_alias_schema">

--- a/src/bundle/Resources/translations/linkmanager.en.xliff
+++ b/src/bundle/Resources/translations/linkmanager.en.xliff
@@ -113,7 +113,7 @@
       </trans-unit>
       <trans-unit id="9ff98d02d294a164470b9491cabfa3526f2f63f6" resname="url.update.success">
         <source>URL updated</source>
-        <target>URL updated</target>
+        <target state="new">URL updated</target>
         <note>key: url.update.success</note>
       </trans-unit>
       <trans-unit id="8fe54f2938f83a529ad5d7aa94d4e2fc9934bac1" resname="url.usages.column.name">

--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -82,7 +82,7 @@ class AdminExceptionListener
 
         $code = $response->getStatusCode();
 
-        $this->notificationHandler->error($this->getNotificationMessage($exception));
+        $this->notificationHandler->error(/** @Ignore */ $this->getNotificationMessage($exception));
 
         switch ($code) {
             case 404:

--- a/src/lib/Form/SubmitHandler.php
+++ b/src/lib/Form/SubmitHandler.php
@@ -79,11 +79,11 @@ class SubmitHandler
                     return $event->getResponse();
                 }
             } catch (Exception $e) {
-                $this->notificationHandler->error($e->getMessage());
+                $this->notificationHandler->error(/** @Ignore */ $e->getMessage());
             }
         } else {
             foreach ($form->getErrors(true, true) as $formError) {
-                $this->notificationHandler->warning($formError->getMessage());
+                $this->notificationHandler->warning(/** @Ignore */ $formError->getMessage());
             }
         }
 

--- a/src/lib/Notification/FlashBagNotificationHandler.php
+++ b/src/lib/Notification/FlashBagNotificationHandler.php
@@ -10,17 +10,17 @@ namespace EzSystems\EzPlatformAdminUi\Notification;
 
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-class FlashBagNotificationHandler implements NotificationHandlerInterface
+final class FlashBagNotificationHandler implements NotificationHandlerInterface
 {
-    const TYPE_INFO = 'info';
-    const TYPE_SUCCESS = 'success';
-    const TYPE_WARNING = 'warning';
-    const TYPE_ERROR = 'danger';
+    private const TYPE_INFO = 'info';
+    private const TYPE_SUCCESS = 'success';
+    private const TYPE_WARNING = 'warning';
+    private const TYPE_ERROR = 'danger';
 
     /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
-    protected $session;
+    private $session;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session

--- a/src/lib/Notification/TranslatableFlashBagNotificationHandler.php
+++ b/src/lib/Notification/TranslatableFlashBagNotificationHandler.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Notification;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class TranslatableFlashBagNotificationHandler implements TranslatableNotificationHandlerInterface
+{
+    /**
+     * @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface
+     */
+    private $notificationHandler;
+    /**
+     *  @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     */
+    public function __construct(
+        NotificationHandlerInterface $notificationHandler,
+        TranslatorInterface $translator
+    ) {
+        $this->notificationHandler = $notificationHandler;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
+    {
+        $translatedMessage = $this->translator->trans(
+            /** @Ignore */
+            $message,
+            $parameters,
+            $domain,
+            $locale
+        );
+        $this->notificationHandler->info(/** @Ignore */ $translatedMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function success(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
+    {
+        $translatedMessage = $this->translator->trans(
+            /** @Ignore */
+            $message,
+            $parameters,
+            $domain,
+            $locale
+        );
+        $this->notificationHandler->success(/** @Ignore */ $translatedMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warning(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
+    {
+        $translatedMessage = $this->translator->trans(
+            /** @Ignore */
+            $message,
+            $parameters,
+            $domain,
+            $locale
+        );
+        $this->notificationHandler->warning(/** @Ignore */ $translatedMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
+    {
+        $translatedMessage = $this->translator->trans(
+            /** @Ignore */
+            $message,
+            $parameters,
+            $domain,
+            $locale
+        );
+        $this->notificationHandler->error(/** @Ignore */ $translatedMessage);
+    }
+}

--- a/src/lib/Notification/TranslatableNotificationHandler.php
+++ b/src/lib/Notification/TranslatableNotificationHandler.php
@@ -10,21 +10,14 @@ namespace EzSystems\EzPlatformAdminUi\Notification;
 
 use Symfony\Component\Translation\TranslatorInterface;
 
-final class TranslatableFlashBagNotificationHandler implements TranslatableNotificationHandlerInterface
+final class TranslatableNotificationHandler implements TranslatableNotificationHandlerInterface
 {
-    /**
-     * @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface
-     */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
     private $notificationHandler;
-    /**
-     *  @var \Symfony\Component\Translation\TranslatorInterface
-     */
+
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
 
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
-     */
     public function __construct(
         NotificationHandlerInterface $notificationHandler,
         TranslatorInterface $translator
@@ -33,9 +26,6 @@ final class TranslatableFlashBagNotificationHandler implements TranslatableNotif
         $this->translator = $translator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function info(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
     {
         $translatedMessage = $this->translator->trans(
@@ -48,9 +38,6 @@ final class TranslatableFlashBagNotificationHandler implements TranslatableNotif
         $this->notificationHandler->info(/** @Ignore */ $translatedMessage);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function success(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
     {
         $translatedMessage = $this->translator->trans(
@@ -63,9 +50,6 @@ final class TranslatableFlashBagNotificationHandler implements TranslatableNotif
         $this->notificationHandler->success(/** @Ignore */ $translatedMessage);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function warning(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
     {
         $translatedMessage = $this->translator->trans(
@@ -78,9 +62,6 @@ final class TranslatableFlashBagNotificationHandler implements TranslatableNotif
         $this->notificationHandler->warning(/** @Ignore */ $translatedMessage);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function error(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void
     {
         $translatedMessage = $this->translator->trans(

--- a/src/lib/Notification/TranslatableNotificationHandlerInterface.php
+++ b/src/lib/Notification/TranslatableNotificationHandlerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Notification;
+
+interface TranslatableNotificationHandlerInterface
+{
+    /**
+     * @param string $message
+     * @param array $parameters
+     * @param string|null $domain
+     * @param string|null $locale
+     */
+    public function info(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
+
+    /**
+     * @param string $message
+     * @param array $parameters
+     * @param string|null $domain
+     * @param string|null $locale
+     */
+    public function success(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
+
+    /**
+     * @param string $message
+     * @param array $parameters
+     * @param string|null $domain
+     * @param string|null $locale
+     */
+    public function warning(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
+
+    /**
+     * @param string $message
+     * @param array $parameters
+     * @param string|null $domain
+     * @param string|null $locale
+     */
+    public function error(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
+}

--- a/src/lib/Notification/TranslatableNotificationHandlerInterface.php
+++ b/src/lib/Notification/TranslatableNotificationHandlerInterface.php
@@ -8,37 +8,16 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Notification;
 
+/**
+ * Generates user notifications with translatable message.
+ */
 interface TranslatableNotificationHandlerInterface
 {
-    /**
-     * @param string $message
-     * @param array $parameters
-     * @param string|null $domain
-     * @param string|null $locale
-     */
     public function info(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
 
-    /**
-     * @param string $message
-     * @param array $parameters
-     * @param string|null $domain
-     * @param string|null $locale
-     */
     public function success(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
 
-    /**
-     * @param string $message
-     * @param array $parameters
-     * @param string|null $domain
-     * @param string|null $locale
-     */
     public function warning(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
 
-    /**
-     * @param string $message
-     * @param array $parameters
-     * @param string|null $domain
-     * @param string|null $locale
-     */
     public function error(string $message, array $parameters, ?string $domain = null, ?string $locale = null): void;
 }

--- a/src/lib/RepositoryForms/Form/Processor/ContentEditNotificationFormProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/ContentEditNotificationFormProcessor.php
@@ -9,21 +9,17 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\RepositoryForms\Form\Processor;
 
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ContentEditNotificationFormProcessor implements EventSubscriberInterface
 {
-    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var \Symfony\Component\Translation\TranslatorInterface */
-    private $translator;
 
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
@@ -32,19 +28,16 @@ class ContentEditNotificationFormProcessor implements EventSubscriberInterface
     private $siteAccessGroups;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface $notificationHandler
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      * @param array $siteAccessGroups
      */
     public function __construct(
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         RequestStack $requestStack,
         array $siteAccessGroups
     ) {
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->requestStack = $requestStack;
         $this->siteAccessGroups = $siteAccessGroups;
     }
@@ -71,12 +64,10 @@ class ContentEditNotificationFormProcessor implements EventSubscriberInterface
             return;
         }
         $this->notificationHandler->success(
-            $this->translator->trans(
-                /** @Desc("Content published.") */
-                'content.published.success',
-                [],
-                'content_edit'
-            )
+            /** @Desc("Content published.") */
+            'content.published.success',
+            [],
+            'content_edit'
         );
     }
 
@@ -91,12 +82,10 @@ class ContentEditNotificationFormProcessor implements EventSubscriberInterface
             return;
         }
         $this->notificationHandler->success(
-            $this->translator->trans(
-                /** @Desc("Content draft saved.") */
-                'content.draft_saved.success',
-                [],
-                'content_edit'
-            )
+            /** @Desc("Content draft saved.") */
+            'content.draft_saved.success',
+            [],
+            'content_edit'
         );
     }
 

--- a/src/lib/RepositoryForms/Form/Processor/PreviewFormProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/PreviewFormProcessor.php
@@ -20,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentStruct;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformAdminUi\Form\Event\ContentEditEvents;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\RepositoryForms\Data\Content\ContentCreateData;
 use EzSystems\RepositoryForms\Data\Content\ContentUpdateData;
 use EzSystems\RepositoryForms\Data\NewnessCheckable;
@@ -32,7 +32,6 @@ use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Listens for and processes RepositoryForm events.
@@ -45,11 +44,8 @@ class PreviewFormProcessor implements EventSubscriberInterface
     /** @var UrlGeneratorInterface */
     private $urlGenerator;
 
-    /** @var NotificationHandlerInterface */
+    /** @var TranslatableNotificationHandlerInterface */
     private $notificationHandler;
-
-    /** @var TranslatorInterface */
-    private $translator;
 
     /** @var LocationService */
     private $locationService;
@@ -57,21 +53,18 @@ class PreviewFormProcessor implements EventSubscriberInterface
     /**
      * @param ContentService $contentService
      * @param UrlGeneratorInterface $urlGenerator
-     * @param NotificationHandlerInterface $notificationHandler
-     * @param TranslatorInterface $translator
+     * @param TranslatableNotificationHandlerInterface $notificationHandler
      * @param LocationService $locationService
      */
     public function __construct(
         ContentService $contentService,
         UrlGeneratorInterface $urlGenerator,
-        NotificationHandlerInterface $notificationHandler,
-        TranslatorInterface $translator,
+        TranslatableNotificationHandlerInterface $notificationHandler,
         LocationService $locationService
     ) {
         $this->contentService = $contentService;
         $this->urlGenerator = $urlGenerator;
         $this->notificationHandler = $notificationHandler;
-        $this->translator = $translator;
         $this->locationService = $locationService;
     }
 
@@ -110,7 +103,9 @@ class PreviewFormProcessor implements EventSubscriberInterface
         } catch (Exception $e) {
             $this->notificationHandler->error(
                 /** @Desc("Cannot save content draft.") */
-                $this->translator->trans('error.preview', [], 'content_preview')
+                'error.preview',
+                [],
+                'content_preview'
             );
             $url = $this->getContentEditUrl($data, $languageCode);
         }

--- a/src/lib/Tests/RepositoryForms/Form/Processor/PreviewFormProcessorTest.php
+++ b/src/lib/Tests/RepositoryForms/Form/Processor/PreviewFormProcessorTest.php
@@ -15,13 +15,12 @@ use EzSystems\RepositoryForms\Data\Content\FieldData;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\ContentService;
 use EzSystems\EzPlatformAdminUi\Form\Event\ContentEditEvents;
-use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
+use EzSystems\EzPlatformAdminUi\Notification\TranslatableNotificationHandlerInterface;
 use EzSystems\RepositoryForms\Data\Content\ContentCreateData;
 use EzSystems\RepositoryForms\Event\FormActionEvent;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Form\FormInterface;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -38,11 +37,8 @@ class PreviewFormProcessorTest extends TestCase
     /** @var UrlGeneratorInterface $urlGenerator */
     private $urlGenerator;
 
-    /** @var NotificationHandlerInterface $notificationHandler */
+    /** @var TranslatableNotificationHandlerInterface $notificationHandler */
     private $notificationHandler;
-
-    /** @var TranslatorInterface $translator */
-    private $translator;
 
     /** @var LocationService $locationService */
     private $locationService;
@@ -51,16 +47,14 @@ class PreviewFormProcessorTest extends TestCase
     {
         $this->contentService = $this->createMock(ContentService::class);
         $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $this->notificationHandler = $this->createMock(NotificationHandlerInterface::class);
-        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->notificationHandler = $this->createMock(TranslatableNotificationHandlerInterface::class);
         $this->locationService = $this->createMock(LocationService::class);
     }
 
     /**
      * @param ContentService|null $contentService
      * @param UrlGeneratorInterface|null $urlGenerator
-     * @param NotificationHandlerInterface|null $notificationHandler
-     * @param TranslatorInterface|null $translator
+     * @param TranslatableNotificationHandlerInterface|null $notificationHandler
      * @param \eZ\Publish\API\Repository\LocationService|null $locationService
      *
      * @return PreviewFormProcessor
@@ -68,15 +62,13 @@ class PreviewFormProcessorTest extends TestCase
     private function createPreviewFormProcessor(
         ContentService $contentService = null,
         UrlGeneratorInterface $urlGenerator = null,
-        NotificationHandlerInterface $notificationHandler = null,
-        TranslatorInterface $translator = null,
+        TranslatableNotificationHandlerInterface $notificationHandler = null,
         LocationService $locationService = null
     ): PreviewFormProcessor {
         return new PreviewFormProcessor(
             $contentService ?? $this->contentService,
             $urlGenerator ?? $this->urlGenerator,
             $notificationHandler ?? $this->notificationHandler,
-            $translator ?? $this->translator,
             $locationService ?? $this->locationService
         );
     }
@@ -99,17 +91,12 @@ class PreviewFormProcessorTest extends TestCase
         $contentService = $this->generateContentServiceMock($contentStruct, $contentDraft);
         $urlGenerator = $this->generateUrlGeneratorMock($contentDraft, $languageCode, $url, $locationId);
 
-        $this->translator
-            ->method('trans')
-            ->with('error.preview', [], 'content_preview')
-            ->willReturn('Cannot save content draft.');
-
         $config = $this->generateConfigMock($languageCode);
         $form = $this->generateFormMock($config);
 
         $event = new FormActionEvent($form, $contentStruct, 'fooAction');
 
-        $previewFormProcessor = $this->createPreviewFormProcessor($contentService, $urlGenerator, $this->notificationHandler, $this->translator);
+        $previewFormProcessor = $this->createPreviewFormProcessor($contentService, $urlGenerator, $this->notificationHandler);
         $previewFormProcessor->processPreview($event);
 
         $this->assertEquals(new RedirectResponse($url), $event->getResponse());
@@ -142,12 +129,7 @@ class PreviewFormProcessorTest extends TestCase
 
         $urlGenerator = $this->generateUrlGeneratorForContentEditUrlMock($contentDraft, $languageCode, $url);
 
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator
-            ->method('trans')
-            ->willReturn('string');
-
-        $previewFormProcessor = $this->createPreviewFormProcessor($contentService, $urlGenerator, $this->notificationHandler, $translator);
+        $previewFormProcessor = $this->createPreviewFormProcessor($contentService, $urlGenerator, $this->notificationHandler);
 
         $previewFormProcessor->processPreview($event);
 

--- a/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Translation\Extractor;
+
+use JMS\TranslationBundle\Exception\RuntimeException;
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Annotation\Meaning;
+use JMS\TranslationBundle\Annotation\Desc;
+use JMS\TranslationBundle\Annotation\Ignore;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\Node\Scalar\String_;
+use Psr\Log\LoggerInterface;
+
+/**
+ * This parser can extract translation information from PHP files.
+ *
+ * It parses all calls that are made to a method named "trans".
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
+{
+    /**
+     * @var FileSourceFactory
+     */
+    private $fileSourceFactory;
+
+    /**
+     * @var NodeTraverser
+     */
+    private $traverser;
+
+    /**
+     * @var MessageCatalogue
+     */
+    private $catalogue;
+
+    /**
+     * @var \SplFileInfo
+     */
+    private $file;
+
+    /**
+     * @var DocParser
+     */
+    private $docParser;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Node
+     */
+    private $previousNode;
+
+    /**
+     * Methods and "domain" parameter offset to extract from PHP code.
+     *
+     * @var array method => position of the "domain" parameter
+     */
+    protected $methodsToExtractFrom = [
+        'success' => 2,
+        'info' => 2,
+        'warning' => 2,
+        'error' => 2,
+    ];
+
+    /**
+     * DefaultPhpFileExtractor constructor.
+     *
+     * @param DocParser $docParser
+     * @param FileSourceFactory $fileSourceFactory
+     */
+    public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
+    {
+        $this->docParser = $docParser;
+        $this->fileSourceFactory = $fileSourceFactory;
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this);
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Node $node
+     */
+    public function enterNode(Node $node)
+    {
+        $methodCallNodeName = null;
+        if ($node instanceof Node\Expr\MethodCall) {
+            $methodCallNodeName = $node->name instanceof Node\Identifier ? $node->name->name : $node->name;
+        }
+
+        if (!is_string($methodCallNodeName)
+            || !in_array(strtolower($methodCallNodeName), array_map('strtolower', array_keys($this->methodsToExtractFrom)))) {
+            $this->previousNode = $node;
+
+            return;
+        }
+
+        $ignore = false;
+        $desc = $meaning = null;
+
+        if (null !== $docComment = $this->getDocCommentForNode($node)) {
+            if ($docComment instanceof Doc) {
+                $docComment = $docComment->getText();
+            }
+
+            foreach ($this->docParser->parse($docComment, 'file ' . $this->file . ' near line ' . $node->getLine()) as $annot) {
+                if ($annot instanceof Ignore) {
+                    $ignore = true;
+                } elseif ($annot instanceof Desc) {
+                    $desc = $annot->text;
+                } elseif ($annot instanceof Meaning) {
+                    $meaning = $annot->text;
+                }
+            }
+        } else {
+            return;
+        }
+
+        if (!$node->args[0]->value instanceof String_) {
+            if ($ignore) {
+                return;
+            }
+
+            $message = sprintf('Can only extract the translation id from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
+
+            if ($this->logger) {
+                $this->logger->error($message);
+
+                return;
+            }
+
+            throw new RuntimeException($message);
+        }
+
+        $id = $node->args[0]->value->value;
+
+        $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
+        if (isset($node->args[$index])) {
+            if (!$node->args[$index]->value instanceof String_) {
+                if ($ignore) {
+                    return;
+                }
+
+                $message = sprintf('Can only extract the translation domain from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[$index]->value), $this->file, $node->args[$index]->value->getLine());
+
+                if ($this->logger) {
+                    $this->logger->error($message);
+
+                    return;
+                }
+
+                throw new RuntimeException($message);
+            }
+
+            $domain = $node->args[$index]->value->value;
+        } else {
+            $domain = 'messages';
+        }
+
+        $message = new Message($id, $domain);
+        $message->setDesc($desc);
+        $message->setMeaning($meaning);
+        $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
+        $this->catalogue->add($message);
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     * @param array $ast
+     */
+    public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    /**
+     * @param array $nodes
+     */
+    public function beforeTraverse(array $nodes)
+    {
+    }
+
+    /**
+     * @param Node $node
+     */
+    public function leaveNode(Node $node)
+    {
+    }
+
+    /**
+     * @param array $nodes
+     */
+    public function afterTraverse(array $nodes)
+    {
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     */
+    public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
+    {
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     * @param \Twig_Node $ast
+     */
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    {
+    }
+
+    /**
+     * @param Node $node
+     *
+     * @return null|string
+     */
+    private function getDocCommentForNode(Node $node)
+    {
+        // check if there is a doc comment for the ID argument
+        // ->trans(/** @Desc("FOO") */ 'my.id')
+        if (null !== $comment = $node->args[0]->getDocComment()) {
+            return $comment->getText();
+        }
+
+        // this may be placed somewhere up in the hierarchy,
+        // -> /** @Desc("FOO") */ trans('my.id')
+        // /** @Desc("FOO") */ ->trans('my.id')
+        // /** @Desc("FOO") */ $translator->trans('my.id')
+        if (null !== $comment = $node->getDocComment()) {
+            return $comment->getText();
+        } elseif (null !== $this->previousNode && $this->previousNode->getDocComment() !== null) {
+            $comment = $this->previousNode->getDocComment();
+
+            return is_object($comment) ? $comment->getText() : $comment;
+        }
+
+        return null;
+    }
+}

--- a/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
@@ -25,48 +25,27 @@ use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
 
-/**
- * This parser can extract translation information from PHP files.
- *
- * It parses all calls that are made to a method named "trans".
- *
- * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- */
 class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
-    /**
-     * @var FileSourceFactory
-     */
+    /** @var \JMS\TranslationBundle\Translation\FileSourceFactory */
     private $fileSourceFactory;
 
-    /**
-     * @var NodeTraverser
-     */
+    /** @var \PhpParser\NodeTraverser */
     private $traverser;
 
-    /**
-     * @var MessageCatalogue
-     */
+    /** @var \JMS\TranslationBundle\Model\MessageCatalogue */
     private $catalogue;
 
-    /**
-     * @var \SplFileInfo
-     */
+    /** @var \SplFileInfo */
     private $file;
 
-    /**
-     * @var DocParser
-     */
+    /** @var \Doctrine\Common\Annotations\DocParser */
     private $docParser;
 
-    /**
-     * @var LoggerInterface
-     */
+    /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
-    /**
-     * @var Node
-     */
+    /** @var \PhpParser\Node */
     private $previousNode;
 
     /**
@@ -81,12 +60,6 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         'error' => 2,
     ];
 
-    /**
-     * DefaultPhpFileExtractor constructor.
-     *
-     * @param DocParser $docParser
-     * @param FileSourceFactory $fileSourceFactory
-     */
     public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
     {
         $this->docParser = $docParser;
@@ -95,17 +68,11 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         $this->traverser->addVisitor($this);
     }
 
-    /**
-     * @param LoggerInterface $logger
-     */
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
 
-    /**
-     * @param Node $node
-     */
     public function enterNode(Node $node)
     {
         $methodCallNodeName = null;
@@ -189,11 +156,6 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         $this->catalogue->add($message);
     }
 
-    /**
-     * @param \SplFileInfo $file
-     * @param MessageCatalogue $catalogue
-     * @param array $ast
-     */
     public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
     {
         $this->file = $file;
@@ -201,50 +163,27 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
         $this->traverser->traverse($ast);
     }
 
-    /**
-     * @param array $nodes
-     */
     public function beforeTraverse(array $nodes)
     {
     }
 
-    /**
-     * @param Node $node
-     */
     public function leaveNode(Node $node)
     {
     }
 
-    /**
-     * @param array $nodes
-     */
     public function afterTraverse(array $nodes)
     {
     }
 
-    /**
-     * @param \SplFileInfo $file
-     * @param MessageCatalogue $catalogue
-     */
     public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
     {
     }
 
-    /**
-     * @param \SplFileInfo $file
-     * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
-     */
     public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
     {
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return null|string
-     */
-    private function getDocCommentForNode(Node $node)
+    private function getDocCommentForNode(Node $node): ?string
     {
         // check if there is a doc comment for the ID argument
         // ->trans(/** @Desc("FOO") */ 'my.id')


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30400
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


To improve developer experience this PR tries simplified using of notifications by removing translator dependency and moving them to the notificationHandler.

Related pull requests: 
- https://github.com/ezsystems/date-based-publisher/pull/103
- https://github.com/ezsystems/ezplatform-page-builder/pull/337
- https://github.com/ezsystems/ezplatform-user/pull/28
- https://github.com/ezsystems/flex-workflow/pull/125


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
