### PR TITLE
EZP-31777: Resolved Locations in Content relations and search module

### DIFF
--- a/src/bundle/Resources/views/admin/search/search_table_row.html.twig
+++ b/src/bundle/Resources/views/admin/search/search_table_row.html.twig
@@ -6,7 +6,7 @@
     </td>
     <td class="ez-table__cell ez-table__cell--after-icon">
         {% if row.mainLocationId is not null %}
-            <a href="{{ path('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.mainLocationId }) }}">
+            <a href="{{ path('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.resolvedLocation.id }) }}">
                 {{ row.name }}
             </a>
         {% else %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
@@ -17,7 +17,9 @@
             <tr>
                 <td>
                     {% if destination.mainLocationId is not null %}
-                        <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': relation.destinationLocation.id }) }}">
+                        <a href="{{ path('_ez_content_view',
+                            { 'contentId': destination.id, 'locationId': relation.resolvedDestinationLocation.id }) }}"
+                        >
                             {{ ez_content_name(destination) }}
                         </a>
                     {% else %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations.html.twig
@@ -17,7 +17,7 @@
             <tr>
                 <td>
                     {% if destination.mainLocationId is not null %}
-                        <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': destination.mainLocationId }) }}">
+                        <a href="{{ path('_ez_content_view', { 'contentId': destination.id, 'locationId': relation.destinationLocation.id }) }}">
                             {{ ez_content_name(destination) }}
                         </a>
                     {% else %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -18,7 +18,9 @@
                 <tr>
                     <td>
                         {% if source.mainLocationId is not null %}
-                            <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': relation.sourceLocation.id }) }}">
+                            <a href="{{ path('_ez_content_view',
+                                { 'contentId': source.id, 'locationId': relation.resolvedSourceLocation.id }) }}"
+                            >
                                 {{ ez_content_name(source) }}
                             </a>
                         {% else %}

--- a/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
+++ b/src/bundle/Resources/views/content/tab/relations/table_relations_reverse.html.twig
@@ -18,7 +18,7 @@
                 <tr>
                     <td>
                         {% if source.mainLocationId is not null %}
-                            <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': source.mainLocationId }) }}">
+                            <a href="{{ path('_ez_content_view', { 'contentId': source.id, 'locationId': relation.sourceLocation.id }) }}">
                                 {{ ez_content_name(source) }}
                             </a>
                         {% else %}

--- a/src/lib/Search/AbstractPagerContentToDataMapper.php
+++ b/src/lib/Search/AbstractPagerContentToDataMapper.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
 use EzSystems\EzPlatformAdminUi\Specification\ContentIsUser;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 
@@ -37,6 +38,9 @@ abstract class AbstractPagerContentToDataMapper
     /** @var \eZ\Publish\API\Repository\LanguageService */
     private $languageService;
 
+    /** @var \eZ\Publish\Core\Repository\LocationResolver\LocationResolver */
+    protected $locationResolver;
+
     /**
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\API\Repository\UserService $userService
@@ -49,13 +53,15 @@ abstract class AbstractPagerContentToDataMapper
         UserService $userService,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
         TranslationHelper $translationHelper,
-        LanguageService $languageService
+        LanguageService $languageService,
+        LocationResolver $locationResolver
     ) {
         $this->contentTypeService = $contentTypeService;
         $this->userService = $userService;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->translationHelper = $translationHelper;
         $this->languageService = $languageService;
+        $this->locationResolver = $locationResolver;
     }
 
     /**

--- a/src/lib/Search/PagerSearchContentToDataMapper.php
+++ b/src/lib/Search/PagerSearchContentToDataMapper.php
@@ -50,6 +50,7 @@ class PagerSearchContentToDataMapper extends AbstractPagerContentToDataMapper
                 'available_enabled_translations' => $this->getAvailableTranslations($content, true),
                 'available_translations' => $this->getAvailableTranslations($content),
                 'translation_language_code' => $searchHit->matchedTranslation,
+                'resolvedLocation' => $this->locationResolver->resolveLocation($contentInfo),
             ];
         }
 

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
 use EzSystems\EzPlatformAdminUi\Search\AbstractPagerContentToDataMapper;
 use Pagerfanta\Pagerfanta;
 
@@ -42,7 +43,8 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
         UserService $userService,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
         TranslationHelper $translationHelper,
-        LanguageService $languageService
+        LanguageService $languageService,
+        LocationResolver $locationResolver
     ) {
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
@@ -53,7 +55,8 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
             $userService,
             $userLanguagePreferenceProvider,
             $translationHelper,
-            $languageService
+            $languageService,
+            $locationResolver
         );
     }
 

--- a/src/lib/UI/Value/Content/Relation.php
+++ b/src/lib/UI/Value/Content/Relation.php
@@ -54,14 +54,14 @@ class Relation extends CoreRelation implements RelationInterface
      *
      * @var Location
      */
-    protected $sourceLocation;
+    protected $resolvedSourceLocation;
 
     /**
      * Destination location for the relation.
      *
      * @var Location
      */
-    protected $destinationLocation;
+    protected $resolvedDestinationLocation;
 
     /**
      * @param APIRelation $relation

--- a/src/lib/UI/Value/Content/Relation.php
+++ b/src/lib/UI/Value/Content/Relation.php
@@ -50,6 +50,20 @@ class Relation extends CoreRelation implements RelationInterface
     protected $relationName;
 
     /**
+     * Source location for the relation.
+     *
+     * @var Location
+     */
+    protected $sourceLocation;
+
+    /**
+     * Destination location for the relation.
+     *
+     * @var Location
+     */
+    protected $destinationLocation;
+
+    /**
      * @param APIRelation $relation
      * @param array $properties
      */

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -181,8 +181,8 @@ class ValueFactory
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
-            'sourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
-            'destinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
+            'resolvedSourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
+            'resolvedDestinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
         ]);
     }
 
@@ -208,8 +208,8 @@ class ValueFactory
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
-            'sourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
-            'destinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
+            'resolvedSourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
+            'resolvedDestinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
         ]);
     }
 

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -181,6 +181,8 @@ class ValueFactory
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
+            'sourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
+            'destinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
         ]);
     }
 
@@ -206,6 +208,8 @@ class ValueFactory
             'relationContentTypeName' => $contentType->getName(),
             'relationLocation' => $this->locationResolver->resolveLocation($content->contentInfo),
             'relationName' => $content->getName(),
+            'sourceLocation' => $this->locationResolver->resolveLocation($relation->sourceContentInfo),
+            'destinationLocation' => $this->locationResolver->resolveLocation($relation->destinationContentInfo),
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |https://jira.ez.no/browse/EZP-31777
| Improvement?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Relation tabs in Content view and Search module have been improved by adding proper URLs to related/found Content based on first available `Location` instead of main `Location`.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
