### PR TITLE
EZP-31742: UDW error for users with restricted content types

### DIFF
--- a/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
@@ -98,9 +98,9 @@ class ContentCreate implements EventSubscriberInterface
 
         $restrictedContentTypes = $this->contentTypeService->loadContentTypeList($restrictedContentTypesIds);
 
-        return array_map(function (ContentType $contentType): string {
+        return array_values(array_map(function (ContentType $contentType): string {
             return $contentType->identifier;
-        }, (array)$restrictedContentTypes);
+        }, (array)$restrictedContentTypes));
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [https://jira.ez.no/browse/EZP-31742](https://jira.ez.no/browse/EZP-31742)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

**Steps to reproduce:**

1. Install clean eZ Platform 3.1.0/3.0.5.
2. Modify editor user role (https://ezplatform310.localhost/admin/role/3):
    - Remove "Content / All functions" limitation
    - Add "Content / Read, Content Type: Folder" limitation
    - Add "Content / Create, Content Type: Folder" limitation
3. Create a test editor user.
4. Login into admin using test editor user credentials.
5. Open "Content Structure" page (https://ezplatform310.localhost/admin/view/content/1/full/1/2).
6. Click "Browse" button in the left menu (`div.ez-sticky-container`).

**Expected result:**
UDW is opened

**Actual result:**
JavaScript error is throw in the browser console

So UDF has serious issues for the users with "Content Type" limitation on "Content / Create" policy. And it is reproducible in OE as well.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
