### PR TITLE
EZP-31367: Do not use translated node name for Location ID 1 in Content Tree

### DIFF
--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -127,7 +127,7 @@ final class NodeFactory
             $depth,
             $location->id,
             $location->contentId,
-            $this->translationHelper->getTranslatedContentName($content),
+            $this->getNodeName($location),
             $contentType ? $contentType->identifier : '',
             $contentType ? $contentType->isContainer : true,
             $location->invisible || $location->hidden,
@@ -244,5 +244,15 @@ final class NodeFactory
         $searchQuery->performCount = true;
 
         return $this->searchService->findLocations($searchQuery)->totalCount;
+    }
+
+    private function getNodeName(Location $location): string
+    {
+        $content = $location->getContent();
+
+        // Location ID 1 (no VersionInfo) needs special handling
+        return null === $content->getVersionInfo()
+            ? $location->getContentInfo()->name
+            : $this->translationHelper->getTranslatedContentName($content);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31367
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This was discovered during testing of https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/264. For Location ID 1 there is no `VersionInfo` thus it is impossible to get translated name. As a fallback it uses `$contentInfo->name` property.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
