### PR TITLE
EZP-31277: added server timezone offset support for ezdate widget

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -94,8 +94,9 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
+            const timezoneOffset = sourceInput.dataset.timezone_offset ? sourceInput.dataset.timezone_offset : defaultDate.getTimezoneOffset();
 
-            defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
+            defaultDate.setTime(defaultDate.getTime() + timezoneOffset * 1000);
         }
 
         const flatpickrInstance = flatpickr(

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -94,7 +94,9 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
-            const timezoneOffset = sourceInput.dataset.timezone_offset ? sourceInput.dataset.timezone_offset : defaultDate.getTimezoneOffset();
+            const timezoneOffset = sourceInput.dataset.timezoneOffset
+                ? sourceInput.dataset.timezoneOffset
+                : defaultDate.getTimezoneOffset() * 60;
 
             defaultDate.setTime(defaultDate.getTime() + timezoneOffset * 1000);
         }

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -99,6 +99,8 @@
                 : defaultDate.getTimezoneOffset() * 60;
 
             defaultDate.setTime(defaultDate.getTime() + timezoneOffset * 1000);
+
+            updateInputValue(sourceInput, [defaultDate]);
         }
 
         const flatpickrInstance = flatpickr(

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,6 +7,7 @@
             </svg>
         </button>
     </div>
-    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden'}) %}
+    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden',
+        'data-timezone-offset': form.parent.vars.value.value.date.offset}) %}
     {{ block('form_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,7 +7,8 @@
             </svg>
         </button>
     </div>
+    {% set offset =  form.parent.vars.value.value.date|length ? form.parent.vars.value.value.date.offset : null %}
     {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden',
-        'data-timezone-offset': form.parent.vars.value.value.date.offset}) %}
+        'data-timezone-offset': offset}) %}
     {{ block('form_widget') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31277
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

flatpickr widget will now instantiate with server's timezone offset if provided, not just be the browser's one in order to handle different timezones.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
