### PR TITLE
EZP-31460: Added Content Type draft management functionality

### DIFF
--- a/src/bundle/Controller/ContentTypeController.php
+++ b/src/bundle/Controller/ContentTypeController.php
@@ -175,7 +175,7 @@ class ContentTypeController extends Controller
             'can_create' => $this->isGranted(new Attribute('class', 'create')),
             'can_update' => $this->isGranted(new Attribute('class', 'update')),
             'can_delete' => $this->isGranted(new Attribute('class', 'delete')),
-            'draftsOnly' => $draftsOnly,
+            'drafts_only' => $draftsOnly,
         ]);
     }
 

--- a/src/bundle/ParamConverter/ContentTypeParamConverter.php
+++ b/src/bundle/ParamConverter/ContentTypeParamConverter.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUiBundle\ParamConverter;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -52,7 +53,11 @@ class ContentTypeParamConverter implements ParamConverterInterface
 
         if ($request->get(self::PARAMETER_CONTENT_TYPE_ID)) {
             $id = (int)$request->get(self::PARAMETER_CONTENT_TYPE_ID);
-            $contentType = $this->contentTypeService->loadContentType($id, $prioritizedLanguages);
+            try {
+                $contentType = $this->contentTypeService->loadContentType($id, $prioritizedLanguages);
+            } catch (NotFoundException $e) {
+                $contentType = $this->contentTypeService->loadContentTypeDraft($id);
+            }
         } elseif ($request->get(self::PARAMETER_CONTENT_TYPE_IDENTIFIER)) {
             $identifier = $request->get(self::PARAMETER_CONTENT_TYPE_IDENTIFIER);
             $contentType = $this->contentTypeService->loadContentTypeByIdentifier($identifier, $prioritizedLanguages);

--- a/src/bundle/ParamConverter/ContentTypeParamConverter.php
+++ b/src/bundle/ParamConverter/ContentTypeParamConverter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUiBundle\ParamConverter;
 
 use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -53,11 +52,7 @@ class ContentTypeParamConverter implements ParamConverterInterface
 
         if ($request->get(self::PARAMETER_CONTENT_TYPE_ID)) {
             $id = (int)$request->get(self::PARAMETER_CONTENT_TYPE_ID);
-            try {
-                $contentType = $this->contentTypeService->loadContentType($id, $prioritizedLanguages);
-            } catch (NotFoundException $e) {
-                $contentType = $this->contentTypeService->loadContentTypeDraft($id);
-            }
+            $contentType = $this->contentTypeService->loadContentType($id, $prioritizedLanguages);
         } elseif ($request->get(self::PARAMETER_CONTENT_TYPE_IDENTIFIER)) {
             $identifier = $request->get(self::PARAMETER_CONTENT_TYPE_IDENTIFIER);
             $contentType = $this->contentTypeService->loadContentTypeByIdentifier($identifier, $prioritizedLanguages);

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -336,6 +336,14 @@ ezplatform.content_type.list:
     requirements:
         contentTypeGroupId: \d+
 
+ezplatform.content_type.draft_list:
+    path: /contenttypegroup/{contentTypeGroupId}/contenttype/draftlist
+    methods: ['GET']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:ContentType:draftList'
+    requirements:
+        contentTypeGroupId: \d+
+
 ezplatform.content_type.add:
     path: /contenttypegroup/{contentTypeGroupId}/contenttype/add
     methods: ['GET', 'POST']
@@ -375,6 +383,14 @@ ezplatform.content_type.bulk_delete:
     methods: ['POST']
     defaults:
         _controller: 'EzPlatformAdminUiBundle:ContentType:bulkDelete'
+    requirements:
+        contentTypeGroupId: \d+
+
+ezplatform.content_type.bulk_draft_delete:
+    path: /content_type/{contentTypeGroupId}/bulk-draft-delete
+    methods: ['POST']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:ContentType:bulkDraftDelete'
     requirements:
         contentTypeGroupId: \d+
 

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -201,6 +201,16 @@
         <target state="new">Creating a new Content Type</target>
         <note>key: content_type.view.create.title</note>
       </trans-unit>
+      <trans-unit id="55ae9368c9511a78e86cdac2f80973a6c731d217" resname="content_type.view.draft_list.action.delete">
+        <source>Delete Draft Content Type</source>
+        <target state="new">Delete Draft Content Type</target>
+        <note>key: content_type.view.draft_list.action.delete</note>
+      </trans-unit>
+      <trans-unit id="f59460be0003dd238d5262b33413f42d09bd5e55" resname="content_type.view.draft_list.title">
+        <source>Draft Content Types in %identifier%</source>
+        <target state="new">Draft Content Types in %identifier%</target>
+        <note>key: content_type.view.draft_list.title</note>
+      </trans-unit>
       <trans-unit id="621f64c5f4acef41bca216c9d712860e3438f742" resname="content_type.view.edit.content_field_definition.delete">
         <source>Delete Content field definition</source>
         <target state="new">Delete Content field definition</target>
@@ -385,6 +395,11 @@
         <source>%identifier%</source>
         <target state="new">%identifier%</target>
         <note>key: content_type_group.view.view.title</note>
+      </trans-unit>
+      <trans-unit id="efc09333aab98099bb89e4d20011aee033eb55d7" resname="draft_content_type.delete.success">
+        <source>Draft Content Type '%name%' deleted.</source>
+        <target state="new">Draft Content Type '%name%' deleted.</target>
+        <note>key: draft_content_type.delete.success</note>
       </trans-unit>
       <trans-unit id="5ae05a3f43e0d104e61174cc27f76e7764fc9f0c" resname="draft_content_type.modal.message">
         <source>Do you want to delete draft Content Types?</source>

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -236,6 +236,11 @@
         <target state="new">Delete Content Type</target>
         <note>key: content_type.view.list.action.delete</note>
       </trans-unit>
+      <trans-unit id="dc81a90ec5471fee7ddb38a888009f8d44b92416" resname="content_type.view.list.action.delete_drafts">
+        <source>Delete draft Content Types</source>
+        <target state="new">Delete draft Content Types</target>
+        <note>key: content_type.view.list.action.delete_drafts</note>
+      </trans-unit>
       <trans-unit id="bef02fc3d41e74bf002af93b413a2a203a04db1a" resname="content_type.view.list.column.id">
         <source>ID</source>
         <target state="new">ID</target>
@@ -255,6 +260,11 @@
         <source>Name</source>
         <target state="new">Name</target>
         <note>key: content_type.view.list.column.name</note>
+      </trans-unit>
+      <trans-unit id="31383de3bbd4d838088dc29ceb8a653e897d32a6" resname="content_type.view.list.drafts_title">
+        <source>Draft Content Types in %identifier%</source>
+        <target state="new">Draft Content Types in %identifier%</target>
+        <note>key: content_type.view.list.drafts_title</note>
       </trans-unit>
       <trans-unit id="7c8c43d61131312dbeeeac5dc536a4f95154f33d" resname="content_type.view.list.title">
         <source>Content Types in %identifier%</source>
@@ -375,6 +385,11 @@
         <source>%identifier%</source>
         <target state="new">%identifier%</target>
         <note>key: content_type_group.view.view.title</note>
+      </trans-unit>
+      <trans-unit id="5ae05a3f43e0d104e61174cc27f76e7764fc9f0c" resname="draft_content_type.modal.message">
+        <source>Do you want to delete draft Content Types?</source>
+        <target state="new">Do you want to delete draft Content Types?</target>
+        <note>key: draft_content_type.modal.message</note>
       </trans-unit>
       <trans-unit id="62ac918fce5389cd868b988e65b4ab96477a1344" resname="location_update_form.sort_field">
         <source>Sort field</source>

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -41,6 +41,11 @@
         <target state="new">Delete content types</target>
         <note>key: content_types_delete_form.delete</note>
       </trans-unit>
+      <trans-unit id="c7830205c6d6a0cdc461fb448fa271f31450f6e8" resname="draft_content_types_delete_form.delete">
+        <source>Delete draft content types</source>
+        <target state="new">Delete draft content types</target>
+        <note>key: draft_content_types_delete_form.delete</note>
+      </trans-unit>
       <trans-unit id="56281d5c292a4fe95f9b1af5ae0b1deaebab7342" resname="ezplatform.change_user_password.change">
         <source>Change</source>
         <target state="new">Change</target>

--- a/src/bundle/Resources/views/admin/content_type/draft_list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/draft_list.html.twig
@@ -1,0 +1,92 @@
+{% trans_default_domain 'content_type' %}
+
+{% import "@ezdesign/admin/content_type/macros.html.twig" as macros %}
+
+{% form_theme form_draft_content_types_delete '@ezdesign/form_fields.html.twig' %}
+
+{% if pager.nbResults %}
+    <section class="container mt-4 px-5">
+        <div class="ez-table-header">
+            <div class="ez-table-header__headline">
+                {{ 'content_type.view.draft_list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Draft Content Types in %identifier%') }}
+            </div>
+            <div>
+                {% if can_delete %}
+                    {% set modal_data_target = 'delete-draft-content-types-modal' %}
+                    <button
+                            id="draft-delete-content-types"
+                            type="button"
+                            class="btn btn-danger"
+                            data-toggle="modal"
+                            data-target="#{{ modal_data_target }}"
+                            title="{{ 'content_type.view.draft_list.action.delete'|trans|desc('Delete Draft Content Type') }}">
+                        <svg class="ez-icon ez-icon-trash">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        </svg>
+                    </button>
+                    {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
+                        'id': modal_data_target,
+                        'message': 'draft_content_type.modal.message'|trans|desc('Do you want to delete draft Content Types?'),
+                        'data_click': '#draft_content_types_delete_delete',
+                    } %}
+                {% endif %}
+            </div>
+        </div>
+
+        {{ form_start(form_draft_content_types_delete, {
+            'action': path('ezplatform.content_type.bulk_draft_delete', {"contentTypeGroupId": group.id} ),
+            'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-draft-content-types' }
+        }) }}
+        <table class="ez-table table">
+            <thead>
+            <tr>
+                <th class="ez-table__header-cell"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
+                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for content_type in pager.currentPageResults %}
+                <tr>
+                    <td class="ez-table__cell ez-table__cell--has-checkbox">
+                        {% if can_delete %}
+                            {{ form_widget(form_draft_content_types_delete.content_types[content_type.id], {"checked": true}) }}
+                        {% else %}
+                            {% do form_draft_content_types_delete.content_types.setRendered %}
+                        {% endif %}
+                    </td>
+                    <td class="ez-table__cell ez-table__cell--has-icon">
+                        <svg class="ez-icon ez-icon--small">
+                            <use xlink:href="{{ ez_content_type_icon(content_type.identifier) }}"></use>
+                        </svg>
+                    </td>
+                    <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">{{ content_type.name }}</td>
+                    <td class="ez-table__cell">{{ content_type.identifier }}</td>
+                    <td class="ez-table__cell">{{ content_type.id }}</td>
+                    <td class="ez-table__cell">{{ content_type.modificationDate|ez_full_datetime }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {{ form_end(form_draft_content_types_delete) }}
+
+        {% if pager.haveToPaginate %}
+            <div class="row justify-content-center align-items-center mb-2 ez-pagination__spacing">
+                <span class="ez-pagination__text">
+                    {{ 'pagination.viewing'|trans({
+                        '%viewing%': pager.currentPageResults|length,
+                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                </span>
+            </div>
+            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5">
+                {{ pagerfanta(pager, 'ez', {
+                    'routeName': route_name,
+                    'routeParams': {'contentTypeGroupId': group.id}
+                }) }}
+            </div>
+        {% endif %}
+    </section>
+{% endif %}

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -4,30 +4,23 @@
 
 {% form_theme form_content_types_delete '@ezdesign/form_fields.html.twig'  %}
 
-{% if pager.nbResults or not drafts_only %}
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
-        <div class="ez-table-header__headline">
-            {% if not drafts_only %}
-                {{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
-            {% else %}
-                {{ 'content_type.view.list.drafts_title'|trans({ '%identifier%': content_type_group.identifier })|desc('Draft Content Types in %identifier%') }}</div>
-            {% endif %}
+        <div class="ez-table-header__headline">{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
         <div>
-            {% if can_create and not drafts_only %}
+            {% if can_create %}
                 <a
-                    href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
-                    title="{{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}"
-                    class="btn btn-primary">
+                        href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
+                        title="{{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}"
+                        class="btn btn-primary">
                     <svg class="ez-icon ez-icon-create">
                         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#create"></use>
                     </svg>
                 </a>
             {% endif %}
             {% if can_delete %}
-                {% if not drafts_only %}
-                    {% set modal_data_target = 'delete-content-types-modal' %}
-                    <button
+                {% set modal_data_target = 'delete-content-types-modal' %}
+                <button
                         id="delete-content-types"
                         type="button"
                         class="btn btn-danger"
@@ -35,30 +28,14 @@
                         data-toggle="modal"
                         data-target="#{{ modal_data_target }}"
                         title="{{ 'content_type.view.list.action.delete'|trans|desc('Delete Content Type') }}">
-                        <svg class="ez-icon ez-icon-trash">
-                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-                        </svg>
-                    </button>
-                {% else %}
-                    {% set modal_data_target = 'delete-draft-content-types-modal' %}
-                    <button
-                        id="delete-draft-content-types"
-                        type="button"
-                        class="btn btn-danger"
-                        data-toggle="modal"
-                        data-target="#{{ modal_data_target }}"
-                        title="{{ 'content_type.view.list.action.delete_drafts'|trans|desc('Delete draft Content Types') }}">
-                        <svg class="ez-icon ez-icon-trash">
-                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-                        </svg>
-                    </button>
-                {% endif %}
+                    <svg class="ez-icon ez-icon-trash">
+                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                    </svg>
+                </button>
                 {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
-                    'message': drafts_only
-                        ? 'draft_content_type.modal.message'|trans|desc('Do you want to delete draft Content Types?')
-                        : 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
-                    'data_click': drafts_only ? '#draft_content_types_delete_delete' : '#content_types_delete_delete',
+                    'message': 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
+                    'data_click': '#content_types_delete_delete',
                 }%}
             {% endif %}
         </div>
@@ -66,29 +43,26 @@
 
     {{ form_start(form_content_types_delete, {
         'action': path('ezplatform.content_type.bulk_delete', {"contentTypeGroupId": group.id} ),
-        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': drafts_only ? '#delete-draft-content-types' : '#delete-content-types' }
+        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-content-types' }
     }) }}
     <table class="ez-table table">
         <thead>
-            <tr>
-                <th class="ez-table__header-cell"></th>
-                <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
-                <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>
-                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
-                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
-                <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
-                {% if not drafts_only %}
-                    <th class="ez-table__header-cell"></th>
-                {% endif %}
-            </tr>
+        <tr>
+            <th class="ez-table__header-cell"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+            <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'content_type.view.list.column.name'|trans|desc('Name') }}</th>
+            <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
+            <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
+            <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
+            <th class="ez-table__header-cell"></th>
+        </tr>
         </thead>
         <tbody>
         {% for content_type in pager.currentPageResults %}
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_delete %}
-                        {{ form_widget(form_content_types_delete.content_types[content_type.id],
-                            {"disabled": not deletable[content_type.id], "checked": drafts_only}) }}
+                        {{ form_widget(form_content_types_delete.content_types[content_type.id], {"disabled": not deletable[content_type.id]}) }}
                     {% else %}
                         {% do form_content_types_delete.content_types.setRendered %}
                     {% endif %}
@@ -99,26 +73,21 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    {% if not drafts_only %}
-                        {% set view_url = path('ezplatform.content_type.view', {
-                                'contentTypeGroupId': content_type_group.id,
-                                'contentTypeId': content_type.id
-                            }) %}
-                        <a href="{{ view_url }}" title="{{ content_type.name }}">{{ content_type.name }}</a>
-                    {% else %}
-                        {{ content_type.name }}
-                    {% endif %}
+                    {% set view_url = path('ezplatform.content_type.view', {
+                        'contentTypeGroupId': content_type_group.id,
+                        'contentTypeId': content_type.id
+                    }) %}
+
+                    <a href="{{ view_url }}" title="{{ content_type.name }}">{{ content_type.name }}</a>
                 </td>
                 <td class="ez-table__cell">{{ content_type.identifier }}</td>
                 <td class="ez-table__cell">{{ content_type.id }}</td>
                 <td class="ez-table__cell">{{ content_type.modificationDate|ez_full_datetime }}</td>
-                {% if not drafts_only %}
-                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-                        {% if can_update %}
-                            {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
-                        {% endif %}
-                    </td>
-                {% endif %}
+                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                    {% if can_update %}
+                        {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
         </tbody>
@@ -141,7 +110,6 @@
         </div>
     {% endif %}
 </section>
-{% endif %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('ezplatform-admin-ui-content-type-list-js', null, 'ezplatform') }}

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -4,17 +4,17 @@
 
 {% form_theme form_content_types_delete '@ezdesign/form_fields.html.twig'  %}
 
-{% if pager.nbResults or not draftsOnly %}
+{% if pager.nbResults or not drafts_only %}
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">
-            {% if not draftsOnly %}
+            {% if not drafts_only %}
                 {{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
             {% else %}
                 {{ 'content_type.view.list.drafts_title'|trans({ '%identifier%': content_type_group.identifier })|desc('Draft Content Types in %identifier%') }}</div>
             {% endif %}
         <div>
-            {% if can_create and not draftsOnly %}
+            {% if can_create and not drafts_only %}
                 <a
                     href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
                     title="{{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}"
@@ -25,7 +25,7 @@
                 </a>
             {% endif %}
             {% if can_delete %}
-                {% if not draftsOnly %}
+                {% if not drafts_only %}
                     {% set modal_data_target = 'delete-content-types-modal' %}
                     <button
                         id="delete-content-types"
@@ -55,10 +55,10 @@
                 {% endif %}
                 {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
-                    'message': draftsOnly
+                    'message': drafts_only
                         ? 'draft_content_type.modal.message'|trans|desc('Do you want to delete draft Content Types?')
                         : 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
-                    'data_click': draftsOnly ? '#draft_content_types_delete_delete' : '#content_types_delete_delete',
+                    'data_click': drafts_only ? '#draft_content_types_delete_delete' : '#content_types_delete_delete',
                 }%}
             {% endif %}
         </div>
@@ -66,7 +66,7 @@
 
     {{ form_start(form_content_types_delete, {
         'action': path('ezplatform.content_type.bulk_delete', {"contentTypeGroupId": group.id} ),
-        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': draftsOnly ? '#delete-draft-content-types' : '#delete-content-types' }
+        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': drafts_only ? '#delete-draft-content-types' : '#delete-content-types' }
     }) }}
     <table class="ez-table table">
         <thead>
@@ -77,7 +77,7 @@
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
-                {% if not draftsOnly %}
+                {% if not drafts_only %}
                     <th class="ez-table__header-cell"></th>
                 {% endif %}
             </tr>
@@ -88,7 +88,7 @@
                 <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_delete %}
                         {{ form_widget(form_content_types_delete.content_types[content_type.id],
-                            {"disabled": not deletable[content_type.id], "checked": draftsOnly ? true : false}) }}
+                            {"disabled": not deletable[content_type.id], "checked": drafts_only}) }}
                     {% else %}
                         {% do form_content_types_delete.content_types.setRendered %}
                     {% endif %}
@@ -99,7 +99,7 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    {% if not draftsOnly %}
+                    {% if not drafts_only %}
                         {% set view_url = path('ezplatform.content_type.view', {
                                 'contentTypeGroupId': content_type_group.id,
                                 'contentTypeId': content_type.id
@@ -112,7 +112,7 @@
                 <td class="ez-table__cell">{{ content_type.identifier }}</td>
                 <td class="ez-table__cell">{{ content_type.id }}</td>
                 <td class="ez-table__cell">{{ content_type.modificationDate|ez_full_datetime }}</td>
-                {% if not draftsOnly %}
+                {% if not drafts_only %}
                     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
                         {% if can_update %}
                             {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}

--- a/src/bundle/Resources/views/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/list.html.twig
@@ -4,11 +4,17 @@
 
 {% form_theme form_content_types_delete '@ezdesign/form_fields.html.twig'  %}
 
+{% if pager.nbResults or not draftsOnly %}
 <section class="container mt-4 px-5">
     <div class="ez-table-header">
-        <div class="ez-table-header__headline">{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
+        <div class="ez-table-header__headline">
+            {% if not draftsOnly %}
+                {{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in %identifier%') }}</div>
+            {% else %}
+                {{ 'content_type.view.list.drafts_title'|trans({ '%identifier%': content_type_group.identifier })|desc('Draft Content Types in %identifier%') }}</div>
+            {% endif %}
         <div>
-            {% if can_create %}
+            {% if can_create and not draftsOnly %}
                 <a
                     href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"
                     title="{{ 'content_type.view.list.action.add'|trans|desc('Create a Content Type') }}"
@@ -19,23 +25,40 @@
                 </a>
             {% endif %}
             {% if can_delete %}
-                {% set modal_data_target = 'delete-content-types-modal' %}
-                <button
-                    id="delete-content-types"
-                    type="button"
-                    class="btn btn-danger"
-                    disabled
-                    data-toggle="modal"
-                    data-target="#{{ modal_data_target }}"
-                    title="{{ 'content_type.view.list.action.delete'|trans|desc('Delete Content Type') }}">
-                    <svg class="ez-icon ez-icon-trash">
-                        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
-                    </svg>
-                </button>
+                {% if not draftsOnly %}
+                    {% set modal_data_target = 'delete-content-types-modal' %}
+                    <button
+                        id="delete-content-types"
+                        type="button"
+                        class="btn btn-danger"
+                        disabled
+                        data-toggle="modal"
+                        data-target="#{{ modal_data_target }}"
+                        title="{{ 'content_type.view.list.action.delete'|trans|desc('Delete Content Type') }}">
+                        <svg class="ez-icon ez-icon-trash">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        </svg>
+                    </button>
+                {% else %}
+                    {% set modal_data_target = 'delete-draft-content-types-modal' %}
+                    <button
+                        id="delete-draft-content-types"
+                        type="button"
+                        class="btn btn-danger"
+                        data-toggle="modal"
+                        data-target="#{{ modal_data_target }}"
+                        title="{{ 'content_type.view.list.action.delete_drafts'|trans|desc('Delete draft Content Types') }}">
+                        <svg class="ez-icon ez-icon-trash">
+                            <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                        </svg>
+                    </button>
+                {% endif %}
                 {% include '@ezdesign/admin/bulk_delete_confirmation_modal.html.twig' with {
                     'id': modal_data_target,
-                    'message': 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
-                    'data_click': '#content_types_delete_delete',
+                    'message': draftsOnly
+                        ? 'draft_content_type.modal.message'|trans|desc('Do you want to delete draft Content Types?')
+                        : 'content_type.modal.message'|trans|desc('Do you want to delete Content Type?'),
+                    'data_click': draftsOnly ? '#draft_content_types_delete_delete' : '#content_types_delete_delete',
                 }%}
             {% endif %}
         </div>
@@ -43,7 +66,7 @@
 
     {{ form_start(form_content_types_delete, {
         'action': path('ezplatform.content_type.bulk_delete', {"contentTypeGroupId": group.id} ),
-        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#delete-content-types' }
+        'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': draftsOnly ? '#delete-draft-content-types' : '#delete-content-types' }
     }) }}
     <table class="ez-table table">
         <thead>
@@ -54,7 +77,9 @@
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.identifier'|trans|desc('Identifier') }}</th>
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.id'|trans|desc('ID') }}</th>
                 <th class="ez-table__header-cell">{{ 'content_type.view.list.column.modification_date'|trans|desc('Modification date') }}</th>
-                <th class="ez-table__header-cell"></th>
+                {% if not draftsOnly %}
+                    <th class="ez-table__header-cell"></th>
+                {% endif %}
             </tr>
         </thead>
         <tbody>
@@ -62,7 +87,8 @@
             <tr>
                 <td class="ez-table__cell ez-table__cell--has-checkbox">
                     {% if can_delete %}
-                        {{ form_widget(form_content_types_delete.content_types[content_type.id], {"disabled": not deletable[content_type.id]}) }}
+                        {{ form_widget(form_content_types_delete.content_types[content_type.id],
+                            {"disabled": not deletable[content_type.id], "checked": draftsOnly ? true : false}) }}
                     {% else %}
                         {% do form_content_types_delete.content_types.setRendered %}
                     {% endif %}
@@ -73,21 +99,26 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                {% set view_url = path('ezplatform.content_type.view', {
-                        'contentTypeGroupId': content_type_group.id,
-                        'contentTypeId': content_type.id
-                    }) %}
-
-                    <a href="{{ view_url }}" title="{{ content_type.name }}">{{ content_type.name }}</a>
+                    {% if not draftsOnly %}
+                        {% set view_url = path('ezplatform.content_type.view', {
+                                'contentTypeGroupId': content_type_group.id,
+                                'contentTypeId': content_type.id
+                            }) %}
+                        <a href="{{ view_url }}" title="{{ content_type.name }}">{{ content_type.name }}</a>
+                    {% else %}
+                        {{ content_type.name }}
+                    {% endif %}
                 </td>
                 <td class="ez-table__cell">{{ content_type.identifier }}</td>
                 <td class="ez-table__cell">{{ content_type.id }}</td>
                 <td class="ez-table__cell">{{ content_type.modificationDate|ez_full_datetime }}</td>
-                <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-                    {% if can_update %}
-                        {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
-                    {% endif %}
-                </td>
+                {% if not draftsOnly %}
+                    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
+                        {% if can_update %}
+                            {{ macros.content_type_edit(content_type, content_type_group, 'btn btn-icon mx-2') }}
+                        {% endif %}
+                    </td>
+                {% endif %}
             </tr>
         {% endfor %}
         </tbody>
@@ -110,6 +141,7 @@
         </div>
     {% endif %}
 </section>
+{% endif %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('ezplatform-admin-ui-content-type-list-js', null, 'ezplatform') }}

--- a/src/bundle/Resources/views/admin/content_type_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/view.html.twig
@@ -25,4 +25,12 @@
         page: page,
         routeName: route_name
     })) }}
+
+    {{ render(controller('EzPlatformAdminUiBundle:ContentType:list', {
+        contentTypeGroupId: content_type_group.id,
+        page: page,
+        routeName: route_name,
+        draftsOnly: true
+    })) }}
+
 {% endblock %}

--- a/src/bundle/Resources/views/admin/content_type_group/view.html.twig
+++ b/src/bundle/Resources/views/admin/content_type_group/view.html.twig
@@ -26,11 +26,10 @@
         routeName: route_name
     })) }}
 
