### PR TITLE
[Behat] Moved and consolidated Trash tests into one feature

### DIFF
--- a/features/standard/ContentManagement.feature
+++ b/features/standard/ContentManagement.feature
@@ -87,18 +87,3 @@ Scenario: Subtree can be copied
   Then success notification that "Subtree 'Files' copied to location 'Images'" appears
     And I should be on content container page "Files" of type "Folder" in "Media/Images"
     And there's "Test Article Manage" "Article" on "Files" Sub-items list
-
-@javascript @common
-Scenario: Content can be moved to trash from non-root location
-  Given I navigate to content "Test Article Manage" of type "Article" in "Media/Files"
-  When I send content to trash
-  Then there's no "Article" "Test Article Manage" on "Files" Sub-items list
-    And going to trash there is "Article" "Test Article Manage" on list
-
-@javascript @common
-Scenario: Content can be moved to trash from root location
-  Given I open UDW and go to "root/Test Article Manage"
-  When I send content to trash
-  Then I should be redirected to root in default view
-    And going to trash there is "Article" "Test Article Manage" on list
-

--- a/features/standard/Trash.feature
+++ b/features/standard/Trash.feature
@@ -59,6 +59,16 @@ Scenario: Element in trash can be restored under new location
     And there is no "Folder" "Folder3" on trash list
     And going to "Media/Files" there is a "Folder3" "Folder" on Sub-items list
 
+@javascript @common @admin
+Scenario: Content can be moved to trash from non-root location
+  Given I create "Folder" Content items in "/Media/Files/" in "eng-GB"
+      | name               | short_name         |
+      | TestFolderToRemove | TestFolderToRemove |
+    And I navigate to content "TestFolderToRemove" of type "Folder" in "Media/Files"
+  When I send content to trash
+  Then there's no "Folder" "TestFolderToRemove" on "Files" Sub-items list
+    And going to trash there is "Folder" "TestFolderToRemove" on list
+
 @javascript @common
 Scenario: Trash can be emptied
   Given I click on the left menu bar button "Trash"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | fix failing tests
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

We have various failing jobs:
- https://travis-ci.org/github/ezsystems/ezplatform/jobs/697879345
- https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/348666587
- https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/348666598

in all of them the following Scenario is failing:
`Scenario: Content can be moved to trash from non-root location`

This is caused because this Scenario is run concurrently with this one: https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/features/standard/Trash.feature#L63
which empties the Trash.

Entries from Travis execution log:
```
  │  	[2020-06-13 01:52:26] Ending Step "I navigate to content "Test Article Manage" of type "Article" in "Media/Files"" 
    │  	[2020-06-13 01:52:26] Starting Step "I send content to trash" 
    │  	[2020-06-13 01:52:29] Ending Step "I send content to trash" 
    │  	[2020-06-13 01:52:29] Starting Step "there's no "Article" "Test Article Manage" on "Files" Sub-items list" 
    │  	[2020-06-13 01:52:29] Ending Step "I go to "Content structure" in "Content" tab" 
    │  	[2020-06-13 01:52:29] Starting Step "I click on the left menu bar button "Trash"" 
    │  	[2020-06-13 01:52:31] Ending Step "I click on the left menu bar button "Trash"" 
    │  	[2020-06-13 01:52:31] Starting Step "I empty the trash" 
    │  	[2020-06-13 01:52:32] Ending Step "I empty the trash" 
    │  	[2020-06-13 01:52:32] Starting Step "trash is empty" 
    │  	[2020-06-13 01:52:32] Ending Step "trash is empty" 
    │  	[2020-06-13 01:52:32] Ending Scenario "Trash can be emptied" 
    │  	[2020-06-13 01:52:33] Starting Scenario "Content draft can be saved" 
    │  	[2020-06-13 01:52:33] Starting Step "I am logged as "admin"" 
    │  	[2020-06-13 01:52:35] Ending Step "I am logged as "admin"" 
    │  	[2020-06-13 01:52:35] Starting Step "I go to "Content structure" in "Content" tab" 
    │  	[2020-06-13 01:52:37] Ending Step "I go to "Content structure" in "Content" tab" 
    │  	[2020-06-13 01:52:37] Starting Step "I start creating a new content "Article"" 
    │  	[2020-06-13 01:52:39] Ending Step "there's no "Article" "Test Article Manage" on "Files" Sub-items list" 
    │  	[2020-06-13 01:52:39] Starting Step "going to trash there is "Article" "Test Article Manage" on list" 
    │  	[2020-06-13 01:52:40] Ending Step "I start creating a new content "Article"" 
    │  	[2020-06-13 01:52:40] Starting Step "I set content fields" 
    │  	[2020-06-13 01:52:41] Ending Step "going to trash there is "Article" "Test Article Manage" on list" 
```

You can see that betwen the `"I send content to trash" ` and `"going to trash there is "Article" "Test Article Manage" on list" ` Steps the trash is emptied by `I empty the trash` Step.

My fix moves all Trash-related Scenarios to the Trash feature (where they don't interfere with each other). I've also decided to remove the `Content can be moved to trash from root location` Scenario because it's already covered by https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/features/standard/Trash.feature#L11

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
