### PR TITLE
EZP-31344: Added border and toggler for preview content

### DIFF
--- a/src/bundle/Resources/encore/ez.js.config.js
+++ b/src/bundle/Resources/encore/ez.js.config.js
@@ -158,6 +158,7 @@ module.exports = (Encore) => {
         .addEntry('ezplatform-admin-ui-change-user-password-js', [path.resolve(__dirname, '../public/js/scripts/user_password.change.js')])
         .addEntry('ezplatform-admin-ui-content-edit-parts-js', [
             path.resolve('./vendor/ezsystems/ezplatform-admin-ui-assets/Resources/public/vendors/leaflet/dist/leaflet.js'),
+            path.resolve(__dirname, '../public/js/scripts/admin.location.tab.js'),
             path.resolve(__dirname, '../public/js/scripts/admin.content.edit.js'),
             path.resolve(__dirname, '../public/js/scripts/fieldType/base/base-field.js'),
             path.resolve(__dirname, '../public/js/scripts/fieldType/base/base-file-field.js'),

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -1,4 +1,4 @@
-(function (global, doc, eZ, $) {
+(function (global, doc, eZ) {
     const enterKeyCode = 13;
     const inputTypeToPreventSubmit = [
         'checkbox',
@@ -83,6 +83,8 @@
                     }, new Set())
             ).join();
 
+            fields.forEach((field) => field.removeAttribute('id'));
+
             doc.querySelectorAll('.ez-tabs__nav-item').forEach((navItem) => {
                 navItem.classList.remove('ez-tabs__nav-item--invalid');
             });
@@ -120,4 +122,4 @@
             itemAuthor.classList.toggle('ez-details-items--collapsed');
         });
     }
-})(window, window.document, window.eZ, window.jQuery);
+})(window, window.document, window.eZ);

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -25,7 +25,6 @@
     const itemAuthor = doc.querySelector('.ez-details-items__author-breadcrumbs');
     const itemAuthorToggler = doc.querySelector('.ez-details-items__toggler');
     const submitBtns = form.querySelectorAll('[type="submit"]:not([formnovalidate])');
-    const firstNavLink = doc.querySelector('.ez-tabs .nav-link');
     const getValidationResults = (validator) => {
         const isValid = validator.isValid();
         const validatorName = validator.constructor.name;
@@ -69,7 +68,6 @@
         const invalidTabs = validators.map(getInvalidTabs);
 
         if (isFormValid) {
-            console.log('valid');
             btn.dataset.isFormValid = 1;
             // for some reason trying to fire click event inside the event handler flow is impossible
             // the following line breaks the flow so it's possible to fire click event on a button again.
@@ -85,7 +83,6 @@
                     }, new Set())
             ).join();
 
-            // Hide warnings icons
             doc.querySelectorAll('.ez-tabs__nav-item').forEach((navItem) => {
                 navItem.classList.remove('ez-tabs__nav-item--invalid');
             });
@@ -122,10 +119,5 @@
             itemAuthorToggler.classList.toggle('ez-details-items__toggler--gray');
             itemAuthor.classList.toggle('ez-details-items--collapsed');
         });
