### PR TITLE
EZEE-2975: In Page Builder dropdown widgets are too low after being expanded

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -26,7 +26,26 @@
                     }
                 };
 
-                btn.classList[methodNameButton](CLASS_ACTIVE_BUTTON);
+                if (actions.classList.contains('ez-extra-actions--dropdown')) {
+                    const actionsRect = actions.getBoundingClientRect();
+
+                    actions.style.opacity = 0;
+
+                    const fitsViewport = actionsRect.height + btn.offsetTop <= global.innerHeight;
+
+                    if (!fitsViewport) {
+                        actions.style.bottom = `0px`;
+                        actions.style.top = 'auto';
+                    } else {
+                        actions.style.top = `${btn.offsetTop}px`;
+                        actions.style.bottom = 'auto';
+                    }
+
+                    actions.style.opacity = 1;
+                } else {
+                    btn.classList[methodNameButton](CLASS_ACTIVE_BUTTON);
+                }
+
                 actions.classList[methodNameContainer](CLASS_HIDDEN);
 
                 if (!actions.classList.contains(CLASS_HIDDEN)) {

--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -28,10 +28,9 @@
 
                 if (actions.classList.contains('ez-extra-actions--dropdown')) {
                     const actionsRect = actions.getBoundingClientRect();
+                    const fitsViewport = actionsRect.height + btn.offsetTop <= global.innerHeight;
 
                     actions.style.opacity = 0;
-
-                    const fitsViewport = actionsRect.height + btn.offsetTop <= global.innerHeight;
 
                     if (!fitsViewport) {
                         actions.style.bottom = `0px`;

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -174,12 +174,12 @@
         opacity: 1;
         transform: translate(calc(-100%), 0) scaleX(1);
         transform-origin: right center;
-        transition: all 0.4s ease-in;
+        transition: transform 0.4s ease-in, opacity 0.4s ease-in;
 
         &--hidden {
             opacity: 0;
             transform: translate(calc(-100%), 0) scaleX(0);
-            transition: all 0.2s ease-out;
+            transition: transform 0.2s ease-out, opacity 0.2s ease-out;
         }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-2975
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Rreverted setting top position
https://github.com/ezsystems/ezplatform-page-builder/pull/502

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
