### PR TITLE
EZP-30812: Fixed deprecated use of Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch method

### DIFF
--- a/src/bundle/Templating/Twig/TabExtension.php
+++ b/src/bundle/Templating/Twig/TabExtension.php
@@ -79,9 +79,9 @@ class TabExtension extends AbstractExtension
         $tabGroupEvent->setData($tabGroup);
         $tabGroupEvent->setParameters($parameters);
 
-        $this->eventDispatcher->dispatch(TabEvents::TAB_GROUP_INITIALIZE, $tabGroupEvent);
+        $this->eventDispatcher->dispatch($tabGroupEvent, TabEvents::TAB_GROUP_INITIALIZE);
 
-        $this->eventDispatcher->dispatch(TabEvents::TAB_GROUP_PRE_RENDER, $tabGroupEvent);
+        $this->eventDispatcher->dispatch($tabGroupEvent, TabEvents::TAB_GROUP_PRE_RENDER);
 
         $tabs = [];
         foreach ($tabGroupEvent->getData()->getTabs() as $tab) {
@@ -108,7 +108,7 @@ class TabExtension extends AbstractExtension
         $tabEvent->setData($tab);
         $tabEvent->setParameters($parameters);
 
-        $this->eventDispatcher->dispatch(TabEvents::TAB_PRE_RENDER, $tabEvent);
+        $this->eventDispatcher->dispatch($tabEvent, TabEvents::TAB_PRE_RENDER);
 
         return $tabEvent;
     }

--- a/src/lib/Component/Renderer/DefaultRenderer.php
+++ b/src/lib/Component/Renderer/DefaultRenderer.php
@@ -28,11 +28,11 @@ class DefaultRenderer implements RendererInterface
 
     public function renderGroup(string $groupName, array $parameters = []): array
     {
-        $this->eventDispatcher->dispatch(RenderGroupEvent::NAME, new RenderGroupEvent(
+        $this->eventDispatcher->dispatch(new RenderGroupEvent(
             $this->registry,
             $groupName,
             $parameters
-        ));
+        ), RenderGroupEvent::NAME);
 
         $components = $this->registry->getComponents($groupName);
 
@@ -46,12 +46,12 @@ class DefaultRenderer implements RendererInterface
 
     public function renderSingle(string $name, $groupName, array $parameters = []): string
     {
-        $this->eventDispatcher->dispatch(RenderSingleEvent::NAME, new RenderSingleEvent(
+        $this->eventDispatcher->dispatch(new RenderSingleEvent(
             $this->registry,
             $groupName,
             $name,
             $parameters
-        ));
+        ), RenderSingleEvent::NAME);
 
         $group = $this->registry->getComponents($groupName);
 

--- a/src/lib/Menu/AbstractBuilder.php
+++ b/src/lib/Menu/AbstractBuilder.php
@@ -51,7 +51,7 @@ abstract class AbstractBuilder
      */
     protected function dispatchMenuEvent(string $name, Event $event): void
     {
-        $this->eventDispatcher->dispatch($name, $event);
+        $this->eventDispatcher->dispatch($event, $name);
     }
 
     /**

--- a/src/lib/Tab/AbstractEventDispatchingTab.php
+++ b/src/lib/Tab/AbstractEventDispatchingTab.php
@@ -49,7 +49,7 @@ abstract class AbstractEventDispatchingTab extends AbstractTab
             $this->getTemplate(),
             $this->getTemplateParameters($parameters)
         );
-        $this->eventDispatcher->dispatch(TabEvents::TAB_RENDER, $event);
+        $this->eventDispatcher->dispatch($event, TabEvents::TAB_RENDER);
 
         return $this->twig->render(
             $event->getTemplate(),

--- a/src/lib/UI/Action/EventDispatcher.php
+++ b/src/lib/UI/Action/EventDispatcher.php
@@ -30,14 +30,8 @@ class EventDispatcher implements EventDispatcherInterface
     {
         $action = $event->getName();
 
-        $this->eventDispatcher->dispatch(EventDispatcherInterface::EVENT_NAME_PREFIX, $event);
-        $this->eventDispatcher->dispatch(
-            sprintf('%s.%s', EventDispatcherInterface::EVENT_NAME_PREFIX, $action),
-            $event
-        );
-        $this->eventDispatcher->dispatch(
-            sprintf('%s.%s.%s', EventDispatcherInterface::EVENT_NAME_PREFIX, $action, $event->getType()),
-            $event
-        );
+        $this->eventDispatcher->dispatch($event, EventDispatcherInterface::EVENT_NAME_PREFIX);
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s', EventDispatcherInterface::EVENT_NAME_PREFIX, $action));
+        $this->eventDispatcher->dispatch($event, sprintf('%s.%s.%s', EventDispatcherInterface::EVENT_NAME_PREFIX, $action, $event->getType()));
     }
 }

--- a/src/lib/UniversalDiscovery/ConfigResolver.php
+++ b/src/lib/UniversalDiscovery/ConfigResolver.php
@@ -54,7 +54,7 @@ class ConfigResolver
         $configResolveEvent->setConfig($config);
 
         /** @var ConfigResolveEvent $event */
-        $event = $this->eventDispatcher->dispatch(ConfigResolveEvent::NAME, $configResolveEvent);
+        $event = $this->eventDispatcher->dispatch($configResolveEvent, ConfigResolveEvent::NAME);
 
         return $event->getConfig();
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30812
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed the following deprecation message:

```
Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
```

by swapping argument order in  `Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()` method calls.  



#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
