### PR TITLE
EZP-30985: Removed usage of deprecated event classes

### DIFF
--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -14,7 +14,7 @@ use EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
@@ -73,9 +73,9 @@ class AdminExceptionListener
     }
 
     /**
-     * @param GetResponseForExceptionEvent $event
+     * @param ExceptionEvent $event
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event)
     {
         if ($this->kernelEnvironment !== 'prod') {
             return;
@@ -125,11 +125,11 @@ class AdminExceptionListener
     }
 
     /**
-     * @param GetResponseForExceptionEvent $event
+     * @param ExceptionEvent $event
      *
      * @return bool
      */
-    private function isAdminException(GetResponseForExceptionEvent $event): bool
+    private function isAdminException(ExceptionEvent $event): bool
     {
         $request = $event->getRequest();
 

--- a/src/lib/EventListener/RequestListener.php
+++ b/src/lib/EventListener/RequestListener.php
@@ -8,7 +8,7 @@ namespace EzSystems\EzPlatformAdminUi\EventListener;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -51,7 +51,7 @@ class RequestListener implements EventSubscriberInterface
         ];
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;

--- a/src/lib/EventListener/RequestLocaleListener.php
+++ b/src/lib/EventListener/RequestLocaleListener.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -67,11 +67,11 @@ class RequestLocaleListener implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      *
      * @throws \EzSystems\EzPlatformAdminUi\Exception\InvalidArgumentException
      */
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/lib/Tests/EventListener/RequestListenerTest.php
+++ b/src/lib/Tests/EventListener/RequestListenerTest.php
@@ -8,7 +8,7 @@ namespace EzSystems\EzPlatformAdminUi\Tests\EventListener;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +24,7 @@ class RequestListenerTest extends TestCase
     /** @var Request */
     private $request;
 
-    /** @var GetResponseEvent */
+    /** @var RequestEvent */
     private $event;
 
     /** @var HttpKernelInterface|MockObject */
@@ -43,7 +43,7 @@ class RequestListenerTest extends TestCase
 
         $this->httpKernel = $this->createMock(HttpKernelInterface::class);
 
-        $this->event = new GetResponseEvent(
+        $this->event = new RequestEvent(
             $this->httpKernel,
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -63,7 +63,7 @@ class RequestListenerTest extends TestCase
 
     public function testOnKernelRequestAllowAccessWithSubRequest()
     {
-        $this->event = new GetResponseEvent(
+        $this->event = new RequestEvent(
             $this->httpKernel,
             $this->request,
             HttpKernelInterface::SUB_REQUEST

--- a/src/lib/Tests/EventListener/RequestLocaleListenerTest.php
+++ b/src/lib/Tests/EventListener/RequestLocaleListenerTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use EzSystems\EzPlatformAdminUi\EventListener\RequestLocaleListener;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use PHPUnit\Framework\TestCase;
@@ -76,7 +76,7 @@ class RequestLocaleListenerTest extends TestCase
 
         $request->attributes->set('siteaccess', new SiteAccess(self::NON_ADMIN_SITEACCESS));
 
-        $event = new GetResponseEvent(
+        $event = new RequestEvent(
             $this->httpKernel,
             $request,
             HttpKernelInterface::MASTER_REQUEST
@@ -101,7 +101,7 @@ class RequestLocaleListenerTest extends TestCase
 
         $request->attributes->set('siteaccess', new SiteAccess(self::ADMIN_SITEACCESS));
 
-        $event = new GetResponseEvent(
+        $event = new RequestEvent(
             $this->httpKernel,
             $request,
             HttpKernelInterface::SUB_REQUEST
@@ -130,7 +130,7 @@ class RequestLocaleListenerTest extends TestCase
             ->method('setLocale')
             ->with('en_US');
 
-        $event = new GetResponseEvent(
+        $event = new RequestEvent(
             $this->httpKernel,
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -163,7 +163,7 @@ class RequestLocaleListenerTest extends TestCase
             ->method('setLocale')
             ->with('en_US');
 
-        $event = new GetResponseEvent(
+        $event = new RequestEvent(
             $this->httpKernel,
             $this->request,
             HttpKernelInterface::MASTER_REQUEST
@@ -204,7 +204,7 @@ class RequestLocaleListenerTest extends TestCase
 
         $this->request->attributes->set('siteaccess', new Attribute());
 
-        $event = new GetResponseEvent(
+        $event = new RequestEvent(
             $this->httpKernel,
             $this->request,
             HttpKernelInterface::MASTER_REQUEST


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30985
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Since Symfony 4.3:

* `\Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent` has been deprecated in favour of `\Symfony\Component\HttpKernel\Event\ExceptionEvent`
* `\Symfony\Component\HttpKernel\Event\GetResponseEvent` has been deprecated in favour of `\Symfony\Component\HttpKernel\Event\RequestEvent`

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
