### PR TITLE
EZP-31371: Copying a web page link w/o protocol in a Word paragraph leads to a 404 error

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -325,6 +325,11 @@
             nativeEditor.on('change', saveRichText);
             nativeEditor.on('customUpdate', saveRichText);
             nativeEditor.on('editorInteraction', saveRichText);
+            nativeEditor.on('paste', () => {
+                setTimeout(() => {
+                    this.setLinksProtocol(container);
+                });
+            });
 
             return alloyEditor;
         }
@@ -389,6 +394,24 @@
 
         splitIntoWords(text) {
             return text.split(' ').filter((word) => word.trim());
+        }
+
+        setLinksProtocol(container) {
+            const links = container.querySelectorAll('a');
+            const anchorPrefix = '#';
+            const protocolPrefix = 'http://';
+
+            links.forEach((link) => {
+                const href = link.getAttribute('href');
+                const protocolPattern = /^https?:\/\//i;
+
+                if (href && href.indexOf(anchorPrefix) !== 0 && !protocolPattern.test(href)) {
+                    const protocolHref = protocolPrefix.concat(href);
+
+                    link.setAttribute('href', protocolHref);
+                    link.setAttribute('data-cke-saved-href', protocolHref);
+                }
+            });
         }
     };
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -325,10 +325,8 @@
             nativeEditor.on('change', saveRichText);
             nativeEditor.on('customUpdate', saveRichText);
             nativeEditor.on('editorInteraction', saveRichText);
-            nativeEditor.on('paste', () => {
-                setTimeout(() => {
-                    this.setLinksProtocol(container);
-                });
+            nativeEditor.on('afterPaste', () => {
+                this.setLinksProtocol(container);
             });
 
             return alloyEditor;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31371](https://jira.ez.no/browse/EZP-31371)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`HTTP` protocol prefix should be added on pasting links from external sources, if not specified already. This behavior is aligned with how prefixing works in RTE at the moment.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
