### PR TITLE
EZP-29386: Removed Admin service aliases in favor of Kernel

### DIFF
--- a/src/bundle/Resources/config/services/service_aliases.yaml
+++ b/src/bundle/Resources/config/services/service_aliases.yaml
@@ -13,17 +13,9 @@ services:
     # that these are available but guess not... these are not. You can use autowiring for these services
     # only because you have EzPlatformAdminUiBundle enabled.
     #
-
-    eZ\Publish\API\Repository\PermissionResolver:
-        # passing class as workaround for missing sudo on the interface
-        class: eZ\Publish\Core\Repository\Permission\PermissionResolver
-        # making it lazy to avoid resolving dynamic (SiteAccess) settings too early
-        lazy: true
-        factory: 'eZ\Publish\API\Repository\Repository:getPermissionResolver'
-
+    
     eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'
     eZ\Publish\Core\MVC\ConfigResolverInterface: '@ezpublish.config.resolver'
-
     eZ\Publish\Core\MVC\Symfony\SiteAccess: '@ezpublish.siteaccess'
 
     # Repository Forms
@@ -36,4 +28,3 @@ services:
 
     # Symfony
     Symfony\Contracts\Translation\TranslatorInterface: '@translator'
-

--- a/src/bundle/Resources/config/services/service_aliases.yaml
+++ b/src/bundle/Resources/config/services/service_aliases.yaml
@@ -14,22 +14,6 @@ services:
     # only because you have EzPlatformAdminUiBundle enabled.
     #
 
-    # Kernel
-    eZ\Publish\API\Repository\Repository: '@ezpublish.api.repository'
-    eZ\Publish\API\Repository\ContentService: '@ezpublish.api.service.content'
-    eZ\Publish\API\Repository\ContentTypeService: '@ezpublish.api.service.content_type'
-    eZ\Publish\API\Repository\LanguageService: '@ezpublish.api.service.language'
-    eZ\Publish\API\Repository\LocationService: '@ezpublish.api.service.location'
-    eZ\Publish\API\Repository\ObjectStateService: '@ezpublish.api.service.object_state'
-    eZ\Publish\API\Repository\RoleService: '@ezpublish.api.service.role'
-    eZ\Publish\API\Repository\SearchService: '@ezpublish.api.service.search'
-    eZ\Publish\API\Repository\SectionService: '@ezpublish.api.service.section'
-    eZ\Publish\API\Repository\UserService: '@ezpublish.api.service.user'
-    eZ\Publish\API\Repository\URLService: '@ezpublish.api.service.url'
-    eZ\Publish\API\Repository\URLAliasService: '@ezpublish.api.service.url_alias'
-    eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
-    eZ\Publish\API\Repository\BookmarkService: '@ezpublish.api.service.bookmark'
-
     eZ\Publish\API\Repository\PermissionResolver:
         # passing class as workaround for missing sudo on the interface
         class: eZ\Publish\Core\Repository\Permission\PermissionResolver


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-29386](https://jira.ez.no/browse/EZP-29386)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

### ~Blocked by: https://github.com/ezsystems/ezpublish-kernel/pull/2380~

This shouldn't be part of Admin UI. There is a PR to Kernel that makes aliases there.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
