### PR TITLE
[Behat] Added waiting until RichText toolbar transition ends

### DIFF
--- a/src/lib/Behat/PageElement/Fields/RichText.php
+++ b/src/lib/Behat/PageElement/Fields/RichText.php
@@ -65,6 +65,7 @@ class RichText extends EzFieldElement
     public function openElementsToolbar(): void
     {
         $this->context->findElement($this->fields['addButton'])->click();
+        usleep(200 * 1000); // wait until the transition animations ends
         $this->context->waitUntilElementIsVisible($this->fields['toolbarButton']);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2944
| Bug fix?      | in tests
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Tests error:
```
        Exception: element click intercepted: Element <button class="ae-button ez-btn-ae ez-btn-ae--unordered-list " tabindex="-1" title="List">...</button> is not clickable at point (150, 346). Other element would receive the click: <div class="ez-richtext-tools">...</div>

          (Session info: chrome=74.0.3729.169)

          (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.4.0-101-generic x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:144
```

AlloyEditor toolbar has a transition that takes 0.15s to finish: https://github.com/liferay/alloy-editor/blob/v1.5.21/src/ui/react/src/assets/sass/components/ae-toolbar/structure.scss#L17 and it looks to me like there is no selector we can wait for to make sure the transition has ended.

There is a class `alloy-editor-visible`, but it looks like it's added when the trasition starts:
https://github.com/liferay/alloy-editor/blob/v1.5.21/src/ui/react/src/components/base/widget-position.js#L205 (and the `ae-toolbar-transition` is not removed after the animation finishes).

Adding a sleep time of 200ms to make sure that the transition is over should solve the TextBlock issues we're facing currently.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
