### PR TITLE
EZP-31509: Fixed missing translation for draft.conflict.close

### DIFF
--- a/src/bundle/Resources/translations/draft_conflict.en.xliff
+++ b/src/bundle/Resources/translations/draft_conflict.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">You can edit any of your existing draft(s)</target>
         <note>key: draft.conflict.choice_content_is_user</note>
       </trans-unit>
+      <trans-unit id="fef7e84ac6fda81cb700fa5519940989c34dd9c7" resname="draft.conflict.close">
+        <source>Close</source>
+        <target state="new">Close</target>
+        <note>key: draft.conflict.close</note>
+      </trans-unit>
       <trans-unit id="57ae8e493adef8a884a3f0c5e9e4501b7f2ec395" resname="draft.conflict.header">
         <source>Draft conflict</source>
         <target state="new">Draft conflict</target>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31509
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
