### PR TITLE
EZP-30961 - Toolbar missed after using navigation path and embed

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-elements-path.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-elements-path.js
@@ -60,13 +60,16 @@
             return;
         }
 
-        editor.fire('editorInteraction', {
-            nativeEvent: {
-                editor: editor,
-                target: element.$,
-            },
-            selectionData: editor.getSelectionData(),
-        });
+        const selectionData = editor.getSelectionData();
+        if (selectionData) {
+            editor.fire('editorInteraction', {
+                nativeEvent: {
+                    editor: editor,
+                    target: element.$,
+                },
+                selectionData: selectionData,
+            });
+        }
     };
     const getElementLabel = (editor, element) => {
         const widgetIdentifier = getWidgetIdentifier(editor, element);

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-custom-tag.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-custom-tag.js
@@ -39,7 +39,7 @@ export default class EzCustomTagConfig extends EzConfigBase {
      * @return {Boolean}
      */
     test(payload) {
-        const element = payload.data.selectionData.element;
+        const element = payload.data.selectionData && payload.data.selectionData.element;
 
         return !!(element && element.$.dataset.ezname === this.name);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30961
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

STR:
1) Open editor
2) add embed object and select it
3) click on item in the navigation path

AR: JS error in console, toolbar not appearing at all (even after further clicks in editor) 
ER: No error returned

video attached in JIRA ticket

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
