### PR TITLE
fix: wrong allowed content types list for object relation(s) fields

### DIFF
--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -42,12 +42,16 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
             return;
         }
 
-        $config['content_on_the_fly']['allowed_content_types'] = array_unique(
-            array_merge(
-                $config['content_on_the_fly']['allowed_content_types'],
-                $context['allowed_content_types']
-            )
-        );
+        if (!empty($config['content_on_the_fly']['allowed_content_types'])) {
+            $config['content_on_the_fly']['allowed_content_types'] = array_values(
+                array_intersect(
+                    $config['content_on_the_fly']['allowed_content_types'],
+                    $context['allowed_content_types']
+                )
+            );
+        } else {
+            $config['content_on_the_fly']['allowed_content_types'] = $context['allowed_content_types'];
+        }
 
         $event->setConfig($config);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31089
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
