### PR TITLE
EZEE-3176: Added context information to Form builders

### DIFF
--- a/src/bundle/Controller/ContentOnTheFlyController.php
+++ b/src/bundle/Controller/ContentOnTheFlyController.php
@@ -162,6 +162,7 @@ class ContentOnTheFlyController extends Controller
         $form = $this->createForm(ContentEditType::class, $data, [
             'languageCode' => $language->languageCode,
             'mainLanguageCode' => $language->languageCode,
+            'contentCreateStruct' => $data,
             'drafts_enabled' => false,
             'intent' => 'create',
         ]);
@@ -230,6 +231,8 @@ class ContentOnTheFlyController extends Controller
             [
                 'languageCode' => $languageCode,
                 'mainLanguageCode' => $content->contentInfo->mainLanguageCode,
+                'content' => $content,
+                'contentUpdateStruct' => $contentUpdate,
                 'drafts_enabled' => true,
             ]
         );

--- a/src/lib/View/Filter/ContentTranslateViewFilter.php
+++ b/src/lib/View/Filter/ContentTranslateViewFilter.php
@@ -172,6 +172,8 @@ class ContentTranslateViewFilter implements EventSubscriberInterface
             [
                 'languageCode' => $toLanguage->languageCode,
                 'mainLanguageCode' => $content->contentInfo->mainLanguageCode,
+                'content' => $content,
+                'contentUpdateStruct' => $contentUpdate,
                 'drafts_enabled' => true,
             ]
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3176
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
