### PR TITLE
EZEE-3030: Links containing 'ezlocation` or 'ezcontent' keywords break RTE validation on paste

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -398,18 +398,40 @@
             const links = container.querySelectorAll('a');
             const anchorPrefix = '#';
             const protocolPrefix = 'http://';
+            const restrictedKeywords = ['ezcontent', 'ezlocation'];
 
             links.forEach((link) => {
                 const href = link.getAttribute('href');
                 const protocolPattern = /^https?:\/\//i;
+                const protocolHref = protocolPrefix.concat(href);
 
-                if (href && href.indexOf(anchorPrefix) !== 0 && !protocolPattern.test(href)) {
-                    const protocolHref = protocolPrefix.concat(href);
+                if (!href && href.indexOf(anchorPrefix) === 0) {
+                    return;
+                }
 
-                    link.setAttribute('href', protocolHref);
-                    link.setAttribute('data-cke-saved-href', protocolHref);
+                if (protocolPattern.test(href)) {
+                    return;
+                }
+
+                if (this.containsAny(href, restrictedKeywords)) {
+                    return;
+                }
+
+                link.setAttribute('href', protocolHref);
+                link.setAttribute('data-cke-saved-href', protocolHref);
+            });
+        }
+
+        containsAny(string, substrings) {
+            let isSubstringPresent = false;
+
+            substrings.forEach((substring) => {
+                if (string.includes(substring)) {
+                    isSubstringPresent = true;
                 }
             });
+
+            return isSubstringPresent;
         }
     };
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -405,7 +405,11 @@
                 const protocolPattern = /^https?:\/\//i;
                 const protocolHref = protocolPrefix.concat(href);
 
-                if (!href && href.indexOf(anchorPrefix) === 0) {
+                if (!href) {
+                    return;
+                }
+
+                if (href.indexOf(anchorPrefix) === 0) {
                     return;
                 }
 
@@ -413,25 +417,13 @@
                     return;
                 }
 
-                if (this.containsAny(href, restrictedKeywords)) {
+                if (restrictedKeywords.some(keyword => href.includes(keyword))) {
                     return;
                 }
 
                 link.setAttribute('href', protocolHref);
                 link.setAttribute('data-cke-saved-href', protocolHref);
             });
-        }
-
-        containsAny(string, substrings) {
-            let isSubstringPresent = false;
-
-            substrings.forEach((substring) => {
-                if (string.includes(substring)) {
-                    isSubstringPresent = true;
-                }
-            });
-
-            return isSubstringPresent;
         }
     };
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -417,7 +417,7 @@
                     return;
                 }
 
-                if (restrictedKeywords.some(keyword => href.includes(keyword))) {
+                if (restrictedKeywords.some((keyword) => href.includes(keyword))) {
                     return;
                 }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZEE-3030](https://jira.ez.no/browse/EZEE-3030)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The recently introduced solution https://github.com/ezsystems/ezplatform-admin-ui/pull/1245 is missing proper checks for `ezcontent` and z`ezlocation` keywords that results in `http` protocol wrongly added, hence broken validation. Added proper conditions and flatten existing ones to increase readability. I will create a PR in `ezplatform-richtext` for 3.0 once this solution is approved.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
