### PR TITLE
EZP-30098 bringing back 'stale edit action bar button' fix

### DIFF
--- a/features/ContentDraft.feature
+++ b/features/ContentDraft.feature
@@ -39,6 +39,7 @@ Feature: Content items creation
         | Title | Test Article draft |
       And I set article main content field to "Test Article draft intro"
       And I click on the edit action bar button "Save"
+      And I should be on "Content Update" "Test Article draft" page
       And I click on the edit action bar button "Publish"
     Then I should be on content container page "Test Article draft" of type "Article" in root path
       And going to dashboard we see there's no draft "Test Article draft" on list

--- a/features/ContentManagement.feature
+++ b/features/ContentManagement.feature
@@ -80,6 +80,7 @@ Scenario: Content can be edited
 Scenario: Content can be previewed during edition
   Given I navigate to content "Test Article edited" of type "Article" in root path
   When I click on the edit action bar button "Edit"
+    And I should be on "Content Update" "Test Article edited" page
     And I click on the edit action bar button "Preview"
     And I go to "tablet" view in "Test Article edited" preview
     And I go to "mobile" view in "Test Article edited" preview

--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -57,7 +57,7 @@ class UniversalDiscoveryWidget extends Element
         if ($this->isMultiSelect()) {
             $itemToSelect = $this->context->getElementByText($expectedContentName, sprintf($this->fields['elementSelector'], $depth));
             $itemToSelect->mouseOver();
-            $this->context->findElement($this->fields['selectContentButton'], self::UDW_BRANCH_LOADING_TIMEOUT, $itemToSelect)->click();
+            $this->context->findElement($this->fields['selectContentButton'], self::UDW_TIMEOUT, $itemToSelect)->click();
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30098
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


- bringing back 'stale edit action bar button' fix
- increasing select button click timeout

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
