### PR TITLE
EZP-29694: Changed publishing to publish last modified translation

### DIFF
--- a/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
@@ -74,7 +74,8 @@ class ContentOnTheFlyProcessor implements EventSubscriberInterface
         }
 
         $draft = $this->contentService->createContent($data, $data->getLocationStructs());
-        $content = $this->contentService->publishVersion($draft->versionInfo);
+        $versionInfo = $draft->versionInfo;
+        $content = $this->contentService->publishVersion($versionInfo, [$versionInfo->initialLanguageCode]);
 
         $event->setResponse(
             new Response(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29694 / https://jira.ez.no/browse/EZEE-2661
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This **change** how **default** behavior for publish works on our UI side. Instead of publishing all translations contained in draft (which right now cannot be edited outside of PAPI/REST) we are publishing draft only in `initialLanguageCode` of draft.

## Other PRs:
https://github.com/ezsystems/repository-forms/pull/296

## Uses:
https://github.com/ezsystems/ezpublish-kernel/pull/2615

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
