### PR TITLE
EZP-31557: Fixed ezdate editing within different timezones

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -94,11 +94,12 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
-            const timezoneOffset = sourceInput.dataset.timezoneOffset
-                ? sourceInput.dataset.timezoneOffset
-                : defaultDate.getTimezoneOffset() * 60;
 
-            defaultDate.setTime(defaultDate.getTime() + timezoneOffset * 1000);
+            // during update the Content's date is in UTC timestamp - in order to instantiate flatPickr widget properly
+            // additional timezone time must be added to prevent setting an invalid date
+            if (sourceInput.dataset.contentId.length) {
+                defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
+            }
 
             updateInputValue(sourceInput, [defaultDate]);
         }

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -94,10 +94,12 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
+            const currentDate = new Date();
 
-            // during update the Content's date is in UTC timestamp - in order to instantiate flatPickr widget properly
-            // additional timezone time must be added to prevent setting an invalid date
-            if (sourceInput.dataset.contentId.length) {
+            const actionType = sourceInput.dataset.actionType;
+            if (actionType.length && actionType === 'create') {
+                defaultDate.setTime(currentDate.getTime() + currentDate.getTimezoneOffset() * 60 * 1000);
+            } else if (actionType.length && actionType === 'edit') {
                 defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
             }
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -96,9 +96,10 @@
             defaultDate = new Date(sourceInput.value * 1000);
 
             const actionType = sourceInput.dataset.actionType;
-            if (actionType.length && actionType === 'create') {
+
+            if (actionType === 'create') {
                 defaultDate.setTime(new Date().getTime());
-            } else if (actionType.length && actionType === 'edit') {
+            } else if (actionType === 'edit') {
                 defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
             }
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezdate.js
@@ -94,11 +94,10 @@
 
         if (sourceInput.value) {
             defaultDate = new Date(sourceInput.value * 1000);
-            const currentDate = new Date();
 
             const actionType = sourceInput.dataset.actionType;
             if (actionType.length && actionType === 'create') {
-                defaultDate.setTime(currentDate.getTime() + currentDate.getTimezoneOffset() * 60 * 1000);
+                defaultDate.setTime(new Date().getTime());
             } else if (actionType.length && actionType === 'edit') {
                 defaultDate.setTime(defaultDate.getTime() + defaultDate.getTimezoneOffset() * 60 * 1000);
             }

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,8 +7,8 @@
             </svg>
         </button>
     </div>
-    {% set offset =  form.parent.vars.value.value.date|length ? form.parent.vars.value.value.date.offset : null %}
+    {% set contentId = app.request.attributes.get('contentId') %}
     {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden',
-        'data-timezone-offset': offset}) %}
+        'data-content-id': contentId}) %}
     {{ block('form_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,8 +7,7 @@
             </svg>
         </button>
     </div>
-    {% set contentId = app.request.attributes.get('contentId') %}
-    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden',
-        'data-content-id': contentId}) %}
+    {% set action_type = app.request.attributes.get('_route') is same as('ez_content_draft_edit') ? 'edit' : 'create' %}
+    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden', 'data-action-type': action_type}) %}
     {{ block('form_widget') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31557
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

There are basically two scenarios: creating new `Content` with `ezdate` fieldtype or updating one:

1. During the creation of a new `Content` the only thing we should care about is initializing valid date when `ezdate` has default date set as current date. What we need to get is just a current time based on the user browser's settings (not the server date as the user can be in a different timezone than the server).
2. During the update when the date has been set previously we need to actually adjust the date with which flatPickr is initialized as this date will be set at 00:00 UTC time in the beginning. Therefore, some hours need to be added to date based on the user's current timezone in order to prevent from displaying invalid date (i.e.: date saved as 14th April 00:00 UTC - timestamp, when the user edits such input and is located in New York his date will be shown as 13th April).

Related PR: https://github.com/ezsystems/repository-forms/pull/341

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
