### PR TITLE
EZP-30900: Added pagination to content's reverse relations

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -175,6 +175,7 @@ class ContentViewController extends Controller
 
         $this->supplyContentType($view);
         $this->supplyDraftPagination($view, $request);
+        $this->supplyReverseRelationPagination($view, $request);
         $this->supplyCustomUrlPagination($view, $request);
         $this->supplySystemUrlPagination($view, $request);
         $this->supplyRolePagination($view, $request);
@@ -387,6 +388,25 @@ class ContentViewController extends Controller
                 'page' => $page['version_draft'] ?? 1,
                 'pages_map' => $page,
                 'limit' => $this->configResolver->getParameter('pagination.version_draft_limit'),
+            ],
+        ]);
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     */
+    private function supplyReverseRelationPagination(ContentView $view, Request $request): void
+    {
+        $page = $request->query->get('page');
+
+        $view->addParameters([
+            'reverse_relation_pagination_params' => [
+                'route_name' => $request->get('_route'),
+                'route_params' => $request->get('_route_params'),
+                'page' => $page['reverse_relation'] ?? 1,
+                'pages_map' => $page,
+                'limit' => $this->configResolver->getParameter('pagination.reverse_relation_limit'),
             ],
         ]);
     }

--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -51,6 +51,7 @@ class Pagination extends AbstractParser
                     ->scalarNode('content_type_group_limit')->isRequired()->end()
                     ->scalarNode('content_type_limit')->isRequired()->end()
                     ->scalarNode('version_draft_limit')->isRequired()->end()
+                    ->scalarNode('reverse_relation_limit')->isRequired()->end()
                     ->scalarNode('content_system_url_limit')->isRequired()->end()
                     ->scalarNode('content_custom_url_limit')->isRequired()->end()
                     ->scalarNode('content_role_limit')->isRequired()->end()
@@ -83,6 +84,7 @@ class Pagination extends AbstractParser
             'content_type_group_limit',
             'content_type_limit',
             'version_draft_limit',
+            'reverse_relation_limit',
             'content_system_url_limit',
             'content_custom_url_limit',
             'content_role_limit',

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -15,6 +15,7 @@ parameters:
     ezsettings.default.pagination.role_assignment_limit: 10
     ezsettings.default.pagination.policy_limit: 10
     ezsettings.default.pagination.version_draft_limit: 5
+    ezsettings.default.pagination.reverse_relation_limit: 10
     ezsettings.default.pagination.content_system_url_limit: 5
     ezsettings.default.pagination.content_custom_url_limit: 5
     ezsettings.default.pagination.content_role_limit: 5

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -51,6 +51,11 @@
         <target state="new">Limited user permissions</target>
         <note>key: content.view.subitems.bulk_action.limited_permissions</note>
       </trans-unit>
+      <trans-unit id="1141888f8212e6140ea4bac1a5fba11c02e94d13" resname="dashboard.table.relation.unauthorized">
+        <source>User does not have access to '%function%' '%module%' with content ID: %contentId%</source>
+        <target state="new">User does not have access to '%function%' '%module%' with content ID: %contentId%</target>
+        <note>key: dashboard.table.relation.unauthorized</note>
+      </trans-unit>
       <trans-unit id="eeb49235f0e3b40e651725430b85a2885174bd2b" resname="location.bookmark.add">
         <source>Add to Bookmarks</source>
         <target state="new">Add to Bookmarks</target>

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -66,6 +66,7 @@
                             'location': location,
                             'contentType': contentType,
                             'draft_pagination_params': draft_pagination_params,
+                            'reverse_relation_pagination_params': reverse_relation_pagination_params,
                             'custom_urls_pagination_params': custom_urls_pagination_params,
                             'system_urls_pagination_params': system_urls_pagination_params,
                             'roles_pagination_params': roles_pagination_params,

--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -1,8 +1,10 @@
 {% trans_default_domain 'locationview' %}
 
 <section>
