### PR TITLE
EZP-31296: As an Editor I want be able to edit custom attributes and styles for links

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-link.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-link.js
@@ -3,7 +3,12 @@ import AlloyEditor from 'alloyeditor';
 export default class EzLinkConfig {
     constructor(config) {
         this.name = 'link';
-        this.buttons = ['ezlinkedit', ...config.extraButtons[this.name]];
+
+        this.buttons = [
+            'ezlinkedit',
+            config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '',
+            ...config.extraButtons[this.name]
+        ];
 
         this.test = AlloyEditor.SelectionTest.link;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31296](https://jira.ez.no/browse/EZP-31296)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

There is no UI to edit custom attributes and styles for link elements. Even if you will specify the following configurations:
```
system:
    default:
        fieldtypes:
            ezrichtext:
                classes:
                    link:
                        choices: [custom-link-1, custom-link-2, custom-link-3]
                        default_value: custom-link-1
                        required: false
                        multiple: false
```
This PR provides a way to edit custom attributes and classes only for existing links. Please note, it still is impossible to set them when a new link is created. Also, some minor UI fixes might be required here. But it is better to have this option than no option at all.

![link_edit_custom_attributes](https://user-images.githubusercontent.com/166894/72518759-e1ca7300-384d-11ea-866d-1819db52c19d.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