-    }
-
-    //Set active for first tab
-    if (firstNavLink) {
-        $(firstNavLink).tab('show');
     }
 })(window, window.document, window.eZ, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -1,4 +1,4 @@
-(function(global, doc, eZ) {
+(function (global, doc, eZ) {
     const enterKeyCode = 13;
     const inputTypeToPreventSubmit = [
         'checkbox',
@@ -28,7 +28,16 @@
     const getValidationResults = (validator) => {
         const isValid = validator.isValid();
         const validatorName = validator.constructor.name;
-        const result = { isValid, validatorName };
+        const tabErroKeys = validator.fieldsToValidate.reduce((tabsId, value) => {
+            const tabPane = value.item.closest('.tab-pane');
+
+            if (tabPane && value.item.classList.contains('is-invalid')) {
+                tabsId.push(tabPane.id);
+            }
+
+            return tabsId;
+        }, []);
+        const result = { isValid, validatorName, tabErroKeys };
 
         return result;
     };
@@ -70,6 +79,25 @@
                         return total;
                     }, new Set())
             ).join();
+
+            // Hide warnings icons
+            doc.querySelectorAll(`.nav-item .ez-warning-icon`).forEach((node) => {
+                node.style.display = 'none';
+            });
+
+            // Show warnings icons for tabs with invalide fields
+            validationResults
+                .reduce((total, result) => {
+                    result.tabErroKeys.map((key) => {
+                        total.push(key);
+                    });
+
+                    return total;
+                }, [])
+                .filter((value, index, self) => self.indexOf(value) === index)
+                .forEach((key) => {
+                    doc.querySelector(`.nav-item--${key} .ez-warning-icon`).style.display = 'block';
+                });
 
             fields.forEach((field) => field.removeAttribute('id'));
 

--- a/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.tooglecontentpreview.js
@@ -1,21 +1,26 @@
-(function(global, doc, localStorage, $) {
+(function (global, doc, localStorage, $) {
     const CONTENT_PREVIEW_COLLAPSE_SELECTOR = '.ez-content-preview-collapse';
-    const CONTENT_PREVIEW_TOGGLE_STATE_KEY = 'ez-content-preview-collapsed';
-    const getContentPreviewToggleState = () => {
-        const value = localStorage.getItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY);
+    const DEFAULT_CONTENT_PREVIEW_TOGGLE_STATE_KEY = 'ez-content-preview-collapsed';
+    const getStateKey = (collapseTarget) => {
+        return collapseTarget.dataset.collapseStateKey || DEFAULT_CONTENT_PREVIEW_TOGGLE_STATE_KEY;
+    };
+    const getContentPreviewToggleState = (collapsable) => {
+        const stateKey = getStateKey(collapsable);
+        const value = localStorage.getItem(stateKey);
 
         return !!JSON.parse(value);
     };
-    const setContentPreviewToggleState = (value) => {
-        localStorage.setItem(CONTENT_PREVIEW_TOGGLE_STATE_KEY, value);
+    const setContentPreviewToggleState = (event, value) => {
+        const stateKey = getStateKey(event.target);
+        localStorage.setItem(stateKey, value);
     };
 
     doc.querySelectorAll(CONTENT_PREVIEW_COLLAPSE_SELECTOR).forEach((collapsable) => {
         collapsable = $(collapsable).collapse({
-            toggle: getContentPreviewToggleState(),
+            toggle: getContentPreviewToggleState(collapsable),
         });
 
-        collapsable.on('hide.bs.collapse', () => setContentPreviewToggleState(true));
-        collapsable.on('show.bs.collapse', () => setContentPreviewToggleState(false));
+        collapsable.on('hide.bs.collapse', (event) => setContentPreviewToggleState(event, true));
+        collapsable.on('show.bs.collapse', (event) => setContentPreviewToggleState(event, false));
     });
 })(window, window.document, window.localStorage, window.jQuery);

--- a/src/bundle/Resources/public/scss/_field-group.scss
+++ b/src/bundle/Resources/public/scss/_field-group.scss
@@ -1,60 +1,21 @@
 .ez-view-rawcontentview {
+    margin-bottom: calculateRem(25px);
+    border: calculateRem(1px) solid $ez-ground-base-dark;
+
     .ez-raw-content-title {
-        border-bottom: calculateRem(1px) solid $ez-color-secondary;
+        min-height: calculateRem(44px);
+        padding: calculateRem(3px) calculateRem(15px);
+        background: $ez-ground-base-dark;
         color: $ez-color-secondary;
+        align-items: center;
 
         h2 {
-            margin-top: calculateRem(16px);
-            margin-bottom: 0;
-            padding-bottom: calculateRem(8px);
+            margin: 0 calculateRem(10px) 0 0;
             font-size: calculateRem(18px);
             font-weight: 400;
         }
 
-        .ez-content-preview-toggle {
-            color: $ez-color-secondary;
-            position: relative;
-            padding-right: calculateRem(24px);
-            display: inline-block;
-
-            &:hover {
-                text-decoration: none;
-            }
-
-            &:before,
-            &:after {
-                content: '';
-                width: calculateRem(1px);
-                height: calculateRem(7px);
-                background-color: $ez-color-secondary;
-                position: absolute;
-                top: 50%;
-                right: calculateRem(-16px);
-                transition: all 0.2s $ez-admin-transition;
-            }
-
-            &:before {
-                transform: translate(calculateRem(-27px), -50%) rotate(135deg);
-            }
-
-            &:after {
-                transform: translate(calculateRem(-22px), -50%) rotate(45deg);
-            }
-
-            &.collapsed {
-                &:before {
-                    transform: translate(calculateRem(-27px), -20%) rotate(45deg);
-                }
-
-                &:after {
-                    transform: translate(calculateRem(-27px), -80%) rotate(-45deg);
-                }
-            }
-        }
-
         .form-inline {
-            padding-bottom: calculateRem(4px);
-
             &.collapsing {
                 -webkit-transition: none;
                 transition: none;
@@ -73,12 +34,49 @@
         font-size: calculateRem(18px);
     }
 
+    &__toggler {
+        position: relative;
+        display: block;
+        width: 100%;
+        margin-bottom: calculateRem(10px);
+        padding: calculateRem(5px) 0;
+        font-size: calculateRem(17px);
+        font-weight: 400;
+        color: $ez-color-secondary;
+        border-bottom: calculateRem(1px) solid;
+
+        &:hover {
+            color: $ez-color-secondary;
+            text-decoration: none;
+        }
+
+        &:after {
+            content: '';
+            position: absolute;
+            top: calculateRem(20px);
+            right: calculateRem(5px);
+            display: inline-block;
+            width: calculateRem(7px);
+            height: calculateRem(7px);
+            border-right: calculateRem(2px) solid $ez-color-secondary;
+            border-bottom: calculateRem(2px) solid $ez-color-secondary;
+            transition: all 0.2s $ez-admin-transition;
+            transform: rotate(-135deg);
+        }
+
+        &.collapsed {
+            &:after {
+                transform: rotate(-45deg);
+            }
+        }
+    }
+
     .ez-content-field-name {
         background-color: $ez-color-base-pale;
     }
 
     .ez-content-field {
-        padding: 0 calculateRem(16px);
+        padding: 0;
         margin-bottom: calculateRem(24px);
 
         .ez-content-field-name {

--- a/src/bundle/Resources/public/scss/_field-group.scss
+++ b/src/bundle/Resources/public/scss/_field-group.scss
@@ -60,7 +60,7 @@
             height: calculateRem(7px);
             border-right: calculateRem(2px) solid $ez-color-secondary;
             border-bottom: calculateRem(2px) solid $ez-color-secondary;
-            transition: all 0.2s $ez-admin-transition;
+            transition: all 0.3s $ez-admin-transition;
             transform: rotate(-135deg);
         }
 

--- a/src/bundle/Resources/public/scss/_tabs.scss
+++ b/src/bundle/Resources/public/scss/_tabs.scss
@@ -149,4 +149,13 @@
     &--role {
         border-bottom: none;
     }
+
+    &--content-edit {
+        border-bottom: none;
+        background-color: $ez-ground-base-pale;
+
+        .nav-item {
+            position: relative;
+        }
+    }
 }

--- a/src/bundle/Resources/public/scss/_warning-icon.scss
+++ b/src/bundle/Resources/public/scss/_warning-icon.scss
@@ -1,23 +1,29 @@
 .ez-tabs {
-    .ez-warning-icon {
-        position: absolute;
-        z-index: 2;
-        right: -0.5rem;
-        left: auto;
-        background: $ez-color-danger;
-        border-radius: 50%;
-        width: 1.25rem;
-        height: 1.25rem;
-        top: -0.5rem;
-        align-items: center;
-        justify-content: center;
-        display: none;
-        
-        .ez-icon {
-            height: calculateRem(12px);
-            width: calculateRem(12px);
-            margin: calculateRem(-10px) calculateRem(4px) 0;
-            fill: $ez-white;
+    &__nav-item {
+        .ez-warning-icon {
+            position: absolute;
+            top: 0;
+            right: 0;
+            left: auto;
+            background: $ez-color-danger;
+            border-radius: 50%;
+            width: 1.25rem;
+            height: 1.25rem;
+            align-items: center;
+            justify-content: center;
+            display: none;
+
+            .ez-icon {
+                height: calculateRem(12px);
+                width: calculateRem(12px);
+                margin: calculateRem(-10px) calculateRem(4px) 0;
+            }
+        }
+
+        &--invalid {
+            .ez-warning-icon {
+                display: block;
+            }
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_warning-icon.scss
+++ b/src/bundle/Resources/public/scss/_warning-icon.scss
@@ -1,9 +1,10 @@
 .ez-tabs {
     .ez-warning-icon {
         position: absolute;
+        z-index: 2;
         right: -0.5rem;
         left: auto;
-        background: #d92d42;
+        background: $ez-color-danger;
         border-radius: 50%;
         width: 1.25rem;
         height: 1.25rem;
@@ -13,10 +14,10 @@
         display: none;
         
         .ez-icon {
-            height: 12px;
-            width: 12px;
-            margin: -10px 4px 0;
-            fill: #fff;
+            height: calculateRem(12px);
+            width: calculateRem(12px);
+            margin: calculateRem(-10px) calculateRem(4px) 0;
+            fill: $ez-white;
         }
     }
 }

--- a/src/bundle/Resources/public/scss/_warning-icon.scss
+++ b/src/bundle/Resources/public/scss/_warning-icon.scss
@@ -1,0 +1,22 @@
+.ez-tabs {
+    .ez-warning-icon {
+        position: absolute;
+        right: -0.5rem;
+        left: auto;
+        background: #d92d42;
+        border-radius: 50%;
+        width: 1.25rem;
+        height: 1.25rem;
+        top: -0.5rem;
+        align-items: center;
+        justify-content: center;
+        display: none;
+        
+        .ez-icon {
+            height: 12px;
+            width: 12px;
+            margin: -10px 4px 0;
+            fill: #fff;
+        }
+    }
+}

--- a/src/bundle/Resources/public/scss/ezplatform.scss
+++ b/src/bundle/Resources/public/scss/ezplatform.scss
@@ -76,3 +76,4 @@
 @import 'main-row';
 @import 'content-tree';
 @import 'flatpickr';
+@import 'warning-icon';

--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -1,35 +1,35 @@
 <section class="ez-view-rawcontentview">
-    <div class="ez-raw-content-title d-flex justify-content-between mb-3">
-        <h2>
-            <a data-toggle="collapse" href=".ez-content-preview-collapse" class="ez-content-preview-toggle">
-                {{ 'tab.view.preview'|trans()|desc('Preview') }}
-            </a>
-        </h2>
+    <div class="ez-raw-content-title d-flex">
+        <h2>{{ 'tab.view.preview'|trans()|desc('Preview') }}</h2>
         {% block extras %}{% endblock %}
     </div>
 
     {% block fields %}
-        <div class="ez-content-preview-collapse collapse show">
+        <div class="ez-content-preview">
             {% for group in field_definitions_by_group %}
                 {% if group.fieldDefinitions|length > 0 %}
                     <section class="ez-fieldgroup container">
-                        <h3 class="ez-fieldgroup__name">{{ group.name|capitalize }}</h3>
-                        {% for field_definition in group.fieldDefinitions %}
-                            {% block field %}
-                                <div class="ez-content-field">
-                                    <p class="ez-content-field-name">{{ field_definition.name }}:</p>
-                                    <div class="ez-content-field-value">
-                                        {% if ez_field_is_empty(content, field_definition.identifier) and field_definition.fieldTypeIdentifier is not same as('ezboolean') %}
-                                            <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
-                                        {% else %}
-                                            {{ ez_render_field(content, field_definition.identifier, {
-                                                'template': '@ezdesign/ui/field_type/preview/content_fields.html.twig'
-                                            }) }}
-                                        {% endif %}
+                        <a data-toggle="collapse" href=".ez-content-fields-{{ group.name|replace({' ': ''}) }}-collapse" class="ez-fieldgroup__toggler">
+                            {{ group.name|capitalize }}
+                        </a>
+                        <div class="ez-content-fields-{{ group.name|replace({' ': ''}) }}-collapse show">
+                            {% for field_definition in group.fieldDefinitions %}
+                                {% block field %}
+                                    <div class="ez-content-field">
+                                        <p class="ez-content-field-name">{{ field_definition.name }}:</p>
+                                        <div class="ez-content-field-value">
+                                            {% if ez_field_is_empty(content, field_definition.identifier) and field_definition.fieldTypeIdentifier is not same as('ezboolean') %}
+                                                <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
+                                            {% else %}
+                                                {{ ez_render_field(content, field_definition.identifier, {
+                                                    'template': '@ezdesign/ui/field_type/preview/content_fields.html.twig'
+                                                }) }}
+                                            {% endif %}
+                                        </div>
                                     </div>
-                                </div>
-                            {% endblock %}
-                        {% endfor %}
+                                {% endblock %}
+                            {% endfor %}
+                        </div>
                     </section>
                 {% endif %}
             {% endfor %}

--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -8,11 +8,13 @@
         <div class="ez-content-preview">
             {% for group in field_definitions_by_group %}
                 {% if group.fieldDefinitions|length > 0 %}
+                    {% set collapse_state_key = 'ez-content-preview-collapse__' ~ group.name|lower|replace({' ': ''}) %}
+
                     <section class="ez-fieldgroup container">
-                        <a data-toggle="collapse" href=".ez-content-fields-{{ group.name|replace({' ': ''}) }}-collapse" class="ez-fieldgroup__toggler">
+                        <a data-toggle="collapse" href=".{{ collapse_state_key }}" class="ez-fieldgroup__toggler">
                             {{ group.name|capitalize }}
                         </a>
-                        <div class="ez-content-fields-{{ group.name|replace({' ': ''}) }}-collapse show">
+                        <div class="{{ collapse_state_key }} ez-content-preview-collapse collapse show" data-collapse-state-key="{{ collapse_state_key }}">
                             {% for field_definition in group.fieldDefinitions %}
                                 {% block field %}
                                     <div class="ez-content-field">

--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -10,7 +10,7 @@
                 {% if group.fieldDefinitions|length > 0 %}
                     {% set group_name = group.name|lower|replace({' ': ''}) %}
                     {% set collapse_state_key = 'collapse-' ~ group_name ~ location.id %}
-                    {% set collapse_class_name = 'ez-content-preview-collapse__' ~ group_name %}
+                    {% set collapse_class_name = 'ez-content-preview-collapse--' ~ group_name %}
 
                     <section class="ez-fieldgroup container">
                         <a data-toggle="collapse" href=".{{ collapse_class_name }}" class="ez-fieldgroup__toggler">

--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -8,13 +8,15 @@
         <div class="ez-content-preview">
             {% for group in field_definitions_by_group %}
                 {% if group.fieldDefinitions|length > 0 %}
-                    {% set collapse_state_key = 'ez-content-preview-collapse__' ~ group.name|lower|replace({' ': ''}) %}
+                    {% set group_name = group.name|lower|replace({' ': ''}) %}
+                    {% set collapse_state_key = 'collapse-' ~ group_name ~ location.id %}
+                    {% set collapse_class_name = 'ez-content-preview-collapse__' ~ group_name %}
 
                     <section class="ez-fieldgroup container">
-                        <a data-toggle="collapse" href=".{{ collapse_state_key }}" class="ez-fieldgroup__toggler">
+                        <a data-toggle="collapse" href=".{{ collapse_class_name }}" class="ez-fieldgroup__toggler">
                             {{ group.name|capitalize }}
                         </a>
-                        <div class="{{ collapse_state_key }} ez-content-preview-collapse collapse show" data-collapse-state-key="{{ collapse_state_key }}">
+                        <div class="{{ collapse_class_name }} ez-content-preview-collapse collapse show" data-collapse-state-key="{{ collapse_state_key }}">
                             {% for field_definition in group.fieldDefinitions %}
                                 {% block field %}
                                     <div class="ez-content-field">

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -59,9 +59,9 @@
 {% endblock %}
 
 {% block form_fields %}
-    <section class="container mt-4 mb-5 px-5">
+    <section class="container mt-4 mb-5">
         <div class="card ez-card">
-            <div class="card-body">
+            <div class="card-body px-0">
                 {{ parent() }}
                 {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
                 {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -24,10 +24,8 @@
 
                 {% block form_fields %}
                     {% if grouped_fields is defined and grouped_fields|length > 1 %}
-                        {% set sortedKeys = grouped_fields|keys|sort %}
-                        
                         <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
-                            {% for key in sortedKeys %}
+                            {% for key, group in grouped_fields %}
                                 <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ key }}">
                                     <a href="#{{ key }}" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
                                         {{ key|capitalize }}

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -23,21 +23,21 @@
                 {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
 
                 {% block form_fields %}
-                    {% if grouped_form_fields_views is defined and grouped_form_fields_views|length > 1 %}
+                    {% if grouped_fields is defined and grouped_fields|length > 1 %}
                         <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
-                            {% for key, group in grouped_form_fields_views %}
-                                <li role="presentation" class="nav-item nav-item--{{ key }}-key">
-                                    <a href="#{{ key }}-key" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
+                            {% for key, group in grouped_fields %}
+                                <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ key }}">
+                                    <a href="#{{ key }}" class="nav-link" role="tab" data-toggle="tab">
                                         {{ key|capitalize }}
                                     </a>
-                                    {% include '@ezdesign/content/warning_icon.html.twig' %}
+                                    {% include '@ezdesign/ui/component/warning_icon.html.twig' %}
                                 </li>
                             {% endfor %}
                         </ul>
 
                         <div class="tab-content px-3">
-                            {% for key, group in grouped_form_fields_views %}
-                                <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ key }}-key">
+                            {% for key, group in grouped_fields %}
+                                <div role="tabpanel" class="tab-pane" id="{{ key }}">
                                     {% for field in group %}
                                         {% set formField = form.fieldsData[field] %}
                                         

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -24,10 +24,12 @@
 
                 {% block form_fields %}
                     {% if grouped_fields is defined and grouped_fields|length > 1 %}
+                        {% set sortedKeys = grouped_fields|keys|sort %}
+                        
                         <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
-                            {% for key, group in grouped_fields %}
+                            {% for key in sortedKeys %}
                                 <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ key }}">
-                                    <a href="#{{ key }}" class="nav-link" role="tab" data-toggle="tab">
+                                    <a href="#{{ key }}" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
                                         {{ key|capitalize }}
                                     </a>
                                     {% include '@ezdesign/ui/component/warning_icon.html.twig' %}
@@ -37,7 +39,7 @@
 
                         <div class="tab-content px-3">
                             {% for key, group in grouped_fields %}
-                                <div role="tabpanel" class="tab-pane" id="{{ key }}">
+                                <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ key }}">
                                     {% for field in group %}
                                         {% set formField = form.fieldsData[field] %}
                                         

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -23,21 +23,60 @@
                 {{ form_start(form, {'attr': {'class': 'ez-form-validate'}}) }}
 
                 {% block form_fields %}
-                    {% for field in form.fieldsData %}
-                        {% if not field.rendered %}
-                            {% if field.value is defined %}
-                                {{- form_widget(field) -}}
-                            {% else %}
-                                <div>
-                                    {{- form_label(field) -}}
-                                    <p class="non-editable">
-                                        {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
-                                    </p>
-                                    {% do field.setRendered() %}
+                    {% if grouped_form_fields_views is defined and grouped_form_fields_views|length > 1 %}
+                        <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
+                            {% for key, group in grouped_form_fields_views %}
+                                <li role="presentation" class="nav-item nav-item--{{ key }}-key">
+                                    <a href="#{{ key }}-key" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
+                                        {{ key|capitalize }}
+                                    </a>
+                                    {% include '@ezdesign/content/warning_icon.html.twig' %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+
+                        <div class="tab-content px-3">
+                            {% for key, group in grouped_form_fields_views %}
+                                <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ key }}-key">
+                                    {% for field in group %}
+                                        {% set formField = form.fieldsData[field] %}
+                                        
+                                        {% if not formField.rendered %}
+                                            {% if formField.value is defined %}
+                                                {{- form_widget(formField) -}}
+                                            {% else %}
+                                                <div>
+                                                    {{- form_label(formField) -}}
+                                                    <p class="non-editable">
+                                                        {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
+                                                    </p>
+                                                    {% do formField.setRendered() %}
+                                                </div>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endfor %}
                                 </div>
-                            {% endif %}
-                        {% endif %}
-                    {%- endfor %}
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <div class="px-3">
+                            {% for field in form.fieldsData %}
+                                {% if not field.rendered %}
+                                    {% if field.value is defined %}
+                                        {{- form_widget(field) -}}
+                                    {% else %}
+                                        <div>
+                                            {{- form_label(field) -}}
+                                            <p class="non-editable">
+                                                {{ "content.field.non_editable"|trans|desc('This Field Type is not editable') }}
+                                            </p>
+                                            {% do field.setRendered() %}
+                                        </div>
+                                    {% endif %}
+                                {% endif %}
+                            {%- endfor %}
+                        </div>
+                    {% endif %}
                 {% endblock %}
 
                 {{ form_end(form) }}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -78,7 +78,7 @@
 {% block form_fields %}
     <section class="container mt-4 px-5 mb-5">
         <div class="card ez-card">
-            <div class="card-body">
+            <div class="card-body px-0">
                 {{ parent() }}
                 {{ form_widget(form.publish, {'attr': {'hidden': 'hidden'}}) }}
                 {{ form_widget(form.saveDraft, {'attr': {'hidden': 'hidden'}}) }}

--- a/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
@@ -93,7 +93,6 @@
                         {{ form_end(form_subitems_content_edit) }}
                         <div class="container px-5">
                             <section class="ez-fieldgroup">
-                                <h2 class="ez-fieldgroup__name">{{ 'content.view.subitems'|trans|desc('Sub-items') }}</h2>
                                 {% set udwConfigSingle = ez_udw_config('single_container', {}) %}
                                 <div class="ez-sil"
                                     data-location="{{ location.id }}"

--- a/src/bundle/Resources/views/themes/admin/content/tab/content.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/content.html.twig
@@ -4,7 +4,7 @@
     {% set current_language = app.request.get('languageCode') ?: content.prioritizedFieldLanguageCode %}
 
     {% if languages|length > 1  %}
-    <form class="form-inline ez-content-preview-collapse collapse show">
+    <form class="form-inline">
         <select class="form-control ez-location-language-change">
             {% for language in languages %}
                 <option value="{{ path('_ez_content_translation_view', {

--- a/src/bundle/Resources/views/themes/admin/content/warning_icon.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/warning_icon.html.twig
@@ -1,0 +1,5 @@
+<span class="ez-warning-icon">
+    <svg class="ez-icon ez-icon--warning">
+        <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#warning"></use>
+    </svg>
+</span>

--- a/src/bundle/Resources/views/themes/admin/ui/component/warning_icon.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/warning_icon.html.twig
@@ -1,5 +1,5 @@
 <span class="ez-warning-icon">
-    <svg class="ez-icon ez-icon--warning">
+    <svg class="ez-icon ez-icon--warning ez-icon--light">
         <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#warning"></use>
     </svg>
 </span>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31344
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no

I made few improvments (not all in this ticket because I need help of backend team).
Changes:
- Added border for preview of content
- Added toggler for field group 
- Removed toggler from preview of content
- Removed sub items section title row

Related PR's:
https://github.com/ezsystems/ezplatform-kernel/pull/73
https://github.com/ezsystems/ezplatform-content-forms/pull/26

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
