### PR TITLE
Added Behat debug info

### DIFF
--- a/src/lib/Behat/Helper/LogFileReader.php
+++ b/src/lib/Behat/Helper/LogFileReader.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\Helper;
+
+class LogFileReader
+{
+    public function getLastLines($filePath, $numberOfLines): array
+    {
+        $logEntries = [];
+        $counter = 0;
+
+        $file = @fopen($filePath, 'r');
+
+        if ($file === false) {
+            return [];
+        }
+
+        while (!feof($file)) {
+            if ($counter >= $numberOfLines) {
+                array_shift($logEntries);
+            }
+
+            $line = fgets($file);
+            $logEntries[] = str_replace(PHP_EOL, '', $line);
+            ++$counter;
+        }
+
+        fclose($file);
+
+        return $logEntries;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | yes, but JIRA is dead 😛 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Recently we've had issues with Content Types and Subitems list not loading on Travis. I'm 90% sure that this is caused by concurrency issues, which right now are almost impossible to debug, because we don't know which scenarios are running in the same time. This PR adds log entries when scenarios/steps stop and end, example log:
```
        │  [2019-08-05 08:56:10] app.ERROR: Starting scenario | SingleLine Form   | Single line input  
        │  [2019-08-05 08:56:10] app.ERROR: Starting step I am logged as "admin"
        │  [2019-08-05 08:56:13] app.ERROR: Ending step I click on the edit action bar button "Publish" 
        │  [2019-08-05 08:56:13] app.ERROR: Starting step success notification that "Content published." appears
        │  [2019-08-05 08:56:14] app.ERROR: Ending step I am logged as "admin"
        │  [2019-08-05 08:56:14] app.ERROR: Starting step I go to "Forms" tab
        │  [2019-08-05 08:56:15] app.ERROR: Ending step success notification that "Content published." appears 
        │  [2019-08-05 08:56:15] app.ERROR: Starting step I should be on content item page "Test-value" of type "Selection CT" in root path
        │  [2019-08-05 08:56:15] app.ERROR: Ending step I should be on content item page "Test-value" of type "Selection CT" in root path
        │  [2019-08-05 08:56:15] app.ERROR: Starting step content attributes equal
        │  [2019-08-05 08:56:16] app.ERROR: Ending step content attributes equal
        │  [2019-08-05 08:56:16] app.ERROR: Ending scenario | ezselection          | Selection                    | value     | Test-value            |            |                       |         |          | Test-value                | 
        │  [2019-08-05 08:56:16] app.ERROR: Starting scenario | ezgmaplocation       | Map location                 | latitude  | 32                    | longitude  | 132                   | address | Acapulco | Acapulco                  | 25
```

This allows us to find out that `SingleLine Form` has been running together with `ezselection` and  `ezgmaplocation` Scenarios, which would allow us to pinpoint the issue if it occured (hopefully).

Other changes:
- I've increased the log count from 10 to 25, this should be still readable but provide more info
- with this change there will be a log of logs, so I've switched to displaying LAST log entries (instead of first ones).

This files have beed moved from AdminUI to BehatBundle in master, so another PR is needed: https://github.com/ezsystems/BehatBundle/pull/90

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
