### PR TITLE
EZP-31719: Verbatim HTML in end of life information on Dashboard

### DIFF
--- a/src/bundle/Resources/translations/dashboard.en.xliff
+++ b/src/bundle/Resources/translations/dashboard.en.xliff
@@ -20,13 +20,13 @@
         <source><![CDATA[Tip: If you upgrade to eZ Platform Enterprise you'll get access to:
                         <a target="_blank" href="%license_url%">A business friendly license</a>,
                         <a target="_blank" href="%ee_product_url%">several productivity features</a>,
-                        <a target="_blank" href="%support_service_url%">professional Support</a> and
-                        <a target="_blank" href="%service_life_url%">longer maintenance periode of your release</a>.]]></source>
+                        <a target="_blank" href="%support_service_url%">professional support</a> and a
+                        <a target="_blank" href="%service_life_url%">longer maintenance period of your release</a>.]]></source>
         <target state="new"><![CDATA[Tip: If you upgrade to eZ Platform Enterprise you'll get access to:
                         <a target="_blank" href="%license_url%">A business friendly license</a>,
                         <a target="_blank" href="%ee_product_url%">several productivity features</a>,
-                        <a target="_blank" href="%support_service_url%">professional Support</a> and
-                        <a target="_blank" href="%service_life_url%">longer maintenance periode of your release</a>.]]></target>
+                        <a target="_blank" href="%support_service_url%">professional support</a> and a
+                        <a target="_blank" href="%service_life_url%">longer maintenance period of your release</a>.]]></target>
         <note>key: dashboard.ez_version.community_end_of_maintenance_upgrade</note>
       </trans-unit>
       <trans-unit id="7eb6ab2973439efa8ff820310952e02bc81209cb" resname="dashboard.ez_version.community_severity_non">

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
@@ -14,8 +14,11 @@
     {% if not ez.release %}
         {% set severity = 1 %}
         <div class="alert alert-warning mb-0 mt-3" role="alert">
-            {{ 'dashboard.ez_version.release_not_determined'|trans|desc("The system could not find your <code>composer.lock</code> file. It's needed to determine information about
-            your eZ install, and recommended to be kept on project development to make sure same package versions are used across all environments.")}}
+            {{ 'dashboard.ez_version.release_not_determined'|trans
+            |desc("The system could not find your <code>composer.lock</code> file. It's needed to determine information about
+                your eZ install, and recommended to be kept on project development to make sure same package versions are
+                used across all environments.")
+            |raw }}
         </div>
     {% elseif ez.stability != 'stable'  %}
         {% set severity = 1 %}
@@ -59,8 +62,13 @@
             {# In the future with retrival of info from updates.ez.no we can detect missing (public) security fixes and then let this become an error #}
             {% set severity = 1 %}
             <div class="alert alert-warning mb-0 mt-3" role="alert">
-                {{ 'dashboard.ez_version.community_end_of_maintenance'|trans({'%release%': ez.release, '%update_url%': urls['update']})
-                |desc("Unfortunately %release% open source version has reached end of life, <a target=\"_blank\" href=\"%update_url%\">please upgrade</a>.")}}
+                {{ 'dashboard.ez_version.community_end_of_maintenance'|trans({
+                    '%release%': ez.release,
+                    '%update_url%': urls['update']
+                })
+                |desc("Unfortunately %release% open source version has reached end of life,
+                    <a target=\"_blank\" href=\"%update_url%\">please upgrade</a>.")
+                |raw }}
                 <em>
                     {{ 'dashboard.ez_version.community_end_of_maintenance_upgrade'|trans({
                         '%license_url%': urls['license'],

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
@@ -16,7 +16,7 @@
         <div class="alert alert-warning mb-0 mt-3" role="alert">
             {{ 'dashboard.ez_version.release_not_determined'|trans
             |desc("The system could not find your <code>composer.lock</code> file. It's needed to determine information about
-                your eZ install, and recommended to be kept on project development to make sure same package versions are
+                your eZ installation. It is recommended to keep it during project development to make sure the same package versions are
                 used across all environments.")
             |raw }}
         </div>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/block/ez.html.twig
@@ -79,8 +79,8 @@
                     |desc("Tip: If you upgrade to eZ Platform Enterprise you'll get access to:
                         <a target=\"_blank\" href=\"%license_url%\">A business friendly license</a>,
                         <a target=\"_blank\" href=\"%ee_product_url%\">several productivity features</a>,
-                        <a target=\"_blank\" href=\"%support_service_url%\">professional Support</a> and
-                        <a target=\"_blank\" href=\"%service_life_url%\">longer maintenance periode of your release</a>.")
+                        <a target=\"_blank\" href=\"%support_service_url%\">professional support</a> and a
+                        <a target=\"_blank\" href=\"%service_life_url%\">longer maintenance period of your release</a>.")
                     |raw }}
                 </em>
             </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31719
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | TBD
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

The alert box for end-of-life shows verbatim (escaped) HTML. This adds `raw` operators and indents in the same way as similar texts in the same template.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
