### PR TITLE
EZP-31399: ez-alert-info in Editing view is not aligned with content card

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/component/preview_unavailable.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/preview_unavailable.html.twig
@@ -1,9 +1,11 @@
 {% trans_default_domain 'content_edit_component_preview_unavailable' %}
 
-<div class="alert alert-info mt-3 mx-5 ez-alert ez-alert--info" role="alert">
-    <svg class="ez-icon ez-icon--small ez-icon-warning">
-        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#warning"></use>
-    </svg>
+<section class="container mt-3 px-5">
+    <div class="alert alert-info ez-alert ez-alert--info" role="alert">
+        <svg class="ez-icon ez-icon--small ez-icon-warning">
+            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#warning"></use>
+        </svg>
 
-    {{ 'preview_unavailable'|trans|desc('You cannot preview this translation because there is no site available for this language. Contact your Administrator.') }}
-</div>
+        {{ 'preview_unavailable'|trans|desc('You cannot preview this translation because there is no site available for this language. Contact your Administrator.') }}
+    </div>
+</section>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31399
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
