### PR TITLE
EZP-31029: Adjust Role transformers to introduced type hints in RoleService

### DIFF
--- a/src/lib/Form/DataTransformer/RoleAssignmentTransformer.php
+++ b/src/lib/Form/DataTransformer/RoleAssignmentTransformer.php
@@ -69,8 +69,12 @@ class RoleAssignmentTransformer implements DataTransformerInterface
             return null;
         }
 
+        if (!ctype_digit($value)) {
+            throw new TransformationFailedException('Expected a numeric string.');
+        }
+
         try {
-            return $this->roleService->loadRoleAssignment($value);
+            return $this->roleService->loadRoleAssignment((int)$value);
         } catch (NotFoundException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/lib/Form/DataTransformer/RoleTransformer.php
+++ b/src/lib/Form/DataTransformer/RoleTransformer.php
@@ -69,8 +69,12 @@ class RoleTransformer implements DataTransformerInterface
             return null;
         }
 
+        if (!ctype_digit($value)) {
+            throw new TransformationFailedException('Expected a numeric string.');
+        }
+
         try {
-            return $this->roleService->loadRole($value);
+            return $this->roleService->loadRole((int)$value);
         } catch (NotFoundException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
@@ -41,8 +41,8 @@ class RoleAssignmentTransformerTest extends TestCase
      */
     public function testTransformWithInvalidInput($value)
     {
-        $languageService = $this->createMock(RoleService::class);
-        $transformer = new RoleAssignmentTransformer($languageService);
+        $roleService = $this->createMock(RoleService::class);
+        $transformer = new RoleAssignmentTransformer($roleService);
 
         $this->expectException(TransformationFailedException::class);
         $this->expectExceptionMessage('Expected a ' . APIRoleAsignment::class . ' object.');
@@ -78,17 +78,34 @@ class RoleAssignmentTransformerTest extends TestCase
         $this->assertNull($result);
     }
 
+    /**
+     * @dataProvider reverseTransformWithInvalidInputDataProvider
+     *
+     * @param $value
+     */
+    public function testReverseTransformWithInvalidInput($value)
+    {
+        $service = $this->createMock(RoleService::class);
+
+        $transformer = new RoleAssignmentTransformer($service);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Expected a numeric string.');
+
+        $transformer->reverseTransform($value);
+    }
+
     public function testReverseTransformWithNotFoundException()
     {
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('Location not found');
-
         $service = $this->createMock(RoleService::class);
         $service->method('loadRoleAssignment')
             ->will($this->throwException(new class('Location not found') extends NotFoundException {
             }));
 
         $transformer = new RoleAssignmentTransformer($service);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Location not found');
 
         $transformer->reverseTransform(654321);
     }
@@ -118,6 +135,22 @@ class RoleAssignmentTransformerTest extends TestCase
             'float' => [12.34],
             'array' => [[]],
             'object' => [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function reverseTransformWithInvalidInputDataProvider(): array
+    {
+        return [
+            'string' => ['string'],
+            'bool' => [true],
+            'float' => [12.34],
+            'array' => [[1]],
+            'object' => [new \stdClass()],
+            'scientific_notation' => ['1337e0'],
+            'hexadecimal' => ['0x539'],
         ];
     }
 }

--- a/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleAssignmentTransformerTest.php
@@ -80,8 +80,6 @@ class RoleAssignmentTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseTransformWithInvalidInputDataProvider
-     *
-     * @param $value
      */
     public function testReverseTransformWithInvalidInput($value)
     {
@@ -138,9 +136,6 @@ class RoleAssignmentTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function reverseTransformWithInvalidInputDataProvider(): array
     {
         return [

--- a/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
@@ -41,8 +41,8 @@ class RoleTransformerTest extends TestCase
      */
     public function testTransformWithInvalidInput($value)
     {
-        $languageService = $this->createMock(RoleService::class);
-        $transformer = new RoleTransformer($languageService);
+        $roleService = $this->createMock(RoleService::class);
+        $transformer = new RoleTransformer($roleService);
 
         $this->expectException(TransformationFailedException::class);
         $this->expectExceptionMessage('Expected a ' . APIRole::class . ' object.');
@@ -76,6 +76,22 @@ class RoleTransformerTest extends TestCase
         $result = $transformer->reverseTransform(null);
 
         $this->assertNull($result);
+    }
+
+    /**
+     * @dataProvider reverseTransformWithInvalidInputDataProvider
+     *
+     * @param $value
+     */
+    public function testReverseTransformWithInvalidInput($value)
+    {
+        $roleService = $this->createMock(RoleService::class);
+        $transformer = new RoleTransformer($roleService);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Expected a numeric string.');
+
+        $transformer->reverseTransform($value);
     }
 
     public function testReverseTransformWithNotFoundException()
@@ -118,6 +134,22 @@ class RoleTransformerTest extends TestCase
             'float' => [12.34],
             'array' => [[]],
             'object' => [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function reverseTransformWithInvalidInputDataProvider(): array
+    {
+        return [
+            'string' => ['string'],
+            'bool' => [true],
+            'float' => [12.34],
+            'array' => [[1]],
+            'object' => [new \stdClass()],
+            'scientific_notation' => ['1337e0'],
+            'hexadecimal' => ['0x539'],
         ];
     }
 }

--- a/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/RoleTransformerTest.php
@@ -80,8 +80,6 @@ class RoleTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseTransformWithInvalidInputDataProvider
-     *
-     * @param $value
      */
     public function testReverseTransformWithInvalidInput($value)
     {
@@ -137,9 +135,6 @@ class RoleTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function reverseTransformWithInvalidInputDataProvider(): array
     {
         return [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31029
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


After adding type hints to RoleService we must pass `integer` as a Role ID to RoleService:: loadRole and RoleService:: loadRoleAssignment methods

Needs https://github.com/ezsystems/ezpublish-kernel/pull/2822

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
