### PR TITLE
EZP-31410: Unable to edit an article with 100+ embed content/images

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/widgets/ez-embed-base.js
@@ -3,6 +3,8 @@ const IS_LINKED_CLASS = 'is-linked';
 const SHOW_EDIT_LINK_TOOLBAR_ATTR = 'data-show-edit-link-toolbar';
 const DATA_ALIGNMENT_ATTR = 'ezalign';
 const ENTER_KEY_CODE = 13;
+const MAX_ACTIVE_CONTENT_LOAD_REQUESTS = 20;
+let activeContentLoadRequestsCount = 0;
 
 const embedBaseDefinition = {
     defaults: {
@@ -107,6 +109,12 @@ const embedBaseDefinition = {
             return;
         }
 
+        if (activeContentLoadRequestsCount >= MAX_ACTIVE_CONTENT_LOAD_REQUESTS) {
+            setTimeout(this.initEditMode.bind(this), 1000);
+            return;
+        }
+
+        activeContentLoadRequestsCount++;
         this.loadContent(contentId);
     },
 
@@ -147,6 +155,10 @@ const embedBaseDefinition = {
         });
 
         fetch(request)
+            .then((response) => {
+                activeContentLoadRequestsCount--;
+                return response;
+            })
             .then((response) => response.json())
             .then(this.handleContentLoaded.bind(this))
             .catch((error) => window.eZ.helpers.notification.showErrorNotification(error));


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31410](https://jira.ez.no/browse/EZP-31410)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

**Steps to reproduce**
1. Set up a new eZ Platform 2.5.8 installation on Platform.sh.
2. Publish a test article and embed 100+ content items/images.
3. Try to edit the test article from the previous step.

**Expected results**
The editor should be able to edit the article without any issues. All the embed content/images should be shown in Online Editor

**Actual results**
REST API request is sent for each embed content item/image. Which results in 100+ simultaneous requests. Because of Platform.sh limits, some of those requests will get 502 responses. And UI for some embed content items/images will be broken.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
