### PR TITLE
EZP-31349: Triggered content tree animation only by clicking by mouse

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.tree.js
@@ -1,6 +1,7 @@
 (function(global, doc, React, ReactDOM, eZ, localStorage) {
     const KEY_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
     const CLASS_CONTENT_TREE_EXPANDED = 'ez-content-tree-container--expanded';
+    const CLASS_CONTENT_TREE_ANIMATE = 'ez-content-tree-container--animate';
     const CLASS_BTN_CONTENT_TREE_EXPANDED = 'ez-btn--content-tree-expanded';
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
@@ -11,6 +12,7 @@
     let frame = null;
     const toggleContentTreePanel = () => {
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
+        contentTreeContainer.classList.add(CLASS_CONTENT_TREE_ANIMATE);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);
         updateContentTreeWrapperHeight();
 

--- a/src/bundle/Resources/public/scss/_content-tree.scss
+++ b/src/bundle/Resources/public/scss/_content-tree.scss
@@ -17,13 +17,11 @@
         transform-origin: left;
 
         &--animate {
-            &--expanded {
+            transition: all 0.2s ease-out;
+            
+            &.ez-content-tree-container--expanded {
                 transition: all 0.4s ease-in;
             }
-        }
-
-        &--animate {
-            transition: all 0.2s ease-out;
         }
 
         &--expanded {

--- a/src/bundle/Resources/public/scss/_content-tree.scss
+++ b/src/bundle/Resources/public/scss/_content-tree.scss
@@ -15,12 +15,18 @@
         color: inherit;
         transform: scaleX(0);
         transform-origin: left;
-        transition: all 0.2s ease-out;
+
+        &--animate {
+            transition: all 0.2s ease-out;
+            
+            &--expanded {
+                transition: all 0.4s ease-in;
+            }
+        }
 
         &--expanded {
             transform-origin: left;
             transform: scaleX(1);
-            transition: all 0.4s ease-in;
             display: initial;
             max-width: 33vw;
         }

--- a/src/bundle/Resources/public/scss/_content-tree.scss
+++ b/src/bundle/Resources/public/scss/_content-tree.scss
@@ -17,11 +17,13 @@
         transform-origin: left;
 
         &--animate {
-            transition: all 0.2s ease-out;
-            
             &--expanded {
                 transition: all 0.4s ease-in;
             }
+        }
+
+        &--animate {
+            transition: all 0.2s ease-out;
         }
 
         &--expanded {


### PR DESCRIPTION
 Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31349
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Disabled content tree animations after reload page

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
