### PR TITLE
EZP-31583: Fixed views for Content without Location

### DIFF
--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -5,10 +5,13 @@
         </svg>
     </td>
     <td class="ez-table__cell ez-table__cell--after-icon">
-        <a href="{{ path('_ezpublishLocation', {
-            'locationId': row.mainLocationId,
-            'languageCode': row.translation_language_code,
-        }) }}">{{ row.name }}</a>
+        {% if row.mainLocationId is not null %}
+            <a href="{{ path('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.mainLocationId }) }}">
+                {{ row.name }}
+            </a>
+        {% else %}
+            {{ row.name }}
+        {% endif %}
     </td>
     <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
     <td class="ez-table__cell">{{ row.type }}</td>
@@ -20,9 +23,11 @@
         </td>
     {% endif %}
     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-        {% include '@ezdesign/parts/edit_translation_button.html.twig' with {
-            'contentId': row.contentId,
-            'translations': row.available_enabled_translations
-        }%}
+        {% if row.mainLocationId is not null %}
+            {% include '@ezdesign/parts/edit_translation_button.html.twig' with {
+                'contentId': row.contentId,
+                'translations': row.available_enabled_translations
+            } %}
+        {% endif %}
     </td>
 </tr>

--- a/src/bundle/Resources/views/content/relation.html.twig
+++ b/src/bundle/Resources/views/content/relation.html.twig
@@ -1,12 +1,16 @@
 <td>
-    <a {% if not content.contentInfo.trashed %}
-        href="{{ path('_ezpublishLocation', { 'locationId': content.contentInfo.mainLocationId } ) }}"
-    {% endif %}>
+    {% if content.contentInfo.mainLocationId is not null %}
+        <a {% if not content.contentInfo.trashed %}
+            href="{{ path('_ezpublishLocation', { 'locationId': content.contentInfo.mainLocationId } ) }}"
+                {% endif %}>
+            {{ content.getName() }}
+            {% if content.contentInfo.trashed %}
+                <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
+            {% endif %}
+        </a>
+    {% else %}
         {{ content.getName() }}
-        {% if content.contentInfo.trashed %}
-            <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
-        {% endif %}
-    </a>
+    {% endif %}
 </td>
 <td>
     {{ contentType.getName() }}

--- a/src/bundle/Resources/views/content/relation.html.twig
+++ b/src/bundle/Resources/views/content/relation.html.twig
@@ -1,15 +1,13 @@
 <td>
     {% if content.contentInfo.mainLocationId is not null %}
-        <a {% if not content.contentInfo.trashed %}
-            href="{{ path('_ezpublishLocation', { 'locationId': content.contentInfo.mainLocationId } ) }}"
-                {% endif %}>
+        <a href="{{ path('_ezpublishLocation', { 'locationId': content.contentInfo.mainLocationId } ) }}">
             {{ content.getName() }}
-            {% if content.contentInfo.trashed %}
-                <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
-            {% endif %}
         </a>
     {% else %}
         {{ content.getName() }}
+        {% if content.contentInfo.trashed %}
+            <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
+        {% endif %}
     {% endif %}
 </td>
 <td>

--- a/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
@@ -16,9 +16,13 @@
             {% set destination = relation.destinationContentInfo %}
             <tr>
                 <td>
-                    <a href="{{ path('_ezpublishLocation', { 'locationId': destination.mainLocationId }) }}">
+                    {% if destination.mainLocationId is not null %}
+                        <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': destination.mainLocationId }) }}">
+                            {{ ez_content_name(destination) }}
+                        </a>
+                    {% else %}
                         {{ ez_content_name(destination) }}
-                    </a>
+                    {% endif %}
                 </td>
                 <td>{{ contentTypes[destination.contentTypeId].name }}</td>
                 <td>

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -17,9 +17,13 @@
                 {% set source = relation.sourceContentInfo %}
                 <tr>
                     <td>
-                        <a href="{{ path('_ezpublishLocation', { 'locationId': source.mainLocationId }) }}">
+                        {% if source.mainLocationId is not null %}
+                            <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': source.mainLocationId }) }}">
+                                {{ ez_content_name(source) }}
+                            </a>
+                        {% else %}
                             {{ ez_content_name(source) }}
-                        </a>
+                        {% endif %}
                     </td>
                     <td>{{ contentTypes[source.contentTypeId].name }}</td>
                     <td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31583
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Some twig views have been tweaked to support `Contents` without `Locations`.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
