### PR TITLE
EZP-31430: Can't select existing object for ImageAsset field

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -88,11 +88,16 @@
          * @param {Object} response
          */
         loadAsset(response) {
-            const imageField = response.CurrentVersion.Version.Fields.field.find((field) => {
+            const imageField = response.ContentInfo.Content.CurrentVersion.Version.Fields.field.find((field) => {
                 return field.fieldDefinitionIdentifier === imageAssetMapping['contentFieldIdentifier'];
             });
 
-            this.updateData(response.ContentInfo.Content._id, response.ContentInfo.Content.TranslatedName, response.id, imageField.fieldValue);
+            this.updateData(
+                response.ContentInfo.Content._id,
+                response.ContentInfo.Content.TranslatedName,
+                response.id,
+                imageField.fieldValue
+            );
         }
 
         /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31430
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
