### PR TITLE
EZP-30509: Location visibility check breaks limitation of Content/Read

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -534,7 +534,12 @@ class ContentViewController extends Controller
     private function supplyIsLocationInvisible(ContentView $view)
     {
         $location = $view->getLocation();
-        $parentLocation = $this->locationService->loadLocation($location->parentLocationId);
+        $parentLocation = $this->permissionResolver->sudo(
+            function (Repository $repository) use ($location) {
+                return $repository->getLocationService()->loadLocation($location->parentLocationId);
+            },
+            $this->repository
+        );
         $isLocationVisible = !($parentLocation->hidden || $parentLocation->invisible);
 
         // Location is invisible when parent location is not visible.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30509
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

After setting Content/Read limitation by Location, it was not able to access `/admin` page.
Changed parent location loading to be used by `sudo` to be able to load root location children.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
