### PR TITLE
EZP-31207: Table header toolbar is added

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -87,6 +87,7 @@ const alloyEditor = [
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-table.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-table-row.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-table-cell.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-table-header.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-link.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-heading.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/toolbars/config/ez-embed.js'),

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
@@ -1,0 +1,16 @@
+import EzConfigTableBase from './base-table';
+
+export default class EzTableHeaderConfig extends EzConfigTableBase {
+    getConfigName() {
+        return 'th';
+    }
+
+    test(payload) {
+        const nativeEditor = payload.editor.get('nativeEditor');
+        const path = nativeEditor.elementPath();
+
+        return path && path.lastElement.is('th');
+    }
+}
+
+eZ.addConfig('ezAlloyEditor.ezTableHeaderConfig', EzTableHeaderConfig);

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -248,6 +248,7 @@
                             new window.eZ.ezAlloyEditor.ezTableConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezTableRowConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezTableCellConfig(toolbarProps),
+                            new window.eZ.ezAlloyEditor.ezTableHeaderConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezEmbedImageLinkConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezEmbedImageConfig(toolbarProps),
                             new window.eZ.ezAlloyEditor.ezEmbedConfig(toolbarProps),

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -21,6 +21,7 @@
                 table: [],
                 tr: [],
                 td: [],
+                th: [],
                 ...global.eZ.adminUiConfig.alloyEditor.extraButtons,
             };
             this.attributes = global.eZ.adminUiConfig.alloyEditor.attributes;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31207](https://jira.ez.no/browse/EZP-31207)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Steps to reproduce:

1. Start editing any content with RichText field
2. Using Online Editor add a table and set its headers
3. Point the cursor into header cells and no toolbar is shown

This PR adds a toolbar for the table header.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
