### PR TITLE
EZP-31295: Unable to use default empty custom CSS class in the OE

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-attributes-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-attributes-update.js
@@ -143,7 +143,12 @@ export default class EzBtnAttributesUpdate extends EzWidgetButton {
             return;
         }
 
-        block.$.classList.remove(...this.classes.choices);
+        const classList = block.$.classList;
+        this.classes.choices.forEach(className => {
+            if (classList.contains(className)) {
+                classList.remove(className);
+            }
+        });
     }
 
     saveValues() {

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-attributes-update.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-attributes-update.js
@@ -144,7 +144,8 @@ export default class EzBtnAttributesUpdate extends EzWidgetButton {
         }
 
         const classList = block.$.classList;
-        this.classes.choices.forEach(className => {
+
+        this.classes.choices.forEach((className) => {
             if (classList.contains(className)) {
                 classList.remove(className);
             }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31295](https://jira.ez.no/browse/EZP-31295)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

In some cases custom CSS class is optional, and it should be possible to not select any. Right now UI is not allowing to do that. As a workaround, we added an empty custom CSS class and made it default, but it was causing some errors.

# Steps to reproduce
1. Setup custom CSS classed and default empty CSS class:
    ```                     
    system:
        default:
            fieldtypes:
                ezrichtext:
                    classes:
                        paragraph:
                            choices: ['', custom-paragraph-1, custom-paragraph-2, custom-paragraph-3]
                            default_value: ''
                            required: false
                            multiple: false
    ```
2. Open the Online Editor and try to update the custom CSS class for the paragraph.

## Actual result

Following JavaScript error is thrown:
```
Uncaught DOMException: Failed to execute 'remove' on 'DOMTokenList': The token provided must not be empty.
    at ButtonAttributesUpdate.clearClasses
    ...
```

## Expected result
Custom CSS class should be changed, and it should be possible to change it to the empty default value at any given time.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
