### PR TITLE
EZP-31137: Fixed styles dropdown when custom ones are in use for RTE

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
@@ -18,12 +18,23 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
                 className={className}
                 dangerouslySetInnerHTML={{ __html: this._preview }}
                 onClick={() => {
+                    this.clearEzAttributes();
                     this._onClick();
                     this.fireCustomUpdateEvent();
                 }}
                 tabIndex={this.props.tabIndex}
             />
         );
+    }
+
+    clearEzAttributes() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+        const block = nativeEditor.elementPath().block;
+        const attrsToRemove = ['ezelement', 'eztype', 'ezname'];
+
+        if (block.$.dataset.eztype === 'style') {
+            attrsToRemove.forEach(attr => block.$.removeAttribute('data-' + attr));
+        }
     }
 
     fireCustomUpdateEvent() {

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
@@ -28,12 +28,14 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
     }
 
     clearEzAttributes() {
+
         const nativeEditor = this.props.editor.get('nativeEditor');
         const block = nativeEditor.elementPath().block;
         const attrsToRemove = ['ezelement', 'eztype', 'ezname'];
+        const targetName = this.props.style.attributes ? this.props.style.attributes['data-ezname'] : '';
 
-        if (block.$.dataset.eztype === 'style') {
-            attrsToRemove.forEach(attr => block.$.removeAttribute('data-' + attr));
+        if (block.$.dataset.eztype === 'style' && block.$.dataset.ezname !== targetName) {
+            attrsToRemove.forEach(attr => block.$.removeAttribute(`data-${attr}`));
         }
     }
 

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js
@@ -28,7 +28,6 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
     }
 
     clearEzAttributes() {
-
         const nativeEditor = this.props.editor.get('nativeEditor');
         const block = nativeEditor.elementPath().block;
         const attrsToRemove = ['ezelement', 'eztype', 'ezname'];

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-custom-style.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-custom-style.js
@@ -20,16 +20,6 @@ export default class EzCustomStyleConfig extends EzConfigBase {
         this.addExtraButtons(config.extraButtons);
     }
 
-    getStyles(customStyles = []) {
-        return {
-            name: 'styles',
-            cfg: {
-                showRemoveStylesItem: false,
-                styles: [...customStyles],
-            },
-        };
-    }
-
     /**
      * Tests whether the `custom style` toolbar should be visible. It is
      * visible when an existing custom style gets the focus.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31137
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    |no
| Tests pass?   |yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

ez-custom-style.js for alloy editor was overriding base config styles by filtering out default styles unnecessarily if custom styles were in use.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
