### PR TITLE
EZP-30701: Removed deprecated 'universal_discovery_widget_module.default_location_id' setting

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/UniversalDiscoveryWidget.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/UniversalDiscoveryWidget.php
@@ -28,10 +28,6 @@ class UniversalDiscoveryWidget extends AbstractParser
             ->arrayNode('universal_discovery_widget_module')
                 ->info('UDW module configuration')
                 ->children()
-                    ->scalarNode('default_location_id')
-                        ->setDeprecated('Use configuration.default.starting_location_id instead.')
-                        ->isRequired()
-                    ->end()
                     ->arrayNode('configuration')
                         ->isRequired()
                         ->useAttributeAsKey('scope_name')
@@ -51,16 +47,6 @@ class UniversalDiscoveryWidget extends AbstractParser
         }
 
         $settings = $scopeSettings['universal_discovery_widget_module'];
-
-        if (!isset($settings['default_location_id']) || empty($settings['default_location_id'])) {
-            return;
-        }
-
-        $contextualizer->setContextualParameter(
-            'universal_discovery_widget_module.default_location_id',
-            $currentScope,
-            $settings['default_location_id']
-        );
 
         $contextualizer->setContextualParameter(
             'universal_discovery_widget_module.configuration',

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -30,9 +30,6 @@ parameters:
     # Subitems Module
     ezsettings.default.subitems_module.limit: 10
 
-    # Universal Discovery Widget Module
-    ezsettings.default.universal_discovery_widget_module.default_location_id: 1
-
     # User identifier
     ezsettings.default.user_content_type_identifier: ['user']
 

--- a/src/bundle/Resources/config/universal_discovery_widget.yaml
+++ b/src/bundle/Resources/config/universal_discovery_widget.yaml
@@ -1,7 +1,6 @@
 system:
     default:
         universal_discovery_widget_module:
-            default_location_id: 1
             configuration:
                 default:
                     multiple: true

--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -24,6 +24,7 @@ use EzSystems\EzPlatformAdminUi\Specification\Location\HasChildren;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUser;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUserGroup;
 use EzSystems\EzPlatformAdminUi\Specification\Location\IsRoot;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver;
 use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
 use EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UniversalDiscoveryExtension;
 use EzSystems\EzPlatformAdminUi\Specification\Location\IsWithinCopySubtreeLimit;
@@ -56,6 +57,9 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
+    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver */
+    private $udwConfigResolver;
+
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
@@ -84,6 +88,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
      * @param \EzSystems\EzPlatformAdminUi\Menu\MenuItemFactory $factory
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver $udwConfigResolver
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\API\Repository\SearchService $searchService
@@ -98,6 +103,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         MenuItemFactory $factory,
         EventDispatcherInterface $eventDispatcher,
         PermissionResolver $permissionResolver,
+        ConfigResolver $udwConfigResolver,
         ConfigResolverInterface $configResolver,
         ContentTypeService $contentTypeService,
         SearchService $searchService,
@@ -112,6 +118,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
 
         $this->permissionResolver = $permissionResolver;
         $this->configResolver = $configResolver;
+        $this->udwConfigResolver = $udwConfigResolver;
         $this->contentTypeService = $contentTypeService;
         $this->searchService = $searchService;
         $this->udwExtension = $udwExtension;
@@ -151,6 +158,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         $content = $options['content'];
         /** @var ItemInterface|ItemInterface[] $menu */
         $menu = $this->factory->createItem('root');
+        $startingLocationId = $this->udwConfigResolver->getConfig('default')['starting_location_id'];
 
         $lookupLimitationsResult = $this->permissionChecker->getContentCreateLimitations($location);
         $canCreate = $lookupLimitationsResult->hasAccess && $contentType->isContainer;
@@ -188,9 +196,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
         $copySubtreeAttributes = [
             'class' => 'ez-btn--udw-copy-subtree',
             'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
-            'data-root-location' => $this->configResolver->getParameter(
-                'universal_discovery_widget_module.default_location_id'
-            ),
+            'data-root-location' => $startingLocationId,
         ];
 
         $copyLimit = $this->configResolver->getParameter(
@@ -236,9 +242,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     'attributes' => [
                         'class' => 'btn--udw-move',
                         'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
-                        'data-root-location' => $this->configResolver->getParameter(
-                            'universal_discovery_widget_module.default_location_id'
-                        ),
+                        'data-root-location' => $startingLocationId,
                     ],
                 ]
             )
