### PR TITLE
EZP-30595 [Behat] Element with selector: .c-select-content-button was not found

### DIFF
--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -26,7 +26,8 @@ class UniversalDiscoveryWidget extends Element
             'confirmButton' => '.m-ud__action--confirm',
             'cancelButton' => '.m-ud__action--cancel',
             'selectContentButton' => '.c-select-content-button',
-            'elementSelector' => '.c-finder-tree-branch:nth-of-type(%d) .c-finder-tree-leaf',
+            'genericElementSelector' => '.c-finder-tree-branch:nth-of-type(%d) .c-finder-tree-leaf',
+            'specificElementSelector' => '.c-finder-tree-branch:nth-of-type(%d) .c-finder-tree-leaf:nth-of-type(%d)',
             'branchLoadingSelector' => '.c-finder-tree-leaf--loading',
             'previewName' => '.c-meta-preview__name',
             'treeBranch' => '.c-finder-tree-branch:nth-child(%d)',
@@ -44,7 +45,7 @@ class UniversalDiscoveryWidget extends Element
             ++$depth;
 
             $this->context->waitUntilElementIsVisible(sprintf($this->fields['treeBranch'], $depth), self::UDW_LONG_TIMEOUT);
-            $this->context->getElementByText($part, sprintf($this->fields['elementSelector'], $depth))->click();
+            $this->context->getElementByText($part, sprintf($this->fields['genericElementSelector'], $depth))->click();
             $this->context->waitUntilElementDisappears($this->fields['branchLoadingSelector'], self::UDW_BRANCH_LOADING_TIMEOUT);
         }
         $expectedContentName = $pathParts[count($pathParts) - 1];
@@ -57,12 +58,14 @@ class UniversalDiscoveryWidget extends Element
         if ($this->isMultiSelect()) {
             for ($i = 0; $i < 3; ++$i) {
                 try {
-                    $itemToSelect = $this->context->getElementByText($expectedContentName, sprintf($this->fields['elementSelector'], $depth));
+                    $itemToSelectIndex = $this->context->getElementPositionByText($expectedContentName, sprintf($this->fields['genericElementSelector'], $depth));
+                    $itemToSelectLocator = sprintf($this->fields['specificElementSelector'], $depth, $itemToSelectIndex);
+                    $itemsSelectButtonLocator = sprintf('%s %s', $itemToSelectLocator, $this->fields['selectContentButton']);
 
                     $this->context->findElement($this->fields['tabSelector'])->mouseOver();
-                    $itemToSelect->mouseOver();
-                    $this->context->waitUntilElementIsVisible($this->fields['selectContentButton'], $this->defaultTimeout, $itemToSelect);
-                    $this->context->findElement($this->fields['selectContentButton'], $this->defaultTimeout, $itemToSelect)->click();
+                    $this->context->findElement($itemToSelectLocator)->mouseOver();
+                    $this->context->waitUntilElementIsVisible($itemsSelectButtonLocator, $this->defaultTimeout);
+                    $this->context->findElement($itemsSelectButtonLocator, $this->defaultTimeout)->click();
                     break;
                 } catch (\Exception $e) {
                     if ($i === 2) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30595](https://jira.ez.no/browse/EZP-30595)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


We can't refresh (redefine) NodeElement so in case of the problem with StaleElementReferenceException on that element we can't use them as a base element (we still can do it in the other situations, where the element doesn't change dynamically). Because of that, to have the possibility to redefine element, we should use the full CSS locator to it, not the partial locator and the base element.

Though it's the most probable error cause, we still should test this solution for a few days after merging, before closing the ticket.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