-    {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.relations.related_content'|trans({'%contentName%' : ez_content_name(content)})|desc('Related content (content items used by %contentName%)') } %}
-
+    {% include '@ezdesign/parts/table_header.html.twig' with {
+        headerText: 'tab.relations.related_content'|trans({
+            '%contentName%' : ez_content_name(content)
+        })|desc('Related content (content items used by %contentName%)') } %}
     {% if relations is not empty %}
         {{ include('@ezdesign/content/tab/relations/table_relations.html.twig', {'relations': relations}) }}
     {% else %}
@@ -11,14 +13,39 @@
         </p>
     {% endif %}
 
-    {% if reverse_relations is defined %}
-        {% include '@ezdesign/parts/table_header.html.twig' with { headerText: 'tab.relations.reverse_relations'|trans({'%contentName%' : ez_content_name(content)})|desc('Reverse relations (content items using %contentName%)') } %}
-        {% if reverse_relations is not empty %}
-            {{ include('@ezdesign/content/tab/relations/table_relations_reverse.html.twig', {'relations': reverse_relations}) }}
-        {% else %}
-            <p class="ez-table-no-content">
-                {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}
-            </p>
+    {% if reverse_relation_pager is defined %}
+        {% include '@ezdesign/parts/table_header.html.twig' with {
+            headerText: 'tab.relations.reverse_relations'|trans({
+                '%contentName%' : ez_content_name(content)
+            })|desc('Reverse relations (content items using %contentName%)')
+        } %}
+        {% if reverse_relation_pager.currentPageResults is not empty %}
+            {{ include('@ezdesign/content/tab/relations/table_relations_reverse.html.twig', {
+                'relations': reverse_relation_pager.currentPageResults
+            }) }}
         {% endif %}
+        {% if reverse_relation_pager.haveToPaginate %}
+            <div class="row justify-content-center align-items-center mb-2">
+                    <span class="ez-pagination__text">
+                        {{ 'pagination.viewing'|trans({
+                            '%viewing%': reverse_relation_pager.currentPageResults|length,
+                            '%total%': reverse_relation_pager.nbResults
+                        }, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                    </span>
+            </div>
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-4">
+                {{ pagerfanta(reverse_relation_pager, 'ez', {
+                    'routeName': reverse_relation_pagination_params.route_name,
+                    'routeParams': reverse_relation_pagination_params.route_params|merge({
+                        '_fragment': constant('EzSystems\\EzPlatformAdminUi\\Tab\\LocationView\\RelationsTab::URI_FRAGMENT'),
+                    }),
+                    'pageParameter': '[page][reverse_relation]'
+                }) }}
+            </div>
+        {% endif %}
+    {% else %}
+        <p class="ez-table-no-content">
+            {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}
+        </p>
     {% endif %}
 </section>

--- a/src/bundle/Resources/views/content/tab/relations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/tab.html.twig
@@ -23,6 +23,10 @@
             {{ include('@ezdesign/content/tab/relations/table_relations_reverse.html.twig', {
                 'relations': reverse_relation_pager.currentPageResults
             }) }}
+        {% else %}
+            <p class="ez-table-no-content">
+                {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}
+            </p>
         {% endif %}
         {% if reverse_relation_pager.haveToPaginate %}
             <div class="row justify-content-center align-items-center mb-2">
@@ -43,9 +47,5 @@
                 }) }}
             </div>
         {% endif %}
-    {% else %}
-        <p class="ez-table-no-content">
-            {{ 'tab.relations.no_reverse_relations'|trans()|desc('This content item has no reverse relations.') }}
-        </p>
     {% endif %}
 </section>

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -13,17 +13,31 @@
         </thead>
         <tbody>
         {% for relation in relations %}
-            {% set source = relation.sourceContentInfo %}
-            <tr>
-                <td><a href="{{ path('_ezpublishLocation', { 'locationId': source.mainLocationId }) }}">{{ source.name }}</a></td>
-                <td>{{ contentTypes[source.contentTypeId].name }}</td>
-                <td>
-                    {{ macros.relation_type(relation) }}
-                    {% if (relation.relationFieldDefinitionName) %}
-                        ({{ relation.relationFieldDefinitionName }})
-                    {% endif %}
-                </td>
-            </tr>
+            {% if relation.isAccessible %}
+                {% set source = relation.sourceContentInfo %}
+                <tr>
+                    <td><a href="{{ path('_ezpublishLocation', { 'locationId': source.mainLocationId }) }}">{{ source.name }}</a></td>
+                    <td>{{ contentTypes[source.contentTypeId].name }}</td>
+                    <td>
+                        {{ macros.relation_type(relation) }}
+                        {% if (relation.relationFieldDefinitionName) %}
+                            ({{ relation.relationFieldDefinitionName }})
+                        {% endif %}
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td class="table__cell ez-table__cell--has-text-info" colspan="8">
+                        {{
+                            'dashboard.table.relation.unauthorized'|trans({
+                                '%module%': relation.unauthorizedRelation.module,
+                                '%function%': relation.unauthorizedRelation.function,
+                                '%contentId%': relation.unauthorizedRelation.payload.contentId,
+                            })|desc('User does not have access to \'%function%\' \'%module%\' with content ID: %contentId%')
+                        }}
+                    </td>
+                </tr>
+            {% endif %}
         {% endfor %}
         </tbody>
     </table>

--- a/src/lib/Pagination/Pagerfanta/ReverseRelationAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/ReverseRelationAdapter.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use Pagerfanta\Adapter\AdapterInterface;
 
