### PR TITLE
EZP-30967: Cannot open View notifications modal on Safari

### DIFF
--- a/src/bundle/Resources/public/scss/_user-menu.scss
+++ b/src/bundle/Resources/public/scss/_user-menu.scss
@@ -67,8 +67,6 @@
             box-shadow: 0 calculateRem(6px) calculateRem(6px) 0 rgba(51, 51, 51, 0.3);
             transform-origin: top center;
             white-space: nowrap;
-            background-clip: content-box;
-            z-index: -1;
 
             &--hidden {
                 padding-top: 0;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30967
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

## Drawback of the solution
Now there is visible on-pixel-tall line of color 0xFDFDFD here:
![Screen Shot 2019-09-25 at 13 24 54](https://user-images.githubusercontent.com/10233057/65597228-eb775480-df98-11e9-8904-21db397a0797.png)
but it is really hard to spot and I think it is OK.