### PR TITLE
EZP-31089: Wrong allowed content types list on object relation(s) fields

### DIFF
--- a/src/bundle/Templating/Twig/UniversalDiscoveryExtension.php
+++ b/src/bundle/Templating/Twig/UniversalDiscoveryExtension.php
@@ -62,12 +62,24 @@ class UniversalDiscoveryExtension extends Twig_Extension
             'cotfPreselectedLanguage' => $config['content_on_the_fly']['preselected_language'],
             'cotfAllowedLanguages' => $config['content_on_the_fly']['allowed_languages'],
             'cotfPreselectedContentType' => $config['content_on_the_fly']['preselected_content_type'],
-            'cotfAllowedContentTypes' => $config['content_on_the_fly']['allowed_content_types'],
+            'cotfAllowedContentTypes' => $this->getAllowedContentTypes($config['content_on_the_fly']['allowed_content_types']),
             'cotfPreselectedLocation' => $config['content_on_the_fly']['preselected_location'],
             'cotfAllowedLocations' => $config['content_on_the_fly']['allowed_locations'],
-            'allowedContentTypes' => $config['allowed_content_types'],
+            'allowedContentTypes' => $this->getAllowedContentTypes($config['allowed_content_types']),
         ];
 
         return json_encode($udwConfig);
+    }
+
+    private function getAllowedContentTypes(array $config): array
+    {
+        // To avoid BC breaks, we're forced to use [null] as empty allowed content types list
+        // It will be handled by frontend component
+        if (count($config) === 1 && $config[0] === null) {
+            return $config;
+        }
+
+        // Remove any false-castable elements (like null)
+        return array_filter($config);
     }
 }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -42,12 +42,16 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
             return;
         }
 
-        $config['content_on_the_fly']['allowed_content_types'] = array_unique(
-            array_merge(
-                $config['content_on_the_fly']['allowed_content_types'],
-                $context['allowed_content_types']
-            )
-        );
+        if (!empty($config['content_on_the_fly']['allowed_content_types'])) {
+            $config['content_on_the_fly']['allowed_content_types'] = array_values(
+                array_intersect(
+                    $config['content_on_the_fly']['allowed_content_types'],
+                    $context['allowed_content_types']
+                )
+            );
+        } else {
+            $config['content_on_the_fly']['allowed_content_types'] = $context['allowed_content_types'];
+        }
 
         $event->setConfig($config);
     }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -49,6 +49,11 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
                     $context['allowed_content_types']
                 )
             );
+
+            // To avoid BC breaks, we're forced to use [null] as empty allowed content types list
+            if (empty($config['content_on_the_fly']['allowed_content_types'])) {
+                $config['content_on_the_fly']['allowed_content_types'] = [null];
+            }
         } else {
             $config['content_on_the_fly']['allowed_content_types'] = $context['allowed_content_types'];
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31089
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->

Frontend PR: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/234
Replaces: https://github.com/ezsystems/ezplatform-admin-ui/pull/1123


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
