### PR TITLE
MFU should be able to create content as specified in locationMappings

### DIFF
--- a/src/lib/UI/Module/Subitems/ContentViewParameterSupplier.php
+++ b/src/lib/UI/Module/Subitems/ContentViewParameterSupplier.php
@@ -250,7 +250,15 @@ class ContentViewParameterSupplier
         $hasAccess = $this->permissionResolver->hasAccess('content', 'create');
         $defaultContentTypeIdentifiers = array_column($this->contentTypeMappings->getConfig()['defaultMappings'], 'contentTypeIdentifier');
         $defaultContentTypeIdentifiers[] = $this->contentTypeMappings->getConfig()['fallbackContentType']['contentTypeIdentifier'];
-        $contentTypeIdentifiers = array_unique($defaultContentTypeIdentifiers);
+        $locationMappingsContentTypeIdentifiers = [];
+        foreach ($this->contentTypeMappings->getConfig()['locationMappings'] as $locationIdentifier => $locationConfiguration) {
+            if ($location->getContent()->getContentType()->identifier == $locationConfiguration['contentTypeIdentifier']) {
+                foreach ($locationConfiguration['mappings'] as $mappingGroup) {
+                    $locationMappingsContentTypeIdentifiers[] = $mappingGroup['contentTypeIdentifier'];
+                }
+            }
+        }
+        $contentTypeIdentifiers = array_unique(array_merge($defaultContentTypeIdentifiers, $locationMappingsContentTypeIdentifiers));
 
         if (\is_bool($hasAccess)) {
             foreach ($contentTypeIdentifiers as $contentTypeIdentifier) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | maybe
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

# Bug

When adding a new `locationMapping` to MFU, admin will not grant permissions to upload.

# Workaround (no patch)

Add your new entry to `ezplatform.multifile_upload.location.default_mappings` specifying your `contentTypeIdentifier`. Quite a dirty solution.

# This patch

MFU permission check takes into account also `contentTypeIdentifiers` specified in `ezplatform.multifile_upload.location.mappings` for a given location (not just default or fallbacks).

# Expected behaviour

I want to be able MFU to upload an `image/jpeg` and create a `bar` content or an `image/png` and create a `baz` content, instead of default `image` content, when uploading under `foo` content type.

```
ezplatform.multifile_upload.location.mappings:
      - # foo
        content_type_identifier: foo
        mime_type_filter:
          - image/jpeg
          - image/png
        mappings:
          - # images
            mime_types:
              - image/jpeg
            content_type_identifier: bar
            content_field_identifier: image
            name_field_identifier: name
          - # other images
            mime_types:
              - image/png
            content_type_identifier: baz
            content_field_identifier: image
            name_field_identifier: name          
```

This patch checks if actual Location has a `locationMapping` entry and adds all the specified mappings to the `contentTypeIdentifiers` used in `createPermissionsInMfu`, allowing such content to be correctly created while uploading a file.

#### Checklist:
- [X ] Coding standards (`$ composer fix-cs`)
- [ X] Ready for Code Review
