### PR TITLE
EZEE-2946: Added missing html nodes for characters counter in the RichText twig template

### DIFF
--- a/src/bundle/Resources/views/form_fields.html.twig
+++ b/src/bundle/Resources/views/form_fields.html.twig
@@ -170,6 +170,12 @@
         <div class="ez-data-source__richtext" id="{{ form.vars.id }}__editable"></div>
         <div class="ez-richtext-tools">
             <ul class="ez-elements-path"></ul>
+            {% if ez_user_settings['character_counter'] == 'enabled' %}
+                <div class="ez-character-counter">
+                    <span class="ez-character-counter__word-count">0</span> {{ 'character_counter.words'|trans|desc('words') }}
+                    <span class="ez-character-counter__character-count">0</span> {{ 'character_counter.characters'|trans|desc('characters') }}
+                </div>
+            {% endif %}
         </div>
         <div class="hidden" data-udw-config-name="richtext_embed" data-udw-config="{{ ez_udw_config('richtext_embed', udw_context) }}"></div>
         <div class="hidden" data-udw-config-name="richtext_embed_image" data-udw-config="{{ ez_udw_config('richtext_embed_image', udw_context) }}"></div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2946
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
