### PR TITLE
EZEE-2793: Lazy-loaded PermissionResolver for auto-wiring

### DIFF
--- a/src/bundle/Resources/config/services/service_aliases.yml
+++ b/src/bundle/Resources/config/services/service_aliases.yml
@@ -21,6 +21,10 @@ services:
     eZ\Publish\API\Repository\BookmarkService: '@ezpublish.api.service.bookmark'
 
     eZ\Publish\API\Repository\PermissionResolver:
+        # passing class as workaround for missing sudo on the interface
+        class: eZ\Publish\Core\Repository\Permission\PermissionResolver
+        # making it lazy to avoid resolving dynamic (SiteAccess) settings too early
+        lazy: true
         factory: 'eZ\Publish\API\Repository\Repository:getPermissionResolver'
 
     eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-2793](https://jira.ez.no/browse/EZEE-2793)
| Required by | ezsystems/date-based-publisher#115
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

PermissionResolver is currently build by a chain of factories (`Repository::getPermissionResolver` -> `RepositoryFactory::buildRepository`) which fetch SiteAccessAware (dynamic) settings and thus trigger too early resolving of them.

Right now the bug manifests itself only when injecting PermissionResolver into commands, which occurs for some EE packages.

The better fix would be to de-couple PermissionResolver to avoid building it via a factory from the Repository, but this is quite complicated and requires BC breaks.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
