### PR TITLE
EZP-30514: Moved default configuration to dedicated ViewProvider for the user_settings_update_view

### DIFF
--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -1,3 +1,10 @@
+parameters:
+    ezsettings.admin_group.user_settings_update_view_defaults:
+        full:
+            default:
+                template: "@@ezdesign/user/settings/update.html.twig"
+                match: []
+
 services:
     _defaults:
         autowire: true

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -50,9 +50,6 @@ system:
                     template: '@ezdesign/user/settings/update_datetime_format.html.twig'
                     match:
                         Identifier: [full_datetime_format, short_datetime_format]
-                ezplatform_admin_ui:
-                    template: '@ezdesign/user/settings/update.html.twig'
-                    match: true
 
         fielddefinition_edit_templates:
             - { template: '@ezdesign/admin/content_type/field_types.html.twig', priority: 10 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30514](https://jira.ez.no/browse/EZP-30514) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


For a more detailed description see https://github.com/ezsystems/ezplatform-user/pull/32

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
