### PR TITLE
EZP-31366: [Behat] Added checking visibility of ContentTypePicker

### DIFF
--- a/src/lib/Behat/PageElement/ContentTypePicker.php
+++ b/src/lib/Behat/PageElement/ContentTypePicker.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
 use EzSystems\Behat\Browser\Context\BrowserContext;
 use EzSystems\Behat\Browser\Element\Element;
+use PHPUnit\Framework\Assert;
 
 class ContentTypePicker extends Element
 {
@@ -19,11 +20,21 @@ class ContentTypePicker extends Element
         parent::__construct($context);
         $this->fields = [
             'contentTypeSelector' => '.form-check-label',
+            'headerSelector' => '.ez-extra-actions--create .ez-extra-actions__header',
         ];
     }
 
     public function select(string $contentType): void
     {
         $this->context->getElementByText($contentType, $this->fields['contentTypeSelector'])->click();
+    }
+
+    public function verifyVisibility(): void
+    {
+        $this->context->waitUntil($this->defaultTimeout, function () {
+            return $this->context->findElement($this->fields['headerSelector'])->getText() !== '';
+        });
+
+        Assert::assertEquals('Create content', $this->context->findElement($this->fields['headerSelector'])->getText());
     }
 }

--- a/src/lib/Behat/PageObject/ContentItemPage.php
+++ b/src/lib/Behat/PageObject/ContentItemPage.php
@@ -58,6 +58,7 @@ class ContentItemPage extends Page
         $this->rightMenu->clickButton('Create');
 
         $contentTypePicker = ElementFactory::createElement($this->context, ContentTypePicker::ELEMENT_NAME);
+        $contentTypePicker->verifyVisibility();
         $contentTypePicker->select($contentType);
 
         $contentUpdatePage = PageObjectFactory::createPage($this->context, ContentUpdateItemPage::PAGE_NAME, $contentType);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31366
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Making sure that the Content Type picker is rendered before we interact with it.
Also added the verifyVisibility call in PageBuilder: https://github.com/ezsystems/ezplatform-page-builder/pull/501

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
