### PR TITLE
EZEE-3176: Make disabled fields are non-interactable

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -44,6 +44,11 @@
     }
 }
 
+.ez-field-edit--disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
 .ez-content-edit {
     .ez-field-edit {
         &__label-wrapper {

--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-field.scss
@@ -8,7 +8,8 @@
         }
     }
 
-    &--nontranslatable {
+    &--nontranslatable,
+    &--disabled {
         opacity: 0.4;
         pointer-events: none;
     }
@@ -42,11 +43,6 @@
             color: $ez-color-danger;
         }
     }
-}
-
-.ez-field-edit--disabled {
-    opacity: 0.4;
-    pointer-events: none;
 }
 
 .ez-content-edit {

--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -72,6 +72,11 @@
     {% set widget_wrapper_attr = widget_wrapper_attr|default({})|merge({'class': (widget_wrapper_attr.class|default('') ~ ' ez-field-edit__data')|trim}) %}
     {% set wrapper_class = 'ez-field-edit ez-field-edit--' ~ fieldtype_identifier %}
 
+    {% if fieldtype.vars.disabled %}
+        {% set wrapper_class = wrapper_class ~ ' ez-field-edit--disabled' %}
+        {% set attr = attr|merge({'readonly': 'readonly'}) %}
+    {% endif %}
+
     {# BC: to maintain BC we have to map errors which orginated from compound fieldtypes #}
     {% for error in form.parent.parent.parent.vars.errors %}
         {% if error.origin == form.vars.errors.form %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3176
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
