### PR TITLE
EZP-30670: Replaced deprecated Symfony Kernel parameters

### DIFF
--- a/src/bundle/Resources/translations/systeminfo.en.xliff
+++ b/src/bundle/Resources/translations/systeminfo.en.xliff
@@ -161,10 +161,10 @@
         <target state="new">Path</target>
         <note>key: symfony_kernel.path</note>
       </trans-unit>
-      <trans-unit id="56014c7eba59799c182934e3a0eb97eff6fd8a97" resname="symfony_kernel.rootDir">
-        <source>Root directory</source>
-        <target state="new">Root directory</target>
-        <note>key: symfony_kernel.rootDir</note>
+      <trans-unit id="9370a0e83c7f7c06d9a328661a3031d99035d582" resname="symfony_kernel.projectDir">
+        <source>Project directory</source>
+        <target state="new">Project directory</target>
+        <note>key: symfony_kernel.projectDir</note>
       </trans-unit>
       <trans-unit id="74fd4792096e74360c7508e16bbe7c1e121d393e" resname="symfony_kernel.version">
         <source>Version</source>

--- a/src/bundle/Resources/views/themes/admin/system_info/symfony_kernel.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/symfony_kernel.html.twig
@@ -28,12 +28,8 @@
             <td class="ez-table__cell">{{ info.version }}</td>
         </tr>
         <tr class="ez-table__row">
-            <td class="ez-table__cell">{{ 'symfony_kernel.name'|trans|desc('Name') }}</td>
-            <td class="ez-table__cell">{{ info.name }}</td>
-        </tr>
-        <tr class="ez-table__row">
-            <td class="ez-table__cell">{{ 'symfony_kernel.rootDir'|trans|desc('Root directory') }}</td>
-            <td class="ez-table__cell">{{ info.rootDir }}</td>
+            <td class="ez-table__cell">{{ 'symfony_kernel.projectDir'|trans|desc('Project directory') }}</td>
+            <td class="ez-table__cell">{{ info.projectDir }}</td>
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ 'symfony_kernel.cacheDir'|trans|desc('Cache directory') }}</td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30670](https://jira.ez.no/browse/EZP-30670)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

According to the symfony documentation, since 4.2 the kernel name and root dir is deprecated so we should stop displaying it in our admin UI
https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-kernel-name-and-the-root-dir

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
