### PR TITLE
EZP-31697: Added remove tooltip when removed node is diffrenty than .…

### DIFF
--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -1,17 +1,27 @@
 (function (global, doc, eZ, $) {
+    let lastInsertTooltipTarget = null;
     const TOOLTIPS_SELECTOR = '[title]';
     const observerConfig = {
         childList: true,
         subtree: true,
     };
     const observer = new MutationObserver((mutationsList) => {
-        mutationsList.forEach((mutation) => {
-            const showedTooltipNode = doc.querySelector('.ez-tooltip.show');
+        if (lastInsertTooltipTarget) {
+            mutationsList.forEach((mutation) => {
+                const { removedNodes } = mutation;
 
-            if (mutation.removedNodes.length && showedTooltipNode) {
-                showedTooltipNode.remove();
-            }
-        });
+                if (removedNodes.length) {
+                    removedNodes.forEach((removedNode) => {
+                        if (removedNode.classList && !removedNode.classList.contains('ez-tooltip')) {
+                            lastInsertTooltipTarget = null;
+                            doc.querySelectorAll('.ez-tooltip.show').forEach((tooltipNode) => {
+                                tooltipNode.remove();
+                            });
+                        }
+                    });
+                }
+            });
+        }
     });
     const parse = (baseElement = doc) => {
         if (!baseElement) {
@@ -38,6 +48,10 @@
                                     <div class="arrow ez-tooltip__arrow"></div>
                                     <div class="tooltip-inner ez-tooltip__inner"></div>
                                </div>`,
+                });
+
+                $(tooltipNode).on('inserted.bs.tooltip', (event) => {
+                    lastInsertTooltipTarget = event.currentTarget;
                 });
             }
         }

--- a/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
+++ b/src/bundle/Resources/public/js/scripts/helpers/tooltips.helper.js
@@ -12,7 +12,7 @@
 
                 if (removedNodes.length) {
                     removedNodes.forEach((removedNode) => {
-                        if (removedNode.classList && !removedNode.classList.contains('ez-tooltip')) {
+                        if (!removedNode.classList.contains('ez-tooltip')) {
                             lastInsertTooltipTarget = null;
                             doc.querySelectorAll('.ez-tooltip.show').forEach((tooltipNode) => {
                                 tooltipNode.remove();


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31697
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Improved tooltip removal. Previously the tooltip was removed if any node was deleted and now I delete it when I delete a node other than .ez-tooltip

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
