### PR TITLE
EZP-31539: Link Validation error in Richtext Editor

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -398,11 +398,10 @@
             const links = container.querySelectorAll('a');
             const anchorPrefix = '#';
             const protocolPrefix = 'http://';
-            const restrictedKeywords = ['ezcontent', 'ezlocation'];
 
             links.forEach((link) => {
                 const href = link.getAttribute('href');
-                const protocolPattern = /^https?:\/\//i;
+                const schemaPattern = /^[a-z0-9]+:\/\//i;
                 const protocolHref = protocolPrefix.concat(href);
 
                 if (!href) {
@@ -413,11 +412,7 @@
                     return;
                 }
 
-                if (protocolPattern.test(href)) {
-                    return;
-                }
-
-                if (restrictedKeywords.some((keyword) => href.includes(keyword))) {
+                if (schemaPattern.test(href)) {
                     return;
                 }
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -401,7 +401,7 @@
 
             links.forEach((link) => {
                 const href = link.getAttribute('href');
-                const schemaPattern = /^[a-z0-9]+:\/\//i;
+                const schemaPattern = /^[a-z0-9]+:\/?\/?/i;
                 const protocolHref = protocolPrefix.concat(href);
 
                 if (!href) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31539](https://jira.ez.no/browse/EZP-31539)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

There are still unhandled cases when pasting links in RTE (`mailto`, `skype`, `callto` etc). Instead of adding more of restricted keywords (which could also be error-prone if the keyword is a present outside schema), I changed regexp to verify whether any schema was present before changing the actual URL. It should also work properly when someone uses some custom link schema, like `myschema://`.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
