### PR TITLE
EZP-31311: Add queryfieldtype tests

### DIFF
--- a/features/standard/ContentTypeFields.feature
+++ b/features/standard/ContentTypeFields.feature
@@ -8,7 +8,7 @@ Feature: Content fields setting and editing
     Given I create a "<fieldName> CT" Content Type in "Content" with "<fieldInternalName>" identifier
       | Field Type  | Name        | Identifier          | Required | Searchable | Translatable | Settings       |
       | <fieldName> | Field       | <fieldInternalName> | no      | no	      | yes          | <fieldSettings>  |
-      | Text line   | Name         | name	           | no      | yes	       | yes          |                 |
+      | Text line   | Name        | name	            | no      | yes	      | yes          |                  |
     And I am logged as "admin"
       And I go to "Content structure" in "Content" tab
     When I start creating a new content "<fieldName> CT"
@@ -91,3 +91,41 @@ Feature: Content fields setting and editing
       | File                         | value     | binary2.txt.zip              |            |                          |         |          | binary1.txt               | binary2.txt                  |
       | Matrix                       | value     | col1:col2:col3,11:12:13,21:22:23,31:32:33 |                         ||         |          | Matrix                    | Matrix                       |
       | Image Asset                  | value     | imageasset2.png.zip          |            |                          |         |          | imageasset1.png           | imageasset2.png              |
+
+  @javascript @common @admin @queryFieldType
+  Scenario Outline: Create content item with Content Query field
+    Given I create a "<fieldName> CT" Content Type in "Content" with "<fieldInternalName>" identifier
+      | Field Type  | Name        | Identifier          | Required | Searchable | Translatable | Settings        |
+      | <fieldName> | Field       | <fieldInternalName> | no       | no	        | yes          | <fieldSettings> |
+      | Text line   | Name        | name	            | no       | yes	    | yes          |                 |
+    And I am logged as "admin"
+    And I go to "Content structure" in "Content" tab
+    When I start creating a new content "<fieldName> CT"
+    And the "Ezcontentquery" field is noneditable
+    And I set content fields
+      | label    | <label1>    |
+      | Name     | <fieldName> |
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And I should be on content item page "<fieldName>" of type "<fieldName> CT" in root path
+    And content attributes equal
+      | label    | <label1> | fieldType   |
+      | Field    | <value1> | <fieldName> |
+    Examples:
+      | fieldInternalName | fieldName     | fieldSettings                                               | label1 | value1                 |
+      | ezcontentquery    | Content query | QueryType-EzPlatformAdminUi:MediaSubtree,ContentType-folder | value  | Media,Files,Multimedia |
+
+  @javascript @common @queryFieldType
+  Scenario: Edit content item with Content Query
+    Given I am logged as "admin"
+    And I navigate to content "Content query" of type "Content query CT" in root path
+    When I click on the edit action bar button "Edit"
+    And I set content fields
+      | label    | <label1>          |
+      | Name     | New Content query |
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And I should be on content item page "New Content query" of type "Content query CT" in root path
+    And content attributes equal
+      | label    | value                  | fieldType     |
+      | Field    | Media,Files,Multimedia | Content query |

--- a/src/lib/Behat/BusinessContext/ContentUpdateContext.php
+++ b/src/lib/Behat/BusinessContext/ContentUpdateContext.php
@@ -8,8 +8,10 @@ namespace EzSystems\EzPlatformAdminUi\Behat\BusinessContext;
 
 use Behat\Gherkin\Node\TableNode;
 use EzSystems\Behat\Core\Environment\EnvironmentConstants;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\NonEditableField;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\ContentUpdateItemPage;
 use EzSystems\Behat\Browser\Factory\PageObjectFactory;
+use PHPUnit\Framework\Assert;
 
 class ContentUpdateContext extends BusinessContext
 {
@@ -24,6 +26,16 @@ class ContentUpdateContext extends BusinessContext
             $values = $this->filterOutNonEmptyValues($row);
             $updateItemPage->contentUpdateForm->fillFieldWithValue($row['label'], $values);
         }
+    }
+
+    /**
+     * @Given the :fieldName field is noneditable
+     */
+    public function verifyFieldIsNotEditable(string $fieldName): void
+    {
+        $updateItemPage = PageObjectFactory::createPage($this->browserContext, ContentUpdateItemPage::PAGE_NAME, '');
+        $field = $updateItemPage->contentUpdateForm->getField($fieldName);
+        Assert::assertEquals(NonEditableField::EXPECTED_NON_EDITABLE_TEXT, $field->getValue()[0]);
     }
 
     private function filterOutNonEmptyValues(array $parameters): array

--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -190,8 +190,8 @@ class ContentViewContext extends BusinessContext
     {
         $hash = $parameters->getHash();
         $contentItemPage = PageObjectFactory::createPage($this->browserContext, ContentItemPage::PAGE_NAME, '');
-        foreach ($hash as $field) {
-            $contentItemPage->contentField->verifyFieldHasValue($field['label'], $field);
+        foreach ($hash as $fieldData) {
+            $contentItemPage->contentField->verifyFieldHasValue($fieldData['label'], $fieldData);
         }
     }
 

--- a/src/lib/Behat/PageElement/ContentUpdateForm.php
+++ b/src/lib/Behat/PageElement/ContentUpdateForm.php
@@ -26,8 +26,9 @@ class ContentUpdateForm extends Element
         $this->fields = [
             'formElement' => '[name=ezplatform_content_forms_content_edit]',
             'closeButton' => '.ez-content-edit-container__close',
-            'fieldLabel' => '.ez-field-edit__label-wrapper label.ez-field-edit__label, .ez-field-edit__label-wrapper legend',
-            'nthField' => '.ez-field-edit:nth-child(%s)',
+            'fieldLabel' => '.ez-field-edit__label-wrapper label.ez-field-edit__label, .ez-field-edit__label-wrapper legend, .ez-card > .card-body > div > legend',
+            'nthField' => '.ez-card .card-body > div:nth-of-type(%s)',
+            'editableFieldClass' => 'ez-field-edit',
             'fieldOfType' => '.ez-field-edit--%s',
         ];
     }
