### PR TITLE
EZEE-3167: Added generation of Site Access name for Sites

### DIFF
--- a/src/bundle/Resources/config/services/controllers.yaml
+++ b/src/bundle/Resources/config/services/controllers.yaml
@@ -14,6 +14,7 @@ services:
             $siteaccessResolver: '@EzSystems\EzPlatformAdminUi\Siteaccess\NonAdminSiteaccessResolver'
             $translationHelper: '@ezpublish.translation_helper'
             $configResolver: '@ezpublish.config.resolver'
+            $siteAccessNameGenerator: '@EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessNameGenerator'
         tags:
             - controller.service_arguments
 

--- a/src/bundle/Resources/config/services/siteaccess.yaml
+++ b/src/bundle/Resources/config/services/siteaccess.yaml
@@ -8,10 +8,12 @@ services:
 
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator: ~
 
+    EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessNameGenerator: ~
+
     EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessResolver:
         arguments:
             $siteaccessPreviewVoters: !tagged ezplatform.admin_ui.siteaccess_preview_voter
-            $siteAccesses: '%ezpublish.siteaccess.list%'
+            $siteAccessService: '@ezpublish.siteaccess_service'
 
     EzSystems\EzPlatformAdminUi\Siteaccess\NonAdminSiteaccessResolver:
         arguments:

--- a/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
@@ -41,8 +41,20 @@
             {% if siteaccesses|length > 1 %}
                 <div class="ez-preview__item ez-preview__item--siteaccess">
                     <select class="form-control">
-                        {% for preview_siteaccess in siteaccesses %}
-                            <option value="{{ path('_ezpublishPreviewContent', {'contentId': content.id, 'versionNo': version_no, 'language': language_code, 'siteAccessName': preview_siteaccess}) }}">{{ preview_siteaccess|trans({}, 'ezplatform_siteaccess') ~ ' (' ~ preview_siteaccess ~ ')' }}</option>
+                        {% for site_accesses_name, site_access_label in siteaccesses %}
+                            <option value="{{
+                                path(
+                                    '_ezpublishPreviewContent',
+                                    {
+                                        'contentId': content.id,
+                                        'versionNo': version_no,
+                                        'language': language_code,
+                                        'siteAccessName': site_accesses_name
+                                    }
+                                )
+                            }}">
+                                {{ site_access_label|trans({}, 'ezplatform_siteaccess') }}
+                            </option>
                         {% endfor %}
                     </select>
                 </div>

--- a/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_preview.html.twig
@@ -42,17 +42,16 @@
                 <div class="ez-preview__item ez-preview__item--siteaccess">
                     <select class="form-control">
                         {% for site_accesses_name, site_access_label in siteaccesses %}
