### PR TITLE
EZP-31600: TableView throws an error when Creator/Contributor is removed for any of the content items

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/components/table-view/table.view.item.component.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/components/table-view/table.view.item.component.js
@@ -249,18 +249,15 @@ export default class TableViewItemComponent extends PureComponent {
     }
 
     renderCreatorCell() {
-        return <div className="c-table-view-item__text-wrapper">{this.props.item.content._info.owner.name}</div>;
+        return <div className="c-table-view-item__text-wrapper">{this.getName(this.props.item.content._info.owner)}</div>;
     }
 
     renderContributorCell() {
-        return <div className="c-table-view-item__text-wrapper">{this.props.item.content._info.currentVersion.creator.name}</div>;
+        return <div className="c-table-view-item__text-wrapper">{this.getName(this.props.item.content._info.currentVersion.creator)}</div>;
     }
 
     renderSectionCell() {
-        const section = this.props.item.content._info.section;
-        const sectionName = section ? section.name : '';
-
-        return <div className="c-table-view-item__text-wrapper">{sectionName}</div>;
+        return <div className="c-table-view-item__text-wrapper">{this.getName(this.props.item.content._info.section)}</div>;
     }
 
     renderLocationIdCell() {
@@ -297,6 +294,10 @@ export default class TableViewItemComponent extends PureComponent {
                 </td>
             );
         });
+    }
+
+    getName(item) {
+        return item ? item.name : '';
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31600](https://jira.ez.no/browse/EZP-31600)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Steps to reproduce:

1. Login as admin and create a "Parent" content
2. Create a new user, and login with its credentials
3. As a new user create "Parent" / "Child" content item
4. Logout as new user and log in as admin
5. Remove new user created on step #2
6. Open "Parent" content item full view in admin UI
7. No sub-items are shown, and the following error is displayed in browser console
```
TypeError: Cannot read property 'name' of null
    at TableViewItemComponent.renderContributorCell (ezplatform-admin-ui-subitems-js.js:2180)
    at ezplatform-admin-ui-subitems-js.js:2242
    at Array.map (<anonymous>)
    at TableViewItemComponent.renderBasicColumns (ezplatform-admin-ui-subitems-js.js:2230)
    at TableViewItemComponent.render (ezplatform-admin-ui-subitems-js.js:2312)
    at ce (react-dom.production.min.js:98)
    at qg (react-dom.production.min.js:97)
    at hi (react-dom.production.min.js:104)
    at Qg (react-dom.production.min.js:144)
    at Rg (react-dom.production.min.js:145) 
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
