### PR TITLE
Fixed _ezplatform_branch_for_behat_tests in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
-        "_ezplatform_branch_for_behat_tests": "ezp_30687_travis",
+        "_ezplatform_branch_for_behat_tests": "master",
         "branch-alias": {
             "dev-tmp_ci_branch": "2.0.x-dev",
             "dev-master": "2.0.x-dev"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Reverted https://github.com/ezsystems/ezplatform-admin-ui/pull/1022/commits/21888e5f6f26ed2a8af7b3a97c6aa35231d20e6f: `_ezplatform_branch_for_behat_tests` in composer.json should point to `master`.

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
