### PR TITLE
[Behat] Changed to comparing keywords ignoring their order

### DIFF
--- a/src/lib/Behat/PageElement/Fields/Keywords.php
+++ b/src/lib/Behat/PageElement/Fields/Keywords.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
+use Behat\Mink\Element\NodeElement;
 use EzSystems\Behat\Browser\Context\BrowserContext;
 use PHPUnit\Framework\Assert;
 
@@ -19,6 +20,7 @@ class Keywords extends EzFieldElement
     {
         parent::__construct($context, $locator, $label);
         $this->fields['fieldInput'] = 'input';
+        $this->fields['keywordItem'] = '.ez-keyword__item';
     }
 
     public function setValue(array $parameters): void
@@ -49,10 +51,26 @@ class Keywords extends EzFieldElement
 
     public function verifyValueInItemView(array $values): void
     {
-        Assert::assertEquals(
-            str_replace(', ', '', $values['value']),
-            $this->context->findElement($this->fields['fieldContainer'])->getText(),
-            'Field has wrong value'
-        );
+        $expectedValues = $this->parseValueString($values['value']);
+
+        $actualValues = array_map(function (NodeElement $element) {
+            return $element->getText();
+        }, $this->context->findAllElements(sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['keywordItem'])));
+        sort($actualValues);
+
+        Assert::assertEquals($expectedValues, $actualValues);
+    }
+
+    private function parseValueString(string $value): array
+    {
+        $parsedValues = [];
+
+        foreach (explode(',', $value) as $singleValue) {
+            $parsedValues[] = trim($singleValue);
+        }
+
+        sort($parsedValues);
+
+        return $parsedValues;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31471
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   |
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

https://jira.ez.no/browse/EZP-31471 changed how the keyword fieldtype behaves, adjusting for changes done there:
- the expected items are not compared as a string, but instead are parsed into separate keywords and are compared as collections (without taking the order into account).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
