### PR TITLE
EZP-31052: Provided minimal support for CustomTag link attr. type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ezsystems/ez-support-tools": "^1.0@dev",
         "ezsystems/ezplatform-design-engine": "^2.0@dev",
         "ezsystems/ezplatform-user": "^1.0@dev",
-        "ezsystems/ezplatform-richtext": "^1.1.2@dev",
+        "ezsystems/ezplatform-richtext": "^1.1.5@dev",
         "white-october/pagerfanta-bundle": "^1.1",
         "knplabs/knp-menu-bundle": "^2.1",
         "mck89/peast": "^1.8",

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-customtag-update.js
@@ -121,6 +121,19 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
     }
 
     /**
+     * Renders the link.
+     *
+     * @method renderLink
+     * @param {Object} config
+     * @param {String} attrName
+     * @return {Object} The rendered link.
+     */
+    renderLink(config, attrName) {
+        // @todo provide dedicated support for link attribute type
+        return this.renderString(config, attrName);
+    }
+
+    /**
      * Renders the option.
      *
      * @method renderChoice
@@ -253,6 +266,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
             boolean: 'renderCheckbox',
             number: 'renderNumber',
             choice: 'renderSelect',
+            link: 'renderLink',
         };
     }
 }

--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-custom-tag-base.js
@@ -441,9 +441,12 @@ const customTagBaseDefinition = {
         let content = [...this.element.getChildren().$].find((child) => child.dataset && child.dataset.ezelement === 'ezcontent');
 
         if (!content) {
+            const para = new CKEDITOR.dom.element('p');
+
             content = new CKEDITOR.dom.element('div');
             content.data('ezelement', 'ezcontent');
-            this.element.append(content);
+            content.append(para);
+            this.element.append(content, true);
         } else {
             content = new CKEDITOR.dom.element(content);
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31052](https://jira.ez.no/browse/EZP-31052)
| Requires | ezsystems/ezplatform-richtext#73
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | [yes](https://travis-ci.org/ezsystems/ezplatform-admin-ui/builds/601814379)
| Doc needed?   | yes, for RichText PR
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR provides a minimal support for the Custom Tag link attribute type added via ezsystems/ezplatform-richtext#73. The support is in the form of a simple string input field, to avoid Online Editor crashing for the new attribute type.

**Note: _AdminUI crashing for RichText (`ezrichtext`) Field migrated from `ezxmltext` is considered here as a bug, nothing more_.**

### Possible alternative solutions

1. Disabling edit button for Custom Tag which contains an attribute of the "link" type.
2. Disabling text input field for such attribute.
3. Hiding input field for such attribute.

#### Checklist:
- [x] Render UI for the "link" attribute type as a string/text field.
- [x] Bump required RichText package version.
- [x] Complete ezsystems/ezplatform-richtext#73.
- [x] Ready for Code Review.
