### PR TITLE
EZP-31459: [UDW] Allowed Content Types are not respected in object relation field

### DIFF
--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -36,7 +36,7 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
         }
 
         if (
-            !isset($context['type'], $context['allowed_content_types'], $config['allowed_content_types'])
+            !isset($context['type'], $context['allowed_content_types'])
             || 'object_relation' !== $context['type']
         ) {
             return;

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ObjectRelationAllowedContentTypes.php
@@ -54,7 +54,9 @@ class ObjectRelationAllowedContentTypes implements EventSubscriberInterface
                 ? null
                 : $intersection;
         } else {
-            $config['allowed_content_types'] = $context['allowed_content_types'];
+            $config['allowed_content_types'] = empty($context['allowed_content_types'])
+                ? null
+                : $context['allowed_content_types'];
         }
 
         $event->setConfig($config);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31459](https://jira.ez.no/browse/EZP-31459)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

If `allowed_content_types` key is not specified in the configuration (`null` value) the whole subscriber stops at this point even though the next condition provides proper handling for that case.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
