### PR TITLE
Merged PR with changed drafts pagination to use limit and offset

### DIFF
--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -35,6 +35,11 @@
             padding-right: calculateRem(20px);
         }
 
+        .table &--has-text-info {
+            padding: calculateRem(16px) calculateRem(8px);
+            text-align: center;
+        }
+
         &--has-checkbox {
             width: 5%;
         }

--- a/src/bundle/Resources/translations/alloy_editor.en.xliff
+++ b/src/bundle/Resources/translations/alloy_editor.en.xliff
@@ -206,6 +206,11 @@
         <target state="new">Remove block</target>
         <note>key: remove_block_btn.title</note>
       </trans-unit>
+      <trans-unit id="b54e4890869a4f4e1ec7065a38f1e9c8b9e8cf3d" resname="removed_content.label">
+        <source>Removed</source>
+        <target state="new">Removed</target>
+        <note>key: removed_content.label</note>
+      </trans-unit>
       <trans-unit id="e51c80180acbd8d90c95344dbdfb0f6a3ada456e" resname="table_btn.label">
         <source>Table</source>
         <target state="new">Table</target>
@@ -230,11 +235,6 @@
         <source>List</source>
         <target state="new">List</target>
         <note>key: unordered_list_btn.label</note>
-      </trans-unit>
-      <trans-unit id="d5a182a917683c8ecd6a8efa75a086321a209f52" resname="removed_content.label">
-        <source>Removed</source>
-        <target state="new">Removed</target>
-        <note>key: removed_content.label</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -71,6 +71,11 @@
         <target state="new">Edit Draft</target>
         <note>key: dashboard.table.draft.edit</note>
       </trans-unit>
+      <trans-unit id="5c6a58e397b164610db6371fe26b4e79aa3962f8" resname="dashboard.table.draft.unauthorized">
+        <source>User does not have access to '%function%' '%module%' with content ID: %contentId%</source>
+        <target state="new">User does not have access to '%function%' '%module%' with content ID: %contentId%</target>
+        <note>key: dashboard.table.draft.unauthorized</note>
+      </trans-unit>
       <trans-unit id="3a857cc58c009830e22845ef1edbd43794206aed" resname="dashboard.table.last_saved">
         <source>Last Saved</source>
         <target state="new">Last Saved</target>

--- a/src/bundle/Resources/translations/drafts.en.xliff
+++ b/src/bundle/Resources/translations/drafts.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="5c6a58e397b164610db6371fe26b4e79aa3962f8" resname="dashboard.table.draft.unauthorized">
+        <source>User does not have access to '%function%' '%module%' with content ID: %contentId%</source>
+        <target state="new">User does not have access to '%function%' '%module%' with content ID: %contentId%</target>
+        <note>key: dashboard.table.draft.unauthorized</note>
+      </trans-unit>
       <trans-unit id="f261167093447f7940efd1484b40e362028a728c" resname="drafts.list">
         <source>Drafts</source>
         <target state="new">Drafts</target>

--- a/src/bundle/Resources/views/themes/admin/content/draft/draft_list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/draft/draft_list.html.twig
@@ -1,0 +1,177 @@
+{% extends "@ezdesign/layout.html.twig" %}
+
+{% trans_default_domain 'drafts' %}
+
+{% form_theme form_remove '@ezdesign/form_fields.html.twig' %}
+
+{% import _self as macros %}
+
+{% block title %}{{ 'drafts.list'|trans|desc('Drafts') }} - {{ parent() }}{% endblock %}
+
+{% block body_class %}ez-drafts-list-view{% endblock %}
+
+{% block content %}
+    <div class="row align-items-stretch ez-main-row">
+        {% block left_sidebar %}
+            {{ parent() }}
+        {% endblock left_sidebar %}
+
+        <div class="px-0 ez-content-container">
+            <section class="container mt-5">
+                {% include '@ezdesign/parts/page_title.html.twig' with {
+                    title: 'drafts.list'|trans|desc('Drafts'),
+                    iconName: 'content-draft'
+                } %}
+
+                <div class="px-4">
+                    {{ form_start(form_remove, {
+                        'action': path('ezplatform.content_draft.remove'),
+                        'attr': {
+                            'class': 'ez-toggle-btn-state',
+                            'data-toggle-button-id': '#confirm-' ~ form_remove.remove.vars.id
+                        }
+                    }) }}
+
+                    {% include '@ezdesign/parts/table_header.html.twig' with {
+                        ground: 'mt-3',
+                        headerText: 'drafts.table.header'|trans|desc('Drafts') ~ ' (' ~ pager.count ~ ')',
+                        tools: macros.table_header_tools(form_remove)
+                     } %}
+                    <div class="ez-scrollable-table-wrapper">
+                        <table class="ez-table table">
+                            <thead>
+                                <tr>
+                                    <th class="ez-table__header-cell"></th>
+                                    <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                                    <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'drafts.list.name'|trans|desc('Name') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'drafts.list.content_type'|trans|desc('Content Type') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'drafts.list.modified_language'|trans|desc('Modified Language') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'drafts.list.version'|trans|desc('Version') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'drafts.list.last_saved'|trans|desc('Last Saved') }}</th>
+                                    <th class="ez-table__header-cell"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in pager.currentPageResults %}
+                                    {% if row.isAccessible %}
+                                        {% set content_draft_edit_url = content_is_user|default(false) ? 'ez_user_update' : 'ez_content_draft_edit' %}
+                                        <tr>
+                                            <td class="ez-table__cell ez-table__cell--has-checkbox">
+                                                {{ form_widget(form_remove.versions[row.versionId ~ '']) }}
+                                            </td>
+                                            <td class="ez-table__cell ez-table__cell--has-icon">
+                                                <svg class="ez-icon ez-icon--small">
+                                                    <use xlink:href="{{ ez_content_type_icon(row.contentType.identifier) }}"></use>
+                                                </svg>
+                                            </td>
+                                            <td class="ez-table__cell ez-table__cell--after-icon">{{ row.versionInfo.name }}</td>
+                                            <td class="ez-table__cell">{{ row.contentType.name }}</td>
+                                            <td class="ez-table__cell">{{ admin_ui_config.languages.mappings[row.versionInfo.initialLanguageCode].name }}</td>
+                                            <td class="ez-table__cell">{{ row.versionInfo.versionNo }}</td>
+                                            <td class="ez-table__cell">{{ row.versionInfo.modificationDate|ez_full_datetime }}</td>
+                                            <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                                                <button class="btn btn-icon mx-2 ez-btn--content-draft-edit"
+                                                        title="{{ 'drafts.list.action.edit'|trans|desc('Edit Draft') }}"
+                                                        data-content-id="{{ row.versionInfo.contentInfo.id }}"
+                                                        data-language-code="{{ row.versionInfo.initialLanguageCode }}"
+                                                        data-content-draft-edit-url="{{ path(content_draft_edit_url, {
+                                                            'contentId': row.versionInfo.contentInfo.id,
+                                                            'versionNo': row.versionInfo.versionNo,
+                                                            'language': row.versionInfo.initialLanguageCode
+                                                        }) }}"
+                                                        data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                                                            'contentId': row.versionInfo.contentInfo.id,
+                                                            'versionNo': row.versionInfo.versionNo,
+                                                            'languageCode': row.versionInfo.initialLanguageCode
+                                                        }) }}">
+                                                    <svg class="ez-icon ez-icon-edit">
+                                                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                                                    </svg>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    {% else %}
+                                        <tr>
+                                            <td class="table__cell ez-table__cell--has-text-info" colspan="8">
+                                                {{
+                                                    'dashboard.table.draft.unauthorized'|trans({
+                                                        '%module%': row.unauthorizedContentDraft.module,
+                                                        '%function%': row.unauthorizedContentDraft.function,
+                                                        '%contentId%': row.unauthorizedContentDraft.payload.contentId,
+                                                    })|desc('User does not have access to \'%function%\' \'%module%\' with content ID: %contentId%')
+                                                }}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                {% else %}
+                                    <tr>
+                                        <td class="ez-table__cell ez-table__cell--no-content" colspan="5">
+                                        <span class="mb-0 py-1 pl-0">
+                                            {{ 'drafts.list.empty'|trans|desc('The draft list is empty. Any Content draft you create will end up here.') }}
+                                        </span>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {{ form_widget(form_remove.remove, {
+                        'attr': {
+                            'hidden': true
+                        }
+                    }) }}
+                    {{ form_end(form_remove) }}
+
+                    {% if pager.haveToPaginate %}
+                        <div class="row justify-content-center align-items-center ez-pagination__spacing mb-2">
+                            <span class="ez-pagination__text">
+                                {{ 'pagination.viewing'|trans({
+                                    '%viewing%': pager.currentPageResults|length,
+                                    '%total%': pager.nbResults
+                                }, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                            </span>
+                        </div>
+                        <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
+                            {{ pagerfanta(pager, 'ez') }}
+                        </div>
+                    {% endif %}
+                </div>
+            </section>
+        </div>
+    </div>
+
+    {% include '@ezdesign/content/modal_version_conflict.html.twig' %}
+{% endblock %}
+
+{% block react_modules %}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-modules-content-tree-js', null, 'ezplatform') }}
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-content-draft-list-js', null, 'ezplatform') }}
+{% endblock %}
+
+{% macro table_header_tools(form) %}
+    {% set modal_data_target = 'modal-' ~ form.remove.vars.id %}
+
+    <button
+        id="confirm-{{ form.remove.vars.id }}"
+        type="button"
+        class="btn btn-danger"
+        disabled
+        data-toggle="modal"
+        data-target="#{{ modal_data_target }}"
+        title="{{ 'drafts.list.action.remove.confirmation.title'|trans|desc('Delete selected drafts') }}"
+    >
+        <svg class="ez-icon ez-icon-trash">
+            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+        </svg>
+    </button>
+
+    {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
+        'id': modal_data_target,
+        'message': 'drafts.list.action.remove.confirmation.text'|trans|desc('Are you sure you want to permanently delete the selected draft(s)?'),
+        'data_click': '#' ~ form.remove.vars.id,
+    } %}
+{% endmacro %}
+

--- a/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/draft/list.html.twig
@@ -1,3 +1,4 @@
+{# This template is deprecated since 2.5 and will be removed in 3.0. Please use src/bundle/Resources/views/admin/content_draft/draft_list.html.twig instead. #}
 {% extends "@ezdesign/ui/layout.html.twig" %}
 
 {% trans_default_domain 'drafts' %}

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_draft_list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_draft_list.html.twig
@@ -1,0 +1,87 @@
+{% trans_default_domain 'dashboard' %}
+
+{% if data|length %}
+    <table class="ez-table table">
+        <thead>
+            <tr>
+                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.modified_language'|trans|desc('Modified Language') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.version'|trans|desc('Version') }}</th>
+                <th class="ez-table__header-cell">{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+                <th class="ez-table__header-cell"></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            {% set content_draft_edit_url = content_is_user|default(false) ? 'ez_user_update' : 'ez_content_draft_edit' %}
+            {% if row.isAccessible %}
+                <tr>
+                    <td class="ez-table__cell ez-table__cell--has-icon">
+                        <svg class="ez-icon ez-icon--small">
+                            <use xlink:href="{{ ez_content_type_icon(row.contentType.identifier) }}"></use>
+                        </svg>
+                    </td>
+                    <td class="ez-table__cell ez-table__cell--after-icon">{{ row.versionInfo.name }}</td>
+                    <td class="ez-table__cell">{{ row.contentType.name }}</td>
+                    <td class="ez-table__cell">{{ ez_admin_ui_config.languages.mappings[row.versionInfo.initialLanguageCode].name }}</td>
+                    <td class="ez-table__cell">{{ row.versionInfo.versionNo }}</td>
+                    <td class="ez-table__cell">{{ row.versionInfo.modificationDate|ez_full_datetime }}</td>
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                        <button class="btn btn-icon mx-2 ez-btn--content-draft-edit"
+                                title="{{ 'dashboard.table.draft.edit'|trans|desc('Edit Draft') }}"
+                                data-content-draft-edit-url="{{ path(content_draft_edit_url, {
+                                    'contentId': row.versionInfo.contentInfo.id,
+                                    'versionNo': row.versionInfo.versionNo,
+                                    'language': row.versionInfo.initialLanguageCode
+                                }) }}"
+                                data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                                    'contentId': row.versionInfo.contentInfo.id,
+                                    'versionNo': row.versionInfo.versionNo,
+                                    'languageCode': row.versionInfo.initialLanguageCode
+                                }) }}"
+                                data-content-id="{{ row.versionInfo.contentInfo.id }}"
+                                data-language-code="{{ row.versionInfo.initialLanguageCode }}">
+                            <svg class="ez-icon ez-icon-edit">
+                                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
+                            </svg>
+                        </button>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td class="table__cell ez-table__cell--has-text-info" colspan="8">
+                        {{
+                            'dashboard.table.draft.unauthorized'|trans({
+                                '%module%': row.unauthorizedContentDraft.module,
+                                '%function%': row.unauthorizedContentDraft.function,
+                                '%contentId%': row.unauthorizedContentDraft.payload.contentId,
+                            })|desc('User does not have access to \'%function%\' \'%module%\' with content ID: %contentId%')
+                        }}
+                    </td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+
+    {% if pager.haveToPaginate %}
+        <div class="row justify-content-center align-items-center mb-2 mt-2 ez-pagination__spacing">
+            <span class="ez-pagination__text">
+                {{ 'pagination.viewing'|trans({
+                    '%viewing%': pager.currentPageResults|length,
+                    '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+            </span>
+        </div>
+        <div class="row justify-content-center align-items-center ez-pagination__btn">
+            {{ pagerfanta(pager, 'ez', pager_options|merge({
+                'routeParams': {
+                    '_fragment': 'ez-tab-dashboard-my-my-drafts'
+                }
+            })) }}
+        </div>
+    {% endif %}
+{% else %}
+    <p class="ez-table-no-content mb-0 py-0">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
+{% endif %}

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_drafts.html.twig
@@ -1,3 +1,5 @@
+{# This template is deprecated since 2.5 and will be removed in 3.0. Please use src/bundle/Resources/views/dashboard/tab/my_draft_list.html.twig instead. #}
+
 {% trans_default_domain 'dashboard' %}
 
 {% if data|length %}

--- a/src/lib/Pagination/Pagerfanta/ContentDraftAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/ContentDraftAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\ContentService;
+use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
+use Pagerfanta\Adapter\AdapterInterface;
+
+final class ContentDraftAdapter implements AdapterInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory */
+    private $datasetFactory;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
+     */
+    public function __construct(ContentService $contentService, DatasetFactory $datasetFactory)
+    {
+        $this->contentService = $contentService;
+        $this->datasetFactory = $datasetFactory;
+    }
+
+    /**
+     * Returns the number of results.
+     *
+     * @return int the number of results
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getNbResults()
+    {
+        return $this->contentService->countContentDrafts();
+    }
+
+    /**
+     * Returns an slice of the results.
+     *
+     * @param int $offset the offset
+     * @param int $length the length
+     *
+     * @return array|\Traversable the slice
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getSlice($offset, $length)
+    {
+        return $this->datasetFactory
+            ->contentDraftList()
+            ->load(null, $offset, $length)
+            ->getContentDrafts();
+    }
+}

--- a/src/lib/Tab/Dashboard/MyDraftsTab.php
+++ b/src/lib/Tab/Dashboard/MyDraftsTab.php
@@ -12,11 +12,11 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
+use EzSystems\EzPlatformAdminUi\Pagination\Pagerfanta\ContentDraftAdapter;
 use EzSystems\EzPlatformAdminUi\Tab\AbstractTab;
 use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
 use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
-use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -135,16 +135,13 @@ class MyDraftsTab extends AbstractTab implements OrderedTabInterface, Conditiona
             self::PAGINATION_PARAM_NAME, 1
         );
 
-        $contentDraftsDataset = $this->datasetFactory->contentDrafts();
-        $contentDraftsDataset->load();
-
         $pagination = new Pagerfanta(
-            new ArrayAdapter($contentDraftsDataset->getContentDrafts())
+            new ContentDraftAdapter($this->contentService, $this->datasetFactory)
         );
         $pagination->setMaxPerPage($this->defaultPaginationLimit);
         $pagination->setCurrentPage(min(max($currentPage, 1), $pagination->getNbPages()));
 
-        return $this->twig->render('@ezdesign/ui/dashboard/tab/my_drafts.html.twig', [
+        return $this->twig->render('@ezdesign/ui/dashboard/tab/my_draft_list.html.twig', [
             'data' => $pagination->getCurrentPageResults(),
             'pager' => $pagination,
             'pager_options' => [

--- a/src/lib/UI/Dataset/ContentDraftListDataset.php
+++ b/src/lib/UI/Dataset/ContentDraftListDataset.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\DraftList\ContentDraftListItemInterface;
+use eZ\Publish\API\Repository\Values\User\User;
+use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
+
+class ContentDraftListDataset
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory */
+    private $valueFactory;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\ContentDraftInterface[] */
+    private $data = [];
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory $valueFactory
+     */
+    public function __construct(
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        ValueFactory $valueFactory
+    ) {
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->valueFactory = $valueFactory;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\User|null $user
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\ContentDraftListDataset
+     */
+    public function load(User $user = null, int $offset = 0, int $limit = 10): self
+    {
+        $contentDraftListItems = $this->contentService->loadContentDraftList($user, $offset, $limit)->items;
+
+        $contentTypes = $contentTypeIds = [];
+        foreach ($contentDraftListItems as $contentDraftListItem) {
+            if ($contentDraftListItem->hasVersionInfo()) {
+                $contentTypeIds[] = $contentDraftListItem->getVersionInfo()->getContentInfo()->contentTypeId;
+            }
+        }
+
+        if (!empty($contentTypeIds)) {
+            $contentTypes = $this->contentTypeService->loadContentTypeList(array_unique($contentTypeIds));
+        }
+
+        $this->data = array_map(
+            function (ContentDraftListItemInterface $contentDraftListItem) use ($contentTypes) {
+                if ($contentDraftListItem->hasVersionInfo()) {
+                    $versionInfo = $contentDraftListItem->getVersionInfo();
+                    $contentType = $contentTypes[$versionInfo->getContentInfo()->contentTypeId];
+
+                    return $this->valueFactory->createContentDraft($contentDraftListItem, $contentType);
+                }
+
+                return $this->valueFactory->createUnauthorizedContentDraft($contentDraftListItem);
+            },
+            $contentDraftListItems
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\ContentDraftInterface[]
+     */
+    public function getContentDrafts(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/lib/UI/Dataset/ContentDraftsDataset.php
+++ b/src/lib/UI/Dataset/ContentDraftsDataset.php
@@ -17,6 +17,9 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
 use EzSystems\EzPlatformAdminUi\UI\Value\Content\VersionId;
 
+/**
+ * @deprecated Please move to use ContentDraftListDataset to get a paginated list of content drafts
+ */
 class ContentDraftsDataset
 {
     /** @var \eZ\Publish\API\Repository\ContentService */

--- a/src/lib/UI/Dataset/DatasetFactory.php
+++ b/src/lib/UI/Dataset/DatasetFactory.php
@@ -191,6 +191,8 @@ class DatasetFactory
     }
 
     /**
+     * @deprecated since version 2.5, to be removed in 3.0. Please use DatasetFactory::contentDraftList instead.
+     *
      * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\ContentDraftsDataset
      */
     public function contentDrafts(): ContentDraftsDataset
@@ -199,6 +201,18 @@ class DatasetFactory
             $this->contentService,
             $this->contentTypeService,
             $this->locationService
+        );
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Dataset\ContentDraftListDataset
+     */
+    public function contentDraftList(): ContentDraftListDataset
+    {
+        return new ContentDraftListDataset(
+            $this->contentService,
+            $this->contentTypeService,
+            $this->valueFactory
         );
     }
 }

--- a/src/lib/UI/Value/Content/ContentDraft.php
+++ b/src/lib/UI/Value/Content/ContentDraft.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
+
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+
+class ContentDraft implements ContentDraftInterface
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\VersionInfo */
+    private $versionInfo;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UI\Value\Content\VersionId */
+    private $versionId;
+
+    /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType */
+    private $contentType;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param \EzSystems\EzPlatformAdminUi\UI\Value\Content\VersionId $versionId
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     */
+    public function __construct(
+        VersionInfo $versionInfo,
+        VersionId $versionId,
+        ContentType $contentType
+    ) {
+        $this->versionInfo = $versionInfo;
+        $this->versionId = $versionId;
+        $this->contentType = $contentType;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo
+     */
+    public function getVersionInfo(): VersionInfo
+    {
+        return $this->versionInfo;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\VersionId
+     */
+    public function getVersionId(): VersionId
+    {
+        return $this->versionId;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    public function getContentType(): ContentType
+    {
+        return $this->contentType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool
+    {
+        return true;
+    }
+}

--- a/src/lib/UI/Value/Content/ContentDraftInterface.php
+++ b/src/lib/UI/Value/Content/ContentDraftInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
+
+interface ContentDraftInterface
+{
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool;
+}

--- a/src/lib/UI/Value/Content/UnauthorizedContentDraft.php
+++ b/src/lib/UI/Value/Content/UnauthorizedContentDraft.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UI\Value\Content;
+
+use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem;
+
+class UnauthorizedContentDraft implements ContentDraftInterface
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem */
+    private $unauthorizedContentDraft;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem $unauthorizedContentDraft
+     */
+    public function __construct(UnauthorizedContentDraftListItem $unauthorizedContentDraft)
+    {
+        $this->unauthorizedContentDraft = $unauthorizedContentDraft;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem
+     */
+    public function getUnauthorizedContentDraft(): UnauthorizedContentDraftListItem
+    {
+        return $this->unauthorizedContentDraft;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAccessible(): bool
+    {
+        return false;
+    }
+}

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -16,10 +16,12 @@ use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\DraftList\Item\ContentDraftListItem;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -285,5 +287,40 @@ class ValueFactory
             'userCanRemove' => $this->permissionResolver->canUser('class', 'update', $contentType),
             'main' => $language->languageCode === $contentType->mainLanguageCode,
         ]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\DraftList\Item\ContentDraftListItem $contentDraftListItem
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\ContentDraftInterface
+     */
+    public function createContentDraft(
+        ContentDraftListItem $contentDraftListItem,
+        ContentType $contentType
+    ): UIValue\Content\ContentDraftInterface {
+        $versionInfo = $contentDraftListItem->getVersionInfo();
+        $contentInfo = $versionInfo->contentInfo;
+        $versionId = new UIValue\Content\VersionId(
+            $contentInfo->id,
+            $versionInfo->versionNo
+        );
+
+        return new UIValue\Content\ContentDraft(
+            $versionInfo,
+            $versionId,
+            $contentType
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem $contentDraftListItem
+     *
+     * @return \EzSystems\EzPlatformAdminUi\UI\Value\Content\ContentDraftInterface
+     */
+    public function createUnauthorizedContentDraft(
+        UnauthorizedContentDraftListItem $contentDraftListItem
+    ): UIValue\Content\ContentDraftInterface {
+        return new UIValue\Content\UnauthorizedContentDraft($contentDraftListItem);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30427
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   |no
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR changed thy way which pagination for content drafts list load objects. The current implementation uses offset and limit to improve performance when many drafts are fetched (more than 5000). That change affects Dashboard and  list of user's drafts (`admin/contentdraft/list`)

If a user has no access to `content/versionread` then he will see information like `User does not have access to 'versionread' 'content' with content ID: 5178`

Related PR: https://github.com/ezsystems/ezpublish-kernel/pull/2753

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review