### PR TITLE
EZP-31696: removed focus after content tree expanded

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.tree.js
@@ -12,7 +12,7 @@
     const userId = window.eZ.helpers.user.getId();
     let frame = null;
     const toggleContentTreePanel = () => {
-        document.activeElement.blur();
+        doc.activeElement.blur();
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
         contentTreeContainer.classList.add(CLASS_CONTENT_TREE_ANIMATE);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);

--- a/src/bundle/Resources/public/js/scripts/admin.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.tree.js
@@ -1,4 +1,4 @@
-(function(global, doc, React, ReactDOM, eZ, localStorage) {
+(function (global, doc, React, ReactDOM, eZ, localStorage) {
     const KEY_CONTENT_TREE_EXPANDED = 'ez-content-tree-expanded';
     const CLASS_CONTENT_TREE_EXPANDED = 'ez-content-tree-container--expanded';
     const CLASS_CONTENT_TREE_ANIMATE = 'ez-content-tree-container--animate';
@@ -12,6 +12,7 @@
     const userId = window.eZ.helpers.user.getId();
     let frame = null;
     const toggleContentTreePanel = () => {
+        document.activeElement.blur();
         contentTreeContainer.classList.toggle(CLASS_CONTENT_TREE_EXPANDED);
         contentTreeContainer.classList.add(CLASS_CONTENT_TREE_ANIMATE);
         btn.classList.toggle(CLASS_BTN_CONTENT_TREE_EXPANDED);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31696
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Removed focus from button after content tree menu expand


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
