### PR TITLE
EZP-30494: Default Time field value is not saved

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/eztime.js
@@ -112,6 +112,7 @@
         window.flatpickr(flatPickrInput, Object.assign({}, timeConfig, {
             enableSeconds,
             onChange: updateInputValue.bind(null, sourceInput),
+            onClose: updateInputValue.bind(null, sourceInput),
             dateFormat: enableSeconds ? 'H:i:S' : 'H:i',
             defaultDate
         }));


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30494](https://jira.ez.no/browse/EZP-30494)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Default Time field value from Flatpicker is not saved.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
