### PR TITLE
EZP-31767: Use version contributor name on dashboard

### DIFF
--- a/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
+++ b/src/lib/Pagination/Mapper/AbstractPagerContentToDataMapper.php
@@ -9,16 +9,16 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Pagination\Mapper;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use EzSystems\EzPlatformAdminUi\Specification\ContentIsUser;
-use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 
 abstract class AbstractPagerContentToDataMapper
 {
@@ -88,19 +88,17 @@ abstract class AbstractPagerContentToDataMapper
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      *
      * @return \eZ\Publish\API\Repository\Values\User\User|null
      */
-    protected function getContributor(ContentInfo $contentInfo): ?User
+    protected function getVersionContributor(VersionInfo $versionInfo): ?User
     {
-        $userExists = (new UserExists($this->userService))->isSatisfiedBy($contentInfo->ownerId);
-
-        if (false === $userExists) {
+        try {
+            return $this->userService->loadUser($versionInfo->creatorId);
+        } catch (NotFoundException $e) {
             return null;
         }
-
-        return $this->userService->loadUser($contentInfo->ownerId);
     }
 
     /**

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -78,7 +78,7 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
                 'contentId' => $content->id,
                 'name' => $this->translationHelper->getTranslatedContentName($content),
                 'language' => $contentInfo->mainLanguageCode,
-                'contributor' => $this->getContributor($contentInfo),
+                'contributor' => $this->getVersionContributor($content->versionInfo),
                 'version' => $content->versionInfo->versionNo,
                 'content_type' => $content->getContentType(),
                 'modified' => $content->versionInfo->modificationDate,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31767](https://jira.ez.no/browse/EZP-31767)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Currently, on content view page, we have displayed name of user who last edited the content.
![Screenshot from 2020-07-22 13-19-47](https://user-images.githubusercontent.com/2779573/88167590-c045ac00-cc21-11ea-826e-040ac4c0be99.png)
But creator name displayed as a contributor on the dashboard (In common content block)
![Screenshot from 2020-07-22 13-20-36](https://user-images.githubusercontent.com/2779573/88167603-c63b8d00-cc21-11ea-84b0-bf0689accef1.png)

I would expect to see name of user who last edited the content.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