-class ReverseRelationAdapter implements AdapterInterface
+final class ReverseRelationAdapter implements AdapterInterface
 {
     /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;

--- a/src/lib/Pagination/Pagerfanta/ReverseRelationAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/ReverseRelationAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
+use Pagerfanta\Adapter\AdapterInterface;
+
+class ReverseRelationAdapter implements AdapterInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory */
+    private $datasetFactory;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $content;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     */
+    public function __construct(
+        ContentService $contentService,
+        DatasetFactory $datasetFactory,
+        Content $content
+    ) {
+        $this->contentService = $contentService;
+        $this->datasetFactory = $datasetFactory;
+        $this->content = $content;
+    }
+
+    /**
+     * Returns the number of results.
+     *
+     * @return int the number of results
+     */
+    public function getNbResults()
+    {
+        return $this->contentService->countReverseRelations($this->content->contentInfo);
+    }
+
+    /**
+     * Returns an slice of the results.
+     *
+     * @param int $offset the offset
+     * @param int $length the length
+     *
+     * @return array|\Traversable the slice
+     */
+    public function getSlice($offset, $length)
+    {
+        return $this->datasetFactory
+            ->reverseRelationList()
+            ->load($this->content, $offset, $length)
+            ->getReverseRelations();
+    }
+}

