### PR TITLE
EZP-31394: Fixed wrong button and behavior for edit action in version table

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
@@ -84,13 +84,19 @@
                                 </svg>
                             </a>
                         {% elseif is_draft %}
-                            <button class="btn btn-icon mx-2 ez-btn--content-edit"
-                                    title="{{ 'tab.versions.table.action.archived.edit'|trans|desc('Restore archived version') }}"
+                            <button
+                                    data-content-draft-edit-url="{{ edit_url }}"
+                                    data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
+                                        'contentId': version.contentInfo.id,
+                                        'versionNo': version.versionNo,
+                                        'languageCode': version.initialLanguageCode
+                                    }) }}"
                                     data-content-id="{{ version.contentInfo.id }}"
-                                    data-version-no="{{ version.versionNo }}"
-                                    data-language-code="{{ version.initialLanguageCode }}">
+                                    data-language-code="{{ version.initialLanguageCode }}"
+                                    class="btn btn-icon mx-2 ez-btn--content-draft-edit"
+                                    title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit draft') }}">
                                 <svg class="ez-icon ez-icon-edit">
-                                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#archive-restore"></use>
+                                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#edit"></use>
                                 </svg>
                             </button>
                         {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31394
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
