### PR TITLE
EZP-30485: Added regexp to check for special characters in anchor name

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-anchoredit.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-anchoredit.js
@@ -71,9 +71,18 @@ export default class EzBtnAnchorEdit extends Component {
 
     updateValue({ nativeEvent }) {
         const value = nativeEvent.target.value;
-        const isValueUnique = this.isValueUnique(value);
 
-        this.setState(() => ({ value, isValueUnique }));
+        if (this.isValueValid(value)) {
+            const isValueUnique = this.isValueUnique(value);
+
+            this.setState(() => ({ value, isValueUnique }));
+        }
+    }
+
+    isValueValid(value) {
+        const acceptablePattern = new RegExp('^[A-Za-z][A-Za-z0-9]*$');
+
+        return acceptablePattern.test(value);
     }
 
     isValueUnique(value) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30485
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Added regexp to allow only letters and numbers in anchor name.
(Even though html specification allow special chars, querySelectorAll throws error in such case)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