--- a/src/lib/UI/Dataset/DatasetFactory.php
+++ b/src/lib/UI/Dataset/DatasetFactory.php
@@ -116,11 +116,35 @@ class DatasetFactory
     }
 
     /**
+     * @deprecated since version 2.5, to be removed in 3.0. Please use DatasetFactory::relationList and DatasetFactory::reverseRelationList instead.
+     *
      * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\RelationsDataset
      */
     public function relations(): RelationsDataset
     {
         return new RelationsDataset($this->contentService, $this->valueFactory);
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\RelationListDataset
+     */
+    public function relationList(): RelationListDataset
+    {
+        return new RelationListDataset(
+            $this->contentService,
+            $this->valueFactory
+        );
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\ReverseRelationListDataset
+     */
+    public function reverseRelationList(): ReverseRelationListDataset
+    {
+        return new ReverseRelationListDataset(
+            $this->contentService,
+            $this->valueFactory
+        );
     }
 
     /**

--- a/src/lib/UI/Dataset/RelationListDataset.php
+++ b/src/lib/UI/Dataset/RelationListDataset.php
@@ -13,16 +13,16 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
 
-class RelationListDataset
+final class RelationListDataset
 {
     /** @var \eZ\Publish\API\Repository\ContentService */
-    protected $contentService;
+    private $contentService;
 
     /** @var \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory */
-    protected $valueFactory;
+    private $valueFactory;
 
     /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[] */
-    protected $relations;
+    private $relations;
 
     /**
      * @param \eZ\Publish\API\Repository\ContentService $contentService

--- a/src/lib/UI/Dataset/RelationListDataset.php
+++ b/src/lib/UI/Dataset/RelationListDataset.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Relation;
+use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
+
+class RelationListDataset
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    protected $contentService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory */
+    protected $valueFactory;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[] */
+    protected $relations;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory $valueFactory
+     */
+    public function __construct(ContentService $contentService, ValueFactory $valueFactory)
+    {
+        $this->contentService = $contentService;
+        $this->valueFactory = $valueFactory;
+        $this->relations = [];
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\RelationListDataset
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function load(
+        Content $content
+    ): self {
+        $versionInfo = $content->getVersionInfo();
+
+        $this->relations = array_map(
+            function (Relation $relation) use ($content) {
+                return $this->valueFactory->createRelation($relation, $content);
+            },
+            $this->contentService->loadRelations($versionInfo)
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[]
+     */
+    public function getRelations(): array
+    {
+        return $this->relations;
+    }
+}

--- a/src/lib/UI/Dataset/ReverseRelationListDataset.php
+++ b/src/lib/UI/Dataset/ReverseRelationListDataset.php
@@ -13,16 +13,16 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface;
 use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
 
-class ReverseRelationListDataset
+final class ReverseRelationListDataset
 {
     /** @var \eZ\Publish\API\Repository\ContentService */
-    protected $contentService;
+    private $contentService;
 
     /** @var \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory */
-    protected $valueFactory;
+    private $valueFactory;
 
     /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[] */
-    protected $reverseRelations;
+    private $reverseRelations;
 
     /**
      * @param \eZ\Publish\API\Repository\ContentService $contentService

--- a/src/lib/UI/Dataset/ReverseRelationListDataset.php
+++ b/src/lib/UI/Dataset/ReverseRelationListDataset.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface;
+use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
+
+class ReverseRelationListDataset
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    protected $contentService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory */
+    protected $valueFactory;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[] */
+    protected $reverseRelations;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory $valueFactory
+     */
+    public function __construct(ContentService $contentService, ValueFactory $valueFactory)
+    {
+        $this->contentService = $contentService;
+        $this->valueFactory = $valueFactory;
+        $this->reverseRelations = [];
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\ReverseRelationListDataset
+     */
+    public function load(
+        Content $content,
+        int $offset = 0,
+        int $limit = 10
+    ): self {
+        $versionInfo = $content->getVersionInfo();
+
+        $reverseRelationListItems = $this->contentService->loadReverseRelationList(
+            $versionInfo->getContentInfo(),
+            $offset,
+            $limit
+        )->items;
+
+        $this->reverseRelations = array_map(
+            function (RelationListItemInterface $relationListItem) use ($content) {
+                if ($relationListItem->hasRelation()) {
+                    /** @var \eZ\Publish\API\Repository\Values\Content\RelationList\Item\RelationListItem $relationListItem */
+                    return $this->valueFactory->createRelationItem(
+                        $relationListItem,
+                        $content
+                    );
+                }
+
+                /** @var \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem $relationListItem */
+                return $this->valueFactory->createUnauthorizedRelationItem(
+                    $relationListItem
+                );
+            },
+            $reverseRelationListItems
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface[]
+     */
+    public function getReverseRelations(): array
+    {
+        return $this->reverseRelations;
+    }
+}

--- a/src/lib/UI/Value/Content/Relation.php
+++ b/src/lib/UI/Value/Content/Relation.php
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Relation as APIRelation;
 /**
  * Extends original value object in order to provide additional fields.
  */
-class Relation extends CoreRelation
+class Relation extends CoreRelation implements RelationInterface
 {
     /**
      * Field definition name for the relation.
@@ -56,5 +56,13 @@ class Relation extends CoreRelation
     public function __construct(APIRelation $relation, array $properties = [])
     {
         parent::__construct(get_object_vars($relation) + $properties);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool
+    {
+        return true;
     }
 }

--- a/src/lib/UI/Value/Content/RelationInterface.php
+++ b/src/lib/UI/Value/Content/RelationInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
+
+interface RelationInterface
+{
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool;
+}

--- a/src/lib/UI/Value/Content/UnauthorizedRelation.php
+++ b/src/lib/UI/Value/Content/UnauthorizedRelation.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
+
+use eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem;
+
+class UnauthorizedRelation implements RelationInterface
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem */
+    private $unauthorizedRelation;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem $unauthorizedContentDraft
+     */
+    public function __construct(UnauthorizedRelationListItem $unauthorizedRelation)
+    {
+        $this->unauthorizedRelation = $unauthorizedRelation;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem
+     */
+    public function getUnauthorizedRelation(): UnauthorizedRelationListItem
+    {
+        return $this->unauthorizedRelation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool
+    {
+        return false;
+    }
+}

--- a/src/lib/UI/Value/Content/UnauthorizedRelation.php
+++ b/src/lib/UI/Value/Content/UnauthorizedRelation.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
 
 use eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem;
 
-class UnauthorizedRelation implements RelationInterface
+final class UnauthorizedRelation implements RelationInterface
 {
     /** @var \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem */
     private $unauthorizedRelation;

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -22,6 +22,8 @@ use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem;
+use eZ\Publish\API\Repository\Values\Content\RelationList\Item\RelationListItem;
+use eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -147,6 +149,8 @@ class ValueFactory
     }
 
     /**
+     * @deprecated since version 2.5, to be removed in 3.0. Please use ValueFactory::createRelationItem instead.
+     *
      * @param Relation $relation
      * @param Content $content
      *
@@ -166,6 +170,40 @@ class ValueFactory
             'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
             'relationName' => $content->getName(),
         ]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\RelationList\Item\RelationListItem $relationListItem
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return UIValue\Content\Relation
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function createRelationItem(RelationListItem $relationListItem, Content $content): UIValue\Content\Relation
+    {
+        $contentType = $content->getContentType();
+        $relation = $relationListItem->getRelation();
+        $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
+
+        return new UIValue\Content\Relation($relation, [
+            'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
+            'relationContentTypeName' => $contentType->getName(),
+            'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
+            'relationName' => $content->getName(),
+        ]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem $relationListItem
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\RelationInterface
+     */
+    public function createUnauthorizedRelationItem(
+        UnauthorizedRelationListItem $relationListItem
+    ): UIValue\Content\RelationInterface {
+        return new UIValue\Content\UnauthorizedRelation($relationListItem);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30900
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


To increase performance when content has many (~61k) reverse relations this PR adds pagination to Reverse relations list in the Location view. When the user has no permission to view the Relation he will see information like `User does not have access to 'read' 'content' with content ID: 100`

Related PRs:
- https://github.com/ezsystems/ezpublish-kernel/pull/2774
- https://github.com/ezsystems/ezpublish-kernel/pull/2777

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
