### PR TITLE
EZP-31461: Added missing $contentType param to LocationCreateStruct

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -542,9 +542,10 @@ class LocationController extends Controller
         if ($form->isSubmitted()) {
             $result = $this->submitHandler->handle($form, function (ContentLocationAddData $data) {
                 $contentInfo = $data->getContentInfo();
+                $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
 
                 foreach ($data->getNewLocations() as $newLocation) {
-                    $locationCreateStruct = $this->locationService->newLocationCreateStruct($newLocation->id);
+                    $locationCreateStruct = $this->locationService->newLocationCreateStruct($newLocation->id, $contentType);
                     $this->locationService->createLocation($contentInfo, $locationCreateStruct);
 
                     $this->notificationHandler->success(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31461
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`newLocationCreateStruct` was injected with missing `ContentType` object which allows newly created `Location` to have proper sorting options.

Related `ezpublish-kernel` PR: https://github.com/ezsystems/ezpublish-kernel/pull/2977

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
