### PR TITLE
EZP-31438: Added tooltips to site builder

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -11,7 +11,7 @@
                 };
                 const extraClasses = tooltipNode.dataset.extraClasses || '';
                 const placement = tooltipNode.dataset.placement || 'bottom';
-                const container = tooltipNode.dataset.tooltipContainer || 'body';
+                const container = tooltipNode.dataset.tooltipContainerSelector || 'body';
 
                 $(tooltipNode).tooltip({
                     delay,

--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,9 +1,10 @@
 (function(global, doc, eZ, $) {
     const TOOLTIPS_SELECTOR = '[title]';
-    const parse = () => {
-        const tooltipsNode = doc.querySelectorAll(TOOLTIPS_SELECTOR);
+    const parse = (domNode) => {
+        const searchIn = domNode ? domNode : doc;
+        const tooltipNodes = searchIn.querySelectorAll(TOOLTIPS_SELECTOR);
 
-        for (tooltipNode of tooltipsNode) {
+        for (tooltipNode of tooltipNodes) {
             if (tooltipNode.title) {
                 const delay = {
                     show: tooltipNode.dataset.delayShow || 150,
@@ -11,10 +12,12 @@
                 };
                 const extraClasses = tooltipNode.dataset.extraClasses || '';
                 const placement = tooltipNode.dataset.placement || 'bottom';
+                const container = tooltipNode.dataset.tooltipContainer || 'body';
 
                 $(tooltipNode).tooltip({
                     delay,
                     placement,
+                    container,
                     template: `<div class="tooltip ez-tooltip ${extraClasses}">
                                     <div class="arrow ez-tooltip__arrow"></div>
                                     <div class="tooltip-inner ez-tooltip__inner"></div>

--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -25,8 +25,8 @@
             }
         }
     };
-    const hideAll = () => {
-        const tooltipsNode = doc.querySelectorAll(TOOLTIPS_SELECTOR);
+    const hideAll = (baseElement = doc) => {
+        const tooltipsNode = baseElement.querySelectorAll(TOOLTIPS_SELECTOR);
 
         for (tooltipNode of tooltipsNode) {
             $(tooltipNode).tooltip('hide');

--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,8 +1,7 @@
 (function(global, doc, eZ, $) {
     const TOOLTIPS_SELECTOR = '[title]';
-    const parse = (domNode) => {
-        const searchIn = domNode ? domNode : doc;
-        const tooltipNodes = searchIn.querySelectorAll(TOOLTIPS_SELECTOR);
+    const parse = (baseElement = doc) => {
+        const tooltipNodes = baseElement.querySelectorAll(TOOLTIPS_SELECTOR);
 
         for (tooltipNode of tooltipNodes) {
             if (tooltipNode.title) {

--- a/src/bundle/Resources/views/themes/admin/content/modal/draft_conflict.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/modal/draft_conflict.html.twig
@@ -7,7 +7,13 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{{ 'draft.conflict.header'|trans|desc('Draft conflict') }}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button 
+                    type="button" 
+                    class="close" 
+                    data-dismiss="modal" 
+                    aria-label={{ 'draft.conflict.close'|trans|desc('Close') }}
+                    title={{ 'draft.conflict.close'|trans|desc('Close') }}
+                >
                     <svg class="ez-icon ez-icon--medium" aria-hidden="true">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#discard"></use>
                     </svg>


### PR DESCRIPTION
Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31438
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| Reletad to | https://github.com/ezsystems/ezplatform-page-builder/pull/529
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

1.) Added in parse method (eZ.tooltips.helpers) optional parameter as domNode where bootstrap execute querySelector('[title]')
2.) Added data-tooltip-container-selector parameter 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
