### PR TITLE
EZP-31321: Dropped injecting zero-width space into ezembed(inline) elements

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-custom-tag.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-custom-tag.js
@@ -1,7 +1,5 @@
 import customTagBaseDefinition from '../widgets/ez-custom-tag-base';
 
-const ZERO_WIDTH_SPACE = '&#8203;';
-
 CKEDITOR.dtd.$editable.span = 1;
 
 (function(global) {

--- a/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-embed.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-embed.js
@@ -1,7 +1,5 @@
 import embedBaseDefinition from '../widgets/ez-embed-base';
 
-const ZERO_WIDTH_SPACE = '&#8203;';
-
 (function(global) {
     if (CKEDITOR.plugins.get('ezembed') && CKEDITOR.plugins.get('ezembedinline')) {
         return;
@@ -64,7 +62,6 @@ const ZERO_WIDTH_SPACE = '&#8203;';
                 },
 
                 insertWrapper: function(wrapper) {
-                    this.editor.insertHtml(ZERO_WIDTH_SPACE);
                     this.editor.insertElement(wrapper);
                 },
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31321](https://jira.ez.no/browse/EZP-31321), related to [EZP-29882](https://jira.ez.no/browse/EZP-29882)
| Requires | ezsystems/ezplatform-richtext#88
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Parent PR: https://github.com/ezsystems/ezplatform-richtext/pull/88.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
