### PR TITLE
EZP-31545: Filtered empty idString

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.limitation.pick.js
+++ b/src/bundle/Resources/public/js/scripts/admin.limitation.pick.js
@@ -158,7 +158,10 @@
 
         const limitationBtn = event.currentTarget;
         const input = doc.querySelector(limitationBtn.dataset.locationInputSelector);
-        const selectedLocationsIds = input.value.split(IDS_SEPARATOR).map((idString) => parseInt(idString, 10));
+        const selectedLocationsIds = input.value
+            .split(IDS_SEPARATOR)
+            .filter((idString) => !!idString)
+            .map((idString) => parseInt(idString, 10));
         const config = JSON.parse(event.currentTarget.dataset.udwConfig);
         const title = Translator.trans(/*@Desc("Choose Locations")*/ 'subtree_limitation.title', {}, 'universal_discovery_widget');
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31545
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As it was reported as "pgsql only", it turned out it is just because
```
SELECT COUNT(*) FROM ezcontentobject_tree t INNER JOIN ezcontentobject c ON t.contentobject_id = c.id INNER JOIN ezcontentobject_version v ON c.id = v.contentobject_id WHERE ((1 = 1) AND (t.node_id IN (?))) AND (c.status = ?) AND (v.status = ?) AND (t.depth <> ?) AND ((c.language_mask & ?) > ?)' with params ["NaN", 1, 1, 0, 3, 0]
```
is _valid_ query for mysql.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
