### PR TITLE
EZP-31120: Image is not replaced in RTE/OE when publishing directly

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-imageupdate.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-imageupdate.js
@@ -26,6 +26,18 @@ export default class EzBtnImageUpdate extends EzEmbedImageButton {
         widget.loadImagePreviewFromCurrentVersion(content.CurrentVersion._href, content.Name);
 
         ReactDOM.unmountComponentAtNode(document.querySelector('#react-udw'));
+        this.fireCustomUpdateEvent();
+    }
+
+    /**
+     * Fires a custom event to reflect changes in the RichText field.
+     *
+     * @method fireCustomUpdateEvent
+     */
+    fireCustomUpdateEvent() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+
+        nativeEditor.fire('customUpdate');
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31120](https://jira.ez.no/browse/EZP-31120)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Updating an image doesn't invoke `customUpdate` event that results in changes being not reflected in the edition form.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
