### PR TITLE
EZP-30665: Custom styles dropdown becomes unusable when contains many…

### DIFF
--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -722,7 +722,7 @@
     font-size: 16px;
     height: 3em;
     line-height: 28px;
-    margin-right: 0;
+    margin-right: 15px;
     max-height: 44px;
     min-width: 100%;
     padding: 8px 12px;

--- a/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
+++ b/src/bundle/Resources/public/css/alloyeditor/alloyeditor-ez.css
@@ -711,8 +711,10 @@
     list-style: none;
     margin: 0;
     min-height: 44px;
+    max-height: 400px;
     min-width: 132px;
     padding: 0;
+    overflow-y: auto;
 }
 
 .ae-ui .ae-dropdown .ae-listbox .ae-toolbar-element,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30665
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

It is not possible to select custom style when having configured many of them.

PR result:
<img width="639" alt="Screenshot 2019-06-13 at 12 55 34" src="https://user-images.githubusercontent.com/22669715/59427347-ba548900-8dda-11e9-9b81-e16df021b233.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
