### PR TITLE
EZP-31500: Menu entry icon is too big

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/menu/top_menu_2nd_level.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/menu/top_menu_2nd_level.html.twig
@@ -24,7 +24,7 @@
 
 {% block label %}
     {% set icon_path = null %}
-    {% set icon_class = (item_class|default('ez-icon ') ~ item.extras.icon_size|default('ez-icon--small-medium ') ~ item.extras.icon_class|default(''))|trim %}
+    {% set icon_class = (item_class|default('ez-icon ') ~ item.extras.icon_size|default('ez-icon--small ') ~ item.extras.icon_class|default(''))|trim %}
     {% if item.extras.icon_path|default %}
         {% set icon_path = item.extras.icon_path %}
     {% elseif item.extras.icon is defined and item.extras.icon is not empty %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31500
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Changed def icon to small

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
