### PR TITLE
EZP-30728: flattenArrayOfLimitationsForCurrentUser works incorect

### DIFF
--- a/src/lib/Permission/PermissionChecker.php
+++ b/src/lib/Permission/PermissionChecker.php
@@ -229,15 +229,15 @@ class PermissionChecker implements PermissionCheckerInterface
 
         $limitations = [];
         foreach ($hasAccess as $permissionSet) {
-            if ($permissionSet['limitation'] !== null) {
-                $limitations[] = $permissionSet['limitation'];
-            }
             /** @var \eZ\Publish\API\Repository\Values\User\Policy $policy */
             foreach ($permissionSet['policies'] as $policy) {
                 $policyLimitations = $policy->getLimitations();
                 if (!empty($policyLimitations)) {
                     foreach ($policyLimitations as $policyLimitation) {
                         $limitations[$policy->id][] = $policyLimitation;
+                        if ($permissionSet['limitation'] !== null) {
+                            $limitations[$policy->id][] = $permissionSet['limitation'];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30728
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
