### PR TITLE
Fixes paths in search templates

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/search/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/index.html.twig
@@ -18,7 +18,7 @@
         <div class="px-0 ez-content-container">
             <section class="container mt-5">
                 {% include '@ezdesign/ui/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), icon_name: 'search' } %}
-                {% include '@ezdesign/ui/search/search.html.twig' with { form: form } %}
+                {% include '@ezdesign/ui/search/form.html.twig' with { form: form } %}
 
                 {% if results is defined %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/search/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/list.html.twig
@@ -15,7 +15,7 @@
             <section class="container mt-5">
                 {% include '@ezdesign/ui/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), icon_name: 'search' } %}
 
-                {% include '@ezdesign/ui/search/search.html.twig' with { form: form } %}
+                {% include '@ezdesignui/search/form.html.twig' with { form: form } %}
 
                 <div class="ez-table-header mt-3">
                     <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pagerfanta.nbResults})|desc('Search results (%total%)') }}</div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |[EZP-30395](https://jira.ez.no/browse/EZP-30395)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

I found the issue/typo that was not catched by our regression tests.  The regression was made by me durring "Move and rename template " task.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
