### PR TITLE
[Behat] Added possibility to read browser logs multiple times

### DIFF
--- a/src/lib/Behat/Helper/TestLogProvider.php
+++ b/src/lib/Behat/Helper/TestLogProvider.php
@@ -18,6 +18,8 @@ class TestLogProvider
     private const APPLICATION_LOGS_LIMIT = 25;
     private const LOG_FILE_NAME = 'travis_test.log';
 
+    private static $LOGS;
+
     /**
      * @var \Behat\Mink\Session
      */
@@ -36,9 +38,20 @@ class TestLogProvider
 
     public function getBrowserLogs(): array
     {
+        if ($this->hasCachedLogs()) {
+            $logs = $this->getCachedLogs();
+            $this->clearCachedLogs();
+
+            return $logs;
+        }
+
         $driver = $this->session->getDriver();
         if ($driver instanceof Selenium2Driver) {
-            return $this->parseBrowserLogs($driver->getWebDriverSession()->log(LogType::BROWSER));
+            $logs = $driver->getWebDriverSession()->log(LogType::BROWSER) ?? [];
+            $parsedLogs = $this->parseBrowserLogs($logs);
+            $this->cacheLogs($parsedLogs);
+
+            return $parsedLogs;
         }
 
         return [];
@@ -69,5 +82,25 @@ class TestLogProvider
         $errorMessages = $filter->filter($errorMessages);
 
         return \array_slice($errorMessages, 0, self::CONSOLE_LOGS_LIMIT);
+    }
+
+    private function hasCachedLogs(): bool
+    {
+        return !empty(self::$LOGS);
+    }
+
+    private function getCachedLogs(): array
+    {
+        return self::$LOGS;
+    }
+
+    private function clearCachedLogs(): void
+    {
+        self::$LOGS = [];
+    }
+
+    private function cacheLogs(array $logs): void
+    {
+        self::$LOGS = $logs;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31453
| Bug fix?      | no
| New feature?  | yes (for tests)
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

### Notes
- CS fixer failure is unrelated and will be fixed in another issue: https://jira.ez.no/browse/EZP-31578
- this PR contains a TMP commit that will be removed

### Description

According to Selenium doc (https://github.com/SeleniumHQ/selenium/wiki/Logging#retrieval-of-logs):
```
In the scenario where a log is retrieved several times the same log entries should not be retrieved more than once. 
For this reason, and to same memory, after each retrieval of a log the log buffer of that log is reset.
```

It's not possible to retrieve the same log multiple times. As this is the approach used in https://github.com/ezsystems/allure-behat/pull/10 I had to introduce a "cache" layer that allows to read the same log entries twice (but no more 😉 ).

There is also one small change: Webdriver can return `null` when the session is not started yet, this case is now handled.

#### To do before merging:
- [x] Rebase with 1.5 to resolve CS issue
- [x] Remove TMP commit
