### PR TITLE
EZP-31465: Fixed invalid redirect after User deletion

### DIFF
--- a/src/bundle/Controller/User/UserDeleteController.php
+++ b/src/bundle/Controller/User/UserDeleteController.php
@@ -79,6 +79,7 @@ class UserDeleteController extends Controller
                 $contentInfo = $data->getContentInfo();
 
                 $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
+                $parentLocation = $this->locationService->loadLocation($location->parentLocationId);
 
                 $user = $this->userService->loadUser($contentInfo->id);
 
@@ -92,7 +93,7 @@ class UserDeleteController extends Controller
                 );
 
                 return new RedirectResponse($this->generateUrl('_ez_content_view', [
-                    'contentId' => $location->contentId,
+                    'contentId' => $parentLocation->contentId,
                     'locationId' => $location->parentLocationId,
                 ]));
             });


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31465
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added valid `contentId` param to `_ez_content_view` route after `User` deletion.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
