### PR TITLE
EZP-29354: Language information in table header is not centered

### DIFF
--- a/src/bundle/Resources/views/admin/language/view.html.twig
+++ b/src/bundle/Resources/views/admin/language/view.html.twig
@@ -26,8 +26,9 @@
 {% block content %}
     <section class="container mt-4 px-5">
         <header class="ez-table-header round">
-            <h5>{{ 'language.information.header'|trans|desc('Language information') }}</h5>
-
+            <div class="ez-table-header__headline">
+                {{ 'language.information.header'|trans|desc('Language information') }}
+            </div>
             <div>
                 {% if can_administrate %}
                     {{ form_start(deleteForm, {"action": path("ezplatform.language.delete", {"languageId": language.id, "redirectErrorsTo": "view"})}) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-29354
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
