### PR TITLE
EZP-31583: Fixed views for Content without Location

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/relation.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/relation.html.twig
@@ -1,12 +1,14 @@
 <td>
-    <a {% if not content.contentInfo.trashed %}
-        href="{{ path('_ez_content_view', { 'contentId': content.id, 'locationId': content.contentInfo.mainLocationId } ) }}"
-    {% endif %}>
+    {% if content.contentInfo.mainLocationId is not null %}
+        <a href="{{ path('_ez_content_view', { 'contentId': content.id, 'locationId': content.contentInfo.mainLocationId } ) }}">
+            {{ content.getName() }}
+        </a>
+    {% else %}
         {{ content.getName() }}
         {% if content.contentInfo.trashed %}
             <em>({{ 'content.in_trash'|trans(domain='content')|desc('In Trash') }})</em>
         {% endif %}
-    </a>
+    {% endif %}
 </td>
 <td>
     {{ contentType.getName() }}

--- a/src/bundle/Resources/views/themes/admin/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/relations/table_relations.html.twig
@@ -16,9 +16,13 @@
             {% set destination = relation.destinationContentInfo %}
             <tr>
                 <td>
-                    <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': destination.mainLocationId }) }}">
+                    {% if (destination.mainLocationId is not null) %}
+                        <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': destination.mainLocationId }) }}">
+                            {{ ez_content_name(destination) }}
+                        </a>
+                    {% else %}
                         {{ ez_content_name(destination) }}
-                    </a>
+                    {% endif %}
                 </td>
                 <td>{{ content_types[destination.contentTypeId].name }}</td>
                 <td>

--- a/src/bundle/Resources/views/themes/admin/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/relations/table_relations_reverse.html.twig
@@ -17,9 +17,13 @@
                 {% set source = relation.sourceContentInfo %}
                 <tr>
                     <td>
-                        <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': source.mainLocationId }) }}">
+                        {% if source.mainLocationId is not null %}
+                            <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': source.mainLocationId }) }}">
+                                {{ ez_content_name(source) }}
+                            </a>
+                        {% else %}
                             {{ ez_content_name(source) }}
-                        </a>
+                        {% endif %}
                     </td>
                     <td>{{ content_types[source.contentTypeId].name }}</td>
                     <td>

--- a/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
@@ -5,7 +5,7 @@
         </svg>
     </td>
     <td class="ez-table__cell ez-table__cell--after-icon">
-        {% if (row.mainLocationId is not null) %}
+        {% if row.mainLocationId is not null %}
             <a href="{{ path('_ez_content_view', {
                 'contentId': row.contentId,
                 'languageCode': row.translation_language_code,
@@ -24,10 +24,12 @@
         </td>
     {% endif %}
     <td class="ez-table__cell ez-table__cell--has-action-btns text-right">
-        {% include '@ezdesign/ui/edit_translation_button.html.twig' with {
-            'contentId': row.contentId,
-            'translations': row.available_enabled_translations,
-            'top_offset': 100
-        }%}
+        {% if row.mainLocationId is not null %}
+            {% include '@ezdesign/ui/edit_translation_button.html.twig' with {
+                'contentId': row.contentId,
+                'translations': row.available_enabled_translations,
+                'top_offset': 100
+            }%}
+        {% endif %}
     </td>
 </tr>

--- a/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
@@ -5,10 +5,14 @@
         </svg>
     </td>
     <td class="ez-table__cell ez-table__cell--after-icon">
-        <a href="{{ path('_ez_content_view', {
-            'contentId': row.contentId,
-            'languageCode': row.translation_language_code,
-        }) }}">{{ row.name }}</a>
+        {% if (row.mainLocationId is not null) %}
+            <a href="{{ path('_ez_content_view', {
+                'contentId': row.contentId,
+                'languageCode': row.translation_language_code,
+            }) }}">{{ row.name }}</a>
+        {% else %}
+            {{ row.name }}
+        {% endif %}
     </td>
     <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
     <td class="ez-table__cell">{{ row.type }}</td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31583
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Some twig views have been tweaked to support `Contents` without `Locations`.

PR is a direct continuation of https://github.com/ezsystems/ezplatform-admin-ui/pull/1353, but for eZ Platform v3.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review