### PR TITLE
[Behat] Changed how the field value is set for DefaultFieldElement

### DIFF
--- a/src/lib/Behat/PageElement/Fields/DefaultFieldElement.php
+++ b/src/lib/Behat/PageElement/Fields/DefaultFieldElement.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields;
 
+use Behat\Mink\Element\NodeElement;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Element;
 use PHPUnit\Framework\Assert;
@@ -13,51 +14,67 @@ use PHPUnit\Framework\Assert;
 class DefaultFieldElement extends Element
 {
     public const ELEMENT_NAME = 'DefaultFieldElement';
-    private $fieldNode;
 
-    public function __construct(UtilityContext $context, string $fieldName, string $container)
+    /** @var string */
+    private $fieldName;
+
+    /** @var string */
+    private $containerSelector;
+
+    public function __construct(UtilityContext $context, string $fieldName, string $containerSelector)
     {
         parent::__construct($context);
-
-        $containerNode = $this->context->findElement($container);
-        $this->fieldNode = $containerNode->findField($fieldName);
-
-        Assert::assertNotNull(!$this->fieldNode, sprintf('Field %s not found.', $fieldName));
+        $this->fieldName = $fieldName;
+        $this->containerSelector = $containerSelector;
     }
 
     public function setValue(string $value): void
     {
-        switch ($this->fieldNode->getAttribute('type')) {
+        $field = $this->findField();
+        switch ($field->getAttribute('type')) {
             case 'text':
             case 'email':
-                $this->fieldNode->setValue($value);
+                $this->context->waitUntil($this->defaultTimeout, function () use ($field, $value) {
+                    $field->setValue($value);
+
+                    return $this->getValue() === $value;
+                });
                 break;
             case 'checkbox':
-                $this->fieldNode->setValue(filter_var($value, FILTER_VALIDATE_BOOLEAN));
+                $field->setValue(filter_var($value, FILTER_VALIDATE_BOOLEAN));
                 break;
             case 'radio':
-                if ($this->fieldNode->isChecked() !== filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
-                    $this->fieldNode->click();
+                if ($field->isChecked() !== filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
+                    $field->click();
                 }
                 break;
             default:
-                throw new \Exception(sprintf('Field type "%s" not defined as behat field element.', $this->fieldNode->getAttribute('type')));
+                throw new \Exception(sprintf('Field type "%s" not defined as Behat field element.', $field->getAttribute('type')));
         }
     }
 
     public function getValue(): string
     {
-        switch ($this->fieldNode->getAttribute('type')) {
+        $field = $this->findField();
+
+        switch ($field->getAttribute('type')) {
             case 'text':
             case 'email':
             case 'checkbox':
-                return $this->fieldNode->getValue();
-                break;
+                return $field->getValue();
             case 'radio':
-                return $this->fieldNode->isChecked() ? 'true' : 'false';
-                break;
+                return $field->isChecked() ? 'true' : 'false';
             default:
-                throw new \Exception(sprintf('Field type "%s" not defined as behat field element.', $this->fieldNode->getAttribute('type')));
+                throw new \Exception(sprintf('Field type "%s" not defined as Behat field element.', $field->getAttribute('type')));
         }
+    }
+
+    private function findField(): NodeElement
+    {
+        $containerNode = $this->context->findElement($this->containerSelector);
+        $field = $containerNode->findField($this->fieldName);
+        Assert::assertNotNull($field, sprintf('Field %s not found.', $this->fieldName));
+
+        return $field;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | JIRA: https://jira.ez.no/browse/EZP-31648
| Bug fix?      | in tests?
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Looks like the tests keep failing even after https://github.com/ezsystems/ezplatform-admin-ui/pull/1389 has been merged:
https://travis-ci.org/github/ezsystems/ezplatform/jobs/694164455
https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/jobs/692537680
https://travis-ci.org/github/ezsystems/ezplatform/jobs/692781698

So this PR tries to make the approach even more robust by:
1) delaying initialisation of the searched field until it's really needed
2) making sure the value that has to be set is really set

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
