### PR TITLE
EZP-31560: [Tests] Fixed namespaces not following PSR-4

### DIFF
--- a/src/bundle/Tests/DependencyInjection/Compiler/ComponentPassTest.php
+++ b/src/bundle/Tests/DependencyInjection/Compiler/ComponentPassTest.php
@@ -6,8 +6,9 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+namespace EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Compiler;
 
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\ComponentPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/bundle/Tests/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
+++ b/src/bundle/Tests/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
@@ -6,10 +6,11 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+namespace EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabGroup;
 use EzSystems\EzPlatformAdminUi\Tab\TabRegistry;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\SystemInfoTabGroupPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/bundle/Tests/DependencyInjection/Compiler/TabPassTest.php
+++ b/src/bundle/Tests/DependencyInjection/Compiler/TabPassTest.php
@@ -6,9 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+namespace EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformAdminUi\Tab\TabRegistry;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\TabPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/bundle/Tests/DependencyInjection/Compiler/UiConfigProviderPassTest.php
+++ b/src/bundle/Tests/DependencyInjection/Compiler/UiConfigProviderPassTest.php
@@ -6,9 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler;
+namespace EzSystems\EzPlatformAdminUiBundle\Tests\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformAdminUi\UI\Config\Aggregator;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Compiler\UiConfigProviderPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/lib/Tests/Behat/BrowserLogFilterTest.php
+++ b/src/lib/Tests/Behat/BrowserLogFilterTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+namespace EzSystems\EzPlatformAdminUi\Tests\Behat;
+
 use EzSystems\EzPlatformAdminUi\Behat\Helper\BrowserLogFilter;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;

--- a/src/lib/Tests/Behat/ExtendedTableNodeTest.php
+++ b/src/lib/Tests/Behat/ExtendedTableNodeTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+namespace EzSystems\EzPlatformAdminUi\Tests\Behat;
+
 use Behat\Gherkin\Node\TableNode;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\TableNodeExtension;
 use PHPUnit\Framework\Assert;

--- a/src/lib/Tests/RepositoryForms/Form/Processor/PreviewFormProcessorTest.php
+++ b/src/lib/Tests/RepositoryForms/Form/Processor/PreviewFormProcessorTest.php
@@ -6,11 +6,12 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUi\RepositoryForms\Form\Processor;
+namespace EzSystems\EzPlatformAdminUi\Tests\RepositoryForms\Form\Processor;
 
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPlatformAdminUi\RepositoryForms\Form\Processor\PreviewFormProcessor;
 use EzSystems\RepositoryForms\Data\Content\FieldData;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\ContentService;

--- a/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
+++ b/src/lib/Tests/UI/Config/Mapper/FieldType/RichText/CustomTagTest.php
@@ -6,9 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText;
+namespace EzSystems\EzPlatformAdminUi\Tests\UI\Config\Mapper\FieldType\RichText;
 
 use ArrayObject;
+use EzSystems\EzPlatformAdminUi\UI\Config\Mapper\FieldType\RichText\CustomTag;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;

--- a/src/lib/Tests/Validator/Constraint/UserPasswordTest.php
+++ b/src/lib/Tests/Validator/Constraint/UserPasswordTest.php
@@ -6,6 +6,8 @@
  */
 declare(strict_types=1);
 
+namespace EzSystems\EzPlatformAdminUi\Tests\Validator\Constraint;
+
 use EzSystems\EzPlatformAdminUi\Validator\Constraints\UserPassword;
 use PHPUnit\Framework\TestCase;
 

--- a/src/lib/Tests/Validator/Constraint/UserPasswordValidatorTest.php
+++ b/src/lib/Tests/Validator/Constraint/UserPasswordValidatorTest.php
@@ -6,6 +6,8 @@
  */
 declare(strict_types=1);
 
+namespace EzSystems\EzPlatformAdminUi\Tests\Validator\Constraint;
+
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface;
 use EzSystems\EzPlatformAdminUi\Validator\Constraints\UserPassword;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31560](https://jira.ez.no/browse/EZP-31560)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.5`+
| **BC breaks**      | no
| **Doc needed**     | no

This PR aligns namespaces not following the defined psr-4 convention.

Only the test cases are affected.

See [EZP-31560](https://jira.ez.no/browse/EZP-31560) for more details.

**TODO**:
- [x] Fix namespaces
- [x] Wait for Travis
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.