### PR TITLE
Use TranslatorInterface for typehint

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/mappers.yml
+++ b/src/bundle/Resources/config/services/ui_config/mappers.yml
@@ -19,6 +19,7 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag:
         autowire: true
         arguments:
+            $translator: '@translator'
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
             $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
             $customTagAttributeMappers: !tagged ezplatform.admin_ui.richtext_custom_tag_attribute_mapper

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\Translator;
 
 /**
  * UI Config Mapper test for RichText Custom Tags configuration.
@@ -172,7 +172,7 @@ class CustomTagTest extends TestCase
             ->withAnyParameters()
             ->willReturn(false);
 
-        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock = $this->createMock(Translator::class);
         $translatorMock
             ->expects($this->any())
             ->method('getCatalogue')

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * UI Config Mapper test for RichText Custom Tags configuration.
@@ -172,7 +172,7 @@ class CustomTagTest extends TestCase
             ->withAnyParameters()
             ->willReturn(false);
 
-        $translatorMock = $this->createMock(Translator::class);
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock
             ->expects($this->any())
             ->method('getCatalogue')

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -22,7 +22,7 @@ class CustomTag
     /** @var array */
     private $customTagsConfiguration;
 
-    /** @var Translator */
+    /** @var TranslatorInterface */
     private $translator;
 
     /** @var Packages */

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
 use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\AttributeMapper;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\Translator;
 use Traversable;
 
 /**
@@ -22,7 +22,7 @@ class CustomTag
     /** @var array */
     private $customTagsConfiguration;
 
-    /** @var TranslatorInterface */
+    /** @var Translator */
     private $translator;
 
     /** @var Packages */
@@ -51,7 +51,7 @@ class CustomTag
      */
     public function __construct(
         array $customTagsConfiguration,
-        TranslatorInterface $translator,
+        Translator $translator,
         string $translationDomain,
         Packages $packages,
         Traversable $customTagAttributeMappers

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
 use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\AttributeMapper;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 use Traversable;
 
 /**
@@ -44,14 +44,14 @@ class CustomTag
      * both TranslatorInterface and TranslatorBagInterface.
      *
      * @param array $customTagsConfiguration
-     * @param \Symfony\Component\Translation\Translator $translator
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
      * @param string $translationDomain
      * @param \Symfony\Component\Asset\Packages $packages
      * @param \Traversable $customTagAttributeMappers
      */
     public function __construct(
         array $customTagsConfiguration,
-        Translator $translator,
+        TranslatorInterface $translator,
         string $translationDomain,
         Packages $packages,
         Traversable $customTagAttributeMappers


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no

In some cases, autowire fails with following error:
`[Symfony\Component\DependencyInjection\Exception\RuntimeException]                                                                                                                                                                         
  Cannot autowire service "EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag": argument "$translator" of method "__construct()" references class "Symfony\Component\Translation\Translator" but no such service exi  
  sts. Try changing the type-hint to "Symfony\Component\Translation\TranslatorInterface" instead.                                           `