### PR TITLE
[Behat] Added ContentContext to adminuimodules suite

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -53,6 +53,7 @@ adminui:
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\RightMenuContext
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\NotificationContext
                 - EzSystems\EzPlatformAdminUi\Behat\BusinessContext\UDWContext
+                - EzSystems\BehatBundle\Context\Object\ContentContext
                 - EzSystems\BehatBundle\Context\Object\ContentTypeContext
                 - EzSystems\BehatBundle\Context\Api\TestContext
 


### PR DESCRIPTION
Small followup for: https://jira.ez.no/browse/EZP-31551

Failing build: https://travis-ci.org/github/ezsystems/BehatBundle/jobs/694940560
```
-- Use --snippets-for CLI option to generate snippets for following adminuimodules suite steps:

    Given I create "Image" Content items in "/Media/Images/" in "eng-GB"
```

The new Image Asset Scenario is also part of the admin-ui-modules suite, but it does not include ContentContext which is required for the Scenario to run. This PR changes that.



