### PR TITLE
EZEE-2819: Changed permission subscriber to be run when create tab is present in UDW

### DIFF
--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\UniversalDiscovery\Event\Subscriber;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
+use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\ContentCreate;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+
+class ContentCreateTest extends TestCase
+{
+    public const ALLOWED_CONTENT_TYPE_IDENTIFIER = 'lorem';
+    private const ALLOWED_LANGUAGE_CODE = 'eng-GB';
+    private const ALLOWED_CONTENT_TYPE_ID = 1;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface|PHPUnit\Framework\MockObject\MockObject */
+    private $permissionChecker;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|PHPUnit\Framework\MockObject\MockObject */
+    private $contentTypeService;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver|PHPUnit\Framework\MockObject\MockObject */
+    private $permissionResolver;
+
+    public function setUp(): void
+    {
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->permissionChecker = $this->createMock(PermissionCheckerInterface::class);
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+    }
+
+    /**
+     * @dataProvider createTab
+     */
+    public function testUdwConfigResolveWithCreateTab(array $config): void
+    {
+        $event = new ConfigResolveEvent();
+        $event->setConfig($config);
+
+        $subscriber = $this->getSubscriberWithRestrictions();
+        $subscriber->onUdwConfigResolve($event);
+
+        $addedConfig = [
+            'content_on_the_fly' => [
+                'allowed_content_types' => [self::ALLOWED_CONTENT_TYPE_IDENTIFIER],
+                'allowed_languages' => [self::ALLOWED_LANGUAGE_CODE],
+            ],
+        ];
+
+        $expectedConfig = $config + $addedConfig;
+
+        $this->assertEquals($expectedConfig, $event->getConfig());
+    }
+
+    /**
+     * @dataProvider withoutCreateTab
+     */
+    public function testUdwConfigResolveWithoutCreateTab($config): void
+    {
+        $event = new ConfigResolveEvent();
+        $event->setConfig($config);
+
+        $subscriber = $this->getSubscriberWithRestrictions();
+        $subscriber->onUdwConfigResolve($event);
+
+        $this->assertEquals($config, $event->getConfig());
+    }
+
+    public function createTab(): array
+    {
+        return [
+            'all_tabs' => [
+                [
+                    'visible_tabs' => [],
+                ],
+            ],
+            'explicit_create_tab' => [
+                [
+                    'visible_tabs' => ['tab', 'create'],
+                ],
+            ],
+        ];
+    }
+
+    public function withoutCreateTab(): array
+    {
+        return [
+            'one_tab' => [
+                [
+                    'visible_tabs' => ['tab'],
+                ],
+            ],
+            'many_tabs' => [
+                [
+                    'visible_tabs' => ['tab', 'other_tab'],
+                ],
+            ],
+        ];
+    }
+
+    private function getSubscriberWithRestrictions(): ContentCreate
+    {
+        $this->permissionResolver
+            ->method('hasAccess')
+            ->with('content', 'create')
+            ->willReturn([]);
+
+        $this->permissionChecker
+            ->method('getRestrictions')
+            ->willReturnMap([
+                [[], ContentTypeLimitation::class, [self::ALLOWED_CONTENT_TYPE_ID]],
+                [[], LanguageLimitation::class, [self::ALLOWED_LANGUAGE_CODE]],
+            ]);
+
+        $this->contentTypeService
+            ->method('loadContentType')
+            ->with(self::ALLOWED_CONTENT_TYPE_ID)
+            ->willReturn(new ContentType(['identifier' => self::ALLOWED_CONTENT_TYPE_IDENTIFIER]));
+
+        return new ContentCreate(
+            $this->permissionResolver,
+            $this->permissionChecker,
+            $this->contentTypeService
+        );
+    }
+}

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
@@ -66,30 +66,31 @@ class ContentCreate implements EventSubscriberInterface
      */
     public function onUdwConfigResolve(ConfigResolveEvent $event): void
     {
-        $configName = $event->getConfigName();
-        if ('create' !== $configName && 'single' !== $configName) {
-            return;
-        }
+        $config = $event->getConfig();
 
-        $context = $event->getContext();
-        if (
-            !isset($context['type'])
-            || 'content_create' !== $context['type']
-        ) {
+        if (!$this->hasCreateTab($config)) {
             return;
         }
 
         if ($this->hasContentTypeRestrictions()) {
-            $config = $event->getConfig();
             $config['content_on_the_fly']['allowed_content_types'] = $this->restrictedContentTypesIdentifiers;
             $event->setConfig($config);
         }
 
         if ($this->hasLanguagesRestrictions()) {
-            $config = $event->getConfig();
             $config['content_on_the_fly']['allowed_languages'] = $this->restrictedLanguagesCodes;
             $event->setConfig($config);
         }
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return bool
+     */
+    private function hasCreateTab(array $config): bool
+    {
+        return empty($config['visible_tabs']) || \in_array('create', $config['visible_tabs'], true);
     }
 
     /**
@@ -99,7 +100,7 @@ class ContentCreate implements EventSubscriberInterface
      */
     private function getRestrictedContentTypesIdentifiers($hasAccess): array
     {
-        if (!is_array($hasAccess)) {
+        if (!\is_array($hasAccess)) {
             return [];
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2819
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


ContentCreate subscriber should check restrictions when COTF is present in UDW. Also, for types other `content_create` or other configurations than `create` or `single`. The problem occurs in many places, e.g. in other PB blocks where user can select (or create it in COTF) content or when user want to move content within the sub-items list.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
