### PR TITLE
EZP-30844: Implemented getExtendedTypes method in Form Type Extensions

### DIFF
--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -20,7 +20,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\Form\Type\Extension\Content\ContentEditTypeExtension:
         tags:
-            - { name: form.type_extension, extended_type: EzSystems\RepositoryForms\Form\Type\Content\ContentEditType }
+            - { name: form.type_extension }
 
     EzSystems\EzPlatformAdminUi\Form\Type\Policy\PolicyChoiceType:
         arguments:
@@ -52,4 +52,4 @@ services:
     EzSystems\EzPlatformAdminUi\Form\Extension\RichTextTypeExtension:
         public: true
         tags:
-            - { name: form.type_extension, extended_type: EzSystems\EzPlatformRichText\Form\Type\RichTextType }
+            - { name: form.type_extension }

--- a/src/lib/Form/Extension/RichTextTypeExtension.php
+++ b/src/lib/Form/Extension/RichTextTypeExtension.php
@@ -38,11 +38,8 @@ class RichTextTypeExtension extends AbstractTypeExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getExtendedType(): string
+    public static function getExtendedTypes(): iterable
     {
-        return RichTextType::class;
+        return [RichTextType::class];
     }
 }

--- a/src/lib/Form/Type/Extension/Content/ContentEditTypeExtension.php
+++ b/src/lib/Form/Type/Extension/Content/ContentEditTypeExtension.php
@@ -31,11 +31,8 @@ class ContentEditTypeExtension extends AbstractTypeExtension
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getExtendedType(): string
+    public static function getExtendedTypes(): iterable
     {
-        return ContentEditType::class;
+        return [ContentEditType::class];
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30844
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Since Symfony 4.2 form type extensions should implement static method  `Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()" 

More information: https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
