### PR TITLE
EZP-31051: Password expired screen incorrectly informs that email has been sent

### DIFF
--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -27,8 +27,8 @@
         <note>key: authentication.credentials_expired</note>
       </trans-unit>
       <trans-unit id="be4c13cda3e93a1e8cb05145c0dc6c3780c40c66" resname="authentication.credentials_expired.message">
-        <source>For security reasons, your password has expired and needs to be changed. An email has been sent to you with instructions.</source>
-        <target state="new">For security reasons, your password has expired and needs to be changed. An email has been sent to you with instructions.</target>
+        <source>Your password has expired and must be changed. You will receive an email with instructions how to reset your password.</source>
+        <target state="new">Your password has expired and must be changed. You will receive an email with instructions how to reset your password.</target>
         <note>key: authentication.credentials_expired.message</note>
       </trans-unit>
       <trans-unit id="2b3f00f63c14c6dc9300d54b42159218f6b5f260" resname="authentication.credentials_expired.reset_password">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31051
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Aligned message with https://github.com/ezsystems/ezplatform-admin-ui/pull/1115

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
