### PR TITLE
EZP-31526: UDW crushes when trying to collapse first row in bookmark tab

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/finder/finder.branch.js
@@ -85,13 +85,16 @@ const FinderBranch = ({ locationData, itemsPerPage }) => {
                 subitem.location.id === markedLocationId
         );
         const contentName = selectedLocation ? selectedLocation.location.ContentInfo.Content.TranslatedName : '';
+        const iconPath = locationData.location
+            ? contentTypesMap[locationData.location.ContentInfo.Content.ContentType._href].thumbnail
+            : "/bundles/ezplatformadminui/img/ez-icons.svg#folder";
 
         return (
             <div className="c-finder-branch__info-wrapper">
                 <span className="c-finder-branch__icon-wrapper">
                     <Icon
                         extraClasses="ez-icon--small ez-icon--light"
-                        customPath={contentTypesMap[locationData.location.ContentInfo.Content.ContentType._href].thumbnail}
+                        customPath={iconPath}
                     />
                 </span>
                 <span className="c-finder-branch__name">{contentName}</span>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31526
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
