### PR TITLE
[Behat] Fixed UDW issue when the newly selected item has no children

### DIFF
--- a/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/PageElement/UniversalDiscoveryWidget.php
@@ -145,9 +145,9 @@ class UniversalDiscoveryWidget extends Element
         Assert::assertTrue($this->context->getElementByText($itemName, sprintf($this->fields['treeLevelSelectedFormat'], $level))->isVisible());
 
         if ($willNextLevelBeReloaded) {
-            // wait until the items displayed previously change
+            // Wait until the items displayed previously disappear or change
             $this->context->waitUntil($this->defaultTimeout, function () use ($currentItems, $level) {
-                return $this->getItemsFromLevel($level + 1) !== $currentItems;
+                return !$this->isNextLevelDisplayed($level) || $this->getItemsFromLevel($level + 1) !== $currentItems;
             });
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | Follow-up to https://github.com/ezsystems/ezplatform-admin-ui/pull/1220
| Bug fix?      | yes, in tests
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

The solution proposed in https://github.com/ezsystems/ezplatform-admin-ui/pull/1220 has one weak point - when a level has been previously selected in UDW we try to compare the current displayed items with the ones that were displayed previously. This scenario doesn't work when the new selected level has no children - the `getItemsFromLevel` does not find anything and throws exception.

We can consider the next level loaded when:
- the children for previously selected level were displayed and now aren't (this is added in this PR)
**OR**
- the children for previously selected level and the children of currently selected item differ

Full regression build: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/283324414

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
