### PR TITLE
EZP-31555: Changed max-height and added overflow to better fit content

### DIFF
--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -121,7 +121,7 @@
 
     &--create {
         #{$block}__content {
-            max-height: 90%;
+            max-height: calc(100% - #{calculateRem(60px)});
             overflow: auto;
         }
 

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -121,7 +121,8 @@
 
     &--create {
         #{$block}__content {
-            max-height: initial;
+            max-height: 90%;
+            overflow: auto;
         }
 
         #{$block}__section-content--content-type {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31555](https://jira.ez.no/browse/EZP-31555)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

After changing the menu theme in eZ Platform v3.0 if has too many CT's then the menu is not correctly displayed

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
