### PR TITLE
EZP-30766: CSS files not loaded in case of error in search results tempate

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -23,6 +23,7 @@ use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
 
 class SearchController extends Controller
 {
@@ -47,6 +48,9 @@ class SearchController extends Controller
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
+    /** @var \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface */
+    private $entrypointLookupCollection;
+
     /** @var int */
     private $defaultPaginationLimit;
 
@@ -61,6 +65,7 @@ class SearchController extends Controller
      * @param \EzSystems\EzPlatformAdminUi\Form\SubmitHandler $submitHandler
      * @param \eZ\Publish\API\Repository\SectionService $sectionService
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface $entrypointLookupCollection
      * @param int $defaultPaginationLimit
      * @param array $userContentTypeIdentifier
      */
@@ -72,6 +77,7 @@ class SearchController extends Controller
         SubmitHandler $submitHandler,
         SectionService $sectionService,
         ContentTypeService $contentTypeService,
+        EntrypointLookupCollectionInterface $entrypointLookupCollection,
         int $defaultPaginationLimit,
         array $userContentTypeIdentifier
     ) {
@@ -84,6 +90,7 @@ class SearchController extends Controller
         $this->contentTypeService = $contentTypeService;
         $this->defaultPaginationLimit = $defaultPaginationLimit;
         $this->userContentTypeIdentifier = $userContentTypeIdentifier;
+        $this->entrypointLookupCollection = $entrypointLookupCollection;
     }
 
     /**
@@ -209,6 +216,7 @@ class SearchController extends Controller
             if ($result instanceof Response) {
                 return $result;
             }
+            $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
         }
 
         return $this->render('@ezdesign/admin/search/search.html.twig', [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30766
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


In case of error appearing after the "encore_entry_link_tags" call (in form handling function) - UI is loading without CSS (as encore think it's already rendered to the page).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
