### PR TITLE
EZP-30828: Replaced \Symfony\Component\EventDispatcher\Event usage in favor of Symfony\Contracts\EventDispatcher\Event

### DIFF
--- a/src/lib/Component/Event/RenderGroupEvent.php
+++ b/src/lib/Component/Event/RenderGroupEvent.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Component\Event;
 
 use EzSystems\EzPlatformAdminUi\Component\Registry;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RenderGroupEvent extends Event
 {

--- a/src/lib/Component/Event/RenderSingleEvent.php
+++ b/src/lib/Component/Event/RenderSingleEvent.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Component\Event;
 
 use EzSystems\EzPlatformAdminUi\Component\Registry;
 use EzSystems\EzPlatformAdminUi\Component\Renderable;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RenderSingleEvent extends Event
 {

--- a/src/lib/Menu/AbstractBuilder.php
+++ b/src/lib/Menu/AbstractBuilder.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Menu;
 
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/src/lib/Menu/Event/ConfigureMenuEvent.php
+++ b/src/lib/Menu/Event/ConfigureMenuEvent.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Menu\Event;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event triggered after building AdminUI menus. Provides extensibility point for menus' customization.

--- a/src/lib/Tab/Event/TabEvent.php
+++ b/src/lib/Tab/Event/TabEvent.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Tab\Event;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TabEvent extends Event
 {

--- a/src/lib/Tab/Event/TabGroupEvent.php
+++ b/src/lib/Tab/Event/TabGroupEvent.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Tab\Event;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabGroup;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TabGroupEvent extends Event
 {

--- a/src/lib/Tab/Event/TabViewRenderEvent.php
+++ b/src/lib/Tab/Event/TabViewRenderEvent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Tab\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TabViewRenderEvent extends Event
 {

--- a/src/lib/UI/Action/UiActionEvent.php
+++ b/src/lib/UI/Action/UiActionEvent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Action;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class ConfigResolveEvent extends Event
 {


### PR DESCRIPTION
 Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30828
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Replaced `\Symfony\Component\EventDispatcher\Event` usage in favour of `Symfony\Contracts\EventDispatcher\Event`. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
