### PR TITLE
EZP-30617 [Behat] Problem with select item in multiselect UDW

### DIFF
--- a/features/ContentType.feature
+++ b/features/ContentType.feature
@@ -30,7 +30,8 @@ Feature: Content types management
       And I add field "Country" to Content Type definition
       And I set "Name" in "Country" to "CountryField"
       And I click on the edit action bar button "Save"
-    Then I should be on "Content Type" "Test Content Type" page
+    Then notification that "Content type" "Test Content Type" is updated appears
+      And I should be on "Content Type" "Test Content Type" page
       And Content Type has proper Global properties
         | label                | value                     |
         | Name                 | Test Content Type         |
@@ -39,7 +40,6 @@ Feature: Content types management
       And Content Type "Test Content Type" has proper fields
         | fieldName      | fieldType |
         | CountryField   | ezcountry |
-      And notification that "Content type" "Test Content Type" is updated appears
 
   @javascript @common
   Scenario: I can navigate to Content Type Group through breadcrumb
@@ -69,7 +69,8 @@ Feature: Content types management
       And I add field "Date" to Content Type definition
       And I set "Name" in "Date" to "DateField"
       And I click on the edit action bar button "Save"
-    Then I should be on "Content Type" "Test Content Type edited" page
+    Then notification that "Content type" "Test Content Type edited" is updated appears
+      And I should be on "Content Type" "Test Content Type edited" page
       And Content Type has proper Global properties
         | label                | value                     |
         | Name                 | Test Content Type edited  |
@@ -79,7 +80,6 @@ Feature: Content types management
         | fieldName      | fieldType |
         | CountryField   | ezcountry |
         | DateField      | ezdate    |
-      And notification that "Content type" "Test Content Type edited" is updated appears
 
   @javascript @common
   Scenario: Content type can be deleted from Content Type Group

--- a/features/ContentTypeFields.feature
+++ b/features/ContentTypeFields.feature
@@ -13,8 +13,8 @@ Feature: Content fields setting and editing
         | label    | <label1> | <label2> | <label3> |
         | Field    | <value1> | <value2> | <value3> |
       And I click on the edit action bar button "Publish"
-    Then I should be on content item page "<contentItemName>" of type "<fieldName> CT" in root path
-      And success notification that "Content published." appears
+    Then success notification that "Content published." appears
+      And I should be on content item page "<contentItemName>" of type "<fieldName> CT" in root path
       And content attributes equal
         | label    | <label1> | <label2> | <label3> |
         | Field    | <value1> | <value2> | <value3> |
@@ -53,8 +53,8 @@ Feature: Content fields setting and editing
         | label    | <label1> | <label2> | <label3> |
         | Field    | <value1> | <value2> | <value3> |
       And I click on the edit action bar button "Publish"
-    Then I should be on content item page "<newContentItemName>" of type "<fieldName> CT" in root path
-      And success notification that "Content published." appears
+    Then success notification that "Content published." appears
+      And I should be on content item page "<newContentItemName>" of type "<fieldName> CT" in root path
       And content attributes equal
         | label    | <label1> | <label2> | <label3> |
         | Field    | <value1> | <value2> | <value3> |


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30617](https://jira.ez.no/browse/EZP-30617)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


There are three fixes here:

- first, for the occasional problems with waiting for notification - moving notification checking steps as close as it can be to action that causes this notification
- second, for the multi-select UDW, where we occasionally but regularly get errors with select button not showing up after performing mouse-over; as there is no clear solution for that problem at the moment, I decided to enclose this action in the three-iteration loop, and throw if the last iteration fails
- third is the increasing of UDW timeouts


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
