### PR TITLE
EZP-30697: Fixed adding RoleLimitation when policy has no limitation itself

### DIFF
--- a/src/lib/Permission/PermissionChecker.php
+++ b/src/lib/Permission/PermissionChecker.php
@@ -119,7 +119,7 @@ class PermissionChecker implements PermissionCheckerInterface
      */
     public function canCreateInLocation(Location $location, $hasAccess): bool
     {
-        if (is_bool($hasAccess)) {
+        if (\is_bool($hasAccess)) {
             return $hasAccess;
         }
         $restrictedLocations = $this->getRestrictions($hasAccess, LocationLimitation::class);
@@ -235,10 +235,10 @@ class PermissionChecker implements PermissionCheckerInterface
                 if (!empty($policyLimitations)) {
                     foreach ($policyLimitations as $policyLimitation) {
                         $limitations[$policy->id][] = $policyLimitation;
-                        if ($permissionSet['limitation'] !== null) {
-                            $limitations[$policy->id][] = $permissionSet['limitation'];
-                        }
                     }
+                }
+                if ($permissionSet['limitation'] !== null) {
+                    $limitations[$policy->id][] = $permissionSet['limitation'];
                 }
             }
         }

--- a/src/lib/Tests/Permission/PermissionCheckerTest.php
+++ b/src/lib/Tests/Permission/PermissionCheckerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Permission;
+
+use EzSystems\EzPlatformAdminUi\Permission\PermissionChecker;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\Content;
+use eZ\Publish\Core\Repository\Values\Content as CoreContent;
+use eZ\Publish\Core\Repository\Values\User\User as CoreUser;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Repository\Values\User\Policy;
+
+class PermissionCheckerTest extends TestCase
+{
+    private const USER_ID = 14;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \eZ\Publish\API\Repository\LanguageService */
+    private $languageService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Permission\PermissionChecker */
+    private $permissionChecker;
+
+    public function setUp()
+    {
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->permissionResolver
+            ->method('getCurrentUserReference')
+            ->willReturn($this->generateUser(self::USER_ID));
+
+        $this->userService = $this->createMock(UserService::class);
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+        $this->languageService = $this->createMock(LanguageService::class);
+
+        $this->permissionChecker = new PermissionChecker(
+            $this->permissionResolver,
+            $this->userService,
+            $this->locationService,
+            $this->contentService,
+            $this->contentTypeService,
+            $this->languageService
+        );
+    }
+
+    /**
+     * @dataProvider restrictionsProvider
+     */
+    public function testGetRestrictions(array $hasAccess, string $class, array $expectedRestrictions): void
+    {
+        $actual = $this->permissionChecker->getRestrictions($hasAccess, $class);
+
+        $this->assertEquals($expectedRestrictions, $actual);
+    }
+
+    public function restrictionsProvider(): array
+    {
+        return [
+            'noPoliciesAndNoRoleLimitation' => [
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [],
+                    ],
+                ],
+                'anyClassName',
+                [],
+            ],
+            'twoPoliciesWihOneLimitationAndRoleLimitationWithoutClassName' => [
+                [
+                    [
+                        'limitation' => new Limitation\SectionLimitation(['limitationValues' => [44]]),
+                        'policies' => [
+                            new Policy(['limitations' => [new Limitation\ContentTypeLimitation(['limitationValues' => [2, 3]])]]),
+                            new Policy(['limitations' => [new Limitation\LanguageLimitation(['limitationValues' => [2, 3]])]]),
+                        ],
+                    ],
+                ],
+                'anyClassName',
+                [],
+            ],
+            'onePolicyOneLimitation' => [
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [
+                            new Policy(['limitations' => [new Limitation\ContentTypeLimitation(['limitationValues' => [2, 3]])]]),
+                        ],
+                    ],
+                ],
+                Limitation\ContentTypeLimitation::class,
+                [2, 3],
+            ],
+            'twoPoliciesWihOneLimitation' => [
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [
+                            new Policy(['limitations' => [new Limitation\ContentTypeLimitation(['limitationValues' => [2, 3]])]]),
+                            new Policy(['limitations' => [new Limitation\LanguageLimitation(['limitationValues' => [2, 3]])]]),
+                        ],
+                    ],
+                ],
+                Limitation\ContentTypeLimitation::class,
+                [2, 3],
+            ],
+            'twoPoliciesWihOneLimitationAndRoleLimitation' => [
+                [
+                    [
+                        'limitation' => new Limitation\SectionLimitation(['limitationValues' => [44]]),
+                        'policies' => [
+                            new Policy(['limitations' => [new Limitation\ContentTypeLimitation(['limitationValues' => [2, 3]])]]),
+                            new Policy(['limitations' => [new Limitation\LanguageLimitation(['limitationValues' => [2, 3]])]]),
+                        ],
+                    ],
+                ],
+                Limitation\SectionLimitation::class,
+                [44],
+            ],
+            'noPoliciesAndRoleLimitation' => [
+                [
+                    [
+                        'limitation' => new Limitation\SectionLimitation(['limitationValues' => [44]]),
+                        'policies' => [],
+                    ],
+                ],
+                Limitation\SectionLimitation::class,
+                [],
+            ],
+            'policyWithoutLimitationAndWithRoleLimitation' => [
+                [
+                    [
+                        'limitation' => new Limitation\SectionLimitation(['limitationValues' => [44]]),
+                        'policies' => [new Policy()],
+                    ],
+                ],
+                Limitation\SectionLimitation::class,
+                [44],
+            ],
+        ];
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    private function generateUser(int $id): User
+    {
+        $contentInfo = new Content\ContentInfo(['id' => $id]);
+        $versionInfo = new CoreContent\VersionInfo(['contentInfo' => $contentInfo]);
+        $content = new CoreContent\Content(['versionInfo' => $versionInfo]);
+
+        return new CoreUser(['content' => $content]);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30697
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This issue was discovered during work on content/create permission. Limitation from Role assigning should be also taken into account when the policy has no her own limitations. Also, tests are added.

Related PR:
- https://github.com/ezsystems/ezpublish-kernel/pull/2701

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
