### PR TITLE
EZP-30925: Added 'LanguageLimitation' functionality to 'Translations' tab

### DIFF
--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -31,6 +31,7 @@ use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
 use EzSystems\EzPlatformAdminUi\UI\Service\PathService;
@@ -141,8 +142,10 @@ class ValueFactory
      */
     public function createLanguage(Language $language, VersionInfo $versionInfo): UIValue\Content\Language
     {
+        $target = (new VersionBuilder())->translateToAnyLanguageOf([$language->languageCode])->build();
+
         return new UIValue\Content\Language($language, [
-            'userCanRemove' => $this->permissionResolver->canUser('content', 'remove', $versionInfo),
+            'userCanRemove' => $this->permissionResolver->canUser('content', 'remove', $versionInfo, [$target]),
             'userCanEdit' => $this->permissionResolver->canUser('content', 'edit', $versionInfo),
             'main' => $language->languageCode === $versionInfo->getContentInfo()->mainLanguageCode,
         ]);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30925
| Improvement?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Language remove checkboxes in `Content's` translations tab will now be checked against `content remove` policy.

Kernel PR: https://github.com/ezsystems/ezpublish-kernel/pull/3036

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review