### PR TITLE
EZP-31223: harmonize headers and exit buttons

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -22,6 +22,8 @@
         'url',
     ];
     const form = doc.querySelector('.ez-form-validate');
+    const itemAuthor = doc.querySelector('.ez-details-items__author-breadcrumbs');
+    const itemAuthorToggler = doc.querySelector('.ez-details-items__toggler');
     const submitBtns = form.querySelectorAll('[type="submit"]:not([formnovalidate])');
     const getValidationResults = (validator) => {
         const isValid = validator.isValid();
@@ -89,4 +91,13 @@
         btn.dataset.isFormValid = 0;
         btn.addEventListener('click', clickHandler, false);
     });
+
+    if (itemAuthorToggler) {
+        itemAuthorToggler.addEventListener('click', (event) => {
+            event.preventDefault();
+
+            itemAuthorToggler.classList.toggle('ez-details-items__toggler--gray');
+            itemAuthor.classList.toggle('ez-details-items--collapsed');
+        });
+    }
 })(window, window.document, window.eZ);

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -20,40 +20,129 @@
 
 .ez-content-edit-container {
     position: relative;
+    width: 100%;
+    padding-top: calculateRem(55px);
 
     &__close {
-        position: absolute;
-        left: 0;
-        top: 0;
-        font-size: calculateRem(32px);
+        position: fixed;
+        z-index: 3;
+        top: calculateRem(6px);
+        left: calculateRem(16px);
+        width: calculateRem(40px);
+        height: calculateRem(40px);
         color: $ez-black;
-        width: calculateRem(32px);
-        height: calculateRem(32px);
-        margin-left: calculateRem(8px);
-        padding: calculateRem(16px);
+        text-align: center;
+        line-height: calculateRem(38px);
 
-        &:before,
-        &:after {
-            content: '';
-            width: calculateRem(32px);
-            height: calculateRem(2px);
-            position: absolute;
-            background-color: $ez-black;
-            top: 50%;
+        &:hover{
+            background: $ez-color-base-light;
+            border-radius: 50%;
+
+            .ez-icon {
+                fill: $ez-white;
+            }
+        }
+    }
+
+    .ez-edit-header {
+        &__content-type-name {
+            position: fixed;
+            z-index: 2;
+            top: 0;
             left: 0;
-        }
-
-        &:before {
-            transform: rotate(45deg);
-        }
-
-        &:after {
-            transform: rotate(-45deg);
-        }
-
-        &:hover {
-            text-decoration: none;
+            width: calc(100% - #{calculateRem(80px)});
+            min-height: calculateRem(55px);
+            padding: calculateRem(12px);
             color: $ez-black;
+            font-size: calculateRem(20px);
+            font-weight: bold;
+            background: $ez-color-base-pale;
+        }
+
+        &__details {
+            color: $ez-black;
+            font-size: calculateRem(12px);
+            background: $ez-ground-base-medium;
+            transition: max-height 0.3s;
+            overflow: hidden;
+
+            .ez-details-items {
+                padding: 0 calculateRem(48px);
+                max-height: calculateRem(32px);
+                transition: max-height 0.3s;
+
+                &__pill {
+                    display: inline-block;
+                    margin: calculateRem(2px) calculateRem(3px);
+                    border-radius: calculateRem(4px);
+
+                    &--content-type {
+                        color: $ez-color-base-medium;
+                        background: $ez-white;
+
+                        .ez-icon {
+                            fill: $ez-color-base-medium;
+                        }
+                    }
+
+                    &--language {
+                        color: $ez-white;
+                        font-style: italic;
+                        background: $ez-color-base-light;
+                    }
+
+                    &--location {
+                        color: $ez-secondary-ground-dark;
+                        background: $ez-white;
+                    }
+                }
+
+                &__connector {
+                    display: inline-block;
+                    color: $ez-color-base-light;
+                    font-size: calculateRem(12px);
+                    font-weight: 600;
+
+                    &--small {
+                        font-size: calculateRem(11px);
+                        font-weight: 100;
+                    }
+                }
+
+                &__toggler {
+                    float: right;
+                    width: calculateRem(20px);
+                    height: calculateRem(20px);
+                    margin: calculateRem(5px) calculateRem(1px) 0 0;
+                    color: $ez-white;
+                    font-size: calculateRem(12px);
+                    text-align: center;
+                    line-height: calculateRem(20px);
+                    background: $ez-color-base-medium;
+                    border-radius: 50%;
+
+                    &--gray {
+                        color: $ez-color-base-medium;
+                        background: none;
+                    }
+
+                    &:hover {
+                        text-decoration: none;
+                    }
+                }
+
+                &__author-breadcrumbs {
+                    height: calculateRem(30px); 
+                    line-height: calculateRem(30px);
+                    color: $ez-color-base-medium;
+                    font-size: calculateRem(12px);
+                    font-style: italic;
+                }
+
+                &--collapsed {
+                    max-height: 0;
+                }
+            }
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_icons.scss
+++ b/src/bundle/Resources/public/scss/_icons.scss
@@ -18,6 +18,11 @@
         height: calculateRem(24px);
     }
 
+    &--medium-large {
+        width: calculateRem(38px);
+        height: calculateRem(38px);
+    }
+
     &--large {
         width: calculateRem(48px);
         height: calculateRem(48px);

--- a/src/bundle/Resources/public/scss/_main-row.scss
+++ b/src/bundle/Resources/public/scss/_main-row.scss
@@ -4,6 +4,8 @@
 
     .ez-side-menu,
     .ez-context-menu {
+        position: relative;
+        z-index: 3;
         flex: 0 0 calculateRem(80px);
     }
 

--- a/src/bundle/Resources/public/scss/_preview.scss
+++ b/src/bundle/Resources/public/scss/_preview.scss
@@ -1,9 +1,9 @@
 .ez-preview {
     .ez-preview__nav {
         display: flex;
-        align-items: center;
+        height: calculateRem(55px);
         justify-content: space-between;
-        background-color: $ez-ground-primary;
+        background-color: $ez-color-base-pale;
         padding: calculateRem(4px) calculateRem(16px);
 
         .ez-preview__item {
@@ -14,7 +14,24 @@
                 align-items: center;
                 justify-content: space-between;
                 line-height: 0;
-                flex-basis: 10%;
+                flex-basis: 3%;
+
+                .ez-preview__link {
+                    display: block;
+                    width: calculateRem(40px);
+                    height: calculateRem(40px);
+                    line-height: calculateRem(38px);
+                    text-align: center;
+                    
+                    &:hover{
+                        background: $ez-color-base-light;
+                        border-radius: 50%;
+            
+                        .ez-icon {
+                            fill: $ez-white;
+                        }
+                    }
+                }
             }
 
             &--actions {
@@ -31,7 +48,7 @@
             }
 
             &--description {
-                flex-basis: 70.5%;
+                flex-basis: 80%;
                 display: flex;
                 align-items: center;
             }
@@ -43,7 +60,8 @@
             &-label {
                 display: inline-block;
                 margin-right: calculateRem(8px);
-                font-size: calculateRem(13px);
+                color: $ez-color-base-medium;
+                font-size: calculateRem(14px);
             }
 
             &-text {
@@ -53,6 +71,7 @@
                 display: inline-block;
                 white-space: nowrap;
                 font-weight: 700;
+                font-size: calculateRem(20px);
             }
 
             .ez-preview__action {

--- a/src/bundle/Resources/translations/content_create.en.xliff
+++ b/src/bundle/Resources/translations/content_create.en.xliff
@@ -6,6 +6,33 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="0f727a5b08f9dd958453e3fe685f22bb9a55a877" resname="creating_details">
+        <source><![CDATA[
+                        <span class="ez-details-items__connector">Creating:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></source>
+        <target state="new"><![CDATA[
+                        <span class="ez-details-items__connector">Creating:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></target>
+        <note>key: creating_details</note>
+      </trans-unit>
       <trans-unit id="109ad031477c8e3c904a45089ea26883d00d264e" resname="creating_in_language">
         <source>Creating a(n) %contentTypeName% in %languageName%</source>
         <target state="new">Creating a(n) %contentTypeName% in %languageName%</target>

--- a/src/bundle/Resources/translations/content_edit.en.xliff
+++ b/src/bundle/Resources/translations/content_edit.en.xliff
@@ -31,10 +31,32 @@
         <target state="new">Created by %name%</target>
         <note>key: created_by</note>
       </trans-unit>
-      <trans-unit id="0474be007e2cbb859dcec4d70ced364af71ba119" resname="editing_in_language">
-        <source>Editing %contentName% in %languageName%</source>
-        <target state="new">Editing %contentName% in %languageName%</target>
-        <note>key: editing_in_language</note>
+      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
+        <source><![CDATA[
+                        <span class="ez-details-items__connector">Editing:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></source>
+        <target state="new"><![CDATA[
+                        <span class="ez-details-items__connector">Editing:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></target>
+        <note>key: editing_details</note>
       </trans-unit>
       <trans-unit id="669edeb37bec7cf4ec99288b90b02ba65e84b4cf" resname="errors.in.the.form">
         <source>Cannot save the form. Check required Fields or validation errors.</source>
@@ -50,6 +72,11 @@
         <source>Location ID: %locationId%</source>
         <target state="new">Location ID: %locationId%</target>
         <note>key: location_id</note>
+      </trans-unit>
+      <trans-unit id="32d50c07b2eacd6fa72742ff1c1f5963c26a251d" resname="new_content_item">
+        <source>New %contentType%</source>
+        <target state="new">New %contentType%</target>
+        <note>key: new_content_item</note>
       </trans-unit>
       <trans-unit id="cce4ced380a283ffdecf364aeb5312ee001e6601" resname="parent_location_id">
         <source>Parent Location ID: %locationId%</source>

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -176,11 +176,6 @@
         <target state="new">Send to Trash</target>
         <note>key: location_trash_form.trash</note>
       </trans-unit>
-      <trans-unit id="f9887d04de58202b07207b1521880373c00c8201" resname="location_trash_form.trash_container">
-        <source>Send %children_count% Content item(s) of this Location to Trash</source>
-        <target state="new">Send %children_count% Content item(s) of this Location to Trash</target>
-        <note>key: location_trash_form.trash_container</note>
-      </trans-unit>
       <trans-unit id="2598fe0050f38f3c02014a404ed14aee248e27d1" resname="location_trash_form.trash_with_asset">
         <source>Send the Content item and its related assets to Trash</source>
         <target state="new">Send the Content item and its related assets to Trash</target>

--- a/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
@@ -7,13 +7,13 @@
 {% block body_class %}ez-content-preview{% endblock %}
 
 {% block navigation %}{% endblock %}
-    {% block content %}
+{% block content %}
     <div class="ez-preview">
         <div class="ez-preview__nav">
             <div class="ez-preview__item ez-preview__item--back">
-                <a href="{{ url('ezplatform.content.draft.edit', {'contentId': content.id, 'versionNo': version_no, 'language': language_code, 'locationId': is_published ? location.id : null}) }}" >
-                    <svg class="ez-icon ez-icon-back">
-                        <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#caret-back"></use>
+                <a class="ez-preview__link" href="{{ url('ezplatform.content.draft.edit', {'contentId': content.id, 'versionNo': version_no, 'language': language_code, 'locationId': is_published ? location.id : null}) }}">
+                    <svg class="ez-icon ez-icon--small-medium">
+                        <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#discard"></use>
                     </svg>
                 </a>
             </div>

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -3,22 +3,40 @@
 {% trans_default_domain 'content_create' %}
 
 {% block meta %}
-    <meta name="LanguageCode" content="{{ language.languageCode }}" />
+    <meta name="LanguageCode" content="{{ language.languageCode }}"/>
 {% endblock %}
 
 {% block details %}
-    <div class="container mt-5 px-5">
-        <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': content_type.name, '%languageName%': language.name})|desc('Creating a(n) %contentTypeName% in %languageName%') }}</h2>
-        <h1>
-            <svg class="ez-icon ez-icon-{{ content_type.identifier }}">
-                <use xlink:href="{{ ez_content_type_icon(content_type.identifier) }}"></use>
-            </svg>
-            {{ 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') }}
-        </h1>
-
-        <div class="small">
-            {{ content_type.name }} / Parent Location ID: {{ parent_location.id }}
+    <div class="ez-edit-header">
+        <div class="ez-edit-header__content-type-name">
+            <div class="container px-5">
+                {{ 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') }}
+            </div>
         </div>
+        <div class="ez-edit-header__details">
+            <div class="container ez-details-items">
+                {{ 'creating_details'|trans({
+                    '%icon%': ez_content_type_icon(content_type.identifier), 
+                    '%content_type_name%': content_type.name, 
+                    '%language_name%': language.name, 
+                    '%location_name%': parent_location.contentInfo.name})
+                    |desc('
+                        <span class="ez-details-items__connector">Creating:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>')
+                    |raw 
+                }}
+            </div>
+        </div>
+
         <div class="ez-content-item__errors-wrapper" hidden>
             {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
         </div>
@@ -39,7 +57,6 @@
                 {{ form_widget(form.cancel, {'attr': {'hidden': 'hidden'}}) }}
             </div>
         </div>
-
     </section>
 {% endblock %}
 
@@ -54,7 +71,11 @@
 {% endblock %}
 
 {% block close_button %}
-    <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': parent_location.id}) }}"></a>
+    <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': parent_location.id}) }}">
+        <svg class="ez-icon ez-icon--small-medium">
+            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#discard"></use>
+        </svg>
+    </a>
 {% endblock %}
 
 {% block form_before %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -13,7 +13,8 @@
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
         {% block left_sidebar %}{% endblock left_sidebar %}
-        <div class="container px-0 pb-4 mt-3 ez-content-edit-container">
+
+        <div class="px-0 pb-4 ez-content-edit-container">
             {% block close_button %}{% endblock %}
             {% block details %}{% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -3,31 +3,55 @@
 {% trans_default_domain 'content_edit' %}
 
 {% block meta %}
-    <meta name="LanguageCode" content="{{ language.languageCode }}" />
+    <meta name="LanguageCode" content="{{ language.languageCode }}"/>
 {% endblock %}
 
 {% block details %}
-    <div class="container mt-5 px-5">
-        {% set title = 'editing_in_language'|trans({'%contentName%': content.name, '%languageName%': language.name})|desc('Editing %contentName% in %languageName%') %}
-        <h2 class="ez-content-item-status" title="{{ title }}">{{ title }}</h2>
-        <h1 class="ez-content-item__title">
-            <svg class="ez-icon ez-icon-{{ content_type.identifier }}">
-                <use xlink:href="{{ ez_content_type_icon(content_type.identifier) }}"></use>
-            </svg>
-            <div class="ez-content-item__name" title="{{ content.name }}">
-                {{ content.name }}
+    <div class="ez-edit-header">
+        <div class="ez-edit-header__content-type-name">
+            <div class="container px-5">
+                {% set content_name = content ? content.name : 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') %}
+                <div class="ez-content-item__name" title="{{ content_name }}">
+                    {{ content_name }}
+                </div>
             </div>
-        </h1>
-        <div class="small">
-            {{ content_type.name }} /
-            {% if creator is not null %}{{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }} /{% endif %}
-            {{ content.versionInfo.contentInfo.publishedDate|ez_full_datetime }} /
-            {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
-            {% if is_published == false %}
-                {{ 'parent_location_id'|trans({'%locationId%': parent_location.id})|desc('Parent Location ID: %locationId%') }}
-            {% else %}
-                {{ 'location_id'|trans({'%locationId%': location.id})|desc('Location ID: %locationId%') }}
-            {% endif %}
+        </div>
+        <div class="ez-edit-header__details">
+            <div class="container ez-details-items">
+                {{ 'editing_details'|trans({
+                    '%icon%': ez_content_type_icon(content_type.identifier), 
+                    '%content_type_name%': content_type.name, 
+                    '%language_name%': language.name, 
+                    '%location_name%': parent_location.contentInfo.name})
+                    |desc('
+                        <span class="ez-details-items__connector">Editing:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>')
+                    |raw 
+                }}
+                <a class="ez-details-items__toggler ez-details-items__toggler--gray" href="#">?</a>
+            </div>
+            <div class="container ez-details-items ez-details-items--collapsed ez-details-items__author-breadcrumbs">
+                {{ content_type.name }}/
+                {% if creator is not null %}
+                    {{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }}/
+                {% endif %}
+                {{ content.versionInfo.contentInfo.publishedDate|ez_full_datetime }}/
+                {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
+                {% if is_published == false %}
+                    {{ 'parent_location_id'|trans({'%locationId%': parent_location.id})|desc('Parent Location ID: %locationId%') }}
+                {% else %}
+                    {{ 'location_id'|trans({'%locationId%': location.id})|desc('Location ID: %locationId%') }}
+                {% endif %}
+            </div>
         </div>
         <div class="ez-content-item__errors-wrapper" hidden>
             {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
@@ -51,7 +75,6 @@
         </div>
     </section>
 {% endblock %}
-
 {% block right_sidebar %}
     {% set content_edit_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.content_edit.sidebar_right', [], {
         'content': content,
@@ -62,12 +85,14 @@
     }) %}
     {{ knp_menu_render(content_edit_sidebar_right, {'template': '@ezdesign/ui/menu/sidebar_right.html.twig'}) }}
 {% endblock %}
-
 {% block close_button %}
     {% set referrer_location = is_published ? location : parent_location %}
-    <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': referrer_location.id }) }}"></a>
+    <a class="ez-content-edit-container__close" href="{{ path('_ezpublishLocation', {'locationId': referrer_location.id }) }}">
+        <svg class="ez-icon ez-icon--small-medium">
+            <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#discard"></use>
+        </svg>
+    </a>
 {% endblock %}
-
 {% block form_before %}
     {{ ez_render_component_group('content-edit-form-before', {
         'content': content,
@@ -77,7 +102,6 @@
         'language': language
     }) }}
 {% endblock %}
-
 {% block form_after %}
     {{ ez_render_component_group('content-edit-form-after', {
         'content': content,


### PR DESCRIPTION
 Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31223
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Harmonized headers and exit buttons for:
- Editing/Creating view in Content View
- Preview view when in Editing/Creating view in Content View
- Form Builder view

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
