### PR TITLE
EZP-27324: Proper media/binary uri is now shown & generated for old content versions

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/preview/content_fields.html.twig
@@ -234,7 +234,12 @@
 {% block ezbinaryfile_field %}
 {% apply spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier, 'inLanguage': content.prioritizedFieldLanguageCode } ) %}
+        {% set route_reference = ez_route( 'ez_content_download', {
+            'content': content,
+            'fieldIdentifier': field.fieldDefIdentifier,
+            'inLanguage': content.prioritizedFieldLanguageCode,
+            'version': versionInfo.versionNo
+        } ) %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezbinaryfile')|trim}) %}
         <div {{ block( 'field_attributes' ) }}>
             <svg class="ez-icon ez-icon--file">
@@ -258,7 +263,11 @@
     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' ez-field-preview ez-field-preview--ezmedia')|trim}) %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
-    {% set route_reference = ez_route( 'ez_content_download', {'content': content, 'fieldIdentifier': field.fieldDefIdentifier} ) %}
+    {% set route_reference = ez_route( 'ez_content_download', {
+        'content': content,
+        'fieldIdentifier': field.fieldDefIdentifier,
+        'version': versionInfo.versionNo
+    } ) %}
     {% set download = path( route_reference ) %}
     {% set hasController = value.hasController ? 'ezmedia.yes'|trans|desc('Yes') : 'ezmedia.no'|trans|desc('No') %}
     {% set autoplay = value.autoplay ? 'ezmedia.yes'|trans|desc('Yes') : 'ezmedia.no'|trans|desc('No') %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-27324
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


related:
https://github.com/ezsystems/ezpublish-kernel/pull/3033

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
