### PR TITLE
EZP-30820: AdminExceptionListener could not be autowired due to missing EncoreBundle definitions

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -99,6 +99,8 @@ services:
             $siteAccessGroups: '%ezpublish.siteaccess.groups%'
             $kernelRootDir: '%kernel.root_dir%'
             $kernelEnvironment: '%kernel.environment%'
+            $encoreTagRenderer: '@webpack_encore.tag_renderer'
+            $entrypointLookupCollection: '@webpack_encore.entrypoint_lookup_collection'
         tags:
             - { name: kernel.event_listener, event: kernel.exception }
 

--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -24,10 +24,10 @@ use Twig\Error\RuntimeError;
 
 class AdminExceptionListener
 {
-    /** @var NotificationHandlerInterface */
+    /** @var \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface */
     protected $notificationHandler;
 
-    /** @var Environment */
+    /** @var \Twig\Environment */
     protected $twig;
 
     /** @var \Symfony\WebpackEncoreBundle\Asset\TagRenderer */
@@ -46,8 +46,10 @@ class AdminExceptionListener
     protected $kernelEnvironment;
 
     /**
-     * @param Environment $twig
-     * @param NotificationHandlerInterface $notificationHandler
+     * @param \Twig\Environment $twig
+     * @param \EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface $notificationHandler
+     * @param \Symfony\WebpackEncoreBundle\Asset\TagRenderer $encoreTagRenderer
+     * @param \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface $entrypointLookupCollection
      * @param array $siteAccessGroups
      * @param string $kernelRootDir
      * @param string $kernelEnvironment


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30820
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
