### PR TITLE
EZP-31195: Set From in twig to empty string

### DIFF
--- a/src/bundle/Resources/views/Security/mail/forgot_user_password.html.twig
+++ b/src/bundle/Resources/views/Security/mail/forgot_user_password.html.twig
@@ -1,5 +1,4 @@
 {%- block from -%}
-    noreply@domain.com
 {%- endblock from -%}
 
 {%- block subject -%}


### PR DESCRIPTION
 Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31195](https://jira.ez.no/browse/EZP-31195)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Removed default mail from twig

Another PR's to this ticket
https://github.com/ezsystems/ezplatform-form-builder/pull/210
https://github.com/ezsystems/ezplatform-user/pull/59

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review