### PR TITLE
EZP-31625: sort trash by trashed date

### DIFF
--- a/src/bundle/Controller/TrashController.php
+++ b/src/bundle/Controller/TrashController.php
@@ -140,7 +140,7 @@ class TrashController extends Controller
         $trashItemsList = [];
 
         $query = new Query([
-            'sortClauses' => [new Query\SortClause\Location\Priority(Query::SORT_ASC)],
+            'sortClauses' => [new Query\SortClause\Trash\DateTrashed(Query::SORT_DESC)],
         ]);
 
         $pagerfanta = new Pagerfanta(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31625](https://jira.ez.no/browse/EZP-31625)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Part of https://github.com/ezsystems/ezpublish-kernel/pull/2954
Currently, trashed items sorted by location priority.
It's hard to find the last removed item in case of incident removal (and in general).
I would like to see the last removed item listed first.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