@@ -55,17 +56,20 @@ class ContentUpdateForm extends Element
     public function getField(string $fieldName): EzFieldElement
     {
         $fieldPosition = $this->context->getElementPositionByText($fieldName, $this->fields['formElement'] . ' ' . $this->fields['fieldLabel']);
-
         if ($fieldPosition === 0) {
             Assert::fail(sprintf('Field %s not found.', $fieldName));
         }
 
-        $fieldClass = $this->context->findElement(sprintf($this->fields['nthField'], $fieldPosition))->getAttribute('class');
-
-        preg_match($this::FIELD_TYPE_CLASS_REGEX, $fieldClass, $matches);
-
-        $fieldType = explode('--', $matches[0])[1];
         $fieldLocator = sprintf($this->fields['nthField'], $fieldPosition);
+
+        $isEditable = $this->context->findElement($fieldLocator)->hasClass($this->fields['editableFieldClass']);
+        if (!$isEditable) {
+            $fieldType = strtolower($fieldName);
+        } else {
+            $fieldClass = $this->context->findElement($fieldLocator)->getAttribute('class');
+            preg_match($this::FIELD_TYPE_CLASS_REGEX, $fieldClass, $matches);
+            $fieldType = explode('--', $matches[0])[1];
+        }
 
         return ElementFactory::createElement($this->context, FieldTypeNameConverter::getFieldTypeNameByIdentifier($fieldType), $fieldLocator, $fieldName);
     }

--- a/src/lib/Behat/PageElement/Fields/ContentQuery.php
+++ b/src/lib/Behat/PageElement/Fields/ContentQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use Behat\Mink\Element\NodeElement;
+use EzSystems\Behat\Browser\Context\BrowserContext;
+use PHPUnit\Framework\Assert;
+
+class ContentQuery extends NonEditableField
+{
+    public const ELEMENT_NAME = 'Content query';
+
+    public function __construct(BrowserContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['queryResultItem'] = 'p a';
+    }
+
+    public function verifyValueInItemView(array $values): void
+    {
+        $expecteditems = explode(',', $values['value']);
+        $actualItems = $this->getValueInItemView();
+        $commonItems = array_intersect($expecteditems, $actualItems);
+
+        Assert::assertEquals([], array_diff($expecteditems, $commonItems));
+    }
+
+    private function getValueInItemView(): array
+    {
+        $items = $this->context->findAllElements(sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['queryResultItem']));
+
+        return array_map(function (NodeElement $element) {
+            return $element->getText();
+        }, $items);
+    }
+}

--- a/src/lib/Behat/PageElement/Fields/NonEditableField.php
+++ b/src/lib/Behat/PageElement/Fields/NonEditableField.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
+
+use EzSystems\Behat\Browser\Context\BrowserContext;
+
+abstract class NonEditableField extends EzFieldElement
+{
+    public const EXPECTED_NON_EDITABLE_TEXT = 'This Field Type is not editable';
+
+    public function __construct(BrowserContext $context, string $locator, string $label)
+    {
+        parent::__construct($context, $locator, $label);
+        $this->fields['valueSelector'] = sprintf('%s %s', $this->fields['fieldContainer'], '.non-editable');
+    }
+
+    public function setValue(array $parameters): void
+    {
+        throw new \Exception('Field is not editable!');
+    }
+
+    public function getValue(): array
+    {
+        return [$this->context->findElement($this->fields['valueSelector'])->getText()];
+    }
+}

--- a/src/lib/Behat/PageElement/PlatformElementFactory.php
+++ b/src/lib/Behat/PageElement/PlatformElementFactory.php
@@ -10,6 +10,7 @@ use EzSystems\Behat\Browser\Context\BrowserContext;
 use EzSystems\Behat\Browser\Factory\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Authors;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Checkbox;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ContentQuery;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ContentRelationMultiple;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\ContentRelationSingle;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\Country;
@@ -155,6 +156,8 @@ class PlatformElementFactory extends ElementFactory
                 return new Image($context, $parameters[0], $parameters[1]);
             case ImageAsset::ELEMENT_NAME:
                 return new ImageAsset($context, $parameters[0], $parameters[1]);
+            case ContentQuery::ELEMENT_NAME:
+                return new ContentQuery($context, $parameters[0], $parameters[1]);
             case File::ELEMENT_NAME:
                 return new File($context, $parameters[0], $parameters[1]);
             case ContentRelationSingle::ELEMENT_NAME:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31311
| Bug fix?      | no
| New feature?  | new tests
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Adding tests for ezcontentquery. This fieldtype is not editable in Content Edit mode:
![obraz](https://user-images.githubusercontent.com/10993858/74036489-ab02fb00-49bc-11ea-8ae1-3d30d1d2af49.png)
which means I had to rewrite a bit of current test logic to take that into account.
Because of that I've also decided that we shoudn't add it to existing examples (which try to set a value in fieldtype and then verify its correctness) but as new separate feature. Scenarios boil down to:
1) A Content Item with contenqeury fieldtype can be created (and Content Query field displays correct data)
1) A Content Item with contenqeury fieldtype can be edited (and Content Query field displays correct data)

PR requires: https://github.com/ezsystems/BehatBundle/pull/126

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
- [x] Remove TMP commit
