### PR TITLE
Install latest dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     },
     "require-dev": {
         "behat/behat": "^3.5",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "phpunit/phpunit": "^8.1",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,6 @@
     "autoload-dev": {
         "psr-4": { "EzSystems\\EzPlatformAdminUi\\Tests\\": "src/lib/Tests" }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": "^7.3",
         "symfony/http-foundation": "^4.3",


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | dependencies bugfix?
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | n/a
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This fails on my machine with:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - ezsystems/ez-support-tools v2.0.0-beta2 requires ezsystems/ezplatform-admin-ui ^2.0 -> satisfiable by ezsystems/ezplatform-admin-ui[2.0.x-dev, v2.0.0-beta1, v2.0.0-beta2, v2.0.0-beta3] but these conflict with your requirements or minimum-stability.
    - ezsystems/ez-support-tools v2.0.0-beta1 requires ezsystems/ezplatform-admin-ui ^2.0@beta -> satisfiable by ezsystems/ezplatform-admin-ui[2.0.x-dev, v2.0.0-beta1, v2.0.0-beta2, v2.0.0-beta3] but these conflict with your requirements or minimum-stability.
    - ezsystems/ez-support-tools 2.0.x-dev requires ezsystems/ezplatform-admin-ui ^2.0@dev -> satisfiable by ezsystems/ezplatform-admin-ui[2.0.x-dev, v2.0.0-beta1, v2.0.0-beta2, v2.0.0-beta3] but these conflict with your requirements or minimum-stability.
    - Installation request for ezsystems/ez-support-tools ^2.0@dev -> satisfiable by ezsystems/ez-support-tools[2.0.x-dev, v2.0.0-beta1, v2.0.0-beta2].
```

(composer 1.9.1, PHP 7.3.12)
But somehow it passes on Travis 😞 

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
