### PR TITLE
EZP-30627: Unified twig helpers naming

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -18,7 +18,7 @@
                             <div class="ez-content-field">
                                 <p class="ez-content-field-name">{{ field_definition.name }}:</p>
                                 <div class="ez-content-field-value">
-                                    {% if ez_is_field_empty(content, field_definition.identifier) %}
+                                    {% if ez_field_is_empty(content, field_definition.identifier) %}
                                         <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
                                     {% else %}
                                         {{ ez_render_field(content, field_definition.identifier, {

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block form_before %}
-    {{ ezplatform_admin_ui_component_group('content-create-form-before', {
+    {{ ez_render_component_group('content-create-form-before', {
         'parent_location': parent_location,
         'content_type': content_type,
         'language': language
@@ -66,7 +66,7 @@
 {% endblock %}
 
 {% block form_after %}
-    {{ ezplatform_admin_ui_component_group('content-create-form-after', {
+    {{ ez_render_component_group('content-create-form-after', {
         'parent_location': parent_location,
         'content_type': content_type,
         'language': language

--- a/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
@@ -74,7 +74,7 @@
                                         </td>
                                         <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
                                         <td class="ez-table__cell">{{ row.content_type.name }}</td>
-                                        <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
+                                        <td class="ez-table__cell">{{ ez_ui_config.languages.mappings[row.language].name }}</td>
                                         <td class="ez-table__cell">{{ row.version }}</td>
                                         <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
                                         <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
@@ -74,7 +74,7 @@
                                         </td>
                                         <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
                                         <td class="ez-table__cell">{{ row.content_type.name }}</td>
-                                        <td class="ez-table__cell">{{ ez_ui_config.languages.mappings[row.language].name }}</td>
+                                        <td class="ez-table__cell">{{ ez_admin_ui_config.languages.mappings[row.language].name }}</td>
                                         <td class="ez-table__cell">{{ row.version }}</td>
                                         <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
                                         <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -1,6 +1,6 @@
 {% extends view_base_layout is defined ? view_base_layout : '@ezdesign/ui/layout.html.twig' %}
 
-{% set default_form_templates = admin_ui_config.contentEditFormTemplates %}
+{% set default_form_templates = ez_ui_config.contentEditFormTemplates %}
 {% set form_templates = form_templates is defined ? default_form_templates|merge(form_templates) : default_form_templates %}
 
 {% trans_default_domain 'content_edit' %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -1,6 +1,6 @@
 {% extends view_base_layout is defined ? view_base_layout : '@ezdesign/ui/layout.html.twig' %}
 
-{% set default_form_templates = ez_ui_config.contentEditFormTemplates %}
+{% set default_form_templates = ez_admin_ui_config.contentEditFormTemplates %}
 {% set form_templates = form_templates is defined ? default_form_templates|merge(form_templates) : default_form_templates %}
 
 {% trans_default_domain 'content_edit' %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -67,7 +67,7 @@
 {% endblock %}
 
 {% block form_before %}
-    {{ ezplatform_admin_ui_component_group('content-edit-form-before', {
+    {{ ez_render_component_group('content-edit-form-before', {
         'content': content,
         'content_type': content_type,
         'location': location,
@@ -77,7 +77,7 @@
 {% endblock %}
 
 {% block form_after %}
-    {{ ezplatform_admin_ui_component_group('content-edit-form-after', {
+    {{ ez_render_component_group('content-edit-form-after', {
         'content': content,
         'content_type': content_type,
         'location': location,

--- a/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
@@ -61,7 +61,7 @@
                 </div>
                 <div class="panel panel-primary">
                     <div class="panel-body">
-                        {{ ez_platform_tabs('location-view', {
+                        {{ ez_render_tab_group('location-view', {
                             'content': content,
                             'location': location,
                             'contentType': content_type,

--- a/src/bundle/Resources/views/themes/admin/content/tab/url/custom_urls_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/url/custom_urls_table.html.twig
@@ -28,7 +28,7 @@
                 <td class="ez-table__cell">{{ custom_url.path }}</td>
                 <td class="ez-table__cell">
                     {% for language_code in custom_url.languageCodes %}
-                        {{ ez_ui_config.languages.mappings[language_code].name }}<br>
+                        {{ ez_admin_ui_config.languages.mappings[language_code].name }}<br>
                     {% endfor %}
                 </td>
                 <td class="ez-table__cell">

--- a/src/bundle/Resources/views/themes/admin/content/tab/url/custom_urls_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/url/custom_urls_table.html.twig
@@ -28,7 +28,7 @@
                 <td class="ez-table__cell">{{ custom_url.path }}</td>
                 <td class="ez-table__cell">
                     {% for language_code in custom_url.languageCodes %}
-                        {{ admin_ui_config.languages.mappings[language_code].name }}<br>
+                        {{ ez_ui_config.languages.mappings[language_code].name }}<br>
                     {% endfor %}
                 </td>
                 <td class="ez-table__cell">

--- a/src/bundle/Resources/views/themes/admin/content/tab/url/system_urls_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/url/system_urls_table.html.twig
@@ -13,7 +13,7 @@
             <tr>
                 <td>{{ system_url.path }}</td>
                 <td>
-                    {% for language_code in system_url.languageCodes %}{{ admin_ui_config.languages.mappings[language_code].name }}<br>{% endfor %}
+                    {% for language_code in system_url.languageCodes %}{{ ez_ui_config.languages.mappings[language_code].name }}<br>{% endfor %}
                 </td>
             </tr>
         {% endfor %}

--- a/src/bundle/Resources/views/themes/admin/content/tab/url/system_urls_table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/url/system_urls_table.html.twig
@@ -13,7 +13,7 @@
             <tr>
                 <td>{{ system_url.path }}</td>
                 <td>
-                    {% for language_code in system_url.languageCodes %}{{ ez_ui_config.languages.mappings[language_code].name }}<br>{% endfor %}
+                    {% for language_code in system_url.languageCodes %}{{ ez_admin_ui_config.languages.mappings[language_code].name }}<br>{% endfor %}
                 </td>
             </tr>
         {% endfor %}

--- a/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
@@ -48,7 +48,7 @@
                     {{ version.versionNo }}
                 </td>
                 <td class="ez-table__cell">
-                    {{ ez_ui_config.languages.mappings[version.initialLanguageCode].name }}
+                    {{ ez_admin_ui_config.languages.mappings[version.initialLanguageCode].name }}
                 </td>
                 {% block custom_columns %}{% endblock %}
                 <td class="ez-table__cell">
@@ -68,7 +68,7 @@
                 </td>
                 {% if is_draft_conflict %}
                     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-                        {% set edit_draft_disabled = version.author.id != ez_ui_config.user.user.id %}
+                        {% set edit_draft_disabled = version.author.id != ez_admin_ui_config.user.user.id %}
                         <a href="{{ edit_url }}"
                             class="btn btn-icon {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
                             title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}"

--- a/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
@@ -48,7 +48,7 @@
                     {{ version.versionNo }}
                 </td>
                 <td class="ez-table__cell">
-                    {{ admin_ui_config.languages.mappings[version.initialLanguageCode].name }}
+                    {{ ez_ui_config.languages.mappings[version.initialLanguageCode].name }}
                 </td>
                 {% block custom_columns %}{% endblock %}
                 <td class="ez-table__cell">
@@ -68,7 +68,7 @@
                 </td>
                 {% if is_draft_conflict %}
                     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-                        {% set edit_draft_disabled = version.author.id != admin_ui_config.user.user.id %}
+                        {% set edit_draft_disabled = version.author.id != ez_ui_config.user.user.id %}
                         <a href="{{ edit_url }}"
                             class="btn btn-icon {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
                             title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit Draft') }}"

--- a/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/create.html.twig
@@ -96,7 +96,7 @@
                             {{ form_row(field_definition.fieldGroup, {'label_attr': {'class': 'ez-label'}}) }}
 
                             {# Field type specific fields below #}
-                            {{ ez_render_fielddefinition_edit(value, {
+                            {{ ez_render_field_definition_edit(value, {
                                 'languageCode': language_code,
                                 'form': field_definition,
                                 'group_class': value.group_class|default('')

--- a/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
@@ -106,7 +106,7 @@
                             {{ form_row(field_definition.fieldGroup, {'label_attr': {'class': 'ez-label'}}) }}
 
                             {# Field type specific fields below #}
-                            {{ ez_render_fielddefinition_edit(value, {
+                            {{ ez_render_field_definition_edit(value, {
                                 'languageCode': language_code,
                                 'form': field_definition,
                                 'group_class': value.group_class|default(''),

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -132,7 +132,7 @@
                 class="ez-button-tree pure-button ez-font-icon ez-button ez-relation-pick-root-button btn btn-secondary btn--udw-relation-default-location"
                 data-relation-root-input-selector="#{{ form.selectionRoot.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionRoot.vars.id }}-selected-root-name"
-                data-starting-location-id="{{ admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
+                data-starting-location-id="{{ ez_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single', {}) }}"
                 {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelation.selection_root_udw_button"
@@ -164,7 +164,7 @@
                 class="ez-button-tree pure-button ez-font-icon ez-button ez-relation-pick-root-button btn btn-secondary btn--udw-relation-default-location"
                 data-relation-root-input-selector="#{{ form.selectionDefaultLocation.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionDefaultLocation.vars.id }}-selected-root-name"
-                data-starting-location-id="{{ admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
+                data-starting-location-id="{{ ez_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single_container', {}) }}"
                 {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelationlist.selection_root_udw_button"

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -132,7 +132,7 @@
                 class="ez-button-tree pure-button ez-font-icon ez-button ez-relation-pick-root-button btn btn-secondary btn--udw-relation-default-location"
                 data-relation-root-input-selector="#{{ form.selectionRoot.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionRoot.vars.id }}-selected-root-name"
-                data-starting-location-id="{{ ez_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
+                data-starting-location-id="{{ ez_admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single', {}) }}"
                 {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelation.selection_root_udw_button"
@@ -164,7 +164,7 @@
                 class="ez-button-tree pure-button ez-font-icon ez-button ez-relation-pick-root-button btn btn-secondary btn--udw-relation-default-location"
                 data-relation-root-input-selector="#{{ form.selectionDefaultLocation.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionDefaultLocation.vars.id }}-selected-root-name"
-                data-starting-location-id="{{ ez_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
+                data-starting-location-id="{{ ez_admin_ui_config.universalDiscoveryWidget.startingLocationId|default(1) }}"
                 data-udw-config="{{ ez_udw_config('single_container', {}) }}"
                 {{ is_translation ? 'disabled' : '' }}
             >{{ "field_definition.ezobjectrelationlist.selection_root_udw_button"

--- a/src/bundle/Resources/views/themes/admin/content_type/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/index.html.twig
@@ -7,7 +7,7 @@
 {% set language_code = content_type.mainLanguageCode %}
 
 {% block content %}
-    {{ ez_platform_tabs('content-type', {
+    {{ ez_render_tab_group('content-type', {
         'content_type': content_type,
         'content_type_group': content_type_group,
         'field_definitions_by_group': field_definitions_by_group,

--- a/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
@@ -21,7 +21,7 @@
     <ul class="list-unstyled" id="{{ form.limitationValues.vars.id }}-selected-location">
         {% for limitationValue in form.limitationValues.vars.data %}
             {% if limitationValue is not empty %}
-                {% set path_locations = ez_path_string_to_locations(limitationValue.pathString) %}
+                {% set path_locations = ez_path_to_locations(limitationValue.pathString) %}
                 {% set content_breadcrumbs = '' %}
                 {% for location in path_locations %}
                     {% set content_breadcrumbs = content_breadcrumbs ~ ez_content_name(location.contentInfo) %}

--- a/src/bundle/Resources/views/themes/admin/system_info/info.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/info.html.twig
@@ -19,5 +19,5 @@
 {% endblock %}
 
 {% block content %}
-    {{ ez_platform_tabs('systeminfo', {}, '@ezdesign/ui/tab/system_info.html.twig') }}
+    {{ ez_render_tab_group('systeminfo', {}, '@ezdesign/ui/tab/system_info.html.twig') }}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/all.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/all.html.twig
@@ -3,6 +3,6 @@
 <div class="card border-light mb-4">
     <div class="card-body">
         <h2 class="mb-3">{{ 'everyone'|trans|desc('Everyone') }}</h2>
-        {{ ez_platform_tabs('dashboard-everyone', []) }}
+        {{ ez_render_tab_group('dashboard-everyone', []) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/me.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/me.html.twig
@@ -3,6 +3,6 @@
 <div class="card border-light my-4">
     <div class="card-body">
         <h2 class="mb-3">{{ 'me'|trans|desc('Me') }}</h2>
-        {{ ez_platform_tabs('dashboard-my', []) }}
+        {{ ez_render_tab_group('dashboard-my', []) }}
     </div>
 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/dashboard.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/dashboard.html.twig
@@ -25,7 +25,7 @@
                 </div>
             </div>
             <div class="container">
-                {{ ezplatform_admin_ui_component_group('dashboard-blocks') }}
+                {{ ez_render_component_group('dashboard-blocks') }}
             </div>
         </div>
         {{ form_start(form_edit, {

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
@@ -24,7 +24,7 @@
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
                 <td class="ez-table__cell">{{ row.content_type.name }}</td>
-                <td class="ez-table__cell">{{ ez_ui_config.languages.mappings[row.language].name }}</td>
+                <td class="ez-table__cell">{{ ez_admin_ui_config.languages.mappings[row.language].name }}</td>
                 <td class="ez-table__cell">{{ row.version }}</td>
                 <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
                 <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
@@ -24,7 +24,7 @@
                 </td>
                 <td class="ez-table__cell ez-table__cell--after-icon">{{ row.name }}</td>
                 <td class="ez-table__cell">{{ row.content_type.name }}</td>
-                <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.language].name }}</td>
+                <td class="ez-table__cell">{{ ez_ui_config.languages.mappings[row.language].name }}</td>
                 <td class="ez-table__cell">{{ row.version }}</td>
                 <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
                 <td class="ez-table__cell ez-table__cell--has-action-btns text-right">

--- a/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
@@ -1,7 +1,7 @@
 {% extends '@ezdesign/ui/layout.html.twig' %}
 
 {% block navigation %}
-    {% if ez_ui_config.user.user is not empty %}
+    {% if ez_admin_ui_config.user.user is not empty %}
         {{ parent() }}
     {% endif %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
@@ -1,7 +1,7 @@
 {% extends '@ezdesign/ui/layout.html.twig' %}
 
 {% block navigation %}
-    {% if admin_ui_config.user.user is not empty %}
+    {% if ez_ui_config.user.user is not empty %}
         {{ parent() }}
     {% endif %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -84,7 +84,7 @@
             locationId: destination_content.contentInfo.mainLocationId
         }) %}
 
-        {% set image_uri = ez_field_value(destination_content, ez_image_asset_content_field_identifier()).uri %}
+        {% set image_uri = ez_field_value(destination_content, ez_content_field_identifier_image_asset()).uri %}
     {% endif %}
 
     <div class="ez-field-edit-preview">

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block ezrichtext_field %}
-    {%- set field_value = field.value.xml|richtext_to_html5 -%}
+    {%- set field_value = field.value.xml|ez_richtext_to_html5 -%}
     {{ block( 'simple_block_field' ) }}
 {% endblock %}
 
@@ -66,7 +66,7 @@
 
 {% block ezdatetime_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.value|ez_full_datetime %}
         {{ block( 'simple_block_field' ) }}
         {% if fieldSettings.useSeconds %}
@@ -80,7 +80,7 @@
 
 {% block ezdate_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.date|ez_full_date('UTC') %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
@@ -89,7 +89,7 @@
 
 {% block eztime_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.time|ez_full_time('UTC') %}
         {{ block( 'simple_block_field' ) }}
         {% if fieldSettings.useSeconds %}
@@ -103,7 +103,7 @@
 
 {% block ezemail_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.email %}
         <a href="mailto:{{ field.value.email|escape( 'url' ) }}" {{ block( 'field_attributes' ) }}>{{ field.value.email }}</a>
     {% endif %}
@@ -112,7 +112,7 @@
 
 {% block ezinteger_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
@@ -121,7 +121,7 @@
 
 {% block ezfloat_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
@@ -130,7 +130,7 @@
 
 {% block ezurl_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         <a href="{{ field.value.link }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.text ? field.value.text : field.value.link }}</a>
     {% endif %}
@@ -146,7 +146,7 @@
 
 {% block ezkeyword_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezkeyword')|trim}) %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for keyword in field.value.values %}
@@ -214,7 +214,7 @@
 
 {% block ezbinaryfile_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
         {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier, 'inLanguage': content.prioritizedFieldLanguageCode } ) %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezbinaryfile')|trim}) %}
         <div {{ block( 'field_attributes' ) }}>
@@ -234,7 +234,7 @@
 {% endblock %}
 
 {% block ezmedia_field %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_field_is_empty( content, field ) %}
 {% spaceless %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezmedia')|trim}) %}
     {% set type = fieldSettings.mediaType %}
@@ -301,7 +301,7 @@
 
 {% block ezobjectrelationlist_field %}
 {% spaceless %}
-    {% if not ez_is_field_empty( content, field ) %}
+    {% if not ez_field_is_empty( content, field ) %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezobjectrelationlist')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
         <div class="ez-table-header ">
@@ -370,7 +370,7 @@
 
 {% block ezimage_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_field_is_empty( content, field ) %}
 {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
 {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezimage')|trim}) %}
@@ -425,7 +425,7 @@
 
 {% block ezimageasset_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) and parameters.available %}
+{% if not ez_field_is_empty( content, field ) and parameters.available %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezimageasset')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
         {{ render(controller('ez_content:viewAction', {
@@ -445,7 +445,7 @@
 
 {% block ezobjectrelation_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_field_is_empty( content, field ) %}
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezobjectrelationlist')|trim}) %}
     <div {{ block( 'field_attributes' ) }}>
         <div class="ez-table-header ">
@@ -473,7 +473,7 @@
 {# pageService is exposed under parameters.pageService thanks to Page\ParameterProvider #}
 {% block ezpage_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_field_is_empty( content, field ) %}
     {% set layout = field.value.page.layout %}
     {% set template = parameters.pageService.getLayoutTemplate( layout ) %}
     {% include template with { 'zones': field.value.page.zones, 'zone_layout': layout, 'pageService': parameters.pageService } %}

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/ezimageasset.html.twig
@@ -1,9 +1,9 @@
 {% trans_default_domain 'fieldtypes_preview' %}
 
-{% set field = ez_field(content, ez_image_asset_content_field_identifier()) %}
+{% set field = ez_field(content, ez_content_field_identifier_image_asset()) %}
 {% set versionInfo = content.versionInfo  %}
 
-{% if not ez_is_field_empty(content, field) %}
+{% if not ez_field_is_empty(content, field) %}
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
     {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -57,7 +57,7 @@
         {% block meta %}
         {% endblock %}
         <script>
-            window.eZ.addConfig('adminUiConfig', {{ ez_ui_config|json_encode|raw }});
+            window.eZ.addConfig('adminUiConfig', {{ ez_admin_ui_config|json_encode|raw }});
             window.eZ.addConfig('errors', {
                 emailRegexp: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
                 emptyField: '{{ 'js.error.empty.field'|trans({}, 'validators')|desc('{fieldName} field is required') }}',
@@ -134,8 +134,8 @@
                         </div>
                     </div>
                     <div class="ez-content-tree-container"
-                        data-user-id="{{ ez_ui_config.user.user.id }}"
-                        data-tree-root-location-id="{{ content_tree_module_root|default(ez_ui_config['contentTree']['treeRootLocationId']) }}"
+                        data-user-id="{{ ez_admin_ui_config.user.user.id }}"
+                        data-tree-root-location-id="{{ content_tree_module_root|default(ez_admin_ui_config['contentTree']['treeRootLocationId']) }}"
                         data-current-location-path="{{ location_path|default('') }}">
                         <div class="ez-content-tree-container__wrapper"></div>
                     </div>

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -57,7 +57,7 @@
         {% block meta %}
         {% endblock %}
         <script>
-            window.eZ.addConfig('adminUiConfig', {{ admin_ui_config|json_encode|raw }});
+            window.eZ.addConfig('adminUiConfig', {{ ez_ui_config|json_encode|raw }});
             window.eZ.addConfig('errors', {
                 emailRegexp: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
                 emptyField: '{{ 'js.error.empty.field'|trans({}, 'validators')|desc('{fieldName} field is required') }}',
@@ -93,8 +93,8 @@
         {{ encore_entry_link_tags('ezplatform-admin-ui-layout-css', null, 'ezplatform') }}
         {% block stylesheets %}{% endblock %}
         <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
-        {{ ezplatform_admin_ui_component_group('stylesheet-head') }}
-        {{ ezplatform_admin_ui_component_group('script-head') }}
+        {{ ez_render_component_group('stylesheet-head') }}
+        {{ ez_render_component_group('script-head') }}
 
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/react/umd/react.production.min.js') }}"></script>
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/react-dom/umd/react-dom.production.min.js') }}"></script>
@@ -134,8 +134,8 @@
                         </div>
                     </div>
                     <div class="ez-content-tree-container"
-                        data-user-id="{{ admin_ui_config.user.user.id }}"
-                        data-tree-root-location-id="{{ content_tree_module_root|default(admin_ui_config['contentTree']['treeRootLocationId']) }}"
+                        data-user-id="{{ ez_ui_config.user.user.id }}"
+                        data-tree-root-location-id="{{ content_tree_module_root|default(ez_ui_config['contentTree']['treeRootLocationId']) }}"
                         data-current-location-path="{{ location_path|default('') }}">
                         <div class="ez-content-tree-container__wrapper"></div>
                     </div>
@@ -152,15 +152,15 @@
             })|e('html_attr')  }}"></div>
         <div class="ez-modal-wrapper"></div>
 
-        {{ ezplatform_admin_ui_component_group('custom-admin-ui-modules') }}
-        {{ ezplatform_admin_ui_component_group('custom-admin-ui-config') }}
+        {{ ez_render_component_group('custom-admin-ui-modules') }}
+        {{ ez_render_component_group('custom-admin-ui-config') }}
 
         {{ encore_entry_script_tags('ezplatform-admin-ui-modules-udw-js', null, 'ezplatform') }}
         {{ encore_entry_script_tags('ezplatform-admin-ui-layout-js', null, 'ezplatform') }}
 
         {% block react_modules %}{% endblock %}
         {% block javascripts %}{% endblock %}
-        {{ ezplatform_admin_ui_component_group('stylesheet-body') }}
-        {{ ezplatform_admin_ui_component_group('script-body') }}
+        {{ ez_render_component_group('stylesheet-body') }}
+        {{ ez_render_component_group('script-body') }}
     </body>
 </html>

--- a/src/bundle/Resources/views/themes/admin/ui/menu/top_navigation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/top_navigation.html.twig
@@ -22,11 +22,11 @@
             </ul>
             <div class="ez-user-menu ml-md-auto">
                 <div class='ez-user-menu__name-wrapper'>
-                    {% set user = ez_ui_config.user.user%}
+                    {% set user = ez_admin_ui_config.user.user%}
                     <span class="ez-user-menu__name">{{ user.name }}</span>
 
-                    {% if ez_ui_config.user.profile_picture_field is not null and ez_ui_config.user.profile_picture_field.value.uri is not null %}
-                        {% set imageVariation = ez_image_alias(ez_ui_config.user.profile_picture_field, user.versionInfo, 'ezplatform_admin_ui_profile_picture_user_menu') %}
+                    {% if ez_admin_ui_config.user.profile_picture_field is not null and ez_admin_ui_config.user.profile_picture_field.value.uri is not null %}
+                        {% set imageVariation = ez_image_alias(ez_admin_ui_config.user.profile_picture_field, user.versionInfo, 'ezplatform_admin_ui_profile_picture_user_menu') %}
                         {% set src = imageVariation ? asset(imageVariation.uri) : asset('bundles/ezplatformadminui/img/default-profile-picture.png') %}
                         <span class="ez-user-menu__avatar-wrapper"><img class="ez-user-menu__avatar" src="{{ src }}" alt="{{ user.name }}"></span>
                     {% else %}

--- a/src/bundle/Resources/views/themes/admin/ui/menu/top_navigation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/top_navigation.html.twig
@@ -22,11 +22,11 @@
             </ul>
             <div class="ez-user-menu ml-md-auto">
                 <div class='ez-user-menu__name-wrapper'>
-                    {% set user = admin_ui_config.user.user%}
+                    {% set user = ez_ui_config.user.user%}
                     <span class="ez-user-menu__name">{{ user.name }}</span>
 
-                    {% if admin_ui_config.user.profile_picture_field is not null and admin_ui_config.user.profile_picture_field.value.uri is not null %}
-                        {% set imageVariation = ez_image_alias(admin_ui_config.user.profile_picture_field, user.versionInfo, 'ezplatform_admin_ui_profile_picture_user_menu') %}
+                    {% if ez_ui_config.user.profile_picture_field is not null and ez_ui_config.user.profile_picture_field.value.uri is not null %}
+                        {% set imageVariation = ez_image_alias(ez_ui_config.user.profile_picture_field, user.versionInfo, 'ezplatform_admin_ui_profile_picture_user_menu') %}
                         {% set src = imageVariation ? asset(imageVariation.uri) : asset('bundles/ezplatformadminui/img/default-profile-picture.png') %}
                         <span class="ez-user-menu__avatar-wrapper"><img class="ez-user-menu__avatar" src="{{ src }}" alt="{{ user.name }}"></span>
                     {% else %}

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -33,7 +33,7 @@
 {% block close_button %}{% endblock %}
 
 {% block form_before %}
-    {{ ezplatform_admin_ui_component_group('content-create-form-before', {
+    {{ ez_render_component_group('content-create-form-before', {
         'parent_location': parent_location,
         'content_type': content_type,
         'language': language
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {% block form_after %}
-    {{ ezplatform_admin_ui_component_group('content-create-form-after', {
+    {{ ez_render_component_group('content-create-form-after', {
         'parent_location': parent_location,
         'content_type': content_type,
         'language': language

--- a/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
@@ -50,7 +50,7 @@
                 {% set content_breadcrumbs = '' %}
                 {% set subtree_selected = form.subtree.vars.value is not empty %}
                 {% if subtree_selected %}
-                    {% set path_locations = ez_path_string_to_locations(form.subtree.vars.value) %}
+                    {% set path_locations = ez_path_to_locations(form.subtree.vars.value) %}
                     {% for location in path_locations %}
                         {% set content_breadcrumbs = content_breadcrumbs ~ ez_content_name(location.contentInfo) %}
                         {% if not loop.last %}

--- a/src/bundle/Templating/Twig/ComponentExtension.php
+++ b/src/bundle/Templating/Twig/ComponentExtension.php
@@ -31,12 +31,12 @@ class ComponentExtension extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction(
-                'ezplatform_admin_ui_component_group',
+                'ez_render_component_group',
                 [$this, 'renderComponentGroup'],
                 ['is_safe' => ['html']]
             ),
             new Twig_SimpleFunction(
-                'ezplatform_admin_ui_component',
+                'ez_render_component',
                 [$this, 'renderComponent'],
                 ['is_safe' => ['html']]
             ),

--- a/src/bundle/Templating/Twig/PathStringExtension.php
+++ b/src/bundle/Templating/Twig/PathStringExtension.php
@@ -29,7 +29,7 @@ class PathStringExtension extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction(
-                'ez_path_string_to_locations',
+                'ez_path_to_locations',
                 [$this, 'getLocationList']
             ),
         ];

--- a/src/bundle/Templating/Twig/TabExtension.php
+++ b/src/bundle/Templating/Twig/TabExtension.php
@@ -55,7 +55,7 @@ class TabExtension extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction(
-                'ez_platform_tabs',
+                'ez_render_tab_group',
                 [$this, 'renderTabGroup'],
                 ['is_safe' => ['html']]
             ),

--- a/src/bundle/Templating/Twig/UiConfigExtension.php
+++ b/src/bundle/Templating/Twig/UiConfigExtension.php
@@ -17,7 +17,7 @@ use Twig_Extension_GlobalsInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ConfigWrapper;
 
 /**
- * Exports `ez_ui_config` providing UI Config as a global Twig variable.
+ * Exports `ez_admin_ui_config` providing UI Config as a global Twig variable.
  */
 class UiConfigExtension extends Twig_Extension implements Twig_Extension_GlobalsInterface
 {
@@ -43,7 +43,7 @@ class UiConfigExtension extends Twig_Extension implements Twig_Extension_Globals
     public function getGlobals(): array
     {
         return [
-            'ez_ui_config' => $this->createConfigWrapper(),
+            'ez_admin_ui_config' => $this->createConfigWrapper(),
         ];
     }
 

--- a/src/bundle/Templating/Twig/UiConfigExtension.php
+++ b/src/bundle/Templating/Twig/UiConfigExtension.php
@@ -17,7 +17,7 @@ use Twig_Extension_GlobalsInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ConfigWrapper;
 
 /**
- * Exports `admin_ui_config` providing UI Config as a global Twig variable.
+ * Exports `ez_ui_config` providing UI Config as a global Twig variable.
  */
 class UiConfigExtension extends Twig_Extension implements Twig_Extension_GlobalsInterface
 {
@@ -43,7 +43,7 @@ class UiConfigExtension extends Twig_Extension implements Twig_Extension_Globals
     public function getGlobals(): array
     {
         return [
-            'admin_ui_config' => $this->createConfigWrapper(),
+            'ez_ui_config' => $this->createConfigWrapper(),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30627](https://jira.ez.no/browse/EZP-30627)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->



### renamed functions:

* ez_path_to_locations <-- ez_path_string_to_locations
* ez_block_value_encode <-- encode_block_value
* ez_http_cache_tag_location <-- ez_http_tag_location 
* ez_field_encode <-- encode_field
* ez_field_is_empty <-- ez_is_field_empty
* ez_render_field_definition_edit <-- ez_render_fielddefinition_edit
* ez_render_field_definition_settings <-- ez_render_fielddefinition_settings
* ez_render_component <-- ezplatform_admin_ui_component ??
* ez_render_component_group <-- ezplatform_admin_ui_component_group
* ez_render_tab_group <-- ez_platform_tabs
* ez_content_field_identifier_image_asset <-- ez_image_asset_content_field_identifier
* ez_content_field_identifier_first_filed_image <-- ez_first_filled_image_field_identifier
* ez_page_builder_cross_origin_helper <-- ezplatform_page_builder_cross_origin_helper

### remooved functions: 
* ez_trans_prop

### renamed globals:

* ez_admin_ui_config <-- admin_ui_config
* ezplatform <-- ezpublish 

### renamed filters:

* ez_richtext_to_html5 <-- richtext_to_html5
* ez_richtext_to_html5_edit <-- richtext_to_html5_edit

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
