### PR TITLE
[Behat] Removed clearing the field before filling input

### DIFF
--- a/src/lib/Behat/PageElement/Fields/DefaultFieldElement.php
+++ b/src/lib/Behat/PageElement/Fields/DefaultFieldElement.php
@@ -30,7 +30,6 @@ class DefaultFieldElement extends Element
         switch ($this->fieldNode->getAttribute('type')) {
             case 'text':
             case 'email':
-                $this->fieldNode->setValue('');
                 $this->fieldNode->setValue($value);
                 break;
             case 'checkbox':


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31648
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Tests for Languages, Sections, Content Types etc. are failing when trying to set the value for input fields. Example: https://res.cloudinary.com/ezplatformtravis/image/upload/v1589987442/screenshots/5ec548724f4d5131244793-vendor_ezsystems_ezplatform-admin-ui_features_standard_languages_feature_22_ndmmry.png (the fields are supposed to be filled, but they are empty).

All these tests are sharing the same (modified in this PR) piece of code, which first tries to clear the input field by setting it to empty string and then tries to set the correct value.

I believe that clearing the field first is the cause of this issue - this is not something we usually do (and as the tests are passing we can see that it's not required).

Build with 20 passing AdminUI suites: https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/builds/691235380
And another 20 jobs passing: https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/builds/691509551


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
- [x] *BEFORE MERGE:* remove TMP commits
