### PR TITLE
EZP-30758: Ensured the latest version is used when editing content

### DIFF
--- a/src/bundle/Controller/ContentController.php
+++ b/src/bundle/Controller/ContentController.php
@@ -14,7 +14,6 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
@@ -199,12 +198,13 @@ class ContentController extends Controller
         if ($form->isSubmitted()) {
             $result = $this->submitHandler->handle($form, function (ContentEditData $data) {
                 $contentInfo = $data->getContentInfo();
-                $versionInfo = $data->getVersionInfo();
                 $language = $data->getLanguage();
-                $versionNo = $versionInfo->versionNo;
                 $location = $data->getLocation();
 
                 $content = $this->contentService->loadContent($contentInfo->id);
+                $versionInfo = $data->getVersionInfo() ?? $content->getVersionInfo();
+                $versionNo = $versionInfo->versionNo;
+
                 if ((new ContentIsUser($this->userService))->isSatisfiedBy($content)) {
                     return $this->redirectToRoute('ez_user_update', [
                         'contentId' => $contentInfo->id,

--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -363,7 +363,7 @@ class ContentViewController extends Controller
         $languageCodes = $versionInfo->languageCodes ?? [];
 
         return $this->formFactory->contentEdit(
-            new ContentEditData($contentInfo, $versionInfo, $language, $location),
+            new ContentEditData($contentInfo, null, $language, $location),
             null,
             [
                 'choice_loader' => new ContentEditTranslationChoiceLoader(

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -26,9 +26,6 @@
         const checkVersionDraftLink = Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
         const submitVersionEditForm = () => {
             doc.querySelector('#form_subitems_content_edit_content_info').value = contentId;
-            doc.querySelector('#form_subitems_content_edit_version_info_content_info').value = contentId;
-            doc.querySelector('#form_subitems_content_edit_version_info_version_no').value =
-                content.CurrentVersion.Version.VersionInfo.versionNo;
             doc.querySelector(`#form_subitems_content_edit_language_${languageCode}`).checked = true;
             doc.querySelector('#form_subitems_content_edit_create').click();
         };

--- a/src/bundle/Resources/public/js/scripts/button.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/button.content.edit.js
@@ -4,9 +4,7 @@
     const editVersion = (event) => {
         const versionEditForm = doc.querySelector(FORM_EDIT);
         const versionEditFormName = versionEditForm.name;
-        const contentId = event.currentTarget.dataset.contentId;
-        const versionNo = event.currentTarget.dataset.versionNo;
-        const languageCode = event.currentTarget.dataset.languageCode;
+        const { contentId, versionNo, languageCode } = event.currentTarget.dataset;
         const contentInfoInput = versionEditForm.querySelector(`input[name="${versionEditFormName}[content_info]"]`);
         const versionInfoContentInfoInput = versionEditForm.querySelector(
             `input[name="${versionEditFormName}[version_info][content_info]"]`
@@ -23,7 +21,7 @@
         const submitVersionEditForm = () => {
             contentInfoInput.value = contentId;
             versionInfoContentInfoInput.value = contentId;
-            versionInfoVersionNoInput.value = versionNo;
+            versionInfoVersionNoInput.value = versionNo !== undefined ? versionNo : null;
             languageInput.checked = true;
             versionEditForm.submit();
         };

--- a/src/bundle/Resources/views/admin/bookmark/list.html.twig
+++ b/src/bundle/Resources/views/admin/bookmark/list.html.twig
@@ -76,7 +76,6 @@
                                             class="btn btn-icon mx-2 ez-btn--content-edit"
                                             title="{{ 'bookmark.list.content.edit'|trans|desc('Edit Content') }}"
                                             data-content-id="{{ bookmark.contentInfo.id }}"
-                                            data-version-no="{{ bookmark.contentInfo.currentVersionNo }}"
                                             data-language-code="{{ bookmark.contentInfo.mainLanguageCode }}">
                                             <svg class="ez-icon ez-icon-edit">
                                                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>

--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -12,7 +12,6 @@
     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
         <button class="btn btn-icon mx-2 ez-btn--content-edit"
                 data-content-id="{{ row.contentId }}"
-                data-version-no="{{ row.version }}"
                 data-language-code="{{ row.initialLanguageCode }}">
             <svg class="ez-icon ez-icon-edit">
                 <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>

--- a/src/bundle/Resources/views/dashboard/macros.html.twig
+++ b/src/bundle/Resources/views/dashboard/macros.html.twig
@@ -2,7 +2,6 @@
     <button class="btn btn-icon mx-2 ez-btn--content-edit"
             title="{{ title }}"
             data-content-id="{{ content.contentId }}"
-            data-version-no="{{ content.version }}"
             data-language-code="{{ content.language }}">
         <svg class="ez-icon ez-icon-edit">
             <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>

--- a/src/bundle/Resources/views/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/link_manager/view.html.twig
@@ -104,7 +104,6 @@
                                 <button class="btn btn-icon btn-link mx-2 ez-btn--content-edit"
                                         title="{{ 'url.action.item.edit'|trans|desc('Edit Item') }}"
                                         data-content-id="{{ content.id }}"
-                                        data-version-no="{{ content.currentVersionNo }}"
                                         data-language-code="{{ content.mainLanguageCode }}">
                                     <svg class="ez-icon ez-icon-edit">
                                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30758](https://jira.ez.no/browse/EZP-30758)
| Required by | EE: eZ Platform Page Builder (see references)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

When creating a new draft via AdminUI, the latest version to create draft from was hard-coded in the form. As a side effect, when another version was published in the meantime by some external process, usually by another user or the same user in a different browser window (tab), the information got outdated and thus the user who opened content/location view page first, edited previous version. Please see the steps to reproduce in the [JIRA ticket](https://jira.ez.no/browse/EZP-30758) for better understanding the issue.

The solution was to:
- [x] allow sending content edit form w/o hard-coded current version,
- [x] handle such situation by editAction when processing submited data - when VersionInfo is missing, it's obtained from a content,
- [x] stop providing VersionInfo for content view form ,(ContentViewController::createContentEditForm), so it's retrieved after clicking edit,
- [x] stop providing version number for Bookmarks list content items edit buttons,
- [x] stop providing version number for search results content items edit buttons,
- [x] stop providing version number for Link Manager "content items using URL" edit buttons,
- [x] stop providing version number for content items in a sub-items list,
- [x] EE: stop providing VersionInfo for view/edit switcher in Page Builder (see references for PR).

### Open questions

Are there more places where we hard-code current version?

### QA

Sanity checks for all content item edit buttons. Keep in mind that some places (like the list of drafts in the Dashboard, or notification for EE Flex Workflow review) require content edit to go to a specific version (please check if the behavior is still the same).

On the other hand, known places where current version should be used: Location view (right blue side bar), sub-items list, search results, bookmarks list, Link Manager list (Content items using given URL).

#### Checklist:
- [x] PR Description
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review