### PR TITLE
EZP-30985: Replaced usage of deprecated transchoice Twig function

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -51,10 +51,15 @@
         <target state="new">Default availability in primary language, if translation is absent</target>
         <note>key: content_type.default_availability.help</note>
       </trans-unit>
-      <trans-unit id="d14799b2ac8854ab3f0bb9976258c3db39213d09" resname="content_type.default_availability.value">
-        <source>{0} Not available|{1} Available</source>
-        <target state="new">{0} Not available|{1} Available</target>
-        <note>key: content_type.default_availability.value</note>
+      <trans-unit id="944e509cd754c05d24aea116e6b307a350da42ea" resname="content_type.default_availability.available">
+        <source>Available</source>
+        <target state="new">Available</target>
+        <note>key: content_type.default_availability.available</note>
+      </trans-unit>
+      <trans-unit id="da6afb475bbd2efbe3929af770d0fc17e6e86132" resname="content_type.default_availability.not_available">
+        <source>Not available</source>
+        <target state="new">Not available</target>
+        <note>key: content_type.default_availability.not_available</note>
       </trans-unit>
       <trans-unit id="5ebf6515da27060877064931a5ac1d5a8540e28d" resname="content_type.default_children_sorting">
         <source>Default field for sorting children</source>
@@ -411,10 +416,15 @@
         <target state="new">View</target>
         <note>key: tab.name.view</note>
       </trans-unit>
-      <trans-unit id="3e9deeb426f08a404990a6926d70558955272593" resname="yes_no">
-        <source>{0}No|{1}Yes</source>
-        <target state="new">{0}No|{1}Yes</target>
-        <note>key: yes_no</note>
+      <trans-unit id="fb360f9c09ac8c5edb2f18be5de4e80ea4c430d0" resname="yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note>key: yes</note>
+      </trans-unit>
+      <trans-unit id="fd1286353570c5703799ba76999323b7c7447b06" resname="no">
+        <source>No</source>
+        <target state="new">No</target>
+        <note>key: no</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/translations/draft_conflict.en.xliff
+++ b/src/bundle/Resources/translations/draft_conflict.en.xliff
@@ -21,10 +21,15 @@
         <target state="new">Draft conflict when editing</target>
         <note>key: draft.conflict.header</note>
       </trans-unit>
-      <trans-unit id="d5fdbb680e6950e955c933e05f15f861c2020517" resname="draft.conflict.number">
-        <source>{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item</source>
-        <target state="new">{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item</target>
-        <note>key: draft.conflict.number</note>
+      <trans-unit id="b72a86589e4df8c7b1ff60e24b71971ef2c6bb86" resname="draft.conflict.number.one">
+        <source>There is 1 draft for this content item.</source>
+        <target state="new">There is 1 draft for this content item.</target>
+        <note>key: draft.conflict.number.one</note>
+      </trans-unit>
+      <trans-unit id="88dbada59962180257d8fec8c842c86c2feb934d" resname="draft.conflict.number.multiple">
+        <source>There are %number% drafts for this content item.</source>
+        <target state="new">There are %number% drafts for this content item.</target>
+        <note>key: draft.conflict.number.multiple</note>
       </trans-unit>
       <trans-unit id="a4297fe31e8eb3307caa2cf855328056c3b98962" resname="tab.versions.action.delete">
         <source>Add draft</source>

--- a/src/bundle/Resources/views/themes/admin/content/modal/draft_conflict.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/modal/draft_conflict.html.twig
@@ -17,9 +17,11 @@
                 <div class="ez-modal-body__main">
                     <p class="ez-modal-body__main-content">
                         {% set number = conflicted_drafts|length %}
-                        {{ 'draft.conflict.number'|transchoice(number, {'%number%': number })|desc(
-                        '{1}There are %number% draft for this content item.|]1,Inf[ There are %number% drafts for this content item'
-                        ) }}
+                        {% if number == 1 %}
+                            {{ 'draft.conflict.number.one'|trans|desc('There is one draft for this content item.') }}
+                        {% else %}
+                            {{ 'draft.conflict.number.multiple'|trans({ '%number%': number })|desc('There are %number% drafts for this content item.') }}
+                        {% endif %}
                     </p>
                     <p class="ez-modal-body__main-content">
                         {% if content_is_user %}

--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -85,7 +85,13 @@
                     {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                 </p>
             </td>
-            <td class="ez-table__cell">{{ content_type.defaultAlwaysAvailable ? 'content_type.default_availability.available'|trans|desc("Available") : 'content_type.default_availability.not_available'|trans|desc("Not available") }}</td>
+            <td class="ez-table__cell">
+                {% if content_type.defaultAlwaysAvailable %}
+                    {{ 'content_type.default_availability.available'|trans|desc("Available") }}
+                {% else %}
+                    {{ 'content_type.default_availability.not_available'|trans|desc("Not available") }}
+                {% endif %}
+            </td>
         </tr>
         </tbody>
     </table>

--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -64,7 +64,7 @@
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.container"|trans|desc("Container") }}</td>
-            <td class="ez-table__cell">{{ 'yes_no'|transchoice(content_type.isContainer ? 1 : 0)|desc("{0}No|{1}Yes") }}</td>
+            <td class="ez-table__cell">{{ content_type.isContainer ? 'yes'|trans|desc("Yes") : 'no'|trans|desc("No") }}</td>
         </tr>
         <tr class="ez-table__row">
             <td class="ez-table__cell">{{ "content_type.default_children_sorting"|trans|desc("Default field for sorting children") }}</td>
@@ -85,7 +85,7 @@
                     {{ "content_type.default_availability.help"|trans|desc("Default availability in primary language, if translation is absent") }}
                 </p>
             </td>
-            <td class="ez-table__cell">{{ 'content_type.default_availability.value'|transchoice(content_type.defaultAlwaysAvailable ? 1 : 0)|desc("{0} Not available|{1} Available") }}</td>
+            <td class="ez-table__cell">{{ content_type.defaultAlwaysAvailable ? 'content_type.default_availability.available'|trans|desc("Available") : 'content_type.default_availability.not_available'|trans|desc("Not available") }}</td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30985
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes? (New translation strings required)
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

`transchoice` has been deprecated since Symfony 4.2.

Here, I've opted for using separate translation strings, rather than reimplementing `trans` with ICU MessageFormat which requires renaming translation files to have a new prefix for ICU messages to be recognized.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
