### PR TITLE
EZP-30819: Removed deprecated controller reference syntax from account/notifications/modal.html.twig

### DIFF
--- a/src/bundle/Resources/views/themes/admin/account/notifications/modal.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/notifications/modal.html.twig
@@ -34,7 +34,7 @@
                     </svg>
                 </div>
                 <div class="ez-notifications-modal__results">
-                    {{ render(controller('EzPlatformAdminUiBundle:Notification:renderNotificationsPage', {
+                    {{ render(controller('EzSystems\\EzPlatformAdminUiBundle\\Controller\\NotificationController::renderNotificationsPageAction', {
                         'page': 1,
                     })) }}
                 </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30819
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Follow up for https://github.com/ezsystems/ezplatform-admin-ui/pull/1051. Removed deprecated controller reference syntax from `account/notifications/modal.html.twig`

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
