### PR TITLE
EZP-31384: Broken Content on the fly create template style

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -59,6 +59,12 @@
             background: $ez-color-base-pale;
         }
 
+        &--create-on-the-fly {
+            .ez-edit-header__content-type-name {
+                width: 100%;
+            }
+        }
+
         &__details {
             color: $ez-black;
             font-size: calculateRem(12px);
@@ -132,7 +138,7 @@
                 }
 
                 &__author-breadcrumbs {
-                    height: calculateRem(30px); 
+                    height: calculateRem(30px);
                     line-height: calculateRem(30px);
                     color: $ez-color-base-medium;
                     font-size: calculateRem(12px);

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -7,30 +7,57 @@
 {% endblock %}
 
 {% block details %}
-    <h2 class="ez-content-item-status">{{ 'creating_in_language'|trans({'%contentTypeName%': content_type.name, '%languageName%': language.name})|desc('Creating a(n) %contentTypeName% in %languageName%') }}</h2>
-    <h1>
-        <svg class="ez-icon ez-icon-{{ content_type.identifier }}">
-            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#{{ content_type.identifier }}"></use>
-        </svg>
-        {{ 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') }}
-    </h1>
+    <div class="ez-edit-header ez-edit-header--create-on-the-fly">
+        <div class="ez-edit-header__content-type-name">
+            <div class="container px-5">
+                {{ 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') }}
+            </div>
+        </div>
+        <div class="ez-edit-header__details">
+            <div class="container ez-details-items">
+                {{ 'creating_details'|trans({
+                    '%icon%': ez_content_type_icon(content_type.identifier),
+                    '%content_type_name%': content_type.name,
+                    '%language_name%': language.name,
+                    '%location_name%': parent_location.contentInfo.name})
+                    |desc('
+                        <span class="ez-details-items__connector">Creating:</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
+                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
+                            <use xlink:href="%icon%"></use>
+                        </svg>
+                        %content_type_name%
+                        </span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
+                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
+                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>')
+                    |raw
+                }}
+            </div>
+        </div>
 
-    <div class="small">
-        {{ content_type.name }} / Parent Location ID: {{ parent_location.id }}
+        <div class="ez-content-item__errors-wrapper" hidden>
+            {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
+        </div>
+        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
+        {% if content_type.descriptions is not empty %}
+            <div class="small text-muted">{{ content_type.description }}</div>
+        {% endif %}
     </div>
-    <div class="ez-content-item__errors-wrapper" hidden>
-        {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
-    </div>
-    {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-    {% if content_type.descriptions is not empty %}
-        <div class="small text-muted">{{ content_type.description }}</div>
-    {% endif %}
 {% endblock %}
 
+{% block form_fields %}
+    <section class="container mt-4 mb-5 px-5">
+        <div class="card ez-card">
+            <div class="card-body">
+                {{ parent() }}
+            </div>
+        </div>
+    </section>
+{% endblock %}
 
 {% block right_sidebar_wrapper %}{% endblock %}
-
-{% block close_button %}{% endblock %}
 
 {% block form_before %}
     {{ ez_render_component_group('content-create-form-before', {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |https://jira.ez.no/browse/EZP-31384
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
