### PR TITLE
EZP-31356: Fixed styles dropdown selection on Firefox and Safari

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -46,6 +46,8 @@ const alloyEditor = [
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-underline.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-subscript.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-superscript.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-dropdown.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-styleslist.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-styleslistitem.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-quote.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-strike.js'),

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-dropdown.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-dropdown.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+
+export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
+    /**
+     * Lifecycle. Renders the UI of the button.
+     *
+     * @instance
+     * @memberof ButtonDropdown
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
+    render() {
+        return (
+            <div className="ae-dropdown ae-arrow-box ae-arrow-box-top-left" onKeyDown={this.handleKey} tabIndex="0">
+                <ul className="ae-listbox" role="listbox">
+                    {this.props.children}
+                </ul>
+            </div>
+        );
+    }
+}
+
+const eZ = (window.eZ = window.eZ || {});
+
+eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
+eZ.ezAlloyEditor.EzBtnDropdown = EzBtnDropdown;

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-dropdown.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-dropdown.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import AlloyEditor from 'alloyeditor';
+import EzBtnImage from "./ez-btn-image";
 
 export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
+    static get key() {
+        return 'ezbtndropdown';
+    }
+
     /**
      * Lifecycle. Renders the UI of the button.
      *
@@ -21,7 +26,5 @@ export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
     }
 }
 
-const eZ = (window.eZ = window.eZ || {});
-
-eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
-eZ.ezAlloyEditor.EzBtnDropdown = EzBtnDropdown;
+AlloyEditor.Buttons[EzBtnDropdown.key] = AlloyEditor.EzBtnDropdown = EzBtnDropdown;
+eZ.addConfig('ezAlloyEditor.ezBtnDropdown', EzBtnDropdown);

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslist.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslist.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+import EzButtonDropdown from './ez-btn-dropdown';
+
+export default class EzButtonStylesList extends AlloyEditor.ButtonStylesList {
+    /**
+     * Lifecycle. Renders the UI of the list.
+     *
+     * @instance
+     * @memberof ButtonStylesList
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
+    render() {
+        let removeStylesItem;
+
+        if (this.props.showRemoveStylesItem) {
+            removeStylesItem = <AlloyEditor.ButtonStylesListItemRemove editor={this.props.editor} onDismiss={this.props.toggleDropdown} />;
+        }
+
+        return (
+            <EzButtonDropdown {...this.props}>
+                {removeStylesItem}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.blockStyles} styles={this._blockStyles} />
+                {this._renderStylesItems(this._blockStyles)}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.inlineStyles} styles={this._inlineStyles} />
+                {this._renderStylesItems(this._inlineStyles)}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.objectStyles} styles={this._objectStyles} />
+                {this._renderStylesItems(this._objectStyles)}
+            </EzButtonDropdown>
+        );
+    }
+}
+
+AlloyEditor.ButtonStylesList = AlloyEditor.EzButtonStylesList = EzButtonStylesList;
+
+const eZ = (window.eZ = window.eZ || {});
+
+eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
+eZ.ezAlloyEditor.EzButtonStylesList = EzButtonStylesList;

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslist.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-styleslist.js
@@ -3,6 +3,10 @@ import AlloyEditor from 'alloyeditor';
 import EzButtonDropdown from './ez-btn-dropdown';
 
 export default class EzButtonStylesList extends AlloyEditor.ButtonStylesList {
+    static get key() {
+        return 'ezbtnstyleslist';
+    }
+
     /**
      * Lifecycle. Renders the UI of the list.
      *
@@ -35,9 +39,5 @@ export default class EzButtonStylesList extends AlloyEditor.ButtonStylesList {
     }
 }
 
-AlloyEditor.ButtonStylesList = AlloyEditor.EzButtonStylesList = EzButtonStylesList;
-
-const eZ = (window.eZ = window.eZ || {});
-
-eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
-eZ.ezAlloyEditor.EzButtonStylesList = EzButtonStylesList;
+AlloyEditor.Buttons[EzButtonStylesList.key] = AlloyEditor.ButtonStylesList = EzButtonStylesList;
+eZ.addConfig('ezAlloyEditor.ezButtonStylesList', EzButtonStylesList);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31356
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The focus event which is hardcoded into the AlloyEditor and attached to the styles dropdown list is not working correctly on Firefox and Safari. The reasoning for the solution was to implement `ButtonDropdown` component without this `focus` event, which does more harm than good and inject it into newly created `EzButtonStylesList` component which overwrites the default AlloyEditor's `ButtonStylesList` in order to prevent other components of being mutated.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
