### PR TITLE
EZP-31380: Disable manage rows/cells buttons for table and row toolbars

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base-table.js
@@ -13,9 +13,6 @@ export default class EzConfigTableBase {
             'tableHeading',
             'ezembedinline',
             'ezanchor',
-            'eztablerow',
-            'eztablecolumn',
-            'eztablecell',
             'eztableremove',
             ...config.extraButtons[this.name],
         ];

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
@@ -1,6 +1,8 @@
-export default class EzTableCellConfig {
+import EzConfigTableBase from './base-table';
+
+export default class EzTableCellConfig extends EzConfigTableBase {
     constructor(config) {
-        this.name = 'td';
+        super(config);
 
         const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
 
@@ -17,9 +19,10 @@ export default class EzTableCellConfig {
             'eztableremove',
             ...config.extraButtons[this.name],
         ];
+    }
 
-        this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
-        this.setPosition = AlloyEditor.SelectionSetPosition.table;
+    getConfigName() {
+        return 'td';
     }
 
     test(payload) {

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
@@ -1,8 +1,25 @@
-import EzConfigTableBase from './base-table';
+export default class EzTableCellConfig {
+    constructor(config) {
+        this.name = 'td';
 
-export default class EzTableCellConfig extends EzConfigTableBase {
-    getConfigName() {
-        return 'td';
+        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
+
+        this.buttons = [
+            'ezmoveup',
+            'ezmovedown',
+            editAttributesButton,
+            'tableHeading',
+            'ezembedinline',
+            'ezanchor',
+            'eztablerow',
+            'eztablecolumn',
+            'eztablecell',
+            'eztableremove',
+            ...config.extraButtons[this.name],
+        ];
+
+        this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
+        this.setPosition = AlloyEditor.SelectionSetPosition.table;
     }
 
     test(payload) {

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
@@ -1,8 +1,25 @@
-import EzConfigTableBase from './base-table';
+export default class EzTableHeaderConfig {
+    constructor(config) {
+        this.name = 'th';
 
-export default class EzTableHeaderConfig extends EzConfigTableBase {
-    getConfigName() {
-        return 'th';
+        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
+
+        this.buttons = [
+            'ezmoveup',
+            'ezmovedown',
+            editAttributesButton,
+            'tableHeading',
+            'ezembedinline',
+            'ezanchor',
+            'eztablerow',
+            'eztablecolumn',
+            'eztablecell',
+            'eztableremove',
+            ...config.extraButtons[this.name],
+        ];
+
+        this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
+        this.setPosition = AlloyEditor.SelectionSetPosition.table;
     }
 
     test(payload) {

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-header.js
@@ -1,25 +1,8 @@
-export default class EzTableHeaderConfig {
-    constructor(config) {
-        this.name = 'th';
+import EzTableCellConfig from './ez-table-cell';
 
-        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
-
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            editAttributesButton,
-            'tableHeading',
-            'ezembedinline',
-            'ezanchor',
-            'eztablerow',
-            'eztablecolumn',
-            'eztablecell',
-            'eztableremove',
-            ...config.extraButtons[this.name],
-        ];
-
-        this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
-        this.setPosition = AlloyEditor.SelectionSetPosition.table;
+export default class EzTableHeaderConfig extends EzTableCellConfig {
+    getConfigName() {
+        return 'th';
     }
 
     test(payload) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31380](https://jira.ez.no/browse/EZP-31380)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

AlloyEdior allows running the commands to manipulate the table content only when active element is `td` or `th`. So there is no need to have "insert rows"/"insert columns" buttons in "table" and "table row" toolbars.

**Steps to reproduce:**
1. Insert a table using the Online Editor
2. Using elements path click on "table" or "tr"
3. Try to insert new rows/cells

**Current results:**
No new rows/cells are inserted

**Expected result:**
New rows/cells will be inserted

This happens because of https://github.com/liferay/alloy-editor/blob/master/src/plugins/tabletools.js#L821

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
