### PR TITLE
EZP-30853: The button "Add Section" has been hidden for a user which has Limitation to view Sections

### DIFF
--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUiBundle\Controller;
 
+use Exception;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\SectionService;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\API\Repository\Values\User\Limitation\NewSectionLimitation;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
-use eZ\Publish\API\Repository\SearchService;
-use eZ\Publish\API\Repository\PermissionResolver;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionContentAssignData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Section\SectionDeleteData;
@@ -30,8 +30,8 @@ use EzSystems\EzPlatformAdminUi\Form\DataMapper\SectionUpdateMapper;
 use EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Form\SubmitHandler;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
-use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
 use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
+use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
 use EzSystems\EzPlatformAdminUiBundle\View\EzPagerfantaView;
 use EzSystems\EzPlatformAdminUiBundle\View\Template\EzPagerfantaTemplate;
 use Pagerfanta\Adapter\ArrayAdapter;
@@ -40,7 +40,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\TranslatorInterface;
-use Exception;
 
 class SectionController extends Controller
 {
@@ -179,8 +178,13 @@ class SectionController extends Controller
             $assignableSections[$section->id] = $this->canUserAssignSectionToSomeContent($section);
         }
 
+        // User can add Section only if he has access to view without any limitation because he must see newly created Section.
+        $canView = $this->permissionResolver->hasAccess('section', 'view') === true;
+        $canEdit = $this->isGranted(new Attribute('section', 'edit'));
+
         return $this->render('@ezdesign/admin/section/list.html.twig', [
-            'can_edit' => $this->isGranted(new Attribute('section', 'edit')),
+            'can_add' => $canView && $canEdit,
+            'can_edit' => $canEdit,
             'can_assign' => $this->isGranted(new Attribute('section', 'assign')),
             'pager' => $pagerfanta,
             'content_count' => $contentCountBySectionId,
@@ -385,7 +389,7 @@ class SectionController extends Controller
                     $this->translator->trans(
                         /** @Desc("%contentItemsCount% content items were assigned to '%name%'") */
                         'section.assign_content.success',
-                        ['%name%' => $section->name, '%contentItemsCount%' => count($contentInfos)],
+                        ['%name%' => $section->name, '%contentItemsCount%' => \count($contentInfos)],
                         'section'
                     )
                 );
@@ -514,13 +518,13 @@ class SectionController extends Controller
     {
         $hasAccess = $this->permissionResolver->hasAccess('section', 'assign');
 
-        if (is_bool($hasAccess)) {
+        if (\is_bool($hasAccess)) {
             return $hasAccess;
         }
 
         $restrictedNewSections = $this->permissionChecker->getRestrictions($hasAccess, NewSectionLimitation::class);
         if (!empty($restrictedNewSections)) {
-            return in_array($section->id, array_map('intval', $restrictedNewSections), true);
+            return \in_array($section->id, array_map('intval', $restrictedNewSections), true);
         }
 
         // If a user has other limitation than NewSectionLimitation, then a decision will be taken later, based on selected Content.

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -178,14 +178,18 @@ class SectionController extends Controller
             $assignableSections[$section->id] = $this->canUserAssignSectionToSomeContent($section);
         }
 
-        // User can add Section only if he has access to view without any limitation because he must see newly created Section.
         $canView = $this->permissionResolver->hasAccess('section', 'view') === true;
-        $canEdit = $this->isGranted(new Attribute('section', 'edit'));
+        $canEdit = $this->permissionResolver->hasAccess('section', 'edit');
+        $canAssign = $this->permissionResolver->hasAccess('section', 'assign');
+
+        // User can add Section only if he has access to edit and view.
+        // View Policy must be without any limitation because the user must see newly created Section.
+        $canAdd = $canView && $canEdit;
 
         return $this->render('@ezdesign/admin/section/list.html.twig', [
-            'can_add' => $canView && $canEdit,
+            'can_add' => $canAdd,
             'can_edit' => $canEdit,
-            'can_assign' => $this->isGranted(new Attribute('section', 'assign')),
+            'can_assign' => $canAssign,
             'pager' => $pagerfanta,
             'content_count' => $contentCountBySectionId,
             'deletable' => $deletableSections,

--- a/src/bundle/Controller/SectionController.php
+++ b/src/bundle/Controller/SectionController.php
@@ -178,13 +178,13 @@ class SectionController extends Controller
             $assignableSections[$section->id] = $this->canUserAssignSectionToSomeContent($section);
         }
 
-        $canView = $this->permissionResolver->hasAccess('section', 'view') === true;
         $canEdit = $this->permissionResolver->hasAccess('section', 'edit');
         $canAssign = $this->permissionResolver->hasAccess('section', 'assign');
 
         // User can add Section only if he has access to edit and view.
         // View Policy must be without any limitation because the user must see newly created Section.
-        $canAdd = $canView && $canEdit;
+        $canAdd = $this->permissionResolver->hasAccess('section', 'view') === true
+            && $this->permissionResolver->hasAccess('section', 'edit') === true;
 
         return $this->render('@ezdesign/admin/section/list.html.twig', [
             'can_add' => $canAdd,

--- a/src/bundle/Resources/views/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/admin/section/list.html.twig
@@ -26,7 +26,7 @@
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'section.list.title'|trans|desc('Sections') }}</div>
             <div>
-                {% if can_edit %}
+                {% if can_add %}
                     <a
                         title="{{ 'section.new'|trans|desc('Create a new Section') }}"
                         href="{{ path('ezplatform.section.create') }}"
@@ -35,6 +35,8 @@
                             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
                         </svg>
                     </a>
+                {% endif %}
+                {% if can_edit %}
                     {% set modal_data_target = 'delete-sections-modal' %}
                     <button
                         id="delete-sections"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30853
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When a user has any Limitation related viewing section then he sees all sections available to him and there is no need to display button "Add Section". The button should be visible only when the user has section/edit Policy and can view a newly created section. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
