### PR TITLE
EZP-31405 - fix embed image link removal

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -84,6 +84,9 @@
                         for (i = 0; i !== element.attributes.length; i++) {
                             importChildNodes(newElement, element.attributes[i], false);
                         }
+                        if (element.localName === 'a' && parent.dataset.ezelement === 'ezembed') {
+                            element.setAttribute('data-cke-survive', '1');
+                        }
 
                         parent.appendChild(newElement);
                     } else if (element.nodeType === Node.TEXT_NODE) {

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -84,6 +84,7 @@
                         for (i = 0; i !== element.attributes.length; i++) {
                             importChildNodes(newElement, element.attributes[i], false);
                         }
+
                         if (element.localName === 'a' && parent.dataset.ezelement === 'ezembed') {
                             element.setAttribute('data-cke-survive', '1');
                         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31405](https://jira.ez.no/browse/EZP-31405)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Make sure <ezlink> not removed by CKEditor HTML parser when `<ezlink>` located above `<ezconfig>` element inside embed image element (which is the case if content migrated from legacy).

not reproducible with eZPlatform v3

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
