### PR TITLE
[Behat] Added verification of notification when adding Image Asset

### DIFF
--- a/src/lib/Behat/PageElement/Fields/ImageAsset.php
+++ b/src/lib/Behat/PageElement/Fields/ImageAsset.php
@@ -6,8 +6,31 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\Notification;
+use PHPUnit\Framework\Assert;
+
 class ImageAsset extends Image
 {
     /** @var string Name by which Element is recognised */
     public const ELEMENT_NAME = 'Image Asset';
+
+    private const IMAGE_ASSET_NOTIFICATION_MESSAGE = 'Image has been published and can now be reused';
+
+    public function setValue(array $parameters): void
+    {
+        $notification = ElementFactory::createElement($this->context, Notification::ELEMENT_NAME);
+
+        // close notification about new draft created successfully if it's still visible
+        if ($notification->isVisible()) {
+            $notification->verifyAlertSuccess();
+            $notification->closeAlert();
+        }
+
+        parent::setValue($parameters);
+
+        $imageAssetNotification = ElementFactory::createElement($this->context, Notification::ELEMENT_NAME);
+        $imageAssetNotification->verifyAlertSuccess();
+        Assert::assertEquals(self::IMAGE_ASSET_NOTIFICATION_MESSAGE, $imageAssetNotification->getMessage());
+    }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31392
| Bug fix?      | no (but makes tests more robust)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Making sure that the Image Asset is created correctly before proceeding with further test actions. I suppose the tests used to click "Publish" to soon (before the Image Asset has been uploaded and processed) which resulted in publishing a Content Item without changes. Making sure the notification is visible should be enough.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
