### PR TITLE
EZP-31340: Corrected outdated choiceloaders (introduced Symfony bugfix)

### DIFF
--- a/src/lib/Form/Type/ChoiceList/Loader/BaseChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/BaseChoiceLoader.php
@@ -55,6 +55,11 @@ abstract class BaseChoiceLoader implements ChoiceLoaderInterface
             return [];
         }
 
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
         return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentCreateContentTypeChoiceLoader.php
@@ -62,11 +62,6 @@ class ContentCreateContentTypeChoiceLoader implements ChoiceLoaderInterface
             return [];
         }
 
-        // If no callable is set, values are the same as choices
-        if (null === $value) {
-            return $values;
-        }
-
         return $this->loadChoiceList($value)->getChoicesForValues($values);
     }
 

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentCreateLanguageChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentCreateLanguageChoiceLoader.php
@@ -61,11 +61,6 @@ class ContentCreateLanguageChoiceLoader implements ChoiceLoaderInterface
             return [];
         }
 
-        // If no callable is set, values are the same as choices
-        if (null === $value) {
-            return $values;
-        }
-
         return $this->loadChoiceList($value)->getChoicesForValues($values);
     }
 

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentTypeChoiceLoader.php
@@ -73,11 +73,6 @@ class ContentTypeChoiceLoader implements ChoiceLoaderInterface
             return [];
         }
 
-        // If no callable is set, values are the same as choices
-        if (null === $value) {
-            return $values;
-        }
-
         return $this->loadChoiceList($value)->getChoicesForValues($values);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31340
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a continue of https://github.com/ezsystems/ezplatform-admin-ui/pull/1211 fixed other places where outdated choice loaders are used (introduced Symfony bugfix)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
