### PR TITLE
EZP-30482: No limitation to image content type when embedding image in RTE

### DIFF
--- a/src/bundle/Resources/config/universal_discovery_widget.yml
+++ b/src/bundle/Resources/config/universal_discovery_widget.yml
@@ -37,6 +37,7 @@ system:
                     multiple: false
                 richtext_embed_image:
                     multiple: false
+                    allowed_content_types: ['image']
                     content_on_the_fly:
                         allowed_content_types: ['image']
                 image_asset:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30482](https://jira.ez.no/browse/EZP-30482)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When embedding images in RTE, there should be restriction only to the "image" Content-Type. It works fine when embedding content newly created via COTF, but UDW is still affected. This issue is not reproducible in new version of UDW in 3.0. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
