### PR TITLE
EZP-31194: Searching in UDW does not take allowed CT's into account when ezobjectrelation FieldType is used

### DIFF
--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -49,6 +49,13 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
             )
         );
 
+        $config['allowed_content_types'] = array_unique(
+            array_merge(
+                $config['allowed_content_types'],
+                $context['allowed_content_types']
+            )
+        );
+
         $event->setConfig($config);
     }
 }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -49,12 +49,21 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
             )
         );
 
-        $config['allowed_content_types'] = array_unique(
-            array_merge(
-                $config['allowed_content_types'],
-                $context['allowed_content_types']
-            )
-        );
+        if (!empty($config['allowed_content_types'])) {
+            $config['allowed_content_types'] = array_values(
+                array_intersect(
+                    $config['allowed_content_types'],
+                    $context['allowed_content_types']
+                )
+            );
+
+            // To avoid BC breaks, we're forced to use [null] as empty allowed content types list
+            if (empty($config['allowed_content_types'])) {
+                $config['allowed_content_types'] = [null];
+            }
+        } else {
+            $config['allowed_content_types'] = $context['allowed_content_types'];
+        }
 
         $event->setConfig($config);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31194
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Related with: [ezsystems/ezplatform-admin-ui-modules#231](https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/231)

<!-- Replace this comment with Pull Request description -->  


#### Checklist:
~~- [ ] Coding standards (`$ composer fix-cs`)~~
- [ ] Ready for Code Review
