### PR TITLE
EZEE-2941: Added missing required argument when SiteAccess is constructed

### DIFF
--- a/src/lib/EventListener/AdminExceptionListener.php
+++ b/src/lib/EventListener/AdminExceptionListener.php
@@ -134,7 +134,7 @@ class AdminExceptionListener
         $request = $event->getRequest();
 
         /** @var SiteAccess $siteAccess */
-        $siteAccess = $request->get('siteaccess', new SiteAccess());
+        $siteAccess = $request->get('siteaccess', new SiteAccess('default'));
 
         return \in_array($siteAccess->name, $this->siteAccessGroups[EzPlatformAdminUiBundle::ADMIN_GROUP_NAME]);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2941
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
