### PR TITLE
EZP-30588: Make possible to translate custom tag choice attributes

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -127,7 +127,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * @param {Array} choice
      * @return {Object} The rendered option.
      */
-    renderChoice(choice, label) {
+    renderChoice(choice) {
         return <option value={choice[0]}>{choice[1]}</option>;
     }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -106,8 +106,6 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * @return {Object} The rendered select.
      */
     renderSelect(config, attrName) {
-        this.choicesLabel = config.choicesLabel;
-
         return (
             <div className="attribute__wrapper">
                 <label className="attribute__label form-control-label">{config.label}</label>
@@ -116,7 +114,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
                     value={this.state.values[attrName].value}
                     onChange={this.updateValues.bind(this)}
                     data-attr-name={attrName}>
-                    {config.choices.map(this.renderChoice.bind(this))}
+                    {config.choices.map(this.renderChoice.bind(this, config.choicesLabel))}
                 </select>
             </div>
         );
@@ -126,11 +124,12 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * Renders the option.
      *
      * @method renderChoice
+     * @param {Array} labels
      * @param {String} choice
      * @return {Object} The rendered option.
      */
-    renderChoice(choice) {
-        return <option value={choice}>{this.choicesLabel[choice]}</option>;
+    renderChoice(labels, choice) {
+        return <option value={choice}>{labels[choice]}</option>;
     }
 
     /**

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -127,8 +127,8 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * @param {Array} choice
      * @return {Object} The rendered option.
      */
-    renderChoice(choice) {
-        return <option value={choice[0]}>{choice[1]}</option>;
+    renderChoice([value, label]) {
+        return <option value={value}>{label}</option>;
     }
 
     /**

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -106,6 +106,8 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * @return {Object} The rendered select.
      */
     renderSelect(config, attrName) {
+        this.choicesLabel = config.choicesLabel;
+
         return (
             <div className="attribute__wrapper">
                 <label className="attribute__label form-control-label">{config.label}</label>
@@ -114,7 +116,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
                     value={this.state.values[attrName].value}
                     onChange={this.updateValues.bind(this)}
                     data-attr-name={attrName}>
-                    {Object.entries(config.choices).map(this.renderChoice.bind(this))}
+                    {config.choices.map(this.renderChoice.bind(this))}
                 </select>
             </div>
         );
@@ -124,11 +126,11 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * Renders the option.
      *
      * @method renderChoice
-     * @param {Array} choice
+     * @param {String} choice
      * @return {Object} The rendered option.
      */
-    renderChoice([value, label]) {
-        return <option value={value}>{label}</option>;
+    renderChoice(choice) {
+        return <option value={choice}>{this.choicesLabel[choice]}</option>;
     }
 
     /**

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -114,7 +114,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
                     value={this.state.values[attrName].value}
                     onChange={this.updateValues.bind(this)}
                     data-attr-name={attrName}>
-                    {config.choices.map(this.renderChoice.bind(this))}
+                    {Object.entries(config.choices).map(this.renderChoice.bind(this))}
                 </select>
             </div>
         );
@@ -124,11 +124,11 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * Renders the option.
      *
      * @method renderChoice
-     * @param {String} choice
+     * @param {Array} choice
      * @return {Object} The rendered option.
      */
-    renderChoice(choice) {
-        return <option value={choice}>{choice}</option>;
+    renderChoice(choice, label) {
+        return <option value={choice[0]}>{choice[1]}</option>;
     }
 
     /**

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -124,7 +124,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      * Renders the option.
      *
      * @method renderChoice
-     * @param {Array} labels
+     * @param {Object} labels
      * @param {String} choice
      * @return {Object} The rendered option.
      */

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -12,7 +12,8 @@ use ArrayObject;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Translator;
 
 /**
  * UI Config Mapper test for RichText Custom Tags configuration.
@@ -147,6 +148,10 @@ class CustomTagTest extends TestCase
                                     '',
                                     'hidden',
                                 ],
+                                'choicesLabel' => [
+                                    '' => '',
+                                    'hidden' => 'hidden',
+                                ],
                             ],
                         ],
                     ],
@@ -160,7 +165,21 @@ class CustomTagTest extends TestCase
      */
     private function getTranslatorMock(): MockObject
     {
-        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $catalogueMock = $this->createMock(MessageCatalogueInterface::class);
+        $catalogueMock
+            ->expects($this->any())
+            ->method('has')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $translatorMock = $this->createMock(Translator::class);
+        $translatorMock
+            ->expects($this->any())
+            ->method('getCatalogue')
+            ->willReturn(
+                $catalogueMock
+            );
+
         $translatorMock
             ->expects($this->any())
             ->method('trans')

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -164,6 +164,17 @@ class CustomTag
                     [],
                     $this->translationDomain
                 );
+
+                if (isset($config[$tagName]['attributes'][$attributeName]['choices'])) {
+                    foreach ($config[$tagName]['attributes'][$attributeName]['choices'] as $choice => $label) {
+                        $config[$tagName]['attributes'][$attributeName]['choices'][$choice] = $this->translator->trans(
+                            /** @Ignore */
+                            $label,
+                            [],
+                            $this->translationDomain
+                        );
+                    }
+                }
             }
         }
 

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -167,12 +167,15 @@ class CustomTag
 
                 if (isset($config[$tagName]['attributes'][$attributeName]['choicesLabel'])) {
                     foreach ($config[$tagName]['attributes'][$attributeName]['choicesLabel'] as $choice => $label) {
-                        $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $this->translator->trans(
+                        $translatedLabel = $this->translator->trans(
                             /** @Ignore */
                             $label,
                             [],
                             $this->translationDomain
                         );
+                        $hasTranslation = $translatedLabel !== $label;
+
+                        $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $hasTranslation ? $translatedLabel : $choice;
                     }
                 }
             }

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -157,6 +157,7 @@ class CustomTag
                 continue;
             }
 
+            $transCatalogue = $this->translator->getCatalogue();
             foreach ($tagConfig['attributes'] as $attributeName => $attributeConfig) {
                 $config[$tagName]['attributes'][$attributeName]['label'] = $this->translator->trans(
                     /** @Ignore */
@@ -167,15 +168,11 @@ class CustomTag
 
                 if (isset($config[$tagName]['attributes'][$attributeName]['choicesLabel'])) {
                     foreach ($config[$tagName]['attributes'][$attributeName]['choicesLabel'] as $choice => $label) {
-                        $translatedLabel = $this->translator->trans(
-                            /** @Ignore */
-                            $label,
-                            [],
-                            $this->translationDomain
-                        );
-                        $hasTranslation = $translatedLabel !== $label;
+                        $translatedLabel = $transCatalogue->has($label, $this->translationDomain)
+                            ? $this->translator->trans($label, [], $this->translationDomain)
+                            : $choice;
 
-                        $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $hasTranslation ? $translatedLabel : $choice;
+                        $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $translatedLabel;
                     }
                 }
             }

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -165,9 +165,9 @@ class CustomTag
                     $this->translationDomain
                 );
 
-                if (isset($config[$tagName]['attributes'][$attributeName]['choices'])) {
-                    foreach ($config[$tagName]['attributes'][$attributeName]['choices'] as $choice => $label) {
-                        $config[$tagName]['attributes'][$attributeName]['choices'][$choice] = $this->translator->trans(
+                if (isset($config[$tagName]['attributes'][$attributeName]['choicesLabel'])) {
+                    foreach ($config[$tagName]['attributes'][$attributeName]['choicesLabel'] as $choice => $label) {
+                        $config[$tagName]['attributes'][$attributeName]['choicesLabel'][$choice] = $this->translator->trans(
                             /** @Ignore */
                             $label,
                             [],

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
 use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\AttributeMapper;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\Translator;
 use Traversable;
 
 /**
@@ -22,7 +22,7 @@ class CustomTag
     /** @var array */
     private $customTagsConfiguration;
 
-    /** @var TranslatorInterface */
+    /** @var Translator */
     private $translator;
 
     /** @var Packages */
@@ -37,9 +37,21 @@ class CustomTag
     /** @var string */
     private $translationDomain;
 
+    /**
+     * CustomTag configuration mapper constructor.
+     *
+     * Note: type-hinting Translator to have an instance which implements
+     * both TranslatorInterface and TranslatorBagInterface.
+     *
+     * @param array $customTagsConfiguration
+     * @param \Symfony\Component\Translation\Translator $translator
+     * @param string $translationDomain
+     * @param \Symfony\Component\Asset\Packages $packages
+     * @param \Traversable $customTagAttributeMappers
+     */
     public function __construct(
         array $customTagsConfiguration,
-        TranslatorInterface $translator,
+        Translator $translator,
         string $translationDomain,
         Packages $packages,
         Traversable $customTagAttributeMappers

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/ChoiceAttributeMapper.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/ChoiceAttributeMapper.php
@@ -30,7 +30,11 @@ class ChoiceAttributeMapper extends CommonAttributeMapper implements AttributeMa
         array $customTagAttributeProperties
     ): array {
         $parentConfig = parent::mapConfig($tagName, $attributeName, $customTagAttributeProperties);
-        $parentConfig['choices'] = $customTagAttributeProperties['choices'];
+
+        $parentConfig['choices'] = [];
+        foreach ($customTagAttributeProperties['choices'] as $choice) {
+            $parentConfig['choices'][$choice] = "ezrichtext.custom_tags.{$tagName}.attributes.{$attributeName}.choices.{$choice}.label";
+        }
 
         return $parentConfig;
     }

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/ChoiceAttributeMapper.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag/ChoiceAttributeMapper.php
@@ -31,9 +31,11 @@ class ChoiceAttributeMapper extends CommonAttributeMapper implements AttributeMa
     ): array {
         $parentConfig = parent::mapConfig($tagName, $attributeName, $customTagAttributeProperties);
 
-        $parentConfig['choices'] = [];
-        foreach ($customTagAttributeProperties['choices'] as $choice) {
-            $parentConfig['choices'][$choice] = "ezrichtext.custom_tags.{$tagName}.attributes.{$attributeName}.choices.{$choice}.label";
+        $parentConfig['choices'] = $customTagAttributeProperties['choices'];
+        $parentConfig['choicesLabel'] = [];
+
+        foreach ($parentConfig['choices'] as $choice) {
+            $parentConfig['choicesLabel'][$choice] = "ezrichtext.custom_tags.{$tagName}.attributes.{$attributeName}.choices.{$choice}.label";
         }
 
         return $parentConfig;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30588
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


Let's say there is `my-tag` custom tag with `size` choice attribute. This custom tag is migrated from legacy, and it is used in a lot of different places. Possible options for "size" attribute are sm, md, lg. There is no way to translate those options and show the formatted label for them.

```
custom_tags:
    test:
        template: '@ezdesign/field_type/ezrichtext/custom_tag/my-tag.html.twig'
        icon: '/bundles/ezplatformadminui/img/ez-icons.svg#my-tag'
        is_inline: false
        attributes:
            size:
                type: 'choice'
                required: false
                default_value: 'md'
                choices: ['sm', 'md', 'lg']
```


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review