### PR TITLE
EZP-31339: Dropped default config enforcement for ContentTree parser

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Module/ContentTree.php
@@ -39,7 +39,6 @@ class ContentTree extends AbstractParser
         $nodeBuilder
             ->arrayNode('content_tree_module')
                 ->info('Content Tree module configuration')
-                ->addDefaultsIfNotSet()
                 ->children()
                     ->integerNode('load_more_limit')
                         ->info('Number of children to load in expand and load more operations')
@@ -73,6 +72,7 @@ class ContentTree extends AbstractParser
                             '5 # Users',
                             '43 # Media',
                         ])
+                        ->defaultValue([])
                         ->integerPrototype()->end()
                     ->end()
                     ->arrayNode('allowed_content_types')

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -69,4 +69,5 @@ parameters:
     ezsettings.default.content_tree_module.allowed_content_types: []
     ezsettings.default.content_tree_module.ignored_content_types: []
     ezsettings.default.content_tree_module.tree_root_location_id: ~
+    ezsettings.default.content_tree_module.contextual_tree_root_location_ids: []
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31339
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Due to the nature of _ConfigResolver_ the site access specific config is resolved before the group's one which is valid behavior, however, in certain cases when _SemanticConfig_ is being built it forces the default values to be taken in consideration for specific site access and there is no fallback to group config, even though there should be one. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
