### PR TITLE
[Behat] Added waiting until RichText toolbar is visible

### DIFF
--- a/src/lib/Behat/PageElement/Fields/RichText.php
+++ b/src/lib/Behat/PageElement/Fields/RichText.php
@@ -37,6 +37,7 @@ class RichText extends EzFieldElement
         $this->fields['styleDropdown'] = '.ae-toolbar-element';
         $this->fields['blockStyle'] = '.ae-listbox li %s';
         $this->fields['moveButton'] = '.ez-btn-ae--move-%s';
+        $this->fields['toolbarButton'] = '.ae-toolbar .ez-btn-ae';
     }
 
     public function setValue(array $parameters): void
@@ -64,6 +65,7 @@ class RichText extends EzFieldElement
     public function openElementsToolbar(): void
     {
         $this->context->findElement($this->fields['addButton'])->click();
+        $this->context->waitUntilElementIsVisible($this->fields['toolbarButton']);
     }
 
     public function changeStyle(string $style): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | part of https://jira.ez.no/browse/EZEE-2944
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR tries to fix the issue from Travis:
```
      | TextBlock             | Text              |

        Exception: element click intercepted: Element <button class="ae-button ez-btn-ae ez-btn-ae--embed " tabindex="-1" title="Embed">...</button> is not clickable at point (250, 284). Other element would receive the click: <div class="ez-data-source__richtext cke_editable cke_editable_inline cke_contents_ltr ae-editable cke_focus" id="block_configuration_attributes_content_value__editable" contenteditable="true" tabindex="0" spellcheck="true" role="textbox" aria-multiline="true" aria-label="Rich Text Editor, block_configuration_attributes_content_value__editable" title="Rich Text Editor, block_configuration_attributes_content_value__editable">...</div>

          (Session info: chrome=74.0.3729.169)
```
(build link: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/264960871?utm_medium=notification&utm_source=slack)

Making sure that the richtext toolbar is visible before interacting with it. Tested in https://github.com/ezsystems/ezplatform-page-builder/pull/442/commits - issue did not occurr in builds run, so this PR probably helps 😉 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
