### PR TITLE
EZP-31584: Created LocationResolver service which provides first available Location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "^7.5.6@dev",
+        "ezsystems/ezpublish-kernel": "dev-EZP-31584",
         "ezsystems/repository-forms": "^2.5@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.5@dev",
         "ezsystems/ez-support-tools": "^1.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.1",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
-        "ezsystems/ezpublish-kernel": "dev-EZP-31584",
+        "ezsystems/ezpublish-kernel": "^7.5.6@dev",
         "ezsystems/repository-forms": "^2.5@dev",
         "ezsystems/ezplatform-admin-ui-modules": "^1.5@dev",
         "ezsystems/ez-support-tools": "^1.0@dev",

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -144,3 +144,9 @@ services:
         lazy: true
 
     EzSystems\EzPlatformAdminUi\UI\Service\ContentTypeIconResolver: ~
+
+    EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver: ~
+
+    EzSystems\EzPlatformAdminUi\Service\LocationResolver:
+        alias: EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver
+

--- a/src/lib/Service/LocationResolver.php
+++ b/src/lib/Service/LocationResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Service;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+/**
+ * @internal For internal use by AdminUI
+ */
+interface LocationResolver
+{
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function resolveLocation(ContentInfo $contentInfo): Location;
+}

--- a/src/lib/Service/PermissionAwareLocationResolver.php
+++ b/src/lib/Service/PermissionAwareLocationResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Service;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+final class PermissionAwareLocationResolver implements LocationResolver
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function resolveLocation(ContentInfo $contentInfo): Location
+    {
+        try {
+            $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
+        } catch (\Exception $e) {
+            // try different locations if main location is not accessible for the user
+            $locations = $this->locationService->loadLocations($contentInfo);
+            if (empty($locations)) {
+                throw $e;
+            }
+
+            // foreach to keep forward compatibility with a type of returned loadLocations() result
+            foreach ($locations as $location) {
+                return $location;
+            }
+        }
+
+        return $location;
+    }
+}

--- a/src/lib/Service/PermissionAwareLocationResolver.php
+++ b/src/lib/Service/PermissionAwareLocationResolver.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Service;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -31,7 +33,7 @@ final class PermissionAwareLocationResolver implements LocationResolver
     {
         try {
             $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
-        } catch (\Exception $e) {
+        } catch (NotFoundException | UnauthorizedException $e) {
             // try different locations if main location is not accessible for the user
             $locations = $this->locationService->loadLocations($contentInfo);
             if (empty($locations)) {

--- a/src/lib/Tests/Service/PermissionAwareLocationResolverTest.php
+++ b/src/lib/Tests/Service/PermissionAwareLocationResolverTest.php
@@ -15,7 +15,7 @@ use EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\LocationService;
 
-class PermissionAwareLocationResolverTest extends TestCase
+final class PermissionAwareLocationResolverTest extends TestCase
 {
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
@@ -23,7 +23,7 @@ class PermissionAwareLocationResolverTest extends TestCase
     /** @var \EzSystems\EzPlatformAdminUi\Service\LocationResolver */
     private $locationResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->locationService = $this->createMock(LocationService::class);
 
@@ -33,18 +33,17 @@ class PermissionAwareLocationResolverTest extends TestCase
     /**
      * Test for the resolveLocation() method.
      *
-     * @see \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
+     * @covers \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
      */
-    public function testResolveMainLocation()
+    public function testResolveMainLocation(): void
     {
         $contentInfo = new ContentInfo(['mainLocationId' => 42]);
         $location = new Location(['id' => 42]);
 
         // User has access to the main Location
         $this->locationService
-            ->expects($this->once())
             ->method('loadLocation')
-            ->will($this->returnValue($location));
+            ->willReturn($location);
 
         $this->assertSame($location, $this->locationResolver->resolveLocation($contentInfo));
     }
@@ -52,9 +51,9 @@ class PermissionAwareLocationResolverTest extends TestCase
     /**
      * Test for the resolveLocation() method.
      *
-     * @see \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
+     * @covers \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
      */
-    public function testResolveSecondaryLocation()
+    public function testResolveSecondaryLocation(): void
     {
         $contentInfo = new ContentInfo(['mainLocationId' => 42]);
         $location1 = new Location(['id' => 43]);
@@ -62,14 +61,12 @@ class PermissionAwareLocationResolverTest extends TestCase
 
         // User doesn't have access to main location but to the third Content's location
         $this->locationService
-            ->expects($this->once())
             ->method('loadLocation')
             ->willThrowException($this->createMock(UnauthorizedException::class));
 
         $this->locationService
-            ->expects($this->once())
             ->method('loadLocations')
-            ->will($this->returnValue([$location1, $location2]));
+            ->willReturn([$location1, $location2]);
 
         $this->assertSame($location1, $this->locationResolver->resolveLocation($contentInfo));
     }

--- a/src/lib/Tests/Service/PermissionAwareLocationResolverTest.php
+++ b/src/lib/Tests/Service/PermissionAwareLocationResolverTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Service;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\LocationService;
+
+class PermissionAwareLocationResolverTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Service\LocationResolver */
+    private $locationResolver;
+
+    public function setUp()
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+
+        $this->locationResolver = new PermissionAwareLocationResolver($this->locationService);
+    }
+
+    /**
+     * Test for the resolveLocation() method.
+     *
+     * @see \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
+     */
+    public function testResolveMainLocation()
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location = new Location(['id' => 42]);
+
+        // User has access to the main Location
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue($location));
+
+        $this->assertSame($location, $this->locationResolver->resolveLocation($contentInfo));
+    }
+
+    /**
+     * Test for the resolveLocation() method.
+     *
+     * @see \EzSystems\EzPlatformAdminUi\Service\PermissionAwareLocationResolver::resolveLocation()
+     */
+    public function testResolveSecondaryLocation()
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location1 = new Location(['id' => 43]);
+        $location2 = new Location(['id' => 44]);
+
+        // User doesn't have access to main location but to the third Content's location
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->willThrowException($this->createMock(UnauthorizedException::class));
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocations')
+            ->will($this->returnValue([$location1, $location2]));
+
+        $this->assertSame($location1, $this->locationResolver->resolveLocation($contentInfo));
+    }
+}

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -176,7 +176,7 @@ class ValueFactory
         return new UIValue\Content\Relation($relation, [
             'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
             'relationContentTypeName' => $contentType->getName(),
-            'relationLocation' => $this->locationService->resolveLocation($content->contentInfo),
+            'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
         ]);
     }

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -31,6 +31,7 @@ use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use EzSystems\EzPlatformAdminUi\Service\LocationResolver;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
@@ -68,6 +69,9 @@ class ValueFactory
     /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
     private $userLanguagePreferenceProvider;
 
