### PR TITLE
EZP-30766: CSS might be not loaded when exception occurs in Twig

### DIFF
--- a/src/bundle/Resources/views/admin/search/search_form.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_form.html.twig
@@ -75,10 +75,12 @@
         <div class="ez-filters__item ez-filters__item--modified">
             <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
             {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-modified-range'}}) }}
+            {{ form_errors(form.last_modified_select) }}
         </div>
         <div class="ez-filters__item ez-filters__item--created">
             <label class="ez-filters__item-label">{{ 'search.created'|trans|desc('Created:') }}</label>
             {{ form_widget(form.created_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-modal--select-created-range'}}) }}
+            {{ form_errors(form.created_select) }}
         </div>
         <div class="ez-filters__item ez-filters__item--creator">
             <label class="ez-filters__item-label">{{ 'search.creator'|trans|desc('Creator:') }}</label>

--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -16,19 +16,28 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Twig\Environment;
 use Throwable;
+use Twig\Error\RuntimeError;
 
 class AdminExceptionListener
 {
     /** @var NotificationHandlerInterface */
     protected $notificationHandler;
 
-    /** @var array */
-    protected $siteAccessGroups;
-
     /** @var Environment */
     protected $twig;
+
+    /** @var \Symfony\WebpackEncoreBundle\Asset\TagRenderer */
+    protected $encoreTagRenderer;
+
+    /** @var \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface */
+    private $entrypointLookupCollection;
+
+    /** @var array */
+    protected $siteAccessGroups;
 
     /** @var string */
     protected $rootDir;
@@ -46,15 +55,19 @@ class AdminExceptionListener
     public function __construct(
         Environment $twig,
         NotificationHandlerInterface $notificationHandler,
+        TagRenderer $encoreTagRenderer,
+        EntrypointLookupCollectionInterface $entrypointLookupCollection,
         array $siteAccessGroups,
         string $kernelRootDir,
         string $kernelEnvironment
     ) {
         $this->twig = $twig;
         $this->notificationHandler = $notificationHandler;
+        $this->encoreTagRenderer = $encoreTagRenderer;
+        $this->entrypointLookupCollection = $entrypointLookupCollection;
         $this->siteAccessGroups = $siteAccessGroups;
-        $this->kernelEnvironment = $kernelEnvironment;
         $this->rootDir = $kernelRootDir . '/..';
+        $this->kernelEnvironment = $kernelEnvironment;
     }
 
     /**
@@ -82,7 +95,16 @@ class AdminExceptionListener
 
         $code = $response->getStatusCode();
 
+        // map exception to UI notification
         $this->notificationHandler->error($this->getNotificationMessage($exception));
+
+        if ($exception instanceof RuntimeError) {
+            // If exception is coming from the template where encore already
+            // rendered resources it would result in no CSS/JS on error page.
+            // Thus we reset TagRenderer to prevent it from breaking error page.
+            $this->encoreTagRenderer->reset();
+            $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
+        }
 
         switch ($code) {
             case 404:
@@ -112,7 +134,7 @@ class AdminExceptionListener
         /** @var SiteAccess $siteAccess */
         $siteAccess = $request->get('siteaccess', new SiteAccess());
 
-        return in_array($siteAccess->name, $this->siteAccessGroups[EzPlatformAdminUiBundle::ADMIN_GROUP_NAME]);
+        return \in_array($siteAccess->name, $this->siteAccessGroups[EzPlatformAdminUiBundle::ADMIN_GROUP_NAME]);
     }
 
     /**

--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -87,6 +87,10 @@ class SearchType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => SearchData::class,
+            'error_mapping' => [
+                'created' => 'created_select',
+                'last_modified' => 'last_modified_select',
+            ],
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30766
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

# Description
### SubmitHandler misuse in SearchController causing whole layout to load twice
`SubmitHandler` was misused in `SearchController::searchAction` as it's not designed to be used with responses rendering twig templates - it should only return `RedirectResponse` objects. 
This affected how page was rendered - when exception occurred in the template rendered inside callable it would make `SubmitHandler` return `null` which in case of `SearchController::searchAction` was rendering "default" template (page no results). The issue mentioned in the ticket (no CSS) was happening because of the Encore - it was omitting already embedded scripts and stylesheets which happened inside mentioned callable.

### Error page is loaded without CSS when exception has happened in Twig
Another commit is fixing related issue - on `prod` environment, Encore has already stored information about rendered CSS so Error page was loading without stylesheets. This was fixed by resetting it's entrypoint lookup table.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
