### PR TITLE
EZP-31547: Autowiring fails for CustomTag service when using 3rd party translator bundle

### DIFF
--- a/src/bundle/Resources/config/services/ui_config/mappers.yml
+++ b/src/bundle/Resources/config/services/ui_config/mappers.yml
@@ -20,6 +20,7 @@ services:
         autowire: true
         arguments:
             $translator: '@translator'
+            $translatorBag: '@translator'
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
             $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
             $customTagAttributeMappers: !tagged ezplatform.admin_ui.richtext_custom_tag_attribute_mapper

--- a/src/bundle/Resources/config/services/ui_config/mappers.yml
+++ b/src/bundle/Resources/config/services/ui_config/mappers.yml
@@ -19,6 +19,7 @@ services:
     EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag:
         autowire: true
         arguments:
+            $translator: '@translator'
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
             $translationDomain: '%ezplatform.field_type.ezrichtext.custom_tags.translation_domain%'
             $customTagAttributeMappers: !tagged ezplatform.admin_ui.richtext_custom_tag_attribute_mapper

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -13,7 +13,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * UI Config Mapper test for RichText Custom Tags configuration.
@@ -31,8 +32,8 @@ class CustomTagTest extends TestCase
     {
         $mapper = new CustomTag(
             $customTagsConfiguration,
-            $this->getTranslatorMock(),
-            $this->getTranslatorMock(),
+            $this->getTranslatorInterfaceMock(),
+            $this->getTranslatorBagInterfaceMock(),
             'custom_tags',
             $this->getPackagesMock(),
             new ArrayObject([
@@ -164,7 +165,22 @@ class CustomTagTest extends TestCase
     /**
      * @return \Symfony\Component\Translation\TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function getTranslatorMock(): MockObject
+    private function getTranslatorInterfaceMock(): MockObject
+    {
+        $translatorInterfaceMock = $this->createMock(TranslatorInterface::class);
+        $translatorInterfaceMock
+            ->expects($this->any())
+            ->method('trans')
+            ->withAnyParameters()
+            ->willReturnArgument(0);
+
+        return $translatorInterfaceMock;
+    }
+
+    /**
+     * @return \Symfony\Component\Translation\TranslatorBagInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getTranslatorBagInterfaceMock(): MockObject
     {
         $catalogueMock = $this->createMock(MessageCatalogueInterface::class);
         $catalogueMock
@@ -173,21 +189,15 @@ class CustomTagTest extends TestCase
             ->withAnyParameters()
             ->willReturn(false);
 
-        $translatorMock = $this->createMock(Translator::class);
-        $translatorMock
+        $translatorBagMock = $this->createMock(TranslatorBagInterface::class);
+        $translatorBagMock
             ->expects($this->any())
             ->method('getCatalogue')
             ->willReturn(
                 $catalogueMock
             );
 
-        $translatorMock
-            ->expects($this->any())
-            ->method('trans')
-            ->withAnyParameters()
-            ->willReturnArgument(0);
-
-        return $translatorMock;
+        return $translatorBagMock;
     }
 
     /**

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -32,6 +32,7 @@ class CustomTagTest extends TestCase
         $mapper = new CustomTag(
             $customTagsConfiguration,
             $this->getTranslatorMock(),
+            $this->getTranslatorMock(),
             'custom_tags',
             $this->getPackagesMock(),
             new ArrayObject([

--- a/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
+++ b/src/lib/UI/Config/Mapper/FieldType/RichText/CustomTag.php
@@ -11,7 +11,8 @@ namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
 use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag\AttributeMapper;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Traversable;
 
 /**
@@ -22,8 +23,11 @@ class CustomTag
     /** @var array */
     private $customTagsConfiguration;
 
-    /** @var Translator */
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
     private $translator;
+
+    /** @var \Symfony\Component\Translation\TranslatorBagInterface */
+    private $translatorBag;
 
     /** @var Packages */
     private $packages;
@@ -44,20 +48,23 @@ class CustomTag
      * both TranslatorInterface and TranslatorBagInterface.
      *
      * @param array $customTagsConfiguration
-     * @param \Symfony\Component\Translation\Translator $translator
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param \Symfony\Component\Translation\TranslatorBagInterface $translatorBag
      * @param string $translationDomain
      * @param \Symfony\Component\Asset\Packages $packages
      * @param \Traversable $customTagAttributeMappers
      */
     public function __construct(
         array $customTagsConfiguration,
-        Translator $translator,
+        TranslatorInterface $translator,
+        TranslatorBagInterface $translatorBag,
         string $translationDomain,
         Packages $packages,
         Traversable $customTagAttributeMappers
     ) {
         $this->customTagsConfiguration = $customTagsConfiguration;
         $this->translator = $translator;
+        $this->translatorBag = $translatorBag;
         $this->translationDomain = $translationDomain;
         $this->packages = $packages;
         $this->customTagAttributeMappers = $customTagAttributeMappers;
@@ -169,7 +176,7 @@ class CustomTag
                 continue;
             }
 
-            $transCatalogue = $this->translator->getCatalogue();
+            $transCatalogue = $this->translatorBag->getCatalogue();
             foreach ($tagConfig['attributes'] as $attributeName => $attributeConfig) {
                 $config[$tagName]['attributes'][$attributeName]['label'] = $this->translator->trans(
                     /** @Ignore */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31547
| Bug fix?      | yes

This is continuation for https://github.com/ezsystems/ezplatform-admin-ui/pull/1058

This PR adds `$translator` argument to `EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag` to prevent autowiring issues.

