### PR TITLE
EZP-31521: Fixed sorting logic listener for ordered menu items

### DIFF
--- a/src/lib/Menu/Listener/ReorderByOrderNumberListener.php
+++ b/src/lib/Menu/Listener/ReorderByOrderNumberListener.php
@@ -25,7 +25,7 @@ final class ReorderByOrderNumberListener
         $menuItemList = [];
         $unorderedMenuItemsList = [];
 
-        foreach ($menuItem->getChildren() as $key => $nestedMenuItem) {
+        foreach ($menuItem->getChildren() as $nestedMenuItem) {
             if ($nestedMenuItem->hasChildren()) {
                 $this->recursiveReorderMenuItems($nestedMenuItem);
             }

--- a/src/lib/Menu/Listener/ReorderByOrderNumberListener.php
+++ b/src/lib/Menu/Listener/ReorderByOrderNumberListener.php
@@ -9,63 +9,44 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Menu\Listener;
 
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use Knp\Menu\ItemInterface;
 
 final class ReorderByOrderNumberListener
 {
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent $event
-     */
     public function reorderMenuItems(ConfigureMenuEvent $event): void
     {
         $menu = $event->getMenu();
-        $menuOrderArray = [];
-        $addLast = [];
-        $alreadyTaken = [];
 
-        foreach ($menu->getChildren() as $key => $menuItem) {
-            if ($menuItem->hasChildren()) {
-                $this->reorderMenuItems($menuItem);
+        $this->recursiveReorderMenuItems($menu);
+    }
+
+    private function recursiveReorderMenuItems(ItemInterface $menuItem): void
+    {
+        $menuItemList = [];
+        $unorderedMenuItemsList = [];
+
+        foreach ($menuItem->getChildren() as $key => $nestedMenuItem) {
+            if ($nestedMenuItem->hasChildren()) {
+                $this->recursiveReorderMenuItems($nestedMenuItem);
             }
-            $orderNumber = $menuItem->getExtra('orderNumber');
 
-            if ($orderNumber != null) {
-                if (!isset($menuOrderArray[$orderNumber])) {
-                    $menuOrderArray[$orderNumber] = $menuItem->getName();
-                } else {
-                    $alreadyTaken[$orderNumber] = $menuItem->getName();
-                }
+            $orderNumber = $nestedMenuItem->getExtra('orderNumber');
+
+            if ($orderNumber === null) {
+                $unorderedMenuItemsList[] = $nestedMenuItem;
             } else {
-                $addLast[] = $menuItem->getName();
-            }
-        }
-        ksort($menuOrderArray);
-
-        if (count($alreadyTaken)) {
-            foreach ($alreadyTaken as $key => $value) {
-                $keysArray = array_keys($menuOrderArray);
-                $position = array_search($key, $keysArray);
-
-                if ($position === false) {
-                    continue;
-                }
-
-                $menuOrderArray = array_merge(
-                    array_slice($menuOrderArray, 0, $position),
-                    [$value],
-                    array_slice($menuOrderArray, $position)
-                );
-            }
-        }
-        ksort($menuOrderArray);
-
-        if (count($addLast)) {
-            foreach ($addLast as $key => $value) {
-                $menuOrderArray[] = $value;
+                $menuItemList[$orderNumber][] = $nestedMenuItem;
             }
         }
 
-        if (count($menuOrderArray)) {
-            $menu->reorderChildren($menuOrderArray);
-        }
+        ksort($menuItemList);
+
+        $menuItemList[] = $unorderedMenuItemsList;
+
+        $menuItem->reorderChildren(
+            array_map(static function (ItemInterface $item): string {
+                return $item->getName();
+            }, array_merge(...$menuItemList))
+        );
     }
 }

--- a/src/lib/Tests/Menu/ReorderByOrderNumberListenerTest.php
+++ b/src/lib/Tests/Menu/ReorderByOrderNumberListenerTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Menu;
+
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use EzSystems\EzPlatformAdminUi\Menu\Listener\ReorderByOrderNumberListener;
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Knp\Menu\MenuFactory;
+use PHPUnit\Framework\TestCase;
+
+final class ReorderByOrderNumberListenerTest extends TestCase
+{
+    public function testUnorderedMenuListUntouched(): void
+    {
+        $factory = new MenuFactory();
+        $menu = $this->recursiveCreateMenuChildren(
+            $factory->createItem('menu'),
+            $factory, [
+                ['name' => 'first'],
+                ['name' => 'second'],
+                ['name' => 'third'],
+                ['name' => 'fourth'],
+                ['name' => 'fifth'],
+            ]
+        );
+
+        $eventMock = $this->getConfigureMenuEventMock($menu);
+
+        $listener = new ReorderByOrderNumberListener();
+        $listener->reorderMenuItems($eventMock);
+
+        $expected = [
+            'first',
+            'second',
+            'third',
+            'fourth',
+            'fifth',
+        ];
+
+        $this->assertEquals($expected, $this->getChildrenNames($menu));
+    }
+
+    public function testOrderedMenuList(): void
+    {
+        $factory = new MenuFactory();
+        $menu = $this->recursiveCreateMenuChildren(
+            $factory->createItem('menu'),
+            $factory, [
+                ['name' => 'first', 'order' => 100],
+                ['name' => 'second', 'order' => 10],
+                ['name' => 'third', 'order' => 55],
+                ['name' => 'fourth', 'order' => 30],
+                ['name' => 'fifth', 'order' => 75],
+            ]
+        );
+
+        $eventMock = $this->getConfigureMenuEventMock($menu);
+
+        $listener = new ReorderByOrderNumberListener();
+        $listener->reorderMenuItems($eventMock);
+
+        $expected = [
+            'second',
+            'fourth',
+            'third',
+            'fifth',
+            'first',
+        ];
+
+        $this->assertEquals($expected, $this->getChildrenNames($menu));
+    }
+
+    public function testSameOrderMenuListUntouched(): void
+    {
+        $factory = new MenuFactory();
+        $menu = $this->recursiveCreateMenuChildren(
+            $factory->createItem('menu'),
+            $factory, [
+                ['name' => 'first', 'order' => 50],
+                ['name' => 'second', 'order' => 10],
+                ['name' => 'third', 'order' => 10],
+                ['name' => 'fourth', 'order' => 10],
+                ['name' => 'fifth', 'order' => 50],
+            ]
+        );
+
+        $eventMock = $this->getConfigureMenuEventMock($menu);
+
+        $listener = new ReorderByOrderNumberListener();
+        $listener->reorderMenuItems($eventMock);
+
+        $expected = [
+            'second',
+            'third',
+            'fourth',
+            'first',
+            'fifth',
+        ];
+
+        $this->assertEquals($expected, $this->getChildrenNames($menu));
+    }
+
+    public function testAppendUnorderedMenuListAtTheEnd(): void
+    {
+        $factory = new MenuFactory();
+        $menu = $this->recursiveCreateMenuChildren(
+            $factory->createItem('menu'),
+            $factory, [
+                ['name' => 'first', 'order' => 100],
+                ['name' => 'unordered'],
+                ['name' => 'second', 'order' => 10],
+                ['name' => 'third', 'order' => 55],
+                ['name' => 'another'],
+                ['name' => 'fourth', 'order' => 30],
+                ['name' => 'fifth', 'order' => 75],
+            ]
+        );
+
+        $eventMock = $this->getConfigureMenuEventMock($menu);
+
+        $listener = new ReorderByOrderNumberListener();
+        $listener->reorderMenuItems($eventMock);
+
+        $expected = [
+            'second',
+            'fourth',
+            'third',
+            'fifth',
+            'first',
+            'unordered',
+            'another',
+        ];
+
+        $this->assertEquals($expected, $this->getChildrenNames($menu));
+    }
+
+    public function testNestedOrderedMenuList(): void
+    {
+        $factory = new MenuFactory();
+        $menu = $this->recursiveCreateMenuChildren(
+            $factory->createItem('menu'),
+            $factory, [
+                ['name' => 'first', 'order' => 100],
+                ['name' => 'unordered'],
+                ['name' => 'second', 'order' => 10],
+                ['name' => 'third', 'order' => 55],
+                ['name' => 'another', 'children' => [
+                    ['name' => 'first_child', 'order' => 100],
+                    ['name' => 'unordered_child'],
+                    ['name' => 'second_child', 'order' => 10],
+                    ['name' => 'third_child', 'order' => 55],
+                ]],
+                ['name' => 'fourth', 'order' => 30],
+                ['name' => 'fifth', 'order' => 75],
+            ]
+        );
+
+        $eventMock = $this->getConfigureMenuEventMock($menu);
+
+        $listener = new ReorderByOrderNumberListener();
+        $listener->reorderMenuItems($eventMock);
+
+        $expected = [
+            'second',
+            'fourth',
+            'third',
+            'fifth',
+            'first',
+            'unordered',
+            'another',
+        ];
+
+        $expectedNested = [
+            'second_child',
+            'third_child',
+            'first_child',
+            'unordered_child',
+        ];
+
+        $this->assertEquals($expected, $this->getChildrenNames($menu));
+        $this->assertEquals($expectedNested, $this->getChildrenNames($menu->getChild('another')));
+    }
+
+    private function getConfigureMenuEventMock(ItemInterface $menu): ConfigureMenuEvent
+    {
+        $mock = $this->createMock(ConfigureMenuEvent::class);
+        $mock
+            ->expects($this->any())
+            ->method('getMenu')
+            ->willReturn($menu);
+
+        return $mock;
+    }
+
+    private function recursiveCreateMenuChildren(
+        ItemInterface $menu,
+        FactoryInterface $factory,
+        array $items
+    ): ItemInterface {
+        foreach ($items as $item) {
+            $child = $factory->createItem($item['name']);
+            $child->setExtra('orderNumber', $item['order'] ?? null);
+
+            $this->recursiveCreateMenuChildren($child, $factory, $item['children'] ?? []);
+
+            $menu->addChild($child);
+        }
+
+        return $menu;
+    }
+
+    private function getChildrenNames(ItemInterface $item): array
+    {
+        return array_map(static function (ItemInterface $item): string {
+            return $item->getName();
+        }, array_values($item->getChildren()));
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31521 https://jira.ez.no/browse/EZEE-2953
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Steps to reproduce:
https://jira.ez.no/browse/EZEE-2953
<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
