### PR TITLE
EZEE-2910: Cannot use Translator when JS is loaded to fast

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -22,11 +22,12 @@ const layout = [
     path.resolve(__dirname, '../public/js/scripts/admin.location.add.translation.js'),
     path.resolve(__dirname, '../public/js/scripts/admin.form.autosubmit.js'),
 ];
+const translations = [];
 const fieldTypes = [];
 
 fs.readdirSync(translationsPath).forEach((file) => {
     if (file !== 'config.js' && path.extname(file) === '.js') {
-        layout.push(path.resolve(translationsPath, file));
+        translations.push(path.resolve(translationsPath, file));
     }
 });
 
@@ -38,6 +39,7 @@ fs.readdirSync(fieldTypesPath).forEach((file) => {
 
 module.exports = (Encore) => {
     Encore.addEntry('ezplatform-admin-ui-layout-js', layout)
+        .addEntry('ezplatform-admin-ui-translations-js', translations)
         .addEntry('ezplatform-admin-ui-bookmark-list-js', [
             path.resolve(__dirname, '../public/js/scripts/button.state.toggle.js'),
             path.resolve(__dirname, '../public/js/scripts/button.content.edit.js'),

--- a/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/layout.html.twig
@@ -94,6 +94,11 @@
         {{ encore_entry_link_tags('ezplatform-admin-ui-layout-css', null, 'ezplatform') }}
         {% block stylesheets %}{% endblock %}
         <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+
+        <script src="{{ asset('bundles/bazingajstranslation/js/translator.min.js') }}"></script>
+        <script src="{{ asset('assets/translations/config.js') }}"></script>
+        {{ encore_entry_script_tags('ezplatform-admin-ui-translations-js', null, 'ezplatform') }}
+
         {{ ez_render_component_group('stylesheet-head') }}
         {{ ez_render_component_group('script-head') }}
 
@@ -107,8 +112,6 @@
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/flatpickr/dist/flatpickr.min.js') }}"></script>
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/moment/min/moment.min.js') }}"></script>
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/moment-timezone/builds/moment-timezone-with-data.min.js') }}"></script>
-        <script src="{{ asset('bundles/bazingajstranslation/js/translator.min.js') }}"></script>
-        <script src="{{ asset('assets/translations/config.js') }}"></script>
         <script src="{{ asset('bundles/ezplatformadminuiassets/vendors/alloyeditor/dist/alloy-editor/alloy-editor-no-react-min.js') }}"></script>
     </head>
     <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2910
| Required by | https://github.com/ezsystems/ezplatform-workflow/pull/80
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
