### PR TITLE
EZP-31030: Introduced strict types for SectionService

### DIFF
--- a/src/lib/Tests/Form/DataTransformer/SectionTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/SectionTransformerTest.php
@@ -80,16 +80,28 @@ class SectionTransformerTest extends TestCase
     public function testReverseTransformWithNotFoundException()
     {
         $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('Location not found');
+        $this->expectExceptionMessage('Section not found');
 
         $service = $this->createMock(SectionService::class);
         $service->method('loadSection')
-            ->will($this->throwException(new class('Location not found') extends NotFoundException {
+            ->will($this->throwException(new class('Section not found') extends NotFoundException {
             }));
 
         $transformer = new SectionTransformer($service);
 
         $transformer->reverseTransform(654321);
+    }
+
+    public function testReverseTransformWithNonNumericString(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Expected a numeric string.');
+
+        $service = $this->createMock(SectionService::class);
+        $service->expects(self::never())->method('loadSection');
+
+        $transformer = new SectionTransformer($service);
+        $transformer->reverseTransform('XYZ');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31030](https://jira.ez.no/browse/EZP-31030)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed error when assigning content to section and removing section discovered while testing https://github.com/ezsystems/ezpublish-kernel/pull/2880

> Argument 1 passed to eZ\Publish\SPI\Repository\Decorator\SectionServiceDecorator::loadSection() must be of the type int, string given, called in /home/vagrant/master/vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/DataTransformer/SectionTransformer.php on line 73

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
