### PR TITLE
EZP-30666: fixed paths to images of error page

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/error_page/403.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/403.html.twig
@@ -6,7 +6,7 @@
 <div class="row align-items-stretch ez-main-row">
     <div class="error-page">
         <div class="error-page__image-wrapper">
-            <img src="{{ asset('bundles/ezplatformadminui/img/error/403.png') }}" />
+            <img src="{{ asset('bundles/ezplatformadminui/img/errors/403.png') }}" />
         </div>
         <h2 class="error-page__title">{{ 'error.page.403.title'|trans|desc('You don\’t have permission for this page. Sorry!') }}</h2>
         <div class="error-page__messages">

--- a/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/404.html.twig
@@ -12,7 +12,7 @@
 <div class="row align-items-stretch ez-main-row">
     <div class="error-page">
         <div class="error-page__image-wrapper">
-            <img src="{{ asset('bundles/ezplatformadminui/img/error/404.png') }}" />
+            <img src="{{ asset('bundles/ezplatformadminui/img/errors/404.png') }}" />
         </div>
         <h2 class="error-page__title">{{ 'error.page.404.title'|trans|desc('Something went wrong. Sorry!') }}</h2>
         <div class="error-page__messages">

--- a/src/bundle/Resources/views/themes/admin/ui/error_page/unknown.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/error_page/unknown.html.twig
@@ -8,7 +8,7 @@
 <div class="row align-items-stretch ez-main-row">
     <div class="error-page">
         <div class="error-page__image-wrapper">
-            <img src="{{ asset('bundles/ezplatformadminui/img/error/500.png') }}" />
+            <img src="{{ asset('bundles/ezplatformadminui/img/errors/500.png') }}" />
         </div>
         <h2 class="error-page__title">{{ 'error.page.default.title'|trans|desc('Something went wrong. Sorry!') }}</h2>
         <div class="error-page__messages">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30666](https://jira.ez.no/browse/EZP-30666)
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
