### PR TITLE
EZP-31138: Fixed missing Elements Path for richtext_widget

### DIFF
--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -168,6 +168,9 @@
     <div class="ez-data-source">
         <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
         <div class="ez-data-source__richtext" id="{{ form.vars.id }}__editable"></div>
+        <div class="ez-richtext-tools">
+            <ul class="ez-elements-path"></ul>
+        </div>
         <div class="hidden" data-udw-config-name="richtext_embed" data-udw-config="{{ ez_udw_config('richtext_embed', udw_context) }}"></div>
         <div class="hidden" data-udw-config-name="richtext_embed_image" data-udw-config="{{ ez_udw_config('richtext_embed_image', udw_context) }}"></div>
     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31138](https://jira.ez.no/browse/EZP-31138)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Elements Path is missing in Page Builder RichText Block. And because of this, it is impossible to use custom attributes/etc.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
