### PR TITLE
Get getNotificationsStatus interval from config

### DIFF
--- a/src/bundle/Controller/NotificationController.php
+++ b/src/bundle/Controller/NotificationController.php
@@ -107,6 +107,7 @@ class NotificationController extends Controller
             'page' => $page,
             'pagination' => $pagination,
             'notifications' => $notifications,
+            'notifications_count_interval' => $this->configResolver->getParameter('notifications.count.interval'),
             'pager' => $pagerfanta,
         ])->getContent());
     }

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -41,6 +41,7 @@ parameters:
     ezsettings.admin_group.subtree_operations.copy_subtree.limit: 100
 
     # Notifications
+    ezsettings.admin_group.notifications.count.interval: 30000
     ezsettings.admin_group.notifications.error.timeout: 0
     ezsettings.admin_group.notifications.warning.timeout: 0
     ezsettings.admin_group.notifications.success.timeout: 5000

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -179,9 +179,11 @@
 
     const notificationsTable = modal.querySelector(SELECTOR_TABLE);
     currentPageLink = notificationsTable.dataset.notifications;
+    let interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval);
+    if (!interval) { interval = INTERVAL; }
 
     modal.querySelectorAll(SELECTOR_MODAL_RESULTS).forEach((link) => link.addEventListener('click', handleModalResultsClick, false));
 
     getNotificationsStatus();
-    global.setInterval(getNotificationsStatus, INTERVAL);
+    global.setInterval(getNotificationsStatus, interval);
 })(window, window.document, window.eZ, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -179,7 +179,7 @@
 
     const notificationsTable = modal.querySelector(SELECTOR_TABLE);
     currentPageLink = notificationsTable.dataset.notifications;
-    const interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval) || INTERVAL;
+    const interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval, 10) || INTERVAL;
 
     modal.querySelectorAll(SELECTOR_MODAL_RESULTS).forEach((link) => link.addEventListener('click', handleModalResultsClick, false));
 

--- a/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
+++ b/src/bundle/Resources/public/js/scripts/admin.notifications.modal.js
@@ -179,8 +179,7 @@
 
     const notificationsTable = modal.querySelector(SELECTOR_TABLE);
     currentPageLink = notificationsTable.dataset.notifications;
-    let interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval);
-    if (!interval) { interval = INTERVAL; }
+    const interval = Number.parseInt(notificationsTable.dataset.notificationsCountInterval) || INTERVAL;
 
     modal.querySelectorAll(SELECTOR_MODAL_RESULTS).forEach((link) => link.addEventListener('click', handleModalResultsClick, false));
 

--- a/src/bundle/Resources/views/themes/admin/account/notifications/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/notifications/list.html.twig
@@ -3,6 +3,7 @@
 <table
     data-notifications="{{ path('ezplatform.notifications.render.page') }}"
     data-notifications-count="{{ path('ezplatform.notifications.count') }}"
+    data-notifications-count-interval="{{ notifications_count_interval }}"
     data-notifications-total="{{ pager.nbResults }}"
     class="table n-table--notifications">
     <thead>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Get `getNotificationsStatus` (`notifications/count`) interval from YAML config parameters.

One could want (or need) to increase this interval to reduce server activity.

Doc could be needed to explain that this is set in milliseconds but I couldn't find any doc for other parameters like `.timeout`.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