@@ -252,9 +256,7 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                         'attributes' => [
                             'class' => 'btn--udw-copy',
                             'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single_container'),
-                            'data-root-location' => $this->configResolver->getParameter(
-                                'universal_discovery_widget_module.default_location_id'
-                            ),
+                            'data-root-location' => $startingLocationId,
                         ],
                     ]
                 )

--- a/src/lib/Menu/LeftSidebarBuilder.php
+++ b/src/lib/Menu/LeftSidebarBuilder.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Menu;
 
 use eZ\Publish\API\Repository\PermissionResolver;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 use EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UniversalDiscoveryExtension;
 use JMS\TranslationBundle\Model\Message;
@@ -31,7 +31,7 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
     const ITEM__TRASH = 'sidebar_left__trash';
     const ITEM__TREE = 'sidebar_left__tree';
 
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver */
     private $configResolver;
 
     /** @var \EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UniversalDiscoveryExtension */
@@ -43,14 +43,14 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
     /**
      * @param \EzSystems\EzPlatformAdminUi\Menu\MenuItemFactory $factory
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver $configResolver
      * @param \EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UniversalDiscoveryExtension $udwExtension
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      */
     public function __construct(
         MenuItemFactory $factory,
         EventDispatcherInterface $eventDispatcher,
-        ConfigResolverInterface $configResolver,
+        ConfigResolver $configResolver,
         UniversalDiscoveryExtension $udwExtension,
         PermissionResolver $permissionResolver
     ) {
@@ -98,9 +98,7 @@ class LeftSidebarBuilder extends AbstractBuilder implements TranslationContainer
                         'data-udw-config' => $this->udwExtension->renderUniversalDiscoveryWidgetConfig('single', [
                             'type' => 'content_create',
                         ]),
-                        'data-starting-location-id' => $this->configResolver->getParameter(
-                            'universal_discovery_widget_module.default_location_id'
-                        ),
+                        'data-starting-location-id' => $this->configResolver->getConfig('default')['starting_location_id'],
                     ],
                 ]
             ),

--- a/src/lib/UI/Config/Provider/Module/UniversalDiscoveryWidget.php
+++ b/src/lib/UI/Config/Provider/Module/UniversalDiscoveryWidget.php
@@ -6,43 +6,26 @@
  */
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider\Module;
 
-use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\LanguageService;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver;
 
 /**
- * Provides information about current user with resolved profile picture.
+ * Provides information about the id of starting Location for the Universal Discovery Widget.
  */
 class UniversalDiscoveryWidget implements ProviderInterface
 {
-    /** @var ConfigResolverInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver */
     private $configResolver;
 
-    /** @var LanguageService */
-    private $languageService;
-
-    /** @var ContentTypeService */
-    private $contentTypeService;
-
     /**
-     * @param ConfigResolverInterface $configResolver
-     * @param LanguageService $languageService
-     * @param ContentTypeService $contentTypeService
+     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver $configResolver
      */
     public function __construct(
-        ConfigResolverInterface $configResolver,
-        LanguageService $languageService,
-        ContentTypeService $contentTypeService
+        ConfigResolver $configResolver
     ) {
         $this->configResolver = $configResolver;
-        $this->languageService = $languageService;
-        $this->contentTypeService = $contentTypeService;
     }
 
-    /**
-     * @return array
-     */
     public function getConfig(): array
     {
         /* config structure has to reflect UDW module's config structure */
@@ -51,13 +34,8 @@ class UniversalDiscoveryWidget implements ProviderInterface
         ];
     }
 
-    /**
-     * @return int|null
-     */
     protected function getStartingLocationId(): ?int
     {
-        return $this->configResolver->getParameter(
-            'universal_discovery_widget_module.default_location_id'
-        );
+        return $this->configResolver->getConfig('default')['starting_location_id'];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30701
| Bug fix?      |no
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Removed deprecated `universal_discovery_widget_module.default_location_id` setting in favor of `universal_discovery_widget_module.configuration.default.starting_location_id`


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
