### PR TITLE
EZP-30470: Filtered Content Types and Languages in ContentCreate widget based on user permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "^7.5@dev",
+        "ezsystems/ezpublish-kernel": "^7.5.2@dev",
         "ezsystems/repository-forms": "^2.5@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.5@dev",
         "ezsystems/ez-support-tools": "^1.0@dev",

--- a/src/bundle/Resources/config/services/forms.yml
+++ b/src/bundle/Resources/config/services/forms.yml
@@ -28,8 +28,8 @@ services:
 
     EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft\ContentCreateType:
         arguments:
-            $contentTypeChoiceLoader: '@EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\PermissionAwareContentTypeChoiceLoader'
-            $languageChoiceLoader: '@EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\PermissionAwareLanguageChoiceLoader'
+            $contentTypeChoiceLoader: '@EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader'
+            $languageChoiceLoader: '@EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\LanguageChoiceLoader'
 
     EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader: ~
 

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+
+class ContentCreateContentTypeChoiceLoader implements ChoiceLoaderInterface
+{
+    /** @var \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader */
+    private $contentTypeChoiceLoader;
+
+    /** @var int[] */
+    private $restrictedContentTypesIds;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentTypeChoiceLoader $contentTypeChoiceLoader
+     * @param array $restrictedContentTypesIds
+     */
+    public function __construct(
+        ContentTypeChoiceLoader $contentTypeChoiceLoader,
+        array $restrictedContentTypesIds
+    ) {
+        $this->contentTypeChoiceLoader = $contentTypeChoiceLoader;
+        $this->restrictedContentTypesIds = $restrictedContentTypesIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        $contentTypesGroups = $this->contentTypeChoiceLoader->getChoiceList();
+        if (empty($this->restrictedContentTypesIds)) {
+            return new ArrayChoiceList($contentTypesGroups, $value);
+        }
+
+        foreach ($contentTypesGroups as $group => $contentTypes) {
+            $contentTypesGroups[$group] = array_filter($contentTypes, function (ContentType $contentType) {
+                return \in_array($contentType->id, $this->restrictedContentTypesIds);
+            });
+        }
+
+        return new ArrayChoiceList($contentTypesGroups, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        $values = array_filter($values);
+        if (empty($values)) {
+            return [];
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        $choices = array_filter($choices);
+        if (empty($choices)) {
+            return [];
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+}

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentCreateLanguageChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentCreateLanguageChoiceLoader.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader;
+
+use eZ\Publish\API\Repository\Values\Content\Language;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+
+class ContentCreateLanguageChoiceLoader implements ChoiceLoaderInterface
+{
+    /** @var \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\LanguageChoiceLoader */
+    private $languageChoiceLoader;
+
+    /** @var string[] */
+    private $restrictedLanguagesCodes;
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\LanguageChoiceLoader $languageChoiceLoader
+     * @param array $restrictedLanguagesCodes
+     */
+    public function __construct(
+        LanguageChoiceLoader $languageChoiceLoader,
+        array $restrictedLanguagesCodes
+    ) {
+        $this->languageChoiceLoader = $languageChoiceLoader;
+        $this->restrictedLanguagesCodes = $restrictedLanguagesCodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        $languages = $this->languageChoiceLoader->getChoiceList();
+
+        if (empty($this->restrictedLanguagesCodes)) {
+            return new ArrayChoiceList($languages, $value);
+        }
+
+        $languages = array_filter($languages, function (Language $language) {
+            return \in_array($language->languageCode, $this->restrictedLanguagesCodes, true);
+        });
+
+        return new ArrayChoiceList($languages, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        $values = array_filter($values);
+        if (empty($values)) {
+            return [];
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        $choices = array_filter($choices);
+        if (empty($choices)) {
+            return [];
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+}

--- a/src/lib/Form/Type/ChoiceList/Loader/PermissionAwareContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/PermissionAwareContentTypeChoiceLoader.php
@@ -15,6 +15,9 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 
+/**
+ * @deprecated since version 2.5, to be removed in 3.0. Use '\EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentCreateContentTypeChoiceLoader' instead.
+ */
 class PermissionAwareContentTypeChoiceLoader implements ChoiceLoaderInterface
 {
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */

--- a/src/lib/Form/Type/ChoiceList/Loader/PermissionAwareLanguageChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/PermissionAwareLanguageChoiceLoader.php
@@ -15,6 +15,9 @@ use eZ\Publish\API\Repository\Values\Content\Language;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 
+/**
+ * @deprecated since version 2.5, to be removed in 3.0. Use '\EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentCreateLanguageChoiceLoader' instead.
+ */
 class PermissionAwareLanguageChoiceLoader implements ChoiceLoaderInterface
 {
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */

--- a/src/lib/Form/Type/Content/Draft/ContentCreateType.php
+++ b/src/lib/Form/Type/Content/Draft/ContentCreateType.php
@@ -9,10 +9,16 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\Content\Draft;
 
 use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Draft\ContentCreateData;
+use EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentCreateContentTypeChoiceLoader;
+use EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\ContentCreateLanguageChoiceLoader;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\LocationType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\ContentTypeChoiceType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Language\LanguageChoiceType;
+use EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer;
+use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -30,23 +36,55 @@ class ContentCreateType extends AbstractType
     /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
     private $languageChoiceLoader;
 
+    /** @var \EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer */
+    private $lookupLimitationsTransformer;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface */
+    private $permissionChecker;
+
     /**
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
      * @param \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface $contentTypeChoiceLoader
      * @param \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface $languageChoiceLoader
+     * @param \EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface $permissionChecker
+     * @param \EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer $lookupLimitationsTransformer
      */
     public function __construct(
         LanguageService $languageService,
         ChoiceLoaderInterface $contentTypeChoiceLoader,
-        ChoiceLoaderInterface $languageChoiceLoader
+        ChoiceLoaderInterface $languageChoiceLoader,
+        PermissionCheckerInterface $permissionChecker,
+        LookupLimitationsTransformer $lookupLimitationsTransformer
     ) {
         $this->languageService = $languageService;
         $this->contentTypeChoiceLoader = $contentTypeChoiceLoader;
         $this->languageChoiceLoader = $languageChoiceLoader;
+        $this->permissionChecker = $permissionChecker;
+        $this->lookupLimitationsTransformer = $lookupLimitationsTransformer;
     }
 
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array $options
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $restrictedContentTypesIds = [];
+        $restrictedLanguageCodes = [];
+
+        /** @var ContentCreateData $contentCreateData */
+        $contentCreateData = $options['data'];
+        if ($location = $contentCreateData->getParentLocation()) {
+            $limitationsValues = $this->getLimitationValuesForLocation($location);
+            $restrictedContentTypesIds = $limitationsValues[Limitation::CONTENTTYPE];
+            $restrictedLanguageCodes = $limitationsValues[Limitation::LANGUAGE];
+        }
+
         $builder
             ->add(
                 'content_type',
@@ -55,7 +93,7 @@ class ContentCreateType extends AbstractType
                     'label' => false,
                     'multiple' => false,
                     'expanded' => true,
-                    'choice_loader' => $this->contentTypeChoiceLoader,
+                    'choice_loader' => new ContentCreateContentTypeChoiceLoader($this->contentTypeChoiceLoader, $restrictedContentTypesIds),
                 ]
             )
             ->add(
@@ -70,7 +108,7 @@ class ContentCreateType extends AbstractType
                     'label' => false,
                     'multiple' => false,
                     'expanded' => false,
-                    'choice_loader' => $this->languageChoiceLoader,
+                    'choice_loader' => new ContentCreateLanguageChoiceLoader($this->languageChoiceLoader, $restrictedLanguageCodes),
                 ]
             )
             ->add(
@@ -90,5 +128,25 @@ class ContentCreateType extends AbstractType
                 'data_class' => ContentCreateData::class,
                 'translation_domain' => 'forms',
             ]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     *
+     * @return array
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function getLimitationValuesForLocation(Location $location): array
+    {
+        $lookupLimitationsResult = $this->permissionChecker->getContentCreateLimitations($location);
+
+        return $this->lookupLimitationsTransformer->getGroupedLimitationValues(
+            $lookupLimitationsResult,
+            [Limitation::CONTENTTYPE, Limitation::LANGUAGE]
+        );
     }
 }

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -135,8 +135,10 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
      *
      * @return \Knp\Menu\ItemInterface
      *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function createStructure(array $options): ItemInterface
@@ -150,9 +152,8 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         /** @var ItemInterface|ItemInterface[] $menu */
         $menu = $this->factory->createItem('root');
 
-        $hasAccess = $this->permissionResolver->hasAccess('content', 'create');
-        $canCreateInLocation = $this->permissionChecker->canCreateInLocation($location, $hasAccess);
-        $canCreate = $canCreateInLocation && $contentType->isContainer;
+        $lookupLimitationsResult = $this->permissionChecker->getContentCreateLimitations($location);
+        $canCreate = $lookupLimitationsResult->hasAccess && $contentType->isContainer;
         $canEdit = $this->permissionResolver->canUser(
             'content',
             'edit',

--- a/src/lib/Permission/LookupLimitationsTransformer.php
+++ b/src/lib/Permission/LookupLimitationsTransformer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Permission;
 
 use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
 
 /**
  * @internal
@@ -24,6 +25,10 @@ final class LookupLimitationsTransformer
     {
         $limitationsValues = [];
 
+        foreach ($lookupLimitations->roleLimitations as $roleLimitation) {
+            $limitationsValues[] = $roleLimitation->limitationValues;
+        }
+
         /** @var \eZ\Publish\API\Repository\Values\User\LookupPolicyLimitations $lookupPolicyLimitation */
         foreach ($lookupLimitations->lookupPolicyLimitations as $lookupPolicyLimitation) {
             /** @var \eZ\Publish\API\Repository\Values\User\Limitation $limitation */
@@ -33,5 +38,50 @@ final class LookupLimitationsTransformer
         }
 
         return !empty($limitationsValues) ? array_unique(array_merge(...$limitationsValues)) : $limitationsValues;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\LookupLimitationResult $lookupLimitations
+     * @param string[] $limitationsIdentifiers
+     *
+     * @return array
+     *
+     * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
+     */
+    public function getGroupedLimitationValues(
+        LookupLimitationResult $lookupLimitations,
+        array $limitationsIdentifiers
+    ): array {
+        if (empty($limitationsIdentifiers)) {
+            throw new InvalidArgumentException('limitationsIdentifiers', 'must contain at least one Limitation identifier');
+        }
+        $groupedLimitationsValues = [];
+
+        foreach ($limitationsIdentifiers as $limitationsIdentifier) {
+            $groupedLimitationsValues[$limitationsIdentifier] = [];
+        }
+
+        foreach ($lookupLimitations->roleLimitations as $roleLimitation) {
+            if (\in_array($roleLimitation->getIdentifier(), $limitationsIdentifiers, true)) {
+                $groupedLimitationsValues[$roleLimitation->getIdentifier()][] = $roleLimitation->limitationValues;
+            }
+        }
+
+        foreach ($lookupLimitations->lookupPolicyLimitations as $lookupPolicyLimitation) {
+            /** @var \eZ\Publish\API\Repository\Values\User\Limitation $limitation */
+            foreach ($lookupPolicyLimitation->limitations as $limitation) {
+                if (\in_array($limitation->getIdentifier(), $limitationsIdentifiers, true)) {
+                    $groupedLimitationsValues[$limitation->getIdentifier()][] = $limitation->limitationValues;
+                }
+            }
+        }
+
+        foreach ($groupedLimitationsValues as $identifier => $limitationsValues) {
+            if (!empty($limitationsValues)) {
+                $groupedLimitationsValues[$identifier] = array_unique(array_merge(...$limitationsValues));
+            }
+        }
+
+        return $groupedLimitationsValues;
     }
 }

--- a/src/lib/Permission/PermissionCheckerInterface.php
+++ b/src/lib/Permission/PermissionCheckerInterface.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformAdminUi\Permission;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
 
 interface PermissionCheckerInterface
 {
@@ -25,4 +26,17 @@ interface PermissionCheckerInterface
      * @return bool
      */
     public function canCreateInLocation(Location $location, $hasAccess): bool;
+
+    /**
+     * @internal
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\LookupLimitationResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getContentCreateLimitations(Location $parentLocation): LookupLimitationResult;
 }

--- a/src/lib/Tests/Permission/LookupLimitationsTransformerTest.php
+++ b/src/lib/Tests/Permission/LookupLimitationsTransformerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Permission;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
+use eZ\Publish\API\Repository\Values\User\LookupPolicyLimitations;
+use eZ\Publish\Core\Repository\Values\User\Policy;
+use EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException;
+use EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer;
+use PHPUnit\Framework\TestCase;
+
+class LookupLimitationsTransformerTest extends TestCase
+{
+    public function testGetFlattenedLimitationsValues(): void
+    {
+        $limitations = [new ContentTypeLimitation(['limitationValues' => [2, 3]])];
+
+        $policy = new Policy(['limitations' => $limitations]);
+
+        $lookupLimitations = new LookupLimitationResult(
+            true,
+            [new ContentTypeLimitation(['limitationValues' => [1, 2]])],
+            [new LookupPolicyLimitations($policy, $limitations)]
+        );
+
+        $flattenedLimitationsValues = (new LookupLimitationsTransformer())->getFlattenedLimitationsValues($lookupLimitations);
+
+        $this->assertEquals([1, 2, 3], $flattenedLimitationsValues, '', 0.0, 10, true);
+    }
+
+    public function testGetGroupedLimitationValues(): void
+    {
+        $roleLimitations = [
+            new SectionLimitation(['limitationValues' => [1]]),
+            new SubtreeLimitation(['limitationValues' => [2]]),
+        ];
+
+        $limitations = [
+            new SubtreeLimitation(['limitationValues' => [3]]),
+            new ContentTypeLimitation(['limitationValues' => [4]]),
+        ];
+
+        $policy = new Policy(['limitations' => $limitations]);
+
+        $lookupLimitations = new LookupLimitationResult(
+            true,
+            $roleLimitations,
+            [new LookupPolicyLimitations($policy, $limitations)]
+        );
+
+        $flattenedLimitationsValues = (new LookupLimitationsTransformer())->getGroupedLimitationValues(
+            $lookupLimitations,
+            [Limitation::SUBTREE, Limitation::CONTENTTYPE]
+        );
+        $expected = [
+            Limitation::SUBTREE => [2, 3],
+            Limitation::CONTENTTYPE => [4],
+        ];
+
+        $this->assertEquals($expected, $flattenedLimitationsValues);
+    }
+
+    public function testGetGroupedLimitationValuesThrowException(): void
+    {
+        $emptyLimitationsIdentifiers = [];
+
+        $limitations = [
+            new SubtreeLimitation(['limitationValues' => [3]]),
+            new ContentTypeLimitation(['limitationValues' => [4]]),
+        ];
+
+        $policy = new Policy(['limitations' => $limitations]);
+
+        $lookupLimitations = new LookupLimitationResult(
+            true,
+            [new ContentTypeLimitation(['limitationValues' => [1, 2]])],
+            [new LookupPolicyLimitations($policy, $limitations)]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument \'limitationsIdentifiers\' is invalid: must contain at least one Limitation identifier');
+
+        (new LookupLimitationsTransformer())->getGroupedLimitationValues($lookupLimitations, $emptyLimitationsIdentifiers);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30470
| Requires | ezsystems/ezpublish-kernel#2628
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR provides better filtering od Content Types and Languages in the content create widget. It depends on new method `\eZ\Publish\SPI\Limitation\Target\Version::createFromAnyContentTypeOf`. It also introduces new method in `\EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface::getContentCreateLimitations` to get Limitations specificaly for Content creation.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