-                            <option value="{{
-                                path(
-                                    '_ezpublishPreviewContent',
-                                    {
-                                        'contentId': content.id,
-                                        'versionNo': version_no,
-                                        'language': language_code,
-                                        'siteAccessName': site_accesses_name
-                                    }
-                                )
-                            }}">
+                            {% set option_value = path(
+                                '_ezpublishPreviewContent',
+                                {
+                                    'contentId': content.id,
+                                    'versionNo': version_no,
+                                    'language': language_code,
+                                    'siteAccessName': site_accesses_name
+                                }
+                            ) %}
+                            <option value="{{ option_value }}">
                                 {{ site_access_label|trans({}, 'ezplatform_siteaccess') }}
                             </option>
                         {% endfor %}

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -42,6 +42,29 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
         );
     }
 
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess[]
+     */
+    public function getSiteAccessesListForLocation(
+        Location $location,
+        int $versionNo = null,
+        string $languageCode = null
+    ): array {
+        if (!array_key_exists('admin_group', $this->siteAccessGroups)) {
+            throw new BadStateException(
+                'siteaccess',
+                'SiteAccess group `admin_group` not found.'
+            );
+        }
+
+        return array_filter(
+            $this->siteaccessResolver->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
+            function ($siteAccess) {
+                return !in_array($siteAccess->name, $this->siteAccessGroups['admin_group']);
+            }
+        );
+    }
+
     public function getSiteaccesses(): array
     {
         return $this->filter($this->siteaccessResolver->getSiteaccesses());

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -49,8 +49,8 @@ class NonAdminSiteaccessResolver implements SiteaccessResolverInterface
      */
     public function getSiteAccessesListForLocation(
         Location $location,
-        int $versionNo = null,
-        string $languageCode = null
+        ?int $versionNo = null,
+        ?string $languageCode = null
     ): array {
         return array_filter(
             $this->siteaccessResolver->getSiteAccessesListForLocation($location, $versionNo, $languageCode),

--- a/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
+++ b/src/lib/Siteaccess/NonAdminSiteaccessResolver.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
 

--- a/src/lib/Siteaccess/SiteAccessNameGenerator.php
+++ b/src/lib/Siteaccess/SiteAccessNameGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Siteaccess;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+
+final class SiteAccessNameGenerator implements SiteAccessNameGeneratorInterface
+{
+    public function generate(SiteAccess $siteAccess): string
+    {
+        return $siteAccess->name;
+    }
+}

--- a/src/lib/Siteaccess/SiteAccessNameGeneratorInterface.php
+++ b/src/lib/Siteaccess/SiteAccessNameGeneratorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Siteaccess;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+
+interface SiteAccessNameGeneratorInterface
+{
+    public function generate(SiteAccess $siteAccessIdentifier): string;
+}

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -53,9 +53,8 @@ class SiteaccessResolver implements SiteaccessResolverInterface
         int $versionNo = null,
         string $languageCode = null
     ): array {
-        return array_column(
-            $this->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
-            'name'
+        return $this->getSiteAccessList(
+            $this->getSiteAccessesListForLocation($location, $versionNo, $languageCode)
         );
     }
 
@@ -88,16 +87,18 @@ class SiteaccessResolver implements SiteaccessResolverInterface
 
     public function getSiteaccesses(): array
     {
-        return $this->getSiteAccessList();
+        $siteAccessList = iterator_to_array($this->siteAccessService->getAll());
+
+        return $this->getSiteAccessList($siteAccessList);
     }
 
     /**
      * @return string[]
      */
-    private function getSiteAccessList(): array
+    private function getSiteAccessList(array $siteAccessList): array
     {
         return array_column(
-            iterator_to_array($this->siteAccessService->getAll()),
+            $siteAccessList,
             'name'
         );
     }

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 
 class SiteaccessResolver implements SiteaccessResolverInterface
 {
@@ -17,10 +18,10 @@ class SiteaccessResolver implements SiteaccessResolverInterface
     private $contentService;
 
     /** @var \EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessPreviewVoterInterface[] */
-    private $siteaccessPreviewVoters;
+    private $siteAccessPreviewVoters;
 
-    /** @var string[] */
-    private $siteAccesses;
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService */
+    private $siteAccessService;
 
     /**
      * @param \eZ\Publish\API\Repository\ContentService $contentService
@@ -30,11 +31,11 @@ class SiteaccessResolver implements SiteaccessResolverInterface
     public function __construct(
         ContentService $contentService,
         iterable $siteaccessPreviewVoters,
-        array $siteAccesses
+        SiteAccessService $siteAccessService
     ) {
         $this->contentService = $contentService;
-        $this->siteaccessPreviewVoters = $siteaccessPreviewVoters;
-        $this->siteAccesses = $siteAccesses;
+        $this->siteAccessPreviewVoters = $siteaccessPreviewVoters;
+        $this->siteAccessService = $siteAccessService;
     }
 
     /**
@@ -52,26 +53,52 @@ class SiteaccessResolver implements SiteaccessResolverInterface
         int $versionNo = null,
         string $languageCode = null
     ): array {
+        return array_column(
+            $this->getSiteAccessesListForLocation($location, $versionNo, $languageCode),
+            'name'
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess[]
+     */
+    public function getSiteAccessesListForLocation(
+        Location $location,
+        int $versionNo = null,
+        string $languageCode = null
+    ): array {
         $contentInfo = $location->getContentInfo();
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $versionNo);
         $languageCode = $languageCode ?? $contentInfo->mainLanguageCode;
 
-        $eligibleSiteaccesses = [];
-        foreach ($this->getSiteaccesses() as $siteaccess) {
-            $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, $languageCode);
-            foreach ($this->siteaccessPreviewVoters as $siteaccessPreviewVoter) {
-                if ($siteaccessPreviewVoter->vote($context)) {
-                    $eligibleSiteaccesses[] = $siteaccess;
+        $eligibleSiteAccesses = [];
+        /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
+        foreach ($this->siteAccessService->getAll() as $siteAccess) {
+            $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteAccess->name, $languageCode);
+            foreach ($this->siteAccessPreviewVoters as $siteAccessPreviewVoter) {
+                if ($siteAccessPreviewVoter->vote($context)) {
+                    $eligibleSiteAccesses[] = $siteAccess;
                     break;
                 }
             }
         }
 
-        return $eligibleSiteaccesses;
+        return $eligibleSiteAccesses;
     }
 
     public function getSiteaccesses(): array
     {
-        return $this->siteAccesses;
+        return $this->getSiteAccessList();
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getSiteAccessList(): array
+    {
+        return array_column(
+            iterator_to_array($this->siteAccessService->getAll()),
+            'name'
+        );
     }
 }

--- a/src/lib/Siteaccess/SiteaccessResolver.php
+++ b/src/lib/Siteaccess/SiteaccessResolver.php
@@ -63,8 +63,8 @@ class SiteaccessResolver implements SiteaccessResolverInterface
      */
     public function getSiteAccessesListForLocation(
         Location $location,
-        int $versionNo = null,
-        string $languageCode = null
+        ?int $versionNo = null,
+        ?string $languageCode = null
     ): array {
         $contentInfo = $location->getContentInfo();
         $versionInfo = $this->contentService->loadVersionInfo($contentInfo, $versionNo);

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -34,8 +34,8 @@ interface SiteaccessResolverInterface
      */
     public function getSiteAccessesListForLocation(
         Location $location,
-        int $versionNo = null,
-        string $languageCode = null
+        ?int $versionNo = null,
+        ?string $languageCode = null
     ): array;
 
     /**

--- a/src/lib/Siteaccess/SiteaccessResolverInterface.php
+++ b/src/lib/Siteaccess/SiteaccessResolverInterface.php
@@ -28,7 +28,18 @@ interface SiteaccessResolverInterface
     ): array;
 
     /**
-     * Returns complete list of siteaccesses.
+     * Returns a complete list of Site Access objects.
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess[]
+     */
+    public function getSiteAccessesListForLocation(
+        Location $location,
+        int $versionNo = null,
+        string $languageCode = null
+    ): array;
+
+    /**
+     * Returns a complete list of Site Access names.
      *
      * @return array
      */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3167
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| Related PR     | https://github.com/ezsystems/ezplatform-site-factory/pull/70
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

List of the Site Accesses should come from `siteAccessService`. Site Factory should have the possibility to modify the Site Access name.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
