### PR TITLE
EZP-30553: User settings pagination limit should be different for admin_group and other siteaccesses

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -13,7 +13,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAw
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**
- * Configuration parser for location ids declaration.
+ * Configuration parser for pagination limits.
  *
  * Example configuration:
  * ```yaml

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -21,7 +21,7 @@ parameters:
     ezsettings.default.pagination.content_policy_limit: 5
     ezsettings.default.pagination.bookmark_limit: 10
     ezsettings.default.pagination.notification_limit: 5
-    ezsettings.default.pagination.user_settings_limit: 10
+    ezsettings.admin_group.pagination.user_settings_limit: 10
     ezsettings.default.pagination.content_draft_limit: 10
 
     # Security


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30553
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR introduce separate pagination limit setting for admin_group and other siteaccesses.

`ezsettings.admin_group.pagination.user_settings_limit: 10`

and 

`ezsettings.default.pagination.user_settings_limit: 10`

Related PR: https://github.com/ezsystems/ezplatform-user/pull/38

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
