### PR TITLE
[Behat] Adjusted Trash tests

### DIFF
--- a/features/standard/Trash.feature
+++ b/features/standard/Trash.feature
@@ -7,7 +7,7 @@ Background:
   Given I am logged as "admin"
     And I go to "Content structure" in "Content" tab
 
-@javascript @common @broken
+@javascript @common
 Scenario Outline: Content can be moved to trash
   Given I start creating a new content "Folder"
     And I set content fields
@@ -27,7 +27,7 @@ Scenario Outline: Content can be moved to trash
     | Folder3     |
     | Folder4     |
 
-@javascript @common @broken
+@javascript @common
 Scenario: Element in trash can be deleted
   Given I click on the left menu bar button "Trash"
     And there is "Folder" "Folder1" on trash list
@@ -37,7 +37,7 @@ Scenario: Element in trash can be deleted
   Then success notification that "Deleted selected item(s) from Trash." appears
     And there is no "Folder" "Folder1" on trash list
 
-@javascript @common @broken
+@javascript @common
 Scenario: Element in trash can be restored
   Given I click on the left menu bar button "Trash"
     And there is "Folder" "Folder2" on trash list
@@ -48,7 +48,7 @@ Scenario: Element in trash can be restored
     And there is no "Folder" "Folder2" on trash list
     And going to root path there is "Folder2" "Folder" on Sub-items list
 
-@javascript @common @broken
+@javascript @common
 Scenario: Element in trash can be restored under new location
   Given I click on the left menu bar button "Trash"
     And there is "Folder" "Folder3" on trash list
@@ -59,7 +59,7 @@ Scenario: Element in trash can be restored under new location
     And there is no "Folder" "Folder3" on trash list
     And going to "Media/Files" there is a "Folder3" "Folder" on Sub-items list
 
-@javascript @common @admin @broken
+@javascript @common @admin
 Scenario: Content can be moved to trash from non-root location
   Given I create "Folder" Content items in "/Media/Files/" in "eng-GB"
       | name               | short_name         |
@@ -69,7 +69,7 @@ Scenario: Content can be moved to trash from non-root location
   Then there's no "Folder" "TestFolderToRemove" on "Files" Sub-items list
     And going to trash there is "Folder" "TestFolderToRemove" on list
 
-@javascript @common @broken
+@javascript @common
 Scenario: Trash can be emptied
   Given I click on the left menu bar button "Trash"
   When I empty the trash

--- a/src/lib/Behat/PageObject/TrashPage.php
+++ b/src/lib/Behat/PageObject/TrashPage.php
@@ -52,7 +52,7 @@ class TrashPage extends Page
     public function verifyIfItemInTrash(string $itemType, string $itemName, bool $elementShouldExist): void
     {
         $isElementInTrash = !$this->isTrashEmpty() &&
-            ($this->trashTable->isElementInTable($itemName) && $this->trashTable->getTableCellValue('Type', $itemName) == $itemType);
+            ($this->trashTable->isElementInTable($itemName) && $this->trashTable->getTableCellValue('Content type', $itemName) == $itemType);
         $elementShouldExistString = $elementShouldExist ? 'n\'t' : '';
 
         Assert::assertTrue(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31717
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Adjusting the tests for the changed Column name - it used to be "Type", now it's called "Content Type".
Previous:
<img width="734" alt="Zrzut ekranu 2020-07-7 o 11 16 04" src="https://user-images.githubusercontent.com/10993858/86757221-43240f80-c043-11ea-9bfb-9bc4361d417c.png">
Current:
<img width="1156" alt="Zrzut ekranu 2020-07-7 o 11 16 21" src="https://user-images.githubusercontent.com/10993858/86757263-4b7c4a80-c043-11ea-8693-84229db880fe.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
