### PR TITLE
EZP-30699: Made dynamic settings loaded too early to be lazy-loaded

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/TabPass.php
+++ b/src/bundle/DependencyInjection/Compiler/TabPass.php
@@ -42,7 +42,7 @@ class TabPass implements CompilerPassInterface
 
             foreach ($tags as $tag) {
                 if (!isset($tag['group'])) {
-                    throw new InvalidArgumentException($id, 'Tag ' . self::TAG_NAME . ' must contain "group" argument.');
+                    throw new InvalidArgumentException($id, 'Tag ' . self::TAG_TAB . ' must contain "group" argument.');
                 }
                 $tabRegistryDefinition->addMethodCall('addTab', [$serviceReference, $tag['group']]);
             }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -123,6 +123,7 @@ services:
         tags:
             - {name: kernel.event_subscriber, priority: -250}
 
-    EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UserPreferencesGlobalExtension: ~
+    EzSystems\EzPlatformAdminUiBundle\Templating\Twig\UserPreferencesGlobalExtension:
+        lazy: true
 
     EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver: ~

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -71,6 +71,7 @@ services:
             - {name: kernel.event_subscriber}
 
     EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory:
+        lazy: true
         arguments:
             $userContentTypeIdentifier: '$user_content_type_identifier$'
             $userGroupContentTypeIdentifier: '$user_group_content_type_identifier$'

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -42,6 +42,7 @@ services:
 
     EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
+        lazy: true
         arguments:
             $defaultPaginationLimit: '$pagination.search_limit$'
             $userContentTypeIdentifier: '$user_content_type_identifier$'

--- a/src/bundle/Resources/config/services/menu.yml
+++ b/src/bundle/Resources/config/services/menu.yml
@@ -31,6 +31,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\Menu\ContentRightSidebarBuilder:
         public: true
+        lazy: true
         arguments:
             $userContentTypeIdentifier: '$user_content_type_identifier$'
             $userGroupContentTypeIdentifier: '$user_group_content_type_identifier$'

--- a/src/bundle/Resources/config/services/tabs.yml
+++ b/src/bundle/Resources/config/services/tabs.yml
@@ -14,7 +14,9 @@ services:
 
     EzSystems\EzPlatformAdminUiBundle\Templating\Twig\ClassTwigExtension: ~
 
-    EzSystems\EzPlatformAdminUi\Tab\TabRegistry: ~
+    EzSystems\EzPlatformAdminUi\Tab\TabRegistry:
+        lazy: true
+
     EzSystems\EzPlatformAdminUi\Tab\SystemInfo\TabFactory: ~
 
     EzSystems\EzPlatformAdminUi\Tab\Event\Subscriber\:

--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -8,6 +8,7 @@ services:
         public: true
 
     EzSystems\EzPlatformAdminUi\UI\Config\Aggregator:
+        lazy: true
         public: true
 
     EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypeMappings:

--- a/src/bundle/Resources/config/services/universal_discovery_widget.yml
+++ b/src/bundle/Resources/config/services/universal_discovery_widget.yml
@@ -13,10 +13,7 @@ services:
         public: true
         tags: ['kernel.event_subscriber']
 
-    EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver:
-        lazy: true
-        arguments:
-            $udwConfiguration: '$universal_discovery_widget_module.configuration$'
+    EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver: ~
 
     EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\UserSelectionAllowedContentTypes:
         arguments:

--- a/src/bundle/Resources/config/services/universal_discovery_widget.yml
+++ b/src/bundle/Resources/config/services/universal_discovery_widget.yml
@@ -14,6 +14,7 @@ services:
         tags: ['kernel.event_subscriber']
 
     EzSystems\EzPlatformAdminUi\UniversalDiscovery\ConfigResolver:
+        lazy: true
         arguments:
             $udwConfiguration: '$universal_discovery_widget_module.configuration$'
 

--- a/src/lib/UniversalDiscovery/ConfigResolver.php
+++ b/src/lib/UniversalDiscovery/ConfigResolver.php
@@ -14,28 +14,24 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ConfigResolver
 {
+    private const UDW_CONFIG_PARAM_NAME = 'universal_discovery_widget_module.configuration';
+
     /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
     protected $eventDispatcher;
 
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     protected $configResolver;
 
-    /** @var array */
-    protected $udwConfiguration;
-
     /**
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-     * @param array $udwConfiguration
      */
     public function __construct(
         ConfigResolverInterface $configResolver,
-        EventDispatcherInterface $eventDispatcher,
-        array $udwConfiguration
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->configResolver = $configResolver;
         $this->eventDispatcher = $eventDispatcher;
-        $this->udwConfiguration = $udwConfiguration;
     }
 
     /**
@@ -46,8 +42,8 @@ class ConfigResolver
      */
     public function getConfig(string $configName, array $context = []): array
     {
-        $config = $this->udwConfiguration[$configName] ?? [];
-        $defaults = $this->udwConfiguration['default'] ?? [];
+        $config = $this->getUDWConfiguration($configName);
+        $defaults = $this->getUDWConfiguration('default');
 
         $config = $this->mergeConfiguration($defaults, $config);
 
@@ -103,5 +99,23 @@ class ConfigResolver
 
         // Check if keys are equal to sequence of 0 .. n-1
         return array_keys($item) !== range(0, count($item) - 1);
+    }
+
+    /**
+     * Get UDW configuration from ConfigResolver.
+     *
+     * It's intentionally not cached as a scope changes dynamically.
+     *
+     * @param string $configName
+     *
+     * @return array
+     */
+    private function getUDWConfiguration(string $configName): array
+    {
+        $udwConfiguration = $this->configResolver->hasParameter(self::UDW_CONFIG_PARAM_NAME)
+            ? $this->configResolver->getParameter(self::UDW_CONFIG_PARAM_NAME)
+            : [];
+
+        return $udwConfiguration[$configName] ?? [];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30699](https://jira.ez.no/browse/EZP-30699)
| Requires | <ul><li>ezsystems/ezpublish-kernel#2676</li><li>https://github.com/ezsystems/ezpublish-kernel/pull/2662</li><ul>
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes, behat TBD
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR resolves issues that cause warnings described in the ticket and in ezsystems/ezpublish-kernel#2676.

Ideally it should be debugged further and all services that rely on dynamic settings should be refactored to use Config resolver, however due to time constraints right now most of the changes is about making related services lazy.

Changes:
- [x] Made Tab and Config registry and aggregate services lazy.
- [x] Replaced UDW dynamic settings injection with ConfigResolver calls.
- [x] Fixed incorrect constant name used by TabPass to report an error (little bit out of scope, but very small and found by accident while debugging).
- [x] Made services relying on dynamic settings lazy.
- [x] Made some Twig Extensions lazy (tried to avoid it, but making extensions dependencies lazy didn't work).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
- [x] CI passes
