### PR TITLE
fix: Missing translations

### DIFF
--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -289,11 +289,6 @@
         <target state="new">Any time</target>
         <note>key: search.any_time</note>
       </trans-unit>
-      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
-        <source>From date - to date</source>
-        <target state="new">From date - to date</target>
-        <note>key: search.date.range</note>
-      </trans-unit>
       <trans-unit id="03d6d5922fd2012e155e50306eaf98e2dfeb21c6" resname="search.section.any">
         <source>Any section</source>
         <target state="new">Any section</target>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -269,11 +269,6 @@
         <target state="new">Cancel</target>
         <note>key: form.cancel</note>
       </trans-unit>
-      <trans-unit id="fb1d64fdeabb5f2fe1671d4f3fb72ccca7722ed3" resname="list.action.edit">
-        <source>Edit</source>
-        <target state="new">Edit</target>
-        <note>key: list.action.edit</note>
-      </trans-unit>
       <trans-unit id="1ada7c495c1592fd70ef48759574e764787bf969" resname="location_trash_form.confirm_label">
         <source>I understand the consequences of this action.</source>
         <target state="new">I understand the consequences of this action.</target>
@@ -293,6 +288,11 @@
         <source>Any time</source>
         <target state="new">Any time</target>
         <note>key: search.any_time</note>
+      </trans-unit>
+      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
+        <source>From date - to date</source>
+        <target state="new">From date - to date</target>
+        <note>key: search.date.range</note>
       </trans-unit>
       <trans-unit id="03d6d5922fd2012e155e50306eaf98e2dfeb21c6" resname="search.section.any">
         <source>Any section</source>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -51,6 +51,11 @@
         <target state="new">Custom range</target>
         <note>key: search.custom_range</note>
       </trans-unit>
+      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
+        <source>From date - to date</source>
+        <target state="new">From date - to date</target>
+        <note>key: search.date.range</note>
+      </trans-unit>
       <trans-unit id="bf24ae2c9083c948931ad1b4d4405b6261eb9bc6" resname="search.filters">
         <source>Filters</source>
         <target state="new">Filters</target>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -51,11 +51,6 @@
         <target state="new">Custom range</target>
         <note>key: search.custom_range</note>
       </trans-unit>
-      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
-        <source>From date - to date</source>
-        <target state="new">From date - to date</target>
-        <note>key: search.date.range</note>
-      </trans-unit>
       <trans-unit id="bf24ae2c9083c948931ad1b4d4405b6261eb9bc6" resname="search.filters">
         <source>Filters</source>
         <target state="new">Filters</target>
@@ -90,11 +85,6 @@
         <source>Last year</source>
         <target state="new">Last year</target>
         <note>key: search.last_year</note>
-      </trans-unit>
-      <trans-unit id="6ceaf9887c3974130781c3dadfcb129926496770" resname="search.list">
-        <source>search.list</source>
-        <target state="new">search.list</target>
-        <note>key: search.list</note>
       </trans-unit>
       <trans-unit id="0ea91510ce49731de30d4d412dc62c83c91b359d" resname="search.modified">
         <source>Modified</source>
@@ -170,11 +160,6 @@
         <source>Select Content</source>
         <target state="new">Select Content</target>
         <note>key: search.udw.select_content</note>
-      </trans-unit>
-      <trans-unit id="fe647ff0e12d67501403559464217be468dba3d8" resname="search.viewing">
-        <source>Viewing %viewing% out of %total% sub-items</source>
-        <target state="new">Viewing %viewing% out of %total% sub-items</target>
-        <note>key: search.viewing</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -192,7 +192,7 @@
         <input 
             type="text"
             class="ez-filters__range-select form-control"
-            placeholder="{{ 'search.date.range'|trans|desc('From date - to date') }}"
+            placeholder="{{ 'search.date.range'|trans(domain='search')|desc('From date - to date') }}"
             data-start="{{ form.parent.vars.data.lastModified.start_date is defined ? form.parent.vars.data.lastModified.start_date|date("Y-m-d") : '' }}"
             data-end="{{ form.parent.vars.data.lastModified.end_date is defined ? form.parent.vars.data.lastModified.end_date|date("Y-m-d") : '' }}"
         />
@@ -209,7 +209,7 @@
         <input 
             type="text"
             class="ez-filters__range-select form-control"
-            placeholder="{{ 'search.date.range'|trans|desc('From date - to date') }}" 
+            placeholder="{{ 'search.date.range'|trans(domain='search')|desc('From date - to date') }}"
             data-start="{{ form.parent.vars.data.created.start_date is defined ? form.parent.vars.data.created.start_date|date("Y-m-d") : '' }}"
             data-end="{{ form.parent.vars.data.created.end_date is defined ? form.parent.vars.data.created.end_date|date("Y-m-d") : '' }}"
         />


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

~This is output from `translation:extract`. Please, take a look if it's Ok (like, `search.date.range` moved from `search` domain to `messages`?)~

`search.date.range` moved back to `search` domain by @ViniTou 