### PR TITLE
EZP-30659: Cannot select image from repository in ImageAsset field

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -169,7 +169,7 @@
                     canSelectContent,
                     title,
                     restInfo: { token, siteaccess },
-                    config,
+                    ...config,
                 }),
                 udwContainer
             );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30659
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->
