### PR TITLE
EZP-31263: trash button set to inactive after deleting relation items

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js
@@ -182,7 +182,7 @@
             addBtn[methodName]('disabled', true);
         };
         const updateTrashBtnState = (event) => {
-            if (!event.target.hasAttribute('type') || event.target.type !== 'checkbox') {
+            if ((!event.target.hasAttribute('type') || event.target.type !== 'checkbox') && event.currentTarget !== trashBtn) {
                 return;
             }
 
@@ -261,6 +261,7 @@
         );
 
         trashBtn.addEventListener('click', removeItem, false);
+        trashBtn.addEventListener('click', updateTrashBtnState, false);
         relationsContainer.addEventListener('change', updateTrashBtnState, false);
 
         validator.init();


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31263
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added event listener to the trash button in order to disable it after rows deletion.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
