### PR TITLE
EZEE-3020: Close tooltips when item is deleted

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,5 +1,18 @@
-(function(global, doc, eZ, $) {
+(function (global, doc, eZ, $) {
     const TOOLTIPS_SELECTOR = '[title]';
+    const observerConfig = {
+        childList: true,
+        subtree: true,
+    };
+    const observer = new MutationObserver((mutationsList) => {
+        mutationsList.forEach((mutation) => {
+            const showedTooltipNode = doc.querySelector('.ez-tooltip.show');
+
+            if (mutation.removedNodes.length && showedTooltipNode) {
+                showedTooltipNode.remove();
+            }
+        });
+    });
     const parse = (baseElement = doc) => {
         if (!baseElement) {
             return;
@@ -40,6 +53,8 @@
             $(tooltipNode).tooltip('hide');
         }
     };
+
+    observer.observe(doc.querySelector('body'), observerConfig);
 
     eZ.addConfig('helpers.tooltips', {
         parse,


### PR DESCRIPTION
Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3020
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Added auto hide of tooltips if tooltip node has been deleted

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
