### PR TITLE
EZP-30888: Moved search query build logic from SearchController to dedicated QueryType

### DIFF
--- a/src/bundle/Resources/config/services/controllers.yaml
+++ b/src/bundle/Resources/config/services/controllers.yaml
@@ -47,6 +47,7 @@ services:
         autowire: true
         lazy: true
         arguments:
+            $searchQueryType: '@EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType'
             $defaultPaginationLimit: '$pagination.search_limit$'
             $userContentTypeIdentifier: '$user_content_type_identifier$'
         tags:

--- a/src/bundle/Resources/config/services/query_types.yaml
+++ b/src/bundle/Resources/config/services/query_types.yaml
@@ -7,3 +7,7 @@ services:
     EzSystems\EzPlatformAdminUi\QueryType\ContentSubtreeQueryType: ~
 
     EzSystems\EzPlatformAdminUi\QueryType\MediaSubtreeQueryType: ~
+
+    EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType:
+        arguments:
+            $searchService: '@ezpublish.api.service.search'

--- a/src/lib/QueryType/SearchQueryType.php
+++ b/src/lib/QueryType/SearchQueryType.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\QueryType;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\QueryType\OptionsResolverBasedQueryType;
+use EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SearchQueryType extends OptionsResolverBasedQueryType
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    public function __construct(SearchService $searchService)
+    {
+        $this->searchService = $searchService;
+    }
+
+    protected function doGetQuery(array $parameters): Query
+    {
+        /** @var \EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData $searchData */
+        $searchData = $parameters['search_data'];
+
+        $query = new Query();
+        if (null !== $searchData->getQuery()) {
+            $query->query = new Criterion\FullText($searchData->getQuery());
+        }
+
+        $criteria = $this->buildCriteria($searchData);
+        if (!empty($criteria)) {
+            $query->filter = new Criterion\LogicalAnd($criteria);
+        }
+
+        if (!$this->searchService->supports(SearchService::CAPABILITY_SCORING)) {
+            $query->sortClauses[] = new SortClause\DateModified(Query::SORT_ASC);
+        }
+
+        return $query;
+    }
+
+    protected function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setDefaults([
+            'search_data' => new SearchData(),
+        ]);
+
+        $optionsResolver->setAllowedTypes('search_data', SearchData::class);
+    }
+
+    public static function getName(): string
+    {
+        return 'EzPlatformAdminUi:SearchQuery';
+    }
+
+    protected function buildCriteria(SearchData $searchData): array
+    {
+        $criteria = [];
+
+        if (null !== $searchData->getSection()) {
+            $criteria[] = new Criterion\SectionId($searchData->getSection()->id);
+        }
+
+        if (!empty($searchData->getContentTypes())) {
+            $criteria[] = new Criterion\ContentTypeId(array_column($searchData->getContentTypes(), 'id'));
+        }
+
+        if (!empty($searchData->getLastModified())) {
+            $modified = $searchData->getLastModified();
+
+            $criteria[] = new Criterion\DateMetadata(
+                Criterion\DateMetadata::MODIFIED,
+                Criterion\Operator::BETWEEN,
+                [
+                    $modified['start_date'],
+                    $modified['end_date'],
+                ]
+            );
+        }
+
+        if (!empty($searchData->getCreated())) {
+            $created = $searchData->getCreated();
+
+            $criteria[] = new Criterion\DateMetadata(
+                Criterion\DateMetadata::CREATED,
+                Criterion\Operator::BETWEEN,
+                [
+                    $created['start_date'],
+                    $created['end_date'],
+                ]
+            );
+        }
+
+        if ($searchData->getCreator() instanceof User) {
+            $criteria[] = new Criterion\UserMetadata(
+                Criterion\UserMetadata::OWNER,
+                Criterion\Operator::EQ,
+                $searchData->getCreator()->id
+            );
+        }
+
+        if (null !== $searchData->getSubtree()) {
+            $criteria[] = new Criterion\Subtree($searchData->getSubtree());
+        }
+
+        return $criteria;
+    }
+}

