### PR TITLE
EZP-31404: Validation error message is not aligned with new create form style

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -44,7 +44,7 @@
             </div>
         </div>
 
-        <div class="ez-content-item__errors-wrapper" hidden>
+        <div class="container px-5 mt-4 ez-content-item__errors-wrapper" hidden>
             {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
         </div>
         {# @todo remove if statement once getDescription() bug is resolved in kernel #}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -61,7 +61,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="ez-content-item__errors-wrapper" hidden>
+        <div class="container px-5 mt-4 ez-content-item__errors-wrapper" hidden>
             {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
         </div>
         {# @todo remove if statement once getDescription() bug is resolved in kernel #}

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -37,7 +37,7 @@
             </div>
         </div>
 
-        <div class="ez-content-item__errors-wrapper" hidden>
+        <div class="container px-5 mt-4 ez-content-item__errors-wrapper" hidden>
             {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
         </div>
         {# @todo remove if statement once getDescription() bug is resolved in kernel #}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31404
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Added container class to error messages

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
