### PR TITLE
EZP-31398: Field type element overlaps with ez-edit-header__content-type-name

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -47,7 +47,7 @@
 
         &__content-type-name {
             position: fixed;
-            z-index: 1;
+            z-index: 1100;
             top: 0;
             left: 0;
             width: calc(100% - #{calculateRem(80px)});

--- a/src/bundle/Resources/public/scss/_main-row.scss
+++ b/src/bundle/Resources/public/scss/_main-row.scss
@@ -7,7 +7,7 @@
         flex: 0 0 calculateRem(80px);
 
         &--expanded {
-            z-index: 2;
+            z-index: 1200;
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31398
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
