### PR TITLE
EZP-31000: Fixed selection of proper tab when using pagination with the embedded content

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.tab.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tab.js
@@ -1,5 +1,20 @@
 (function (global, doc, $) {
-    $('.ez-tabs a[href="#' + global.location.hash.split('#')[1] + '"]').tab('show');
+    const location = global.location;
+
+    /**
+     * Returns tab identifier from hash or url parameter
+     *
+     * @function createContentTypeDataMap
+     * @param {Location} location
+     * @returns {string}
+     */
+    const getTabId = (location) => {
+        return location.hash.split('#')[1]
+            || new URL(location.href).searchParams.get("_fragment")
+            || '';
+    };
+
+    $('.ez-tabs a[href="#' + getTabId(location) + '"]').tab('show');
 
     // Change hash for page-reload
     $('.ez-tabs a').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31000
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When the user enters the view of the location and there click a link to embedded content, then he is redirected to view rendered by `ez_urlalias` route. This PR adds support to `_fragment` parameter in the URL to select the proper tab.

This bug occurs for all pagination lists in content preview.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
