### PR TITLE
EZP-31257: Load field definition only if relation is field related in ValueFactory::{createRelation,createRelationItem}

### DIFF
--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -163,15 +163,8 @@ class ValueFactory
     {
         $contentType = $content->getContentType();
 
-        $relationFieldDefinitionName = '';
-        if ($relation->sourceFieldDefinitionIdentifier !== null) {
-            $relationFieldDefinitionName = $contentType->getFieldDefinition(
-                $relation->sourceFieldDefinitionIdentifier
-            )->getName();
-        }
-
         return new UIValue\Content\Relation($relation, [
-            'relationFieldDefinitionName' => $relationFieldDefinitionName,
+            'relationFieldDefinitionName' => $this->getRelationFieldDefinitionName($relation, $contentType),
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
             'relationName' => $content->getName(),
@@ -192,15 +185,8 @@ class ValueFactory
         $contentType = $content->getContentType();
         $relation = $relationListItem->getRelation();
 
-        $relationFieldDefinitionName = '';
-        if ($relation->sourceFieldDefinitionIdentifier !== null) {
-            $relationFieldDefinitionName = $contentType->getFieldDefinition(
-                $relation->sourceFieldDefinitionIdentifier
-            )->getName();
-        }
-
         return new UIValue\Content\Relation($relation, [
-            'relationFieldDefinitionName' => $relationFieldDefinitionName,
+            'relationFieldDefinitionName' => $this->getRelationFieldDefinitionName($relation, $contentType),
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
             'relationName' => $content->getName(),
@@ -372,5 +358,20 @@ class ValueFactory
         UnauthorizedContentDraftListItem $contentDraftListItem
     ): UIValue\Content\ContentDraftInterface {
         return new UIValue\Content\UnauthorizedContentDraft($contentDraftListItem);
+    }
+
+    private function getRelationFieldDefinitionName(?Relation $relation, ContentType $contentType): string
+    {
+        if ($relation !== null && $relation->sourceFieldDefinitionIdentifier !== null) {
+            $fieldDefinition = $contentType->getFieldDefinition(
+                $relation->sourceFieldDefinitionIdentifier
+            );
+
+            if ($fieldDefinition !== null) {
+                return $fieldDefinition->getName();
+            }
+        }
+
+        return '';
     }
 }

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -162,10 +162,16 @@ class ValueFactory
     public function createRelation(Relation $relation, Content $content): UIValue\Content\Relation
     {
         $contentType = $content->getContentType();
-        $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
+
+        $relationFieldDefinitionName = '';
+        if ($relation->sourceFieldDefinitionIdentifier !== null) {
+            $relationFieldDefinitionName = $contentType->getFieldDefinition(
+                $relation->sourceFieldDefinitionIdentifier
+            )->getName();
+        }
 
         return new UIValue\Content\Relation($relation, [
-            'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
+            'relationFieldDefinitionName' => $relationFieldDefinitionName,
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
             'relationName' => $content->getName(),
@@ -185,10 +191,16 @@ class ValueFactory
     {
         $contentType = $content->getContentType();
         $relation = $relationListItem->getRelation();
-        $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
+
+        $relationFieldDefinitionName = '';
+        if ($relation->sourceFieldDefinitionIdentifier !== null) {
+            $relationFieldDefinitionName = $contentType->getFieldDefinition(
+                $relation->sourceFieldDefinitionIdentifier
+            )->getName();
+        }
 
         return new UIValue\Content\Relation($relation, [
-            'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
+            'relationFieldDefinitionName' => $relationFieldDefinitionName,
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationService->loadLocation($content->contentInfo->mainLocationId),
             'relationName' => $content->getName(),


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


EZP-31257: Load field definition only if the relation is a field related in `\EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory::{createRelation,createRelationItem}`

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
