### PR TITLE
EZP-31291: Fix Content Type creation filter on certain words such as "File"

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/instant.filter.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/instant.filter.js
@@ -28,7 +28,7 @@
         const groups = [...filter.querySelectorAll('.ez-instant-filter__group')];
         const items = [...filter.querySelectorAll(SELECTOR_ITEM)];
         const itemsMap = items.reduce((total, item) => [...total, {
-            label: item.innerHTML.toLowerCase(),
+            label: item.textContent.toLowerCase(),
             element: item
         }], []);
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31291
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

If you try to filter the Content Type creation list, "File" does not work, nor does a bunch of words that are found in the HTML of the quick filter list (form, check, type, content, and more). This is because the filter is applied against the entire HTML of each item.