### PR TITLE
EZEE-2914: Custom inline style does not update textarea after click on

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -46,6 +46,7 @@ const alloyEditor = [
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-underline.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-subscript.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-superscript.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-quote.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-strike.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-link.js'),

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+
+export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListItem {
+    /**
+     * Lifecycle. Renders the UI of the button.
+     *
+     * @instance
+     * @memberof ButtonStylesListItem
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
+    render() {
+        const className = this.props.name === this.props.activeStyle ? 'ae-toolbar-element active' : 'ae-toolbar-element';
+        return (
+            <button
+                className={className}
+                dangerouslySetInnerHTML={{ __html: this._preview }}
+                onClick={() => {
+                    this._onClick();
+                    this.fireCustomUpdateEvent();
+                }}
+                tabIndex={this.props.tabIndex}
+            />
+        );
+    }
+
+    fireCustomUpdateEvent() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+
+        nativeEditor.fire('customUpdate');
+    }
+}
+
+AlloyEditor.ButtonStylesListItem = AlloyEditor.EzBtnStylesListItem = EzBtnStylesListItem;
+eZ.addConfig('ezAlloyEditor.ezBtnStylesListItem', EzBtnStylesListItem);

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
@@ -12,6 +12,7 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
      */
     render() {
         const className = this.props.name === this.props.activeStyle ? 'ae-toolbar-element active' : 'ae-toolbar-element';
+
         return (
             <button
                 className={className}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
         ezBtnUnderline: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-underline.js',
         ezBtnSubscript: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-subscript.js',
         ezBtnSuperscript: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-superscript.js',
+        ezBtnStylesListItem: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js',
         ezBtnQuote: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-quote.js',
         ezBtnStrike: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-strike.js',
         ezBtnLink: './src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-link.js',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-2914](https://jira.ez.no/browse/EZEE-2914)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

AlloyEditor.ButtonStylesListItem on click does not update textarea element, because function _onClick is protected and we cannot override, so we need an override render function, for add a new function into onClick in order to update textarea

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
