### PR TITLE
EZP-30489: Improve console logs in tests

### DIFF
--- a/src/lib/Behat/Helper/BrowserLogFilter.php
+++ b/src/lib/Behat/Helper/BrowserLogFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\Helper;
+
+class BrowserLogFilter
+{
+    private $excludedPatterns = [
+        '@.*/api/ezp/v2/bookmark/.* - Failed to load resource: the server responded with a status of 404 \(Not Found\)@',
+        '@.*/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.@',
+        '@.*/admin/version-draft/has-no-conflict/.* - Failed to load resource: the server responded with a status of 409 \(Conflict\)@',
+        '@webpack:///./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js\? 91:12 "EzObjectRelation fieldtype is deprecated. Please, use EzObjectRelationList fieldtype instead."@',
+    ];
+
+    public function filter(array $logEntries): array
+    {
+        return array_values(array_filter($logEntries, function ($logEntry) {
+            foreach ($this->excludedPatterns as $excludedPattern) {
+                if (preg_match($excludedPattern, $logEntry)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+}

--- a/src/lib/Behat/Helper/Hooks.php
+++ b/src/lib/Behat/Helper/Hooks.php
@@ -65,21 +65,29 @@ class Hooks extends RawMinkContext
         $driver = $this->getSession()->getDriver();
         if ($driver instanceof Selenium2Driver) {
             $logEntries = $driver->getWebDriverSession()->log(LogType::BROWSER);
+            $this->displayLogErrors($logEntries);
+        }
+    }
 
-            if (empty($logEntries)) {
+    private function displayLogErrors($logEntries): void
+    {
+        $filter = new BrowserLogFilter();
+        $errorMessages = array_column($logEntries, 'message');
+        $errorMessages = $filter->filter($errorMessages);
+
+        if (empty($errorMessages)) {
+            return;
+        }
+
+        $this->print('JS console errors:');
+        $counter = 0;
+        foreach ($errorMessages as $message) {
+            if ($counter >= self::CONSOLE_LOGS_LIMIT) {
                 return;
             }
 
-            $this->print('JS console errors:');
-            $counter = 0;
-            foreach ($logEntries as $entry) {
-                if ($counter >= self::CONSOLE_LOGS_LIMIT) {
-                    return;
-                }
-
-                $this->print($entry['message']);
-                ++$counter;
-            }
+            $this->print($message);
+            ++$counter;
         }
     }
 

--- a/src/lib/Tests/Behat/BrowserLogFilterTest.php
+++ b/src/lib/Tests/Behat/BrowserLogFilterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+use EzSystems\EzPlatformAdminUi\Behat\Helper\BrowserLogFilter;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class BrowserLogFilterTest extends TestCase
+{
+    public function testFiltersOutExcludedPatterns()
+    {
+        $initialLogEntries = [
+            'http://web/api/ezp/v2/bookmark/43 - Failed to load resource: the server responded with a status of 404 (Not Found)',
+            'https://varnish/api/ezp/v2/bookmark/1 - Failed to load resource: the server responded with a status of 404 (Not Found)',
+            'Real JS Error',
+            'http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.',
+            'https://web/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.',
+            'Another real JS error',
+            'http://web.prod/admin/version-draft/has-no-conflict/124/eng-GB - Failed to load resource: the server responded with a status of 409 (Conflict)',
+            'http://varnish.prod/admin/version-draft/has-no-conflict/1/pol-PL - Failed to load resource: the server responded with a status of 409 (Conflict)',
+            'webpack:///./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js? 91:12 "EzObjectRelation fieldtype is deprecated. Please, use EzObjectRelationList fieldtype instead."',
+            ];
+
+        $filter = new BrowserLogFilter();
+        $actualResult = $filter->filter($initialLogEntries);
+
+        Assert::assertEquals(['Real JS Error', 'Another real JS error'], $actualResult);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30489
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As seen in https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/195075830 , the console logs are not that useful now - we're displaying only 10 first errors, making the result look like this:
```
   │  JS console errors:
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
    │  http://varnish/api/ezp/v2/bookmark/43 - Failed to load resource: the server responded with a status of 404 (Not Found)
    │  http://varnish/api/ezp/v2/bookmark/52 - Failed to load resource: the server responded with a status of 404 (Not Found)
    │  http://varnish/api/ezp/v2/bookmark/51 - Failed to load resource: the server responded with a status of 404 (Not Found)
    │  http://varnish/api/ezp/v2/bookmark/53 - Failed to load resource: the server responded with a status of 404 (Not Found)
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
    │  http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.
```

This PR adds filtering of the errors so that only the relevant are left - as of now only two excluded entries are added (the ones mentioned above).

This PR contains a TMP commit (to showcase that it's still working) and cannot be merged `as is` because of that.

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review