### PR TITLE
Use Twig namespaces

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -109,9 +109,9 @@ services:
 
     # @todo 3.0: Remove this service once all twig |truncate calls are removed from link_manager/* templates
     #            composer.json doesn't have dependency on twig/extensions which is required for this service
-    Twig_Extensions_Extension_Text:
+    Twig\Extensions\TextExtension:
         public: true
-        class: \Twig_Extensions_Extension_Text
+        class: Twig\Extensions\TextExtension
         tags:
             - { name: twig.extension }
 

--- a/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
+++ b/src/lib/RepositoryForms/Form/Processor/Content/ContentOnTheFlyProcessor.php
@@ -48,9 +48,9 @@ class ContentOnTheFlyProcessor implements EventSubscriberInterface
     /**
      * @param \EzSystems\RepositoryForms\Event\FormActionEvent $event
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException

--- a/src/lib/Tab/Dashboard/MyDraftsTab.php
+++ b/src/lib/Tab/Dashboard/MyDraftsTab.php
@@ -125,9 +125,9 @@ class MyDraftsTab extends AbstractTab implements OrderedTabInterface, Conditiona
      *
      * @return string
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function renderView(array $parameters): string
     {

--- a/src/lib/Translation/Extractor/JavaScriptFileVisitor.php
+++ b/src/lib/Translation/Extractor/JavaScriptFileVisitor.php
@@ -21,6 +21,7 @@ use Peast\Syntax\Node;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use SplFileInfo;
+use Twig\Node\Node as TwigNode;
 
 class JavaScriptFileVisitor implements FileVisitorInterface, LoggerAwareInterface
 {
@@ -103,7 +104,7 @@ class JavaScriptFileVisitor implements FileVisitorInterface, LoggerAwareInterfac
     {
     }
 
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 

--- a/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
+++ b/src/lib/Translation/Extractor/NotificationTranslationExtractor.php
@@ -24,6 +24,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts translations from TranslatableNotificationHandler::{info,success,warning,error} method calls.
@@ -171,7 +172,7 @@ class NotificationTranslationExtractor implements LoggerAwareInterface, FileVisi
     {
     }
 
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Part of the patch changes methods which implement `JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface::visitTwigFile` which still uses old Twig class names. However, this is perfectly valid. The following code runs fine:

```php
<?php

require 'vendor/autoload.php';

interface Foo
{
    public function foo(\Twig_Node $node);
}

class Bar implements Foo
{
    public function foo(\Twig\Node\Node $node)
    {
        return 'foo';
    }
}


$b = new Bar();

echo $b->foo(new \Twig\Node\Node());
echo $b->foo(new \Twig_Node());
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
