### PR TITLE
EZP-31096: Custom toolbars in Alloy Editor

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -58,6 +58,9 @@
                 }
             );
             this.alloyEditorExtraPlugins = global.eZ.adminUiConfig.alloyEditor.extraPlugins;
+            this.customStyleSelections = window.eZ.ezAlloyEditor.CustomSelections
+                ? Object.values(window.eZ.ezAlloyEditor.CustomSelections)
+                : {};
 
             this.xhtmlify = this.xhtmlify.bind(this);
         }
@@ -192,6 +195,9 @@
 
         init(container) {
             const toolbarProps = { extraButtons: this.alloyEditorExtraButtons, attributes: this.attributes, classes: this.classes };
+            const customSelections = this.customStyleSelections.map((selection) => {
+                return new selection(toolbarProps);
+            });
             const alloyEditor = global.AlloyEditor.editable(container.getAttribute('id'), {
                 toolbars: {
                     ezadd: {
@@ -250,6 +256,7 @@
                             new window.eZ.ezAlloyEditor.ezEmbedImageLinkConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezEmbedImageConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezEmbedConfig(toolbarProps),
+                            ...customSelections,
                         ],
                         tabIndex: 1,
                     },

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -60,7 +60,7 @@
             this.alloyEditorExtraPlugins = global.eZ.adminUiConfig.alloyEditor.extraPlugins;
             this.customStyleSelections = window.eZ.ezAlloyEditor.CustomSelections
                 ? Object.values(window.eZ.ezAlloyEditor.CustomSelections)
-                : {};
+                : [];
 
             this.xhtmlify = this.xhtmlify.bind(this);
         }

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -58,8 +58,8 @@
                 }
             );
             this.alloyEditorExtraPlugins = global.eZ.adminUiConfig.alloyEditor.extraPlugins;
-            this.customStyleSelections = window.eZ.ezAlloyEditor.CustomSelections
-                ? Object.values(window.eZ.ezAlloyEditor.CustomSelections)
+            this.customStyleSelections = global.eZ.ezAlloyEditor.customSelections
+                ? Object.values(global.eZ.ezAlloyEditor.customSelections)
                 : [];
 
             this.xhtmlify = this.xhtmlify.bind(this);
@@ -195,8 +195,8 @@
 
         init(container) {
             const toolbarProps = { extraButtons: this.alloyEditorExtraButtons, attributes: this.attributes, classes: this.classes };
-            const customSelections = this.customStyleSelections.map((selection) => {
-                return new selection(toolbarProps);
+            const customSelections = this.customStyleSelections.map((Selection) => {
+                return new Selection(toolbarProps);
             });
             const alloyEditor = global.AlloyEditor.editable(container.getAttribute('id'), {
                 toolbars: {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31096
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR allows injecting custom toolbars into the Alloy Editor. Usage:
1. Create the new toolbar config.
2. Add the toolbar config to `ezplatform-admin-ui-alloyeditor-js` entry using encore.
3. Add toolbar JavaScript class to `ezAlloyEditor.CustomSelections.<TOOLBAR_NAME>` eZ config. You can do it at the botton of toolbar config file:
```
eZ.addConfig('ezAlloyEditor.CustomSelections.ContentVariableEdit', ContentVariableEditConfig);
```
4. `ContentVariableEditConfig` toolbar is injected and can be used.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