+    /** @var \EzSystems\EzPlatformAdminUi\Service\LocationResolver */
+    protected $locationResolver;
+
     /**
      * @param \eZ\Publish\API\Repository\UserService $userService
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
@@ -79,6 +83,7 @@ class ValueFactory
      * @param \EzSystems\EzPlatformAdminUi\UI\Service\PathService $pathService
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
      * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
+     * @param \EzSystems\EzPlatformAdminUi\Service\LocationResolver $locationResolver
      */
     public function __construct(
         UserService $userService,
@@ -90,7 +95,8 @@ class ValueFactory
         PermissionResolver $permissionResolver,
         PathService $pathService,
         DatasetFactory $datasetFactory,
-        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
+        UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
+        LocationResolver $locationResolver
     ) {
         $this->userService = $userService;
         $this->languageService = $languageService;
@@ -102,6 +108,7 @@ class ValueFactory
         $this->pathService = $pathService;
         $this->datasetFactory = $datasetFactory;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
+        $this->locationResolver = $locationResolver;
     }
 
     /**
@@ -158,6 +165,8 @@ class ValueFactory
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      */
     public function createRelation(Relation $relation, Content $content): UIValue\Content\Relation
     {
@@ -167,7 +176,7 @@ class ValueFactory
         return new UIValue\Content\Relation($relation, [
             'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
             'relationContentTypeName' => $contentType->getName(),
-            'relationLocation' => $this->locationService->loadFirstAvailableLocation($content->contentInfo),
+            'relationLocation' => $this->locationService->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
         ]);
     }
@@ -180,6 +189,8 @@ class ValueFactory
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      */
     public function createRelationItem(RelationListItem $relationListItem, Content $content): UIValue\Content\Relation
     {
@@ -190,7 +201,7 @@ class ValueFactory
         return new UIValue\Content\Relation($relation, [
             'relationFieldDefinitionName' => $fieldDefinition ? $fieldDefinition->getName() : '',
             'relationContentTypeName' => $contentType->getName(),
-            'relationLocation' => $this->locationService->loadFirstAvailableLocation($content->contentInfo),
+            'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
         ]);
     }

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -173,7 +173,7 @@ class ValueFactory
         } catch (UnauthorizedException $e) {
             // try different locations if main location is not accessible for the user
             $relationLocations = $this->locationService->loadLocations($contentInfo);
-            if (!empty($relationLocations)) {
+            if (empty($relationLocations)) {
                 throw $e;
             }
             $relationLocation = reset($relationLocations);

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -31,7 +31,6 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
@@ -175,7 +174,7 @@ class ValueFactory
             // try different locations if main location is not accessible for the user
             $relationLocations = $this->locationService->loadLocations($contentInfo);
             if (!empty($relationLocations)) {
-                throw new NotFoundException('Locations related to main location', $contentInfo->mainLocationId);
+                throw $e;
             }
             $relationLocation = reset($relationLocations);
         }
@@ -212,7 +211,7 @@ class ValueFactory
             // try different locations if main location is not accessible for the user
             $relationLocations = $this->locationService->loadLocations($contentInfo);
             if (empty($relationLocations)) {
-                throw new NotFoundException('Locations related to main location', $contentInfo->mainLocationId);
+                throw $e;
             }
             $relationLocation = reset($relationLocations);
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31584
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When loading `Relation` main `Location` might not be accessible for the end-user due to permissions which results in `Unauthorized Exception` even though the user can have access to different `Locations` of this `Relation`. 

The `LocationResolver` service has been added specifically for `admin-ui` internal use.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Implement tests
- [x] Ready for Code Review
