### PR TITLE
EZP-31495: As an Editor I want be able to format text inside table cells

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -26,6 +26,7 @@ const alloyEditor = [
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-anchor.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-anchoredit.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-paragraph.js'),
+    path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-paragraph-table-cell.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-heading.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-movedown.js'),
     path.resolve(__dirname, '../public/js/alloyeditor/src/buttons/ez-btn-moveup.js'),

--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-paragraph-table-cell.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-paragraph-table-cell.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import AlloyEditor from 'alloyeditor';
+import EzButton from '../base/ez-button';
+
+export default class EzBtnParagraphTableCell extends EzButton {
+    static get key() {
+        return 'ezparagraph-tablecell';
+    }
+
+    addParagraph() {
+        this.props.editor.get('nativeEditor').insertHtml('<p></p>');
+    }
+
+    /**
+     * Lifecycle. Renders the UI of the button.
+     *
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
+    render() {
+        const label = Translator.trans(/*@Desc("Paragraph")*/ 'paragraph_btn.label', {}, 'alloy_editor');
+        const css = 'ae-button ez-btn-ae ez-btn-ae--paragraph ' + this.getStateClasses();
+
+        return (
+            <button className={css} onClick={this.addParagraph.bind(this)} tabIndex={this.props.tabIndex} title={label}>
+                <svg className="ez-icon ez-btn-ae__icon">
+                    <use xlinkHref="/bundles/ezplatformadminui/img/ez-icons.svg#paragraph-add" />
+                </svg>
+            </button>
+        );
+    }
+}
+
+AlloyEditor.Buttons[EzBtnParagraphTableCell.key] = AlloyEditor.EzBtnParagraphTableCell = EzBtnParagraphTableCell;
+eZ.addConfig('ezAlloyEditor.EzBtnParagraphTableCell', EzBtnParagraphTableCell);

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/ez-table-cell.js
@@ -11,6 +11,7 @@ export default class EzTableCellConfig extends EzConfigTableBase {
             'ezmovedown',
             editAttributesButton,
             'tableHeading',
+            'ezparagraph-tablecell',
             'ezembedinline',
             'ezanchor',
             'eztablerow',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31495](https://jira.ez.no/browse/EZP-31495)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Right now there is no way to format the text inside table cells. It is because there is no way to add a new paragraph into the table cell.

This PR provides a way to insert paragraphs into the table cell:
![insert_para_into_tablecell](https://user-images.githubusercontent.com/166894/76876667-27191a00-686a-11ea-9c9e-9283bb626788.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