--- a/src/lib/QueryType/SearchQueryType.php
+++ b/src/lib/QueryType/SearchQueryType.php
@@ -63,6 +63,11 @@ final class SearchQueryType extends OptionsResolverBasedQueryType
         return 'EzPlatformAdminUi:SearchQuery';
     }
 
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData $searchData
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion[]
+     */
     protected function buildCriteria(SearchData $searchData): array
     {
         $criteria = [];

--- a/src/lib/Tests/QueryType/SearchQueryTypeTest.php
+++ b/src/lib/Tests/QueryType/SearchQueryTypeTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\QueryType;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Section;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData;
+use EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType;
+use PHPUnit\Framework\TestCase;
+
+final class SearchQueryTypeTest extends TestCase
+{
+    private const EXPECTED_QUERY_STRING = 'eZ Platform';
+    private const EXPECTED_SECTION_ID = 2;
+    private const EXPECTED_CONTENT_TYPE_IDS = [3, 5, 7];
+    private const EXPECTED_USER_ID = 11;
+    private const EXPECTED_SUBTREE = '/13/17/19/';
+    private const EXPECTED_DATE_RANGE = [1431993600, 1587340800];
+
+    /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit\Framework\MockObject\MockObject */
+    private $searchService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType */
+    private $queryType;
+
+    protected function setUp(): void
+    {
+        $this->searchService = $this->createMock(SearchService::class);
+        $this->queryType = new SearchQueryType($this->searchService);
+    }
+
+    /**
+     * @dataProvider dataProviderForGetQuery
+     */
+    public function testGetQuery(array $parameters, Query $expectedQuery, bool $isScoringSupported): void
+    {
+        $this->searchService
+            ->method('supports')
+            ->with(SearchService::CAPABILITY_SCORING)
+            ->willReturn($isScoringSupported);
+
+        $this->assertEquals($expectedQuery, $this->queryType->getQuery($parameters));
+    }
+
+    public function dataProviderForGetQuery(): array
+    {
+        return [
+            [
+                [],
+                new Query(['sortClauses' => []]),
+                true,
+            ],
+            [
+                [
+                    'search_data' => $this->createSearchDataWithAllCriteria(),
+                ],
+                $this->createExpectedQueryForAllCriteria([]),
+                true,
+            ],
+            [
+                [],
+                new Query([
+                    'sortClauses' => [
+                        new SortClause\DateModified(),
+                    ],
+                ]),
+                false,
+            ],
+            [
+                [
+                    'search_data' => $this->createSearchDataWithAllCriteria(),
+                ],
+                $this->createExpectedQueryForAllCriteria(),
+                false,
+            ],
+        ];
+    }
+
+    private function createContentTypesList(array $ids): array
+    {
+        return array_map(function (int $id): ContentType {
+            return new ContentType(['id' => $id]);
+        }, $ids);
+    }
+
+    private function createSearchDataWithAllCriteria(): SearchData
+    {
+        $searchData = new SearchData();
+        $searchData->setQuery(self::EXPECTED_QUERY_STRING);
+        $searchData->setSection(new Section(['id' => self::EXPECTED_SECTION_ID]));
+        $searchData->setContentTypes($this->createContentTypesList(self::EXPECTED_CONTENT_TYPE_IDS));
+        $searchData->setCreated([
+            'start_date' => self::EXPECTED_DATE_RANGE[0],
+            'end_date' => self::EXPECTED_DATE_RANGE[1],
+        ]);
+        $searchData->setLastModified([
+            'start_date' => self::EXPECTED_DATE_RANGE[0],
+            'end_date' => self::EXPECTED_DATE_RANGE[1],
+        ]);
+        $searchData->setCreator($this->createUser(self::EXPECTED_USER_ID));
+        $searchData->setSubtree(self::EXPECTED_SUBTREE);
+
+        return $searchData;
+    }
+
+    private function createUser(int $id): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('__get')->with('id')->willReturn($id);
+
+        return $user;
+    }
+
+    private function createExpectedQueryForAllCriteria(?array $expectedSortClauses = null): Query
+    {
+        if ($expectedSortClauses === null) {
+            $expectedSortClauses = [
+                new SortClause\DateModified(),
+            ];
+        }
+
+        return new Query([
+            'query' => new Criterion\FullText(self::EXPECTED_QUERY_STRING),
+            'filter' => new Criterion\LogicalAnd([
+                new Criterion\SectionId(self::EXPECTED_SECTION_ID),
+                new Criterion\ContentTypeId(self::EXPECTED_CONTENT_TYPE_IDS),
+                new Criterion\DateMetadata(
+                    Criterion\DateMetadata::MODIFIED,
+                    Criterion\Operator::BETWEEN,
+                    self::EXPECTED_DATE_RANGE
+                ),
+                new Criterion\DateMetadata(
+                    Criterion\DateMetadata::CREATED,
+                    Criterion\Operator::BETWEEN,
+                    self::EXPECTED_DATE_RANGE
+                ),
+                new Criterion\UserMetadata(
+                    Criterion\UserMetadata::OWNER,
+                    Criterion\Operator::EQ,
+                    self::EXPECTED_USER_ID
+                ),
+                new Criterion\Subtree(self::EXPECTED_SUBTREE),
+            ]),
+            'sortClauses' => $expectedSortClauses,
+        ]);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30888
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Moved query build logic from  the `\EzSystems\EzPlatformAdminUiBundle\Controller\SearchController::searchAction` to dedicated `QueryType` class in order to make ezplatform-admin-ui code more SOLID.

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
