### PR TITLE
EZP-30848: Fixed usage of hasAccess method with section/view permission in Admin UI

### DIFF
--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -69,7 +69,7 @@ class SearchType extends AbstractType
             ])
         ;
 
-        if ($this->permissionResolver->hasAccess('section', 'view')) {
+        if ($this->permissionResolver->hasAccess('section', 'view') !== false) {
             $builder->add('section', SectionChoiceType::class, [
                 'required' => false,
                 'multiple' => false,

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -155,7 +155,7 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
             );
         }
 
-        if ($this->permissionResolver->hasAccess('section', 'view')) {
+        if ($this->permissionResolver->hasAccess('section', 'view') !== false) {
             $menuItems[self::ITEM_ADMIN__SECTIONS] = $this->createMenuItem(
                 self::ITEM_ADMIN__SECTIONS,
                 ['route' => 'ezplatform.section.list', 'extras' => [

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -234,7 +234,7 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
      */
     private function supplySectionParameters(ArrayObject $parameters, ContentInfo $contentInfo, Location $location): void
     {
-        $canSeeSection = $this->permissionResolver->hasAccess('section', 'view');
+        $canSeeSection = $this->permissionResolver->canUser('section', 'view', $contentInfo);
 
         $parameters['section'] = null;
         $parameters['can_see_section'] = $canSeeSection;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30848
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When a user has a Section Limitation we can not rely on hasAccess method to check if we can load Section. We must use a canUser method. 

If we need to load a list of Sections it would be better and more readable to compare the result of hasAccess method with `false`. Because section list is filtered, so we should display it when `hasAccess` method return `true` or an array of Limitation.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
