### PR TITLE
EZP-31201: Fixed Field Definition Edit Form rendering when custom edit template is not defined

### DIFF
--- a/src/bundle/Resources/views/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/edit.html.twig
@@ -115,14 +115,7 @@
 
                             {# Default rendering #}
                             {% for child in field_definition %}
-                                {# Iterable children means collections, they are handled in field_types.html.twig #}
-                                {% if not child.rendered and child is not iterable %}
-                                    <div{% if group_class is not empty %} class="{{ group_class }}"{% endif %}>
-                                        {{- form_label(child) -}}
-                                        {{- form_errors(child) -}}
-                                        {{- form_widget(child) -}}
-                                    </div>
-                                {% endif %}
+                                {{ form_row(child) }}
                             {% endfor %}
                         </div>
                     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31201
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

In the following code snippet the `child is not iterable` expression is always `false` (`child` is instance of `Symfony\Component\Form\FormView` which implement  `\IteratorAggregate`)

https://github.com/ezsystems/ezplatform-admin-ui/blob/b380a2b4601992976270e5ef3c5c8d6cc205f364/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig#L116-L126

Moreover `group_class` variable is not defined. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
