### PR TITLE
EZP-31118: Introduced strict types for ContentService

### DIFF
--- a/src/lib/Form/DataTransformer/ContentInfoTransformer.php
+++ b/src/lib/Form/DataTransformer/ContentInfoTransformer.php
@@ -9,38 +9,25 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\DataTransformer;
 
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
-use Symfony\Component\Form\DataTransformerInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use Symfony\Component\Form\Exception\TransformationFailedException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * Transforms between a Content's ID and a domain specific ContentInfo object.
  */
-class ContentInfoTransformer implements DataTransformerInterface
+final class ContentInfoTransformer implements DataTransformerInterface
 {
-    /** @var ContentService */
-    protected $contentService;
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
 
-    /**
-     * @param ContentService $contentService
-     */
     public function __construct(ContentService $contentService)
     {
         $this->contentService = $contentService;
     }
 
-    /**
-     * Transforms a domain specific ContentInfo object into a Content's ID.
-     *
-     * @param ContentInfo|null $value
-     *
-     * @return mixed|null
-     *
-     * @throws TransformationFailedException
-     */
-    public function transform($value)
+    public function transform($value): ?int
     {
         if (null === $value) {
             return null;
@@ -53,29 +40,18 @@ class ContentInfoTransformer implements DataTransformerInterface
         return $value->id;
     }
 
-    /**
-     * Transforms a Content's ID integer into a domain specific ContentInfo object.
-     *
-     * @param mixed|null $value
-     *
-     * @return ContentInfo|null
-     *
-     * @throws UnauthorizedException
-     * @throws TransformationFailedException if the given value is not an integer
-     *                                       or if the value can not be transformed
-     */
     public function reverseTransform($value): ?ContentInfo
     {
         if (empty($value)) {
             return null;
         }
 
-        if (!is_numeric($value)) {
+        if (!is_int($value) && !ctype_digit($value)) {
             throw new TransformationFailedException('Expected a numeric string.');
         }
 
         try {
-            return $this->contentService->loadContentInfo($value);
+            return $this->contentService->loadContentInfo((int)$value);
         } catch (NotFoundException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/lib/Form/DataTransformer/ContentInfoTransformer.php
+++ b/src/lib/Form/DataTransformer/ContentInfoTransformer.php
@@ -27,6 +27,9 @@ final class ContentInfoTransformer implements DataTransformerInterface
         $this->contentService = $contentService;
     }
 
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo|null $value
+     */
     public function transform($value): ?int
     {
         if (null === $value) {
@@ -40,6 +43,9 @@ final class ContentInfoTransformer implements DataTransformerInterface
         return $value->id;
     }
 
+    /**
+     * @param int|string|null $value
+     */
     public function reverseTransform($value): ?ContentInfo
     {
         if (empty($value)) {

--- a/src/lib/Form/DataTransformer/VersionInfoTransformer.php
+++ b/src/lib/Form/DataTransformer/VersionInfoTransformer.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\DataTransformer;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -27,6 +29,9 @@ final class VersionInfoTransformer implements DataTransformerInterface
         $this->contentService = $contentService;
     }
 
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo|null $value
+     */
     public function transform($value): ?array
     {
         if (null === $value) {
@@ -45,6 +50,9 @@ final class VersionInfoTransformer implements DataTransformerInterface
         ];
     }
 
+    /**
+     * @param array|null $value
+     */
     public function reverseTransform($value): ?VersionInfo
     {
         if (null === $value || !is_array($value)) {
@@ -61,6 +69,10 @@ final class VersionInfoTransformer implements DataTransformerInterface
             return null;
         }
 
-        return $this->contentService->loadVersionInfo($value['content_info'], (int)$value['version_no']);
+        try {
+            return $this->contentService->loadVersionInfo($value['content_info'], (int)$value['version_no']);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/src/lib/Form/DataTransformer/VersionInfoTransformer.php
+++ b/src/lib/Form/DataTransformer/VersionInfoTransformer.php
@@ -9,8 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\DataTransformer;
 
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -18,27 +17,17 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * Translates Content's ID to domain specific VersionInfo object.
  */
-class VersionInfoTransformer implements DataTransformerInterface
+final class VersionInfoTransformer implements DataTransformerInterface
 {
-    /** @var ContentService */
-    protected $contentService;
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
 
-    /**
-     * @param ContentService $contentService
-     */
     public function __construct(ContentService $contentService)
     {
         $this->contentService = $contentService;
     }
 
-    /**
-     * @param VersionInfo|null $value
-     *
-     * @return array|null
-     *
-     * @throws TransformationFailedException
-     */
-    public function transform($value)
+    public function transform($value): ?array
     {
         if (null === $value) {
             return null;
@@ -50,19 +39,13 @@ class VersionInfoTransformer implements DataTransformerInterface
             );
         }
 
-        return ['content_info' => $value->getContentInfo(), 'version_no' => $value->versionNo];
+        return [
+            'content_info' => $value->getContentInfo(),
+            'version_no' => $value->versionNo,
+        ];
     }
 
-    /**
-     * @param array|null $value
-     *
-     * @return VersionInfo|null
-     *
-     * @throws TransformationFailedException
-     * @throws UnauthorizedException
-     * @throws NotFoundException
-     */
-    public function reverseTransform($value)
+    public function reverseTransform($value): ?VersionInfo
     {
         if (null === $value || !is_array($value)) {
             return null;
@@ -74,10 +57,10 @@ class VersionInfoTransformer implements DataTransformerInterface
             );
         }
 
-        if (null === $value['content_info'] || null === $value['version_no']) {
+        if (!($value['content_info'] instanceof ContentInfo) || null === $value['version_no']) {
             return null;
         }
 
-        return $this->contentService->loadVersionInfo($value['content_info'], $value['version_no']);
+        return $this->contentService->loadVersionInfo($value['content_info'], (int)$value['version_no']);
     }
 }

--- a/src/lib/Strategy/NotificationTwigStrategy.php
+++ b/src/lib/Strategy/NotificationTwigStrategy.php
@@ -53,6 +53,8 @@ class NotificationTwigStrategy
      */
     public function decide($contentId): string
     {
+        $contentId = (int)$contentId;
+
         if ($this->isContentPermanentlyDeleted($contentId)) {
             return '@ezdesign/account/notifications/list_item_deleted.html.twig';
         }

--- a/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
@@ -43,7 +43,7 @@ final class ContentInfoTransformerTest extends TestCase
     /**
      * @dataProvider transformDataProvider
      */
-    public function testTransform($value, $expected): void
+    public function testTransform(?ContentInfo $value, ?int $expected): void
     {
         $result = $this->contentInfoTransformer->transform($value);
 
@@ -64,7 +64,7 @@ final class ContentInfoTransformerTest extends TestCase
     /**
      * @dataProvider reverseTransformDataProvider
      */
-    public function testReverseTransform($value, $expected): void
+    public function testReverseTransform($value, ?ContentInfo $expected): void
     {
         $result = $this->contentInfoTransformer->reverseTransform($value);
 

--- a/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
@@ -16,30 +16,34 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class ContentInfoTransformerTest extends TestCase
+final class ContentInfoTransformerTest extends TestCase
 {
-    /** @var ContentInfoTransformer */
+    private const EXAMPLE_CONTENT_ID = 123456;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Form\DataTransformer\ContentInfoTransformer */
     private $contentInfoTransformer;
 
     protected function setUp(): void
     {
-        /** @var ContentService|MockObject $contentService */
+        /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject $contentService */
         $contentService = $this->createMock(ContentService::class);
-        $contentService->expects(self::any())
+        $contentService
             ->method('loadContentInfo')
-            ->with(123456)
-            ->willReturn(new ContentInfo(['id' => 123456]));
+            ->with($this->logicalAnd(
+                $this->equalTo(self::EXAMPLE_CONTENT_ID),
+                $this->isType('int')
+            ))
+            ->willReturn(new ContentInfo([
+                'id' => self::EXAMPLE_CONTENT_ID,
+            ]));
 
         $this->contentInfoTransformer = new ContentInfoTransformer($contentService);
     }
 
     /**
      * @dataProvider transformDataProvider
-     *
-     * @param $value
-     * @param $expected
      */
-    public function testTransform($value, $expected)
+    public function testTransform($value, $expected): void
     {
         $result = $this->contentInfoTransformer->transform($value);
 
@@ -48,10 +52,8 @@ class ContentInfoTransformerTest extends TestCase
 
     /**
      * @dataProvider transformWithInvalidInputDataProvider
-     *
-     * @param $value
      */
-    public function testTransformWithInvalidInput($value)
+    public function testTransformWithInvalidInput($value): void
     {
         $this->expectException(TransformationFailedException::class);
         $this->expectExceptionMessage('Expected a ' . ContentInfo::class . ' object.');
@@ -61,11 +63,8 @@ class ContentInfoTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseTransformDataProvider
-     *
-     * @param $value
-     * @param $expected
      */
-    public function testReverseTransform($value, $expected)
+    public function testReverseTransform($value, $expected): void
     {
         $result = $this->contentInfoTransformer->reverseTransform($value);
 
@@ -74,10 +73,8 @@ class ContentInfoTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseTransformWithInvalidInputDataProvider
-     *
-     * @param $value
      */
-    public function testReverseTransformWithInvalidInput($value)
+    public function testReverseTransformWithInvalidInput($value): void
     {
         $this->expectException(TransformationFailedException::class);
         $this->expectExceptionMessage('Expected a numeric string.');
@@ -85,7 +82,7 @@ class ContentInfoTransformerTest extends TestCase
         $this->contentInfoTransformer->reverseTransform($value);
     }
 
-    public function testReverseTransformWithNotFoundException()
+    public function testReverseTransformWithNotFoundException(): void
     {
         $this->expectException(TransformationFailedException::class);
         $this->expectExceptionMessage('ContentInfo not found');
@@ -101,35 +98,31 @@ class ContentInfoTransformerTest extends TestCase
         $transformer->reverseTransform(654321);
     }
 
-    /**
-     * @return array
-     */
     public function transformDataProvider(): array
     {
-        $contentInfo = new ContentInfo(['id' => 123456]);
+        $contentInfo = new ContentInfo([
+            'id' => self::EXAMPLE_CONTENT_ID,
+        ]);
 
         return [
-            'content_info_with_id' => [$contentInfo, 123456],
+            'content_info_with_id' => [$contentInfo, self::EXAMPLE_CONTENT_ID],
             'null' => [null, null],
         ];
     }
 
-    /**
-     * @return array
-     */
     public function reverseTransformDataProvider(): array
     {
-        $contentInfo = new ContentInfo(['id' => 123456]);
+        $contentInfo = new ContentInfo([
+            'id' => self::EXAMPLE_CONTENT_ID,
+        ]);
 
         return [
-            'integer' => [123456, $contentInfo],
+            'integer' => [self::EXAMPLE_CONTENT_ID, $contentInfo],
+            'string' => [(string)self::EXAMPLE_CONTENT_ID, $contentInfo],
             'null' => [null, null],
         ];
     }
 
-    /**
-     * @return array
-     */
     public function transformWithInvalidInputDataProvider(): array
     {
         return [
@@ -142,9 +135,6 @@ class ContentInfoTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function reverseTransformWithInvalidInputDataProvider(): array
     {
         return [

--- a/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/ContentInfoTransformerTest.php
@@ -41,16 +41,8 @@ final class ContentInfoTransformerTest extends TestCase
     }
 
     /**
-     * @dataProvider transformDataProvider
-     */
-    public function testTransform(?ContentInfo $value, ?int $expected): void
-    {
-        $result = $this->contentInfoTransformer->transform($value);
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
+     * @param mixed $value
+     *
      * @dataProvider transformWithInvalidInputDataProvider
      */
     public function testTransformWithInvalidInput($value): void
@@ -59,6 +51,16 @@ final class ContentInfoTransformerTest extends TestCase
         $this->expectExceptionMessage('Expected a ' . ContentInfo::class . ' object.');
 
         $this->contentInfoTransformer->transform($value);
+    }
+
+    /**
+     * @dataProvider transformDataProvider
+     */
+    public function testTransform(?ContentInfo $value, ?int $expected): void
+    {
+        $result = $this->contentInfoTransformer->transform($value);
+
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -72,6 +74,8 @@ final class ContentInfoTransformerTest extends TestCase
     }
 
     /**
+     * @param mixed $value
+     *
      * @dataProvider reverseTransformWithInvalidInputDataProvider
      */
     public function testReverseTransformWithInvalidInput($value): void

--- a/src/lib/Tests/Form/DataTransformer/VersionInfoTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/VersionInfoTransformerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Form\DataTransformer;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPlatformAdminUi\Form\DataTransformer\VersionInfoTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+final class VersionInfoTransformerTest extends TestCase
+{
+    private const EXAMPLE_CONTENT_ID = 123456;
+    private const EXAMPLE_VERSION_NO = 7;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Form\DataTransformer\VersionInfoTransformer */
+    private $transformer;
+
+    protected function setUp(): void
+    {
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->transformer = new VersionInfoTransformer($this->contentService);
+    }
+
+    /**
+     * @dataProvider dataProviderForTransformWithValidInput
+     */
+    public function testTransformWithValidInput(?VersionInfo $value, ?array $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            $this->transformer->transform($value)
+        );
+    }
+
+    public function dataProviderForTransformWithValidInput(): array
+    {
+        $contentInfo = new ContentInfo([
+            'id' => self::EXAMPLE_CONTENT_ID,
+        ]);
+
+        $versionInfo = $this->createVersionInfoMock($contentInfo, self::EXAMPLE_VERSION_NO);
+
+        return [
+            [null, null],
+            [
+                $versionInfo,
+                [
+                    'content_info' => $contentInfo,
+                    'version_no' => self::EXAMPLE_VERSION_NO,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTransformWithInvalidInput
+     */
+    public function testTransformWithInvalidInput($value): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Value cannot be transformed because the passed value is not a VersionInfo object');
+
+        $this->transformer->transform($value);
+    }
+
+    public function dataProviderForTransformWithInvalidInput(): array
+    {
+        $object = new class() {
+        };
+
+        return [
+            'string' => ['string'],
+            'integer' => [123456],
+            'bool' => [true],
+            'float' => [12.34],
+            'array' => [[]],
+            'object' => [$object],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransformWithValidInput
+     */
+    public function testReverseTransformWithValidInput(?array $value, ?VersionInfo $expected): void
+    {
+        if ($expected !== null) {
+            $this->contentService
+                ->expects($this->once())
+                ->method('loadVersionInfo')
+                ->with(
+                    $this->equalTo($value['content_info']),
+                    $this->logicalAnd(
+                        $this->equalTo($value['version_no']),
+                        // Make sure value is casted to int
+                        $this->isType('int')
+                    )
+                )
+                ->willReturn($expected);
+        }
+
+        $this->assertEquals(
+            $expected,
+            $this->transformer->reverseTransform($value)
+        );
+    }
+
+    public function dataProviderForReverseTransformWithValidInput(): array
+    {
+        $contentInfo = new ContentInfo([
+            'id' => self::EXAMPLE_CONTENT_ID,
+        ]);
+
+        $versionInfo = $this->createVersionInfoMock($contentInfo, self::EXAMPLE_VERSION_NO);
+
+        return [
+            'null' => [null, null],
+            'empty' => [
+                [
+                    'content_info' => null,
+                    'version_no' => null,
+                ],
+                null,
+            ],
+            'non_empty' => [
+                [
+                    'content_info' => $contentInfo,
+                    'version_no' => self::EXAMPLE_VERSION_NO,
+                ],
+                $versionInfo,
+            ],
+            'non_empty_with_version_cast' => [
+                [
+                    'content_info' => $contentInfo,
+                    'version_no' => (string)self::EXAMPLE_VERSION_NO,
+                ],
+                $versionInfo,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForReverseTransformWithInvalidInput
+     */
+    public function testReverseTransformWithInvalidInput($value): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage("Invalid data. Value array is missing 'content_info' and/or 'version_no' keys");
+
+        $this->transformer->reverseTransform($value);
+    }
+
+    public function dataProviderForReverseTransformWithInvalidInput(): array
+    {
+        return [
+            'empty_array' => [
+                [],
+            ],
+        ];
+    }
+
+    private function createVersionInfoMock(ContentInfo $contentInfo, int $versionNo): VersionInfo
+    {
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $versionInfo
+            ->method('__get')
+            ->willReturnMap([
+                ['versionNo', $versionNo],
+            ]);
+        $versionInfo->method('getContentInfo')->willReturn($contentInfo);
+
+        return $versionInfo;
+    }
+}

--- a/src/lib/View/Filter/ContentTranslateViewFilter.php
+++ b/src/lib/View/Filter/ContentTranslateViewFilter.php
@@ -96,7 +96,7 @@ class ContentTranslateViewFilter implements EventSubscriberInterface
         $languageCode = $request->attributes->get('toLanguageCode');
         $baseLanguageCode = $request->attributes->get('fromLanguageCode');
         $content = $this->contentService->loadContent(
-            $request->attributes->get('contentId'),
+            (int)$request->attributes->get('contentId'),
             null !== $baseLanguageCode ? [$baseLanguageCode] : null
         );
         $contentType = $this->contentTypeService->loadContentType(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31118](https://jira.ez.no/browse/EZP-31118)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |  `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Fixed issues reported in https://github.com/ezsystems/ezpublish-kernel/pull/2866#pullrequestreview-324628931

https://github.com/ezsystems/ezplatform-admin-ui/pull/1148/commits/72be1abbdcd8010430a68162c350d1c70af175e4: 


```
Argument 1 passed to eZ\Publish\SPI\Repository\Decorator\ContentServiceDecorator::loadContentInfo() must be of the type int, string given, called in /home/vagrant/master/vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/DataTransformer/ContentInfoTransformer.php on line 78
```

https://github.com/ezsystems/ezplatform-admin-ui/pull/1148/commits/97a7a7dc8b3095d3163e599383ce4ed208017ad5

```
Argument 1 passed to eZ\Publish\SPI\Repository\Decorator\ContentServiceDecorator::loadContent() must be of the type int, string given, called in /home/vagrant/master/vendor/ezsystems/ezplatform-admin-ui/src/lib/View/Filter/ContentTranslateViewFilter.php on line 100
```

https://github.com/ezsystems/ezplatform-admin-ui/pull/1148/commits/b80dbd42a4a44a32cb8ec7b7f3de13298b1aefe6

```
Argument 2 passed to eZ\Publish\SPI\Repository\Decorator\ContentServiceDecorator::loadVersionInfo() must be of the type int or null, string given, called in /home/vagrant/master/vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/DataTransformer/VersionInfoTransformer.php on line 81
```

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
