### PR TITLE
[Behat] EZP-31604: Removed loading Context classes in test env

### DIFF
--- a/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
@@ -36,7 +36,7 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         $loader->load('role.yaml');
 
         $environment = $container->getParameter('kernel.environment');
-        if (in_array($environment, ['behat', 'test'])) {
+        if ($environment === 'behat') {
             $loader->load('services/feature_contexts.yaml');
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31604
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Behat Context classes were loaded also in `test` environemnt, but BehatBundle is loaded only in `behat` env, which caused the reported issue.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
