### PR TITLE
[Behat] Refactored displaying of application/browser logs

### DIFF
--- a/src/lib/Behat/Helper/Hooks.php
+++ b/src/lib/Behat/Helper/Hooks.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformAdminUi\Behat\Helper;
 
 use Behat\Behat\Hook\Call\BeforeStep;
@@ -11,20 +13,18 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Symfony2Extension\Context\KernelDictionary;
 use Behat\Testwork\Tester\Result\TestResult;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\PageObjectFactory;
 use Psr\Log\LoggerInterface;
-use WebDriver\LogType;
 
 class Hooks extends RawMinkContext
 {
-    private const CONSOLE_LOGS_LIMIT = 10;
-    private const APPLICATION_LOGS_LIMIT = 25;
-    private const LOG_FILE_NAME = 'travis_test.log';
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
     private $logger;
 
     use KernelDictionary;
@@ -41,28 +41,28 @@ class Hooks extends RawMinkContext
      */
     public function logStartingScenario(BeforeScenarioScope $scope)
     {
-        $this->logger->error(sprintf('Starting Scenario "%s"', $scope->getScenario()->getTitle()));
+        $this->logger->error(sprintf('Behat: Starting Scenario "%s"', $scope->getScenario()->getTitle()));
     }
 
     /** @BeforeStep
      */
     public function logStartingStep(BeforeStepScope $scope)
     {
-        $this->logger->error(sprintf('Starting Step %s', $scope->getStep()->getText()));
+        $this->logger->error(sprintf('Behat: Starting Step "%s"', $scope->getStep()->getText()));
     }
 
     /** @AfterScenario
      */
     public function logEndingScenario(AfterScenarioScope $scope)
     {
-        $this->logger->error(sprintf('Ending Scenario "%s"', $scope->getScenario()->getTitle()));
+        $this->logger->error(sprintf('Behat: Ending Scenario "%s"', $scope->getScenario()->getTitle()));
     }
 
     /** @AfterStep
      */
     public function logEndingStep(AfterStepScope $scope)
     {
-        $this->logger->error(sprintf('Ending Step %s', $scope->getStep()->getText()));
+        $this->logger->error(sprintf('Behat: Ending Step "%s"', $scope->getStep()->getText()));
     }
 
     /** @BeforeScenario
@@ -84,42 +84,27 @@ class Hooks extends RawMinkContext
             return;
         }
 
-        $driver = $this->getSession()->getDriver();
-        if ($driver instanceof Selenium2Driver) {
-            $browserLogEntries = $this->parseBrowserLogs($driver->getWebDriverSession()->log(LogType::BROWSER));
-            $this->displayLogEntries('JS console errors:', $browserLogEntries);
-        }
+        $testLogProvider = new TestLogProvider($this->getSession(), $this->getKernel()->getLogDir());
 
-        $logReader = new LogFileReader();
+        $applicationsLogs = $testLogProvider->getApplicationLogs();
+        $browserLogs = $testLogProvider->getBrowserLogs();
 
-        $applicationLogEntries = $logReader->getLastLines(sprintf('%s/%s', $this->getKernel()->getLogDir(), self::LOG_FILE_NAME), self::APPLICATION_LOGS_LIMIT);
-        $this->displayLogEntries('Application errors:', $applicationLogEntries);
+        echo $this->formatForDisplay($browserLogs, 'JS Console errors:');
+        echo $this->formatForDisplay($applicationsLogs, 'Application logs:');
     }
 
-    private function parseBrowserLogs($logEntries): array
+    public function formatForDisplay(array $logEntries, string $sectionName)
     {
-        $filter = new BrowserLogFilter();
+        $output = sprintf('%s' . PHP_EOL, $sectionName);
 
         if (empty($logEntries)) {
-            return [];
+            $output .= sprintf("\t No logs for this section.") . PHP_EOL;
         }
-
-        $errorMessages = array_column($logEntries, 'message');
-        $errorMessages = $filter->filter($errorMessages);
-
-        return \array_slice($errorMessages, 0, self::CONSOLE_LOGS_LIMIT);
-    }
-
-    private function displayLogEntries($sectionName, $logEntries)
-    {
-        if (empty($logEntries)) {
-            return;
-        }
-
-        echo sprintf('%s' . PHP_EOL, $sectionName);
 
         foreach ($logEntries as $logEntry) {
-            echo sprintf('%s' . PHP_EOL, $logEntry);
+            $output .= sprintf("\t%s" . PHP_EOL, $logEntry);
         }
+
+        return $output;
     }
 }

--- a/src/lib/Behat/Helper/TestLogProvider.php
+++ b/src/lib/Behat/Helper/TestLogProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Behat\Helper;
+
+use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Session;
+use WebDriver\LogType;
+
+class TestLogProvider
+{
+    private const CONSOLE_LOGS_LIMIT = 10;
+    private const APPLICATION_LOGS_LIMIT = 25;
+    private const LOG_FILE_NAME = 'travis_test.log';
+
+    /**
+     * @var \Behat\Mink\Session
+     */
+    private $session;
+
+    /**
+     * @var string
+     */
+    private $logDirectory;
+
+    public function __construct(Session $session, string $logDirectory)
+    {
+        $this->session = $session;
+        $this->logDirectory = $logDirectory;
+    }
+
+    public function getBrowserLogs(): array
+    {
+        $driver = $this->session->getDriver();
+        if ($driver instanceof Selenium2Driver) {
+            return $this->parseBrowserLogs($driver->getWebDriverSession()->log(LogType::BROWSER));
+        }
+
+        return [];
+    }
+
+    public function getApplicationLogs(): array
+    {
+        $logReader = new LogFileReader();
+        $lines = $logReader->getLastLines(sprintf('%s/%s', $this->logDirectory, self::LOG_FILE_NAME), self::APPLICATION_LOGS_LIMIT);
+        $parsedLines = [];
+        foreach ($lines as $line) {
+            $parsedLine = str_replace([' app.ERROR: Behat:', '[] []'], '', $line);
+            $parsedLines[] = $parsedLine;
+        }
+
+        return $parsedLines;
+    }
+
+    private function parseBrowserLogs(array $logEntries): array
+    {
+        $filter = new BrowserLogFilter();
+
+        if (empty($logEntries)) {
+            return [];
+        }
+
+        $errorMessages = array_column($logEntries, 'message');
+        $errorMessages = $filter->filter($errorMessages);
+
+        return \array_slice($errorMessages, 0, self::CONSOLE_LOGS_LIMIT);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31453
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR refactors how the logs are displayed (by moving the responsibility of providing the logs into a new class) so that most of the logic can be reused in Allure bundles (and add the logs as attachments).

Required by: https://github.com/ezsystems/allure-behat/pull/8

This PR also introduces some formatting changes to how the output is displayed, to make it more readable.

See: https://travis-ci.org/ezsystems/ezplatform-admin-ui/jobs/660613158?utm_medium=notification&utm_source=github_status for how it looks now:
```
        │  JS Console errors:
        │  	http://web/assets/ezplatform/build/ezplatform-admin-ui-content-edit-parts-js.js 9401:12 "EzObjectRelation fieldtype is deprecated. Please, use EzObjectRelationList fieldtype instead."
        │  Application logs:
        │  	[2020-03-10 13:08:16] Starting Step "I go to "Content structure" in "Content" tab" 
        │  	[2020-03-10 13:08:17] Ending Step "I go to "Test Object State Group edited2" "Object State Group" page" 
        │  	[2020-03-10 13:08:17] Starting Step "I start creating new "Object State" in "Test Object State Group edited2"" 
        │  	[2020-03-10 13:08:18] Ending Step "I start creating new "Object State" in "Test Object State Group edited2"" 
        │  	[2020-03-10 13:08:18] Starting Step "I set fields" 
        │  	[2020-03-10 13:08:19] Ending Step "I set fields" 
        │  	[2020-03-10 13:08:19] Starting Step "I click on the edit action bar button "Create"" 
        │  	[2020-03-10 13:08:20] Ending Step "I click on the edit action bar button "Create"" 
        │  	[2020-03-10 13:08:20] Starting Step "I should be on "Object State" "Test Object State" page" 
        │  	[2020-03-10 13:08:21] Ending Step "I should be on "Object State" "Test Object State" page" 
        │  	[2020-03-10 13:08:21] Starting Step ""Object State" "Test Object State" has proper attributes" 
        │  	[2020-03-10 13:08:21] Ending Step ""Object State" "Test Object State" has proper attributes" 
        │  	[2020-03-10 13:08:21] Starting Step "notification that "Object state" "Test Object State" is created appears" 
        │  	[2020-03-10 13:08:22] Ending Step "I go to "Content structure" in "Content" tab" 
        │  	[2020-03-10 13:08:22] Starting Step "I start creating a new content "Country CT"" 
        │  	[2020-03-10 13:08:23] Ending Step "notification that "Object state" "Test Object State" is created appears" 
        │  	[2020-03-10 13:08:23] Ending Scenario "New Object State can be added" 
        │  	[2020-03-10 13:08:23] Starting Scenario "I can navigate to Object State Group page through breadcrumb" 
        │  	[2020-03-10 13:08:23] Starting Step "I am logged as "admin"" 
        │  	[2020-03-10 13:08:25] Ending Step "I am logged as "admin"" 
        │  	[2020-03-10 13:08:25] Starting Step "I go to "Object States" in "Admin" tab" 
        │  	[2020-03-10 13:08:27] Ending Step "I start creating a new content "Country CT"" 
        │  	[2020-03-10 13:08:27] Starting Step "I set content fields" 
        │  	[2020-03-10 13:08:27] Ending Step "I set content fields" 
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review

#### Before merge:
- [x] rebase and remove TMP commits
