### PR TITLE
EZP-31449: Adapted TranslatablePropertyTransformer to properly handle nulls

### DIFF
--- a/src/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
+++ b/src/lib/Form/DataTransformer/TranslatablePropertyTransformer.php
@@ -36,9 +36,7 @@ class TranslatablePropertyTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
-        if (!$value) {
-            return null;
-        }
+        $value = (false === $value || [] === $value) ? null : $value;
 
         return [$this->languageCode => $value];
     }

--- a/src/lib/Tests/Form/DataTransformer/TranslatablePropertyTransformerTest.php
+++ b/src/lib/Tests/Form/DataTransformer/TranslatablePropertyTransformerTest.php
@@ -60,8 +60,8 @@ class TranslatablePropertyTransformerTest extends TestCase
     public function reverseTransformProvider()
     {
         return [
-            [false, 'fre-FR', null],
-            [null, 'fre-FR', null],
+            [false, 'fre-FR', ['fre-FR' => null]],
+            [null, 'fre-FR', ['fre-FR' => null]],
             ['français', 'fre-FR', ['fre-FR' => 'français']],
             ['english', 'eng-GB', ['eng-GB' => 'english']],
             ['norsk', 'nor-NO', ['nor-NO' => 'norsk']],


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31449
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Reverse transformation in `TranslatablePropertyTransformer` was adapted to properly handle `ContentType` and `ContentType's`  fieldtype translatable fields when the empty value was provided in form.

Original kernel PR and discussion: https://github.com/ezsystems/ezpublish-kernel/pull/2988 -> closed right now.

Corresponding PR for 2.5: https://github.com/ezsystems/repository-forms/pull/338

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
