### PR TITLE
EZP-30717: Removed misleading and redundant configuration of pagination limit

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -88,7 +88,6 @@ class Pagination extends AbstractParser
             'content_role_limit',
             'content_policy_limit',
             'notification_limit',
-            'user_settings_limit',
             'content_draft_limit',
         ];
 

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -21,7 +21,6 @@ parameters:
     ezsettings.default.pagination.content_policy_limit: 5
     ezsettings.default.pagination.bookmark_limit: 10
     ezsettings.default.pagination.notification_limit: 5
-    ezsettings.admin_group.pagination.user_settings_limit: 10
     ezsettings.default.pagination.content_draft_limit: 10
 
     # Security


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | (https://jira.ez.no/browse/EZP-30717)[EZP-30717]
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This is one of 2 PR's that moves the default value of `pagination.user_setting_limit` for `admin_group` from bundle defaults to meta repos. This is done to improve developers experience and avoid misunderstandings described here :  https://jira.ez.no/browse/EZP-30717 .

orginal ticket : https://jira.ez.no/browse/EZP-30553

related PR:
https://github.com/ezsystems/ezplatform/pull/439

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
