### PR TITLE
[BEHAT]added test case regarding selecting ImageAsset from repository (EZP-31551)

### DIFF
--- a/features/standard/ContentTypeFields.feature
+++ b/features/standard/ContentTypeFields.feature
@@ -50,6 +50,25 @@ Feature: Content fields setting and editing
       | ezmatrix             | Matrix                       | Min_rows:2,Columns:col1-col2-col3                                     | value     | col1:col2:col3,Ala:miała:kota,Szpak:dziobał:bociana,Bociana:dziobał:szpak |            |                       |         |             | Matrix                    |
       | ezimageasset         | Image Asset                  |                                                                       | value     |  imageasset1.png.zip                                                      |            |                       |         |             | imageasset1.png           |
 
+  @javascript @common @admin
+  Scenario: Create an ImageAsset Content item and edit specified field
+    Given I create "Image" Content items in "/Media/Images/" in "eng-GB"
+      | name             | image                                                                              |
+      | ImageAssetImage  | vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Images/small2.jpg  |
+      And I create a 'Image Asset CT2' Content Type in "Content" with 'ImageAssetCT2' identifier
+      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable | Settings        |
+      | Image Asset | ImageAField  | imageafield       | yes      | no	       | yes          |                 |
+      And I am logged as "admin"
+      And I go to "Content structure" in "Content" tab
+    When I start creating a new content 'Image Asset CT2'
+      And I select "ImageAssetImage" from Image Asset Repository for "ImageAField" field
+      And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+      And I should be on content item page "ImageAssetImage" of type "Image Asset CT2" in root path
+      And content attributes equal
+      | label          | value      |
+      | ImageAField    | small2.jpg |
+
   @javascript @common
   Scenario Outline: Edit content item with given field
     Given I am logged as "admin"

--- a/src/lib/Behat/BusinessContext/ContentUpdateContext.php
+++ b/src/lib/Behat/BusinessContext/ContentUpdateContext.php
@@ -8,6 +8,8 @@ namespace EzSystems\EzPlatformAdminUi\Behat\BusinessContext;
 
 use Behat\Gherkin\Node\TableNode;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\EzEnvironmentConstants;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ContentUpdateForm;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\ContentUpdateItemPage;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\PageObjectFactory;
 
@@ -24,6 +26,15 @@ class ContentUpdateContext extends BusinessContext
             $values = $this->filterOutNonEmptyValues($row);
             $updateItemPage->contentUpdateForm->fillFieldWithValue($row['label'], $values);
         }
+    }
+
+    /**
+     * @When I select :contentPath from Image Asset Repository for :fieldName field
+     */
+    public function selectContentFromIARepository(string $contentPath, string $fieldName): void
+    {
+        $contentUpdateForm = ElementFactory::createElement($this->utilityContext, ContentUpdateForm::ELEMENT_NAME);
+        $contentUpdateForm->getField($fieldName)->selectFromRepository($contentPath);
     }
 
     private function filterOutNonEmptyValues(array $parameters): array

--- a/src/lib/Behat/PageElement/ContentField.php
+++ b/src/lib/Behat/PageElement/ContentField.php
@@ -20,7 +20,7 @@ class ContentField extends Element
     {
         parent::__construct($context);
         $this->fields = [
-            'nthFieldContainer' => '.ez-content-field:nth-child(%s)',
+            'nthFieldContainer' => 'div.ez-content-field:nth-of-type(%s)',
             'fieldName' => '.ez-content-field-name',
             'fieldValue' => '.ez-content-field-value',
             'fieldValueContainer' => ':first-child',
@@ -32,7 +32,7 @@ class ContentField extends Element
         $fieldIndex = $this->context->getElementPositionByText(sprintf('%s:', $label), $this->fields['fieldName']);
         $fieldLocator = sprintf(
             '%s %s',
-            sprintf($this->fields['nthFieldContainer'], $fieldIndex + 1),
+            sprintf($this->fields['nthFieldContainer'], $fieldIndex),
             $this->fields['fieldValue']
         );
 

--- a/src/lib/Behat/PageElement/Fields/ImageAsset.php
+++ b/src/lib/Behat/PageElement/Fields/ImageAsset.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Notification;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\UniversalDiscoveryWidget;
 use PHPUnit\Framework\Assert;
 
 class ImageAsset extends Image
@@ -32,5 +33,14 @@ class ImageAsset extends Image
         $imageAssetNotification = ElementFactory::createElement($this->context, Notification::ELEMENT_NAME);
         $imageAssetNotification->verifyAlertSuccess();
         Assert::assertEquals(self::IMAGE_ASSET_NOTIFICATION_MESSAGE, $imageAssetNotification->getMessage());
+    }
+
+    public function selectFromRepository(string $path): void
+    {
+        $this->context->findElement(sprintf('%s .ez-data-source__btn-select', $this->fields['fieldContainer']))->click();
+        $udw = ElementFactory::createElement($this->context, UniversalDiscoveryWidget::ELEMENT_NAME);
+        $udw->verifyVisibility();
+        $udw->selectContent($path);
+        $udw->confirm();
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31551
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Adds a new Scenario that tests that an existing Image from the repository can be selected when creating a Content Type with Image Asset.
Also adds a new way of selecting content in ContentField.php


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
