### PR TITLE
EZP-30959: Long URL overlaps "clear URL input" button in Online Editor

### DIFF
--- a/src/bundle/Resources/public/scss/_alloyeditor-link-edit.scss
+++ b/src/bundle/Resources/public/scss/_alloyeditor-link-edit.scss
@@ -130,6 +130,7 @@
             height: calculateRem(36px);
             border: calculateRem(1px) solid $ez-ground-base-dark;
             border-radius: calculateRem(4px);
+            padding-right: calculateRem(32px);
         }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30959](https://jira.ez.no/browse/EZP-30959)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Long URL overlaps "clear URL button" which makes it hard to edit.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
