### PR TITLE
EZP-30128: Expose user content types in adminUiConfig

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/common.yml
+++ b/src/bundle/Resources/config/services/ui_config/common.yml
@@ -110,3 +110,7 @@ services:
     EzSystems\EzPlatformAdminUiBundle\Templating\Twig\PathStringExtension: ~
 
     EzSystems\EzPlatformAdminUiBundle\Templating\Twig\ContentTypeIconExtension: ~
+
+    EzSystems\EzPlatformAdminUi\UI\Config\Provider\UserContentTypes:
+        tags:
+            - { name: ezplatform.admin_ui.config_provider, key: 'userContentTypes' }

--- a/src/lib/UI/Config/Provider/UserContentTypes.php
+++ b/src/lib/UI/Config/Provider/UserContentTypes.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
+
+class UserContentTypes implements ProviderInterface
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver */
+    private $configResolver;
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver $configResolver
+     */
+    public function __construct(ConfigResolver $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @return mixed Anything that is serializable via json_encode()
+     */
+    public function getConfig()
+    {
+        return $this->configResolver->getParameter('user_content_type_identifier');
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30128
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Expose array of content type identifiers under `userContentTypes` key.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
