### PR TITLE
EZP-30802: Fixed OE JS error in case of missing element path

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
@@ -8,9 +8,8 @@ export default class EzTableCellConfig extends EzConfigTableBase {
     test(payload) {
         const nativeEditor = payload.editor.get('nativeEditor');
         const path = nativeEditor.elementPath();
-        const lastElement = path.lastElement;
 
-        return lastElement.is('td');
+        return path && path.lastElement.is('td');
     }
 }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-row.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-row.js
@@ -8,9 +8,8 @@ export default class EzTableRowConfig extends EzConfigTableBase {
     test(payload) {
         const nativeEditor = payload.editor.get('nativeEditor');
         const path = nativeEditor.elementPath();
-        const lastElement = path.lastElement;
 
-        return lastElement.is('tr');
+        return path && path.lastElement.is('tr');
     }
 }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table.js
@@ -8,9 +8,8 @@ export default class EzTableConfig extends EzConfigTableBase {
     test(payload) {
         const nativeEditor = payload.editor.get('nativeEditor');
         const path = nativeEditor.elementPath();
-        const lastElement = path.lastElement;
 
-        return lastElement.is('table');
+        return path && path.lastElement.is('table');
     }
 }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
@@ -45,7 +45,6 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
         const path = nativeEditor.elementPath();
         const table = path && path.elements.find((element) => element.is('table'));
         const element = table || nativeEditor.element;
-
         const rect = element.$.getBoundingClientRect();
 
         new CKEDITOR.dom.element(domNode).setStyles({ top: `${rect.top}px` });

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
@@ -42,8 +42,11 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
         const { editor } = this.props;
         const domNode = ReactDOM.findDOMNode(this);
         const path = editor.get('nativeEditor').elementPath();
-        const table = path.elements.find((element) => element.is('table'));
+        if (!path) {
+            return;
+        }
 
+        const table = path.elements.find((element) => element.is('table'));
         if (!table) {
             return;
         }

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
@@ -11,6 +11,7 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
         super(props);
 
         this.setPosition = this.setPosition.bind(this);
+        this.setTopPosition = this.setTopPosition.bind(this);
     }
 
     setPosition() {
@@ -21,18 +22,22 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        const { selectionData } = this.props;
+        const { selectionData, renderExclusive } = this.props;
 
         this._updatePosition();
 
-        if (selectionData && !selectionData.region.top) {
+        if (!renderExclusive && selectionData && !selectionData.region.top) {
             this.setTopPosition();
         }
 
         // In case of exclusive rendering, focus the first descendant (button)
         // so the user will be able to start interacting with the buttons immediately.
-        if (this.props.renderExclusive) {
+        if (renderExclusive) {
             this.focus();
+
+            if (selectionData && !selectionData.region.top) {
+                this._animate(this.setTopPosition);
+            }
 
             this._animate(this.setPosition);
         }

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
@@ -51,8 +51,13 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
         const table = path && path.elements.find((element) => element.is('table'));
         const element = table || nativeEditor.element;
         const rect = element.$.getBoundingClientRect();
+        let topPosition = rect.top;
 
-        new CKEDITOR.dom.element(domNode).setStyles({ top: `${rect.top}px` });
+        if (!table) {
+            topPosition += window.pageYOffset;
+        }
+
+        new CKEDITOR.dom.element(domNode).setStyles({ top: `${topPosition}px` });
     }
 
     /**

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/ez-add.js
@@ -41,17 +41,12 @@ export default class EzToolbarAdd extends AlloyEditor.Toolbars.add {
     setTopPosition() {
         const { editor } = this.props;
         const domNode = ReactDOM.findDOMNode(this);
-        const path = editor.get('nativeEditor').elementPath();
-        if (!path) {
-            return;
-        }
+        const nativeEditor = editor.get('nativeEditor');
+        const path = nativeEditor.elementPath();
+        const table = path && path.elements.find((element) => element.is('table'));
+        const element = table || nativeEditor.element;
 
-        const table = path.elements.find((element) => element.is('table'));
-        if (!table) {
-            return;
-        }
-
-        const rect = table.$.getBoundingClientRect();
+        const rect = element.$.getBoundingClientRect();
 
         new CKEDITOR.dom.element(domNode).setStyles({ top: `${rect.top}px` });
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30802](https://jira.ez.no/browse/EZP-30802)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Steps to reproduce:

1. Start to create any content with Richt Text field.
2. In Online Editor add any custom tag
3. Set "Right" align for added custom tag
4. Remove an empty paragraph above the custom tag (using trash icon)
5. Click on the area in Online Editor left to the custom tag

You will get following JavaScript error in the console:
```
TypeError: Cannot read property 'lastElement' of null
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
