### PR TITLE
EZP-31417: Prevent execute querySelectorAll on null in tooltips helper

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,6 +1,10 @@
 (function(global, doc, eZ, $) {
     const TOOLTIPS_SELECTOR = '[title]';
     const parse = (baseElement = doc) => {
+        if (!baseElement) {
+            return;
+        }
+
         const tooltipNodes = baseElement.querySelectorAll(TOOLTIPS_SELECTOR);
 
         for (tooltipNode of tooltipNodes) {
@@ -26,6 +30,10 @@
         }
     };
     const hideAll = (baseElement = doc) => {
+        if (!baseElement) {
+            return;
+        }
+
         const tooltipsNode = baseElement.querySelectorAll(TOOLTIPS_SELECTOR);
 
         for (tooltipNode of tooltipsNode) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31417
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| Related to | https://github.com/ezsystems/date-based-publisher/pull/157
|| https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/278
|| https://github.com/ezsystems/ezplatform-calendar/pull/49
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
