### PR TITLE
[Online Editor] Make sure custom tag elements has all required CSS cl…

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
@@ -37,6 +37,7 @@ const customTagBaseDefinition = {
      */
     insert: function() {
         const element = CKEDITOR.dom.element.createFromHtml(this.template.output(this.defaults));
+
         const wrapper = this.editor.widgets.wrapElement(element, this.name);
 
         this.editor.widgets.initOn(element, this.name);
@@ -65,6 +66,11 @@ const customTagBaseDefinition = {
     },
 
     init: function() {
+        // Converted from eZ XML custom tags might miss some required classes
+        if (this.element.hasClass('ez-custom-tag') === false) {
+            this.element.addClass('ez-custom-tag');
+        }
+
         this.on('focus', this.fireEditorInteraction);
         this.syncAlignment(true);
         this.renderAttributes();


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

1. Convert eZ XML to RichtText using https://github.com/ezsystems/ezplatform-xmltext-fieldtype
2. Setup custom tags
3. Try to edit any content with converted RichtText field which has any custom tag.
4. Custom tag edit UI will behave very strange. This PR fixes it.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
