### PR TITLE
EZP-30899: Change default CT sorting field from identifier to name in AdminUI

### DIFF
--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -136,9 +136,14 @@ class ContentTypeController extends Controller
     public function listAction(ContentTypeGroup $group, string $routeName, int $page): Response
     {
         $deletableTypes = [];
+        $contentTypes = $this->contentTypeService->loadContentTypes($group, $this->languages);
+
+        usort($contentTypes, function (ContentType $contentType1, ContentType $contentType2) {
+            return strnatcasecmp($contentType1->getName(), $contentType2->getName());
+        });
 
         $pagerfanta = new Pagerfanta(
-            new ArrayAdapter($this->contentTypeService->loadContentTypes($group, $this->languages))
+            new ArrayAdapter($contentTypes)
         );
 
         $pagerfanta->setMaxPerPage($this->defaultPaginationLimit);

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
@@ -36,14 +37,19 @@ class ContentTypeChoiceLoader implements ChoiceLoaderInterface
      */
     public function getChoiceList(): array
     {
-        $contentTypes = [];
+        $contentTypesList = [];
         $preferredLanguages = $this->userLanguagePreferenceProvider->getPreferredLanguages();
         $contentTypeGroups = $this->contentTypeService->loadContentTypeGroups($preferredLanguages);
         foreach ($contentTypeGroups as $contentTypeGroup) {
-            $contentTypes[$contentTypeGroup->identifier] = $this->contentTypeService->loadContentTypes($contentTypeGroup, $preferredLanguages);
+            $contentTypes = $this->contentTypeService->loadContentTypes($contentTypeGroup, $preferredLanguages);
+            usort($contentTypes, function (ContentType $contentType1, ContentType $contentType2) {
+                return strcasecmp($contentType1->getName(), $contentType2->getName());
+            });
+
+            $contentTypesList[$contentTypeGroup->identifier] = $contentTypes;
         }
 
-        return $contentTypes;
+        return $contentTypesList;
     }
 
     /**

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
@@ -43,7 +43,7 @@ class ContentTypeChoiceLoader implements ChoiceLoaderInterface
         foreach ($contentTypeGroups as $contentTypeGroup) {
             $contentTypes = $this->contentTypeService->loadContentTypes($contentTypeGroup, $preferredLanguages);
             usort($contentTypes, function (ContentType $contentType1, ContentType $contentType2) {
-                return strcasecmp($contentType1->getName(), $contentType2->getName());
+                return strnatcasecmp($contentType1->getName(), $contentType2->getName());
             });
 
             $contentTypesList[$contentTypeGroup->identifier] = $contentTypes;

--- a/src/lib/UI/Config/Provider/ContentTypes.php
+++ b/src/lib/UI/Config/Provider/ContentTypes.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformAdminUi\UI\Config\Provider;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\ProviderInterface;
 use EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver;
@@ -60,6 +61,11 @@ class ContentTypes implements ProviderInterface
                 $contentTypeGroup,
                 $preferredLanguages
             );
+
+            usort($contentTypes, function (ContentType $contentType1, ContentType $contentType2) {
+                return strnatcasecmp($contentType1->getName(), $contentType2->getName());
+            });
+
             foreach ($contentTypes as $contentType) {
                 $contentTypeGroups[$contentTypeGroup->identifier][] = [
                     'identifier' => $contentType->identifier,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30899](https://jira.ez.no/browse/EZP-30899)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Excerpt from JIRA:
>Content Types are by default sorted by their identifiers. From Editor's perspective, it would be more convenient to sort them by name.
#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
