### PR TITLE
EZP-28900: Added `localizednumber` filter to ezfloat value preview

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -122,7 +122,7 @@
 {% block ezfloat_field %}
 {% apply spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set field_value = field.value.value %}
+        {% set field_value = field.value.value|localizednumber %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
 {% endapply %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28900
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Despite browser language, `ezfloat` was always displayed using dot as a decimal separator. This PR adds `localizednumber` filter to the output which formats the value according to locale. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
