### PR TITLE
EZP-30864: Handle removed content which is embed

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -170,6 +170,12 @@ const embedBaseDefinition = {
      * @param {Object} hits The result of content search
      */
     handleContentLoaded: function(hits) {
+        if (hits.View.Result.searchHits.searchHit.length === 0) {
+            const title = Translator.trans(/*@Desc("Removed")*/ 'removed_content.label', {}, 'alloy_editor');
+            //this.renderEmbedPreview(title);
+            //return;
+        }
+
         const isEmbedImage = this.element.$.classList.contains(IMAGE_TYPE_CLASS);
         const content = hits.View.Result.searchHits.searchHit[0].value.Content;
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -172,7 +172,10 @@ const embedBaseDefinition = {
     handleContentLoaded: function(hits) {
         if (hits.View.Result.searchHits.searchHit.length === 0) {
             const title = Translator.trans(/*@Desc("Removed")*/ 'removed_content.label', {}, 'alloy_editor');
+            
             this.renderEmbedPreview(title);
+            
+            return;
             return;
         }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -172,8 +172,8 @@ const embedBaseDefinition = {
     handleContentLoaded: function(hits) {
         if (hits.View.Result.searchHits.searchHit.length === 0) {
             const title = Translator.trans(/*@Desc("Removed")*/ 'removed_content.label', {}, 'alloy_editor');
-            //this.renderEmbedPreview(title);
-            //return;
+            this.renderEmbedPreview(title);
+            return;
         }
 
         const isEmbedImage = this.element.$.classList.contains(IMAGE_TYPE_CLASS);

--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -176,7 +176,6 @@ const embedBaseDefinition = {
             this.renderEmbedPreview(title);
             
             return;
-            return;
         }
 
         const isEmbedImage = this.element.$.classList.contains(IMAGE_TYPE_CLASS);

--- a/src/bundle/Resources/translations/alloy_editor.en.xliff
+++ b/src/bundle/Resources/translations/alloy_editor.en.xliff
@@ -231,6 +231,11 @@
         <target state="new">List</target>
         <note>key: unordered_list_btn.label</note>
       </trans-unit>
+      <trans-unit id="d5a182a917683c8ecd6a8efa75a086321a209f52" resname="removed_content.label">
+        <source>Removed</source>
+        <target state="new">Removed</target>
+        <note>key: removed_content.label</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30864](https://jira.ez.no/browse/EZP-30864)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Steps to reproduce:
1. Create content A
2. Create content B, which has RichtText fields
3. Embed content A in RichtText field of the content B
4. Remove content A
5. Try to edit content B

Expected result: you would be able to edit the content
Actual result: "Cannot read property 'value' of undefined" error is shown. And if you have a lot of content in the RichText field, it is hard to understand where this error comes from.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
