### PR TITLE
EZP-30881: Cannot add table after list in RTE

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-table.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-table.js
@@ -8,6 +8,32 @@ export default class EzBtnTable extends Component {
     }
 
     /**
+     * Checks if the command is disabled in the current selection.
+     *
+     * @method isDisabled
+     * @return {Boolean} True if the command is disabled, false otherwise.
+     */
+    isDisabled() {
+        const editor = this.props.editor.get('nativeEditor');
+        const predecessors = editor.elementPath().elements;
+        const restrictedPredecessors = ['li'];
+
+        let isDisabled = false;
+
+        predecessors.forEach((predecessor) => {
+            const predecessorName = predecessor.getName();
+
+            if (restrictedPredecessors.includes(predecessorName)) {
+                isDisabled = true;
+
+                return;
+            }
+        });
+
+        return isDisabled;
+    }
+
+    /**
      * Lifecycle. Renders the UI of the button.
      *
      * @method render
@@ -20,9 +46,15 @@ export default class EzBtnTable extends Component {
 
         const label = Translator.trans(/*@Desc("Table")*/ 'table_btn.label', {}, 'alloy_editor');
         const css = 'ae-button ez-btn-ae ez-btn-ae--table';
+        const disabled = this.isDisabled();
 
         return (
-            <button className={css} onClick={this.props.requestExclusive} tabIndex={this.props.tabIndex} title={label}>
+            <button
+                className={css}
+                disabled={disabled}
+                onClick={this.props.requestExclusive}
+                tabIndex={this.props.tabIndex}
+                title={label}>
                 <svg className="ez-icon ez-btn-ae__icon">
                     <use xlinkHref="/bundles/ezplatformadminui/img/ez-icons.svg#table-add" />
                 </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30881](https://jira.ez.no/browse/EZP-30881)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Currently, placing tables inside list items produces validation errors. Moreover, the table button isn't present in the inline toolbar so disabling it in the embed toolbar seems to be the way to go. PR for 3.0 will be created once this solution is approved. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
