### PR TITLE
EZEE-2782 [Behat] Problems with form preview and with notification close

### DIFF
--- a/src/lib/Behat/Helper/UtilityContext.php
+++ b/src/lib/Behat/Helper/UtilityContext.php
@@ -25,10 +25,10 @@ class UtilityContext extends MinkContext
      */
     public function waitUntilElementIsVisible(string $cssSelector, int $timeout = 5, TraversableElement $baseElement = null): void
     {
-        $baseElement = $baseElement ?? $this->getSession()->getPage();
-
         try {
             $this->waitUntil($timeout, function () use ($cssSelector, $baseElement) {
+                $baseElement = $baseElement ?? $this->getSession()->getPage();
+
                 $element = $baseElement->find('css', $cssSelector);
 
                 return isset($element) && $element->isVisible();
@@ -203,7 +203,7 @@ class UtilityContext extends MinkContext
         } while (time() < $end);
 
         if ($throwOnFailure) {
-            throw new Exception('Spin function did not return in time. Internal exception:' . $lastInternalExceptionMessage);
+            throw new Exception('Spin function did not return in time. Last internal exception:' . $lastInternalExceptionMessage);
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-2782](https://jira.ez.no/browse/EZEE-2782)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


fixing `waitUntilElementIsVisible` function

It seems, that there are situations when behat has a problem with nodeElement references when `callback` uses previously (outside) defined base element.

There is still one place, where the base element will be pre-defined (`UniversalDiscoveryWidget.php:62`), but changing that will be harder (as forwarded baseElement is found not only by its locator but also by text content). I'll fix that, but I need a little more time, and I want Form-Builder tests to be green at last.

related PR with test builds:
https://github.com/ezsystems/ezplatform-form-builder/pull/164

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
