### PR TITLE
EZP-30648: Values of checkboxes are not displayed properly in Content  Type view

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -64,7 +64,7 @@
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.container"|trans|desc("Container") }}</td>
-            <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer)|desc("{0}No|{1}Yes") }}</td>
+            <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer|number_format)|desc("{0}No|{1}Yes") }}</td>
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.default_children_sorting"|trans|desc("Default field for sorting children") }}</td>
@@ -85,7 +85,7 @@
                     {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                 </p>
             </td>
-            <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable)|desc("{0} Not available|{1} Available") }}</td>
+            <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable|number_format)|desc("{0} Not available|{1} Available") }}</td>
         </tr>
         </tbody>
     </table>

--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -64,7 +64,7 @@
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.container"|trans|desc("Container") }}</td>
-            <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer|number_format)|desc("{0}No|{1}Yes") }}</td>
+            <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer ? 1 : 0)|desc("{0}No|{1}Yes") }}</td>
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.default_children_sorting"|trans|desc("Default field for sorting children") }}</td>

--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -85,7 +85,7 @@
                     {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                 </p>
             </td>
-            <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable|number_format)|desc("{0} Not available|{1} Available") }}</td>
+            <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable ? 1 : 0)|desc("{0} Not available|{1} Available") }}</td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30648](https://jira.ez.no/browse/EZP-30648)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

fix

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
