### PR TITLE
EZP-31477: Fixed loading Site Accesses on limitation list

### DIFF
--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -37,7 +37,7 @@ services:
         autoconfigure: false
         public: false
         class: "%ezplatform.content_forms.limitation.form_mapper.siteaccess.class%"
-        arguments: ["%ezpublish.siteaccess.list%"]
+        arguments: ['@ezpublish.siteaccess_service']
         tags:
             - { name: ez.limitation.formMapper, limitationType: SiteAccess }
             - { name: ez.limitation.valueMapper, limitationType: SiteAccess }

--- a/src/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
@@ -7,25 +7,25 @@
 namespace EzSystems\EzPlatformAdminUi\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzPlatformAdminUi\Limitation\LimitationValueMapperInterface;
 
 class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
-    /**
-     * @var array
-     */
-    private $siteAccessList;
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface */
+    private $siteAccessService;
 
-    public function __construct(array $siteAccessList)
-    {
-        $this->siteAccessList = $siteAccessList;
+    public function __construct(
+        SiteAccessServiceInterface $siteAccessService
+    ) {
+        $this->siteAccessService = $siteAccessService;
     }
 
     protected function getSelectionChoices()
     {
         $siteAccesses = [];
-        foreach ($this->siteAccessList as $sa) {
-            $siteAccesses[$this->getSiteAccessKey($sa)] = $sa;
+        foreach ($this->siteAccessService->getAll() as $sa) {
+            $siteAccesses[$this->getSiteAccessKey($sa->name)] = $sa->name;
         }
 
         return $siteAccesses;
@@ -34,9 +34,9 @@ class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper implements
     public function mapLimitationValue(Limitation $limitation)
     {
         $values = [];
-        foreach ($this->siteAccessList as $sa) {
-            if (in_array($this->getSiteAccessKey($sa), $limitation->limitationValues)) {
-                $values[] = $sa;
+        foreach ($this->siteAccessService->getAll() as $sa) {
+            if (in_array($this->getSiteAccessKey($sa->name), $limitation->limitationValues)) {
+                $values[] = $sa->name;
             }
         }
 

--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -7,6 +7,8 @@
 namespace EzSystems\EzPlatformAdminUi\Tests\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzPlatformAdminUi\Limitation\Mapper\SiteAccessLimitationMapper;
 use PHPUnit\Framework\TestCase;
 
@@ -20,11 +22,21 @@ class SiteAccessLimitationMapperTest extends TestCase
             '2015626392' => 'baz',
         ];
 
+        $siteAccesses = array_map(
+            static function ($siteAccessName) {
+                return new SiteAccess($siteAccessName);
+            },
+            $siteAccessList
+        );
+
         $limitation = new SiteAccessLimitation([
             'limitationValues' => array_keys($siteAccessList),
         ]);
 
-        $mapper = new SiteAccessLimitationMapper($siteAccessList);
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $siteAccessService->method('getAll')->willReturn($siteAccesses);
+
+        $mapper = new SiteAccessLimitationMapper($siteAccessService);
         $result = $mapper->mapLimitationValue($limitation);
 
         $this->assertEquals(array_values($siteAccessList), $result);

--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -23,7 +23,7 @@ class SiteAccessLimitationMapperTest extends TestCase
         ];
 
         $siteAccesses = array_map(
-            static function ($siteAccessName) {
+            static function (string $siteAccessName): SiteAccess {
                 return new SiteAccess($siteAccessName);
             },
             $siteAccessList


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31477
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| Needs   | https://github.com/ezsystems/ezpublish-kernel/pull/2983
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

List of SiteAccesses on limitation list should be fetched from the service, not from configuration


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
