### PR TITLE
Fixed EZP-31639: media and file fields not loaded correctly in edit mode

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -72,6 +72,12 @@ services:
         tags:
             - {name: kernel.event_subscriber}
 
+    EzSystems\EzPlatformAdminUi\EventListener\ContentDownloadRouteReferenceListener:
+        arguments:
+            $siteAccessGroups: '%ezpublish.siteaccess.groups%'
+        tags:
+            - {name: kernel.event_subscriber}
+
     EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory:
         lazy: true
         arguments:

--- a/src/lib/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/src/lib/EventListener/ContentDownloadRouteReferenceListener.php
@@ -16,6 +16,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Ensures that download urls generated in ezplatform-admin-ui are in the scope of admin siteaccess.
+ *
+ * @internal for internal use by AdminUI
  */
 final class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
 {

--- a/src/lib/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/src/lib/EventListener/ContentDownloadRouteReferenceListener.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Ensures that download urls generated in ezplatform-admin-ui are in the scope of admin siteaccess.
+ */
+final class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
+{
+    public const CONTENT_DOWNLOAD_ROUTE_NAME = 'ez_content_download';
+
+    /** @var array */
+    private $siteAccessGroups;
+
+    public function __construct(array $siteAccessGroups)
+    {
+        $this->siteAccessGroups = $siteAccessGroups;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MVCEvents::ROUTE_REFERENCE_GENERATION => 'onRouteReferenceGeneration',
+        ];
+    }
+
+    public function onRouteReferenceGeneration(RouteReferenceGenerationEvent $event): void
+    {
+        $routeReference = $event->getRouteReference();
+
+        if ($routeReference->getRoute() != self::CONTENT_DOWNLOAD_ROUTE_NAME) {
+            return;
+        }
+
+        /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteaccess */
+        $siteaccess = $event->getRequest()->attributes->get('siteaccess');
+        if ($this->isAdminSiteAccess($siteaccess)) {
+            $routeReference->set('siteaccess', $siteaccess->name);
+        }
+    }
+
+    private function isAdminSiteAccess(SiteAccess $siteAccess): bool
+    {
+        return (new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($siteAccess);
+    }
+}

--- a/src/lib/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
+++ b/src/lib/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
+use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use EzSystems\EzPlatformAdminUi\EventListener\ContentDownloadRouteReferenceListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ContentDownloadRouteReferenceListenerTest extends TestCase
+{
+    private const EXAMPLE_SITEACCESS_GROUPS = [
+        'admin_group' => [
+            'admin',
+        ],
+        'site_group' => [
+            'non-admin',
+        ],
+    ];
+
+    public function testOnRouteReferenceGenerationSkipNonSupportedRoutes(): void
+    {
+        $expectedRouteReference = new RouteReference(
+            'non_supported_route',
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]
+        );
+
+        $event = new RouteReferenceGenerationEvent(
+            clone $expectedRouteReference,
+            $this->createMock(Request::class)
+        );
+
+        $listener = new ContentDownloadRouteReferenceListener(self::EXAMPLE_SITEACCESS_GROUPS);
+        $listener->onRouteReferenceGeneration($event);
+
+        $this->assertEquals($expectedRouteReference, $event->getRouteReference());
+    }
+
+    public function testOnRouteReferenceGenerationSkipNonAdminSiteAccesses(): void
+    {
+        $expectedRouteReference = new RouteReference(
+            ContentDownloadRouteReferenceListener::CONTENT_DOWNLOAD_ROUTE_NAME,
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]
+        );
+
+        $request = new Request();
+        $request->attributes->set('siteaccess', new SiteAccess('non-admin'));
+
+        $event = new RouteReferenceGenerationEvent(clone $expectedRouteReference, $request);
+
+        $listener = new ContentDownloadRouteReferenceListener(self::EXAMPLE_SITEACCESS_GROUPS);
+        $listener->onRouteReferenceGeneration($event);
+
+        $this->assertEquals($expectedRouteReference, $event->getRouteReference());
+    }
+
+    public function testOnRouteReferenceGenerationForcesAdminSiteAccess(): void
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', new SiteAccess('admin'));
+
+        $event = new RouteReferenceGenerationEvent(
+            new RouteReference(
+                ContentDownloadRouteReferenceListener::CONTENT_DOWNLOAD_ROUTE_NAME,
+                [
+                    'foo' => 'foo',
+                    'bar' => 'bar',
+                    'baz' => 'baz',
+                ]
+            ),
+            $request
+        );
+
+        $listener = new ContentDownloadRouteReferenceListener(self::EXAMPLE_SITEACCESS_GROUPS);
+        $listener->onRouteReferenceGeneration($event);
+
+        $this->assertEquals(
+            new RouteReference(
+                ContentDownloadRouteReferenceListener::CONTENT_DOWNLOAD_ROUTE_NAME,
+                [
+                    'foo' => 'foo',
+                    'bar' => 'bar',
+                    'baz' => 'baz',
+                    'siteaccess' => 'admin',
+                ]
+            ),
+            $event->getRouteReference()
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31639
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

TL;DR: URLs to binary content of ezmedia/ezfile fields used in ezplatform-admin-ui should generated in scope of the current siteaccess, otherwise additional auth. might be required if resource is not public available e.g. specific versions (sessions are not shared between siteaccesses by default).  

### Alternative solution 

1. Pass `siteaccess` parameter explicitly to `ez_content_download` route to force url generation in specific siteaccess. _it's not as easy as it sounds see `ez_content_download_field_id` route_ 

2. Create dedicated download controller for ezplatform-admin-ui (`ez_content_download` is designed to be used in frontend)

### Known issues

Issue discovered while testing: the content preview / edit view doesn't take current translation language into account when displaying field value. We need follow up story here.

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
