### PR TITLE
[Behat] Changed navigation to UDW from Subitems in "Content can be moved to trash from root location" test

### DIFF
--- a/features/standard/ContentManagement.feature
+++ b/features/standard/ContentManagement.feature
@@ -97,7 +97,7 @@ Scenario: Content can be moved to trash from non-root location
 
 @javascript @common
 Scenario: Content can be moved to trash from root location
-  Given I navigate to content "Test Article Manage" of type "Article" in root path
+  Given I open UDW and go to "root/Test Article Manage"
   When I send content to trash
   Then I should be redirected to root in default view
     And going to trash there is "Article" "Test Article Manage" on list


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31283
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This is a tricky one, so a longer explanaition is needed 😉 

Tests are failing with:
```
  @javascript @common

  Scenario: Content can be moved to trash from root location                         # vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentManagement.feature:99

    Given I navigate to content "Test Article Manage" of type "Article" in root path # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\NavigationContext::iNavigateToContentInRoot()

      There's no subitem Test Article Manage on Sub-item list

      Failed asserting that false is true.
```
(source: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/273793371)

What we know (from the log):
```
    │  [2020-01-09 09:38:17] app.ERROR: Starting Step I go to "Content structure" in Content tab
    │  [2020-01-09 09:38:20] app.ERROR: Ending Step I go to "Content structure" in Content tab
    │  [2020-01-09 09:38:20] app.ERROR: Starting Step going to trash there is "Landing page" "VersionsLandingPage" on list
    │  [2020-01-09 09:38:21] app.ERROR: Ending Step going to trash there is "Landing page" "VersionsLandingPage" on list
    │  [2020-01-09 09:38:21] app.ERROR: Ending Scenario "Landing Page can be sent to Trash"
    │  [2020-01-09 09:38:22] app.ERROR: Starting Scenario "Changes can be discarded while creating new Content Type Group"
    │  [2020-01-09 09:38:22] app.ERROR: Starting Step I am logged as "admin"
    │  [2020-01-09 09:38:24] ezrecommendation.ERROR: Recommendation login event notification error: cURL error 1: Protocol "/api/https" not supported or disabled in libcurl (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
    │  [2020-01-09 09:38:25] app.ERROR: Ending Step I am logged as "admin"
    │  [2020-01-09 09:38:25] app.ERROR: Starting Step I go to "Content Types" in "Admin" tab
    │  [2020-01-09 09:38:27] app.ERROR: Ending Step I navigate to content "Test Article Manage" of type "Article" in root path
```

So, there are two Scenarios running in parallel:
- `Content can be moved to trash from root location`
- `Landing Page can be sent to Trash` (https://github.com/ezsystems/ezplatform-page-builder/blob/c373db91dfa636fcd09d171307e7acd9f765c57c/features/DynamicLandingPage/PageBuilderActions.feature#L87). This one is deleting an item present in Home.

These are facts, here comes what I think is happening:
Imagine there are 12 items on subitems list, and the one we're searching for is the eleventh:
![Zrzut ekranu 2020-01-10 o 12 46 03](https://user-images.githubusercontent.com/10993858/72150972-392c9700-33a7-11ea-8481-cf6cd3b388aa.png)
![Zrzut ekranu 2020-01-10 o 12 46 38](https://user-images.githubusercontent.com/10993858/72150985-46e21c80-33a7-11ea-93c5-444dde119935.png)

It's not present on the first result page, it should be visible on the second one. But if I do following steps:
- open a new browser tab and delete one of the items visible in first page in Subitems
- go back to original tab and switch to second page in Subitems

The result is:
![Zrzut ekranu 2020-01-10 o 12 48 53](https://user-images.githubusercontent.com/10993858/72151089-96c0e380-33a7-11ea-9165-e7e80c932e0f.png)
Assuming I don't know that the subitems list has been modified when I was searching for an item (the tests don't know that) the item I'm searching for is not found in all displayed pages (it reality it's displayed in page one).

In this scenario I've decided to switch navigation to UDW, where such issue should not occur.
Here are 15 jobs where this Scenario has been run (on EE Demo) and all of them passed: https://github.com/ezsystems/ezplatform-page-builder/pull/467 . This is not a bullet-proof solution, the same problem could appear again in the future - I have some ideas how to handle that, but I'm afraid it could increase the time required to run tests.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
