### PR TITLE
EZP-31310: Fixed VersionDraftConflict for content having multiple locations

### DIFF
--- a/src/bundle/Controller/Content/VersionDraftConflictController.php
+++ b/src/bundle/Controller/Content/VersionDraftConflictController.php
@@ -71,7 +71,7 @@ class VersionDraftConflictController extends Controller
     public function draftHasNoConflictAction(
         int $contentId,
         string $languageCode,
-        ?int $locationId
+        ?int $locationId = null
     ): Response {
         $content = $this->contentService->loadContent($contentId);
         $contentInfo = $content->contentInfo;

--- a/src/bundle/Controller/Content/VersionDraftConflictController.php
+++ b/src/bundle/Controller/Content/VersionDraftConflictController.php
@@ -60,16 +60,20 @@ class VersionDraftConflictController extends Controller
     /**
      * @param int $contentId
      * @param string $languageCode
+     * @param int|null $locationId
      *
      * @return Response
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function draftHasNoConflictAction(int $contentId, string $languageCode): Response
-    {
+    public function draftHasNoConflictAction(
+        int $contentId,
+        string $languageCode,
+        ?int $locationId
+    ): Response {
         $content = $this->contentService->loadContent($contentId);
-        $location = $this->locationService->loadLocation($content->contentInfo->mainLocationId);
         $contentInfo = $content->contentInfo;
 
         try {
@@ -89,6 +93,14 @@ class VersionDraftConflictController extends Controller
             $versionsDataset = $this->datasetFactory->versions();
             $versionsDataset->load($contentInfo);
             $conflictedDrafts = $versionsDataset->getConflictedDraftVersions($contentInfo->currentVersionNo, $languageCode);
+            $locationId = $locationId ?? $contentInfo->mainLocationId;
+            try {
+                $location = $this->locationService->loadLocation($locationId);
+            } catch (UnauthorizedException $e) {
+                $availableLocations = $this->locationService->loadLocations($contentInfo);
+                // will return null if array of availableLocations is empty
+                $location = array_shift($availableLocations);
+            }
 
             $modalContent = $this->renderView('@ezdesign/content/modal_draft_conflict.html.twig', [
                 'conflicted_drafts' => $conflictedDrafts,

--- a/src/bundle/Controller/Content/VersionDraftConflictController.php
+++ b/src/bundle/Controller/Content/VersionDraftConflictController.php
@@ -97,6 +97,7 @@ class VersionDraftConflictController extends Controller
             try {
                 $location = $this->locationService->loadLocation($locationId);
             } catch (UnauthorizedException $e) {
+                // Will return list of locations user has *read* access to, or empty array if none
                 $availableLocations = $this->locationService->loadLocations($contentInfo);
                 // will return null if array of availableLocations is empty
                 $location = array_shift($availableLocations);

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -494,11 +494,12 @@ ezplatform.version.has_no_conflict:
         languageCode: ~
 
 ezplatform.version_draft.has_no_conflict:
-    path: /version-draft/has-no-conflict/{contentId}/{languageCode}
+    path: /version-draft/has-no-conflict/{contentId}/{languageCode}/{locationId}
     options:
         expose: true
     defaults:
         _controller: 'EzPlatformAdminUiBundle:Content\VersionDraftConflict:draftHasNoConflict'
+        locationId: ~
 
 # LocationView / Locations tab
 

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -20,10 +20,11 @@
         },
         currentLanguage: mfuContainer.dataset.currentLanguage,
     };
-    const handleEditItem = (content) => {
+    const handleEditItem = (content, location) => {
         const contentId = content._id;
+        const locationId = location._id;
         const languageCode = content.mainLanguageCode;
-        const checkVersionDraftLink = Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
+        const checkVersionDraftLink = Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode, locationId });
         const submitVersionEditForm = () => {
             doc.querySelector('#form_subitems_content_edit_content_info').value = contentId;
             doc.querySelector(`#form_subitems_content_edit_language_${languageCode}`).checked = true;

--- a/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/btn/location.edit.js
@@ -4,6 +4,8 @@
     const form = editActions.querySelector('form');
     const contentIdInput = form.querySelector('#content_edit_content_info') || form.querySelector('#user_edit_content_info');
     const contentId = contentIdInput.value;
+    const locationInput = form.querySelector('#content_edit_location') || form.querySelector('#user_edit_location');
+    const locationId = locationInput.value;
     const resetRadioButtons = () =>
         btns.forEach((btn) => {
             btn.checked = false;
@@ -48,7 +50,10 @@
     const changeHandler = (event) => {
         const checkedBtn = event.currentTarget;
         const languageCode = checkedBtn.value;
-        const checkVersionDraftLink = global.Routing.generate('ezplatform.version_draft.has_no_conflict', { contentId, languageCode });
+        const checkVersionDraftLink = global.Routing.generate(
+            'ezplatform.version_draft.has_no_conflict',
+            { contentId, languageCode, locationId }
+        );
 
         fetch(checkVersionDraftLink, {
             credentials: 'same-origin',

--- a/src/bundle/Resources/views/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/content/tab/versions/table.html.twig
@@ -36,7 +36,7 @@
                 'contentId': version.contentInfo.id,
                 'versionNo': version.versionNo,
                 'language': version.initialLanguageCode,
-                'locationId': location.id
+                'locationId': location.id ?? null
             })
             %}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31310
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| Needs | <ul><li>https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/269 </li><li>https://github.com/ezsystems/repository-forms/pull/333</li></ul>
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When the user wants to edit the content that has multiple locations and occurs checking if unpublished draft exists then we need to know in which location the user tries to do this. This is needed to prepare proper links to edit versions. We should do this when it is possible (when a user is on the location view). When the user wants to edit content from a dashboard then the location is unknown. Therefore ContentEditViewBuilder must not only check the main Location but also other possible locations to which a user may have access. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