-    {{ render(controller('EzPlatformAdminUiBundle:ContentType:list', {
+    {{ render(controller('EzPlatformAdminUiBundle:ContentType:draftList', {
         contentTypeGroupId: content_type_group.id,
         page: page,
-        routeName: route_name,
-        draftsOnly: true
+        routeName: route_name
     })) }}
 
 {% endblock %}

--- a/src/lib/Form/Data/ContentType/DraftContentTypesDeleteData.php
+++ b/src/lib/Form/Data/ContentType/DraftContentTypesDeleteData.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Data\ContentType;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+
+class DraftContentTypesDeleteData
+{
+    /** @var ContentType[]|null */
+    protected $contentTypes;
+
+    /**
+     * @param ContentType[]|null $contentTypes
+     */
+    public function __construct(?array $contentTypes = [])
+    {
+        $this->contentTypes = $contentTypes;
+    }
+
+    public function getContentTypes(): ?array
+    {
+        return $this->contentTypes;
+    }
+
+    /**
+     * @param ContentType[]|null $contentTypes
+     */
+    public function setContentTypes(?array $contentTypes)
+    {
+        $this->contentTypes = $contentTypes;
+    }
+}

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -21,6 +21,7 @@ use EzSystems\EzPlatformAdminUi\Form\Data\Content\Location\ContentMainLocationUp
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentType\ContentTypesDeleteData;
+use EzSystems\EzPlatformAdminUi\Form\Data\ContentType\DraftContentTypesDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupCreateData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupDeleteData;
 use EzSystems\EzPlatformAdminUi\Form\Data\ContentTypeGroup\ContentTypeGroupsDeleteData;
@@ -87,6 +88,7 @@ use EzSystems\EzPlatformAdminUi\Form\Type\Content\Location\ContentMainLocationUp
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\TranslationAddType;
 use EzSystems\EzPlatformAdminUi\Form\Type\Content\Translation\TranslationDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\ContentTypesDeleteType;
+use EzSystems\EzPlatformAdminUi\Form\Type\ContentType\DraftContentTypesDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentTypeGroup\ContentTypeGroupCreateType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentTypeGroup\ContentTypeGroupDeleteType;
 use EzSystems\EzPlatformAdminUi\Form\Type\ContentTypeGroup\ContentTypeGroupsDeleteType;
@@ -241,6 +243,18 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(ContentTypesDeleteType::class);
 
         return $this->formFactory->createNamed($name, ContentTypesDeleteType::class, $data);
+    }
+
+    /**
+     * @throws InvalidOptionsException
+     */
+    public function deleteDraftContentTypes(
+        DraftContentTypesDeleteData $data = null,
+        ?string $name = null
+    ): FormInterface {
+        $name = $name ?: StringUtil::fqcnToBlockPrefix(DraftContentTypesDeleteType::class);
+
+        return $this->formFactory->createNamed($name, DraftContentTypesDeleteType::class, $data);
     }
 
     /**

--- a/src/lib/Form/Type/ContentType/DraftContentTypesDeleteType.php
+++ b/src/lib/Form/Type/ContentType/DraftContentTypesDeleteType.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Form\Type\ContentType;
+
+use EzSystems\EzPlatformAdminUi\Form\Data\ContentType\DraftContentTypesDeleteData;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DraftContentTypesDeleteType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('content_types', CollectionType::class, [
+                'entry_type' => CheckboxType::class,
+                'required' => false,
+                'allow_add' => true,
+                'label' => false,
+                'entry_options' => ['label' => false],
+            ])
+            ->add('delete', SubmitType::class, [
+                'attr' => ['hidden' => true],
+                'label' => /** @Desc("Delete draft content types") */ 'draft_content_types_delete_form.delete',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => DraftContentTypesDeleteData::class,
+            'translation_domain' => 'forms',
+        ]);
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31460
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When `ContentTypeGroup` have some drafts assigned to it it's impossible to delete such a group. Under the list of available `ContentTypes` there has been added a table that contains draft records and the possibility to delete them, which will resolve the problem with group being unable to be deleted.

Required kernel PR: https://github.com/ezsystems/ezpublish-kernel/pull/3035

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
