### PR TITLE
Injected Site Access List directly into EzSystems\EzPlatformAdminUi\UI\Config\Provider\Languages

### DIFF
--- a/src/bundle/Resources/config/services/siteaccess.yml
+++ b/src/bundle/Resources/config/services/siteaccess.yml
@@ -5,9 +5,15 @@ services:
         public: false
 
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface: '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver'
+
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver:
         arguments:
             $siteaccessPreviewVoters: !tagged ezplatform.admin_ui.siteaccess_preview_voter
-    EzSystems\EzPlatformAdminUi\Siteaccess\NonAdminSiteaccessResolver: ~
+            $siteAccesses: '%ezpublish.siteaccess.list%'
+
+    EzSystems\EzPlatformAdminUi\Siteaccess\NonAdminSiteaccessResolver:
+        arguments:
+            $siteAccessGroups: '%ezpublish.siteaccess.groups%'
+
     EzSystems\EzPlatformAdminUi\Siteaccess\AdminSiteaccessPreviewVoter:
         tags: ['ezplatform.admin_ui.siteaccess_preview_voter']

--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -48,6 +48,8 @@ services:
             - { name: ezplatform.admin_ui.config_provider, key: 'user' }
 
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\Languages:
+        arguments:
+            $siteAccesses: '%ezpublish.siteaccess.list%'
         tags:
             - { name: ezplatform.admin_ui.config_provider, key: 'languages' }
 

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -10,27 +10,26 @@ namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 /**
  * Decorator for SiteaccessResolverInterface filtering out all non admin siteaccesses.
  */
 class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
 {
-    /** @var SiteaccessResolver */
+    /** @var \EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver */
     private $siteaccessResolver;
 
-    /** @var ConfigResolverInterface */
-    private $configResolver;
+    /** @var string[] */
+    private $siteAccessGroups;
 
     /**
-     * @param SiteaccessResolver $siteaccessResolver
-     * @param ConfigResolverInterface $configResolver
+     * @param \EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver $siteaccessResolver
+     * @param string[] $siteAccessGroups
      */
-    public function __construct(SiteaccessResolver $siteaccessResolver, ConfigResolverInterface $configResolver)
+    public function __construct(SiteaccessResolver $siteaccessResolver, array $siteAccessGroups)
     {
         $this->siteaccessResolver = $siteaccessResolver;
-        $this->configResolver = $configResolver;
+        $this->siteAccessGroups = $siteAccessGroups;
     }
 
     public function getSiteaccessesForLocation(
@@ -48,21 +47,15 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
         return $this->filter($this->siteaccessResolver->getSiteaccesses());
     }
 
-    private function filter(array $siteaccesses)
+    private function filter(array $siteaccesses): array
     {
-        $siteaccessGroups = $this->configResolver->getParameter(
-            'groups',
-            'ezpublish',
-            'siteaccess'
-        );
-
-        if (!array_key_exists('admin_group', $siteaccessGroups)) {
+        if (!array_key_exists('admin_group', $this->siteAccessGroups)) {
             throw new BadStateException(
                 'siteaccess',
                 'Siteaccess group `admin_group` not found.'
             );
         }
 
-        return array_diff($siteaccesses, $siteaccessGroups['admin_group']);
+        return array_diff($siteaccesses, $this->siteAccessGroups['admin_group']);
     }
 }

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -10,32 +10,31 @@ namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 class SiteaccessResolver implements SiteaccessResolverInterface
 {
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
-    private $configResolver;
-
     /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
     /** @var \EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessPreviewVoterInterface[] */
     private $siteaccessPreviewVoters;
 
+    /** @var string[] */
+    private $siteAccesses;
+
     /**
-     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param iterable $siteaccessPreviewVoters
+     * @param array $siteAccesses
      */
     public function __construct(
-        ConfigResolverInterface $configResolver,
         ContentService $contentService,
-        iterable $siteaccessPreviewVoters
+        iterable $siteaccessPreviewVoters,
+        array $siteAccesses
     ) {
-        $this->configResolver = $configResolver;
         $this->contentService = $contentService;
         $this->siteaccessPreviewVoters = $siteaccessPreviewVoters;
+        $this->siteAccesses = $siteAccesses;
     }
 
     /**
@@ -73,6 +72,6 @@ class SiteaccessResolver implements SiteaccessResolverInterface
 
     public function getSiteaccesses(): array
     {
-        return $this->configResolver->getParameter('list', 'ezpublish', 'siteaccess');
+        return $this->siteAccesses;
     }
 }

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -23,16 +23,22 @@ class Languages implements ProviderInterface
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
+    /** @var string[] */
+    private $siteAccesses;
+
     /**
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param string[]
      */
     public function __construct(
         LanguageService $languageService,
-        ConfigResolverInterface $configResolver
+        ConfigResolverInterface $configResolver,
+        array $siteAccesses
     ) {
         $this->languageService = $languageService;
         $this->configResolver = $configResolver;
+        $this->siteAccesses = $siteAccesses;
     }
 
     /**
@@ -80,9 +86,8 @@ class Languages implements ProviderInterface
     {
         $priority = [];
         $fallback = [];
-        $siteAccesses = $this->configResolver->getParameter('list', 'ezpublish', 'siteaccess');
 
-        foreach ($siteAccesses as $siteAccess) {
+        foreach ($this->siteAccesses as $siteAccess) {
             $siteAccessLanguages = $this->configResolver->getParameter('languages', null, $siteAccess);
             $priority[] = array_shift($siteAccessLanguages);
             $fallback = array_merge($fallback, $siteAccessLanguages);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Parameter `ezpublish.siteaccess.list` is not siteaccess aware and it should be directly injected into `\EzSystems\EzPlatformAdminUi\UI\Config\Provider\Languages`.

_Bug discovered during working on https://jira.ez.no/browse/EZEE-2775_

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
