### PR TITLE
EZEE-3071: Moved generate key for SiteAccess to new Class

### DIFF
--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -37,7 +37,9 @@ services:
         autoconfigure: false
         public: false
         class: "%ezplatform.content_forms.limitation.form_mapper.siteaccess.class%"
-        arguments: ['@ezpublish.siteaccess_service', '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator']
+        arguments:
+            - '@ezpublish.siteaccess_service'
+            - '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator'
         tags:
             - { name: ez.limitation.formMapper, limitationType: SiteAccess }
             - { name: ez.limitation.valueMapper, limitationType: SiteAccess }

--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -37,7 +37,7 @@ services:
         autoconfigure: false
         public: false
         class: "%ezplatform.content_forms.limitation.form_mapper.siteaccess.class%"
-        arguments: ['@ezpublish.siteaccess_service']
+        arguments: ['@ezpublish.siteaccess_service', '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator']
         tags:
             - { name: ez.limitation.formMapper, limitationType: SiteAccess }
             - { name: ez.limitation.valueMapper, limitationType: SiteAccess }

--- a/src/bundle/Resources/config/services/siteaccess.yaml
+++ b/src/bundle/Resources/config/services/siteaccess.yaml
@@ -6,6 +6,8 @@ services:
 
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolverInterface: '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver'
 
+    EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator: ~
+
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver:
         arguments:
             $siteaccessPreviewVoters: !tagged ezplatform.admin_ui.siteaccess_preview_voter

--- a/src/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/SiteAccessLimitationMapper.php
@@ -9,23 +9,29 @@ namespace EzSystems\EzPlatformAdminUi\Limitation\Mapper;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzPlatformAdminUi\Limitation\LimitationValueMapperInterface;
+use EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGeneratorInterface;
 
 class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper implements LimitationValueMapperInterface
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface */
     private $siteAccessService;
 
+    /** @var \EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGeneratorInterface */
+    private $siteAccessKeyGenerator;
+
     public function __construct(
-        SiteAccessServiceInterface $siteAccessService
+        SiteAccessServiceInterface $siteAccessService,
+        SiteAccessKeyGeneratorInterface $siteAccessKeyGenerator
     ) {
         $this->siteAccessService = $siteAccessService;
+        $this->siteAccessKeyGenerator = $siteAccessKeyGenerator;
     }
 
     protected function getSelectionChoices()
     {
         $siteAccesses = [];
         foreach ($this->siteAccessService->getAll() as $sa) {
-            $siteAccesses[$this->getSiteAccessKey($sa->name)] = $sa->name;
+            $siteAccesses[$this->siteAccessKeyGenerator->generate($sa->name)] = $sa->name;
         }
 
         return $siteAccesses;
@@ -35,16 +41,11 @@ class SiteAccessLimitationMapper extends MultipleSelectionBasedMapper implements
     {
         $values = [];
         foreach ($this->siteAccessService->getAll() as $sa) {
-            if (in_array($this->getSiteAccessKey($sa->name), $limitation->limitationValues)) {
+            if (in_array($this->siteAccessKeyGenerator->generate($sa->name), $limitation->limitationValues)) {
                 $values[] = $sa->name;
             }
         }
 
         return $values;
-    }
-
-    private function getSiteAccessKey($sa)
-    {
-        return sprintf('%u', crc32($sa));
     }
 }

--- a/src/lib/Siteaccess/SiteAccessKeyGenerator.php
+++ b/src/lib/Siteaccess/SiteAccessKeyGenerator.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
-class SiteAccessKeyGenerator implements SiteAccessKeyGeneratorInterface
+final class SiteAccessKeyGenerator implements SiteAccessKeyGeneratorInterface
 {
     public function generate(string $siteAccessIdentifier): string
     {

--- a/src/lib/Siteaccess/SiteAccessKeyGenerator.php
+++ b/src/lib/Siteaccess/SiteAccessKeyGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Siteaccess;
+
+class SiteAccessKeyGenerator implements SiteAccessKeyGeneratorInterface
+{
+    public function generate(string $siteAccessIdentifier): string
+    {
+        return sprintf('%u', crc32($siteAccessIdentifier));
+    }
+}

--- a/src/lib/Siteaccess/SiteAccessKeyGeneratorInterface.php
+++ b/src/lib/Siteaccess/SiteAccessKeyGeneratorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Siteaccess;
+
+interface SiteAccessKeyGeneratorInterface
+{
+    public function generate(string $siteAccessIdentifier): string;
+}

--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -10,6 +10,8 @@ use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzPlatformAdminUi\Limitation\Mapper\SiteAccessLimitationMapper;
+use EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator;
+use EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
 class SiteAccessLimitationMapperTest extends TestCase
@@ -29,14 +31,21 @@ class SiteAccessLimitationMapperTest extends TestCase
             $siteAccessList
         );
 
-        $limitation = new SiteAccessLimitation([
-            'limitationValues' => array_keys($siteAccessList),
-        ]);
+        $limitation = new SiteAccessLimitation(
+            [
+                'limitationValues' => array_keys($siteAccessList),
+            ]
+        );
+
+        $siteAccessesGenerator = $this->createMock(SiteAccessKeyGeneratorInterface::class);
+        $siteAccessesGenerator
+            ->method('generate')
+            ->will($this->returnValue(new SiteAccessKeyGenerator()));
 
         $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $siteAccessService->method('getAll')->willReturn($siteAccesses);
 
-        $mapper = new SiteAccessLimitationMapper($siteAccessService);
+        $mapper = new SiteAccessLimitationMapper($siteAccessService, $siteAccessesGenerator);
         $result = $mapper->mapLimitationValue($limitation);
 
         $this->assertEquals(array_values($siteAccessList), $result);

--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -37,15 +37,15 @@ class SiteAccessLimitationMapperTest extends TestCase
             ]
         );
 
-        $siteAccessesGenerator = $this->createMock(SiteAccessKeyGeneratorInterface::class);
-        $siteAccessesGenerator
+        $siteAccessesGeneratorInterface = $this->createMock(SiteAccessKeyGeneratorInterface::class);
+        $siteAccessesGeneratorInterface
             ->method('generate')
-            ->will($this->returnValue(new SiteAccessKeyGenerator()));
+            ->willReturn(new SiteAccessKeyGenerator());
 
         $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $siteAccessService->method('getAll')->willReturn($siteAccesses);
 
-        $mapper = new SiteAccessLimitationMapper($siteAccessService, $siteAccessesGenerator);
+        $mapper = new SiteAccessLimitationMapper($siteAccessService, $siteAccessesGeneratorInterface);
         $result = $mapper->mapLimitationValue($limitation);
 
         $this->assertEquals(array_values($siteAccessList), $result);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3071](https://jira.ez.no/browse/EZEE-3071)
| **Type**                                   | bug/improvement
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Another PR for this ticket: https://github.com/ezsystems/ezplatform-site-factory/pull/58


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
