### PR TITLE
Fixed Location ID type-casting issues in Policy Limitation update

### DIFF
--- a/src/bundle/Templating/Twig/PathStringExtension.php
+++ b/src/bundle/Templating/Twig/PathStringExtension.php
@@ -36,23 +36,16 @@ class PathStringExtension extends AbstractExtension
     }
 
     /**
-     * @param string $pathString
-     *
-     * @return array
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @return \eZ\Publish\API\Repository\Values\Content\Location[]
      */
     public function getLocationList(string $pathString): array
     {
-        $pathStringParts = explode('/', trim($pathString, '/'));
-        array_shift($pathStringParts);
+        $locationIds = array_map(
+            'intval',
+            explode('/', trim($pathString, '/'))
+        );
+        array_shift($locationIds);
 
-        $locationList = [];
-        foreach ($pathStringParts as $locationId) {
-            $locationList[] = $this->locationService->loadLocation($locationId);
-        }
-
-        return $locationList;
+        return $this->locationService->loadLocationList($locationIds);
     }
 }

--- a/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
@@ -70,15 +70,16 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
 
     /**
      * Extracts and returns an item id from a path, e.g. /1/2/58/ => 58.
-     *
-     * @param string $path
-     *
-     * @return string|null
      */
-    private function extractLocationIdFromPath(string $path): ?string
+    private function extractLocationIdFromPath(string $path): int
     {
         $pathParts = explode('/', trim($path, '/'));
 
-        return array_pop($pathParts);
+        $locationId = array_pop($pathParts);
+        if ($locationId === null) {
+            throw new TransformationFailedException("Path '{$path}' does not contain Location ID");
+        }
+
+        return (int)$locationId;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Bug fix?      | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes 2 issues when trying to edit/update Policy with already set Location ID:

In `admin/role/{roleId}/policy/{policyId}/update`;
```
Argument 1 passed to eZ\Publish\Core\Repository\SiteAccessAware\LocationService::loadLocation() must be of the type int, string given, called in src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php on line 49
```

```
Argument 1 passed to eZ\Publish\Core\Repository\SiteAccessAware\LocationService::loadLocation() must be of the type int, string given, called in src/bundle/Templating/Twig/PathStringExtension.php on line 53
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
