### PR TITLE
[Behat] Fixed tests running on PostgreSQL

### DIFF
--- a/features/standard/ContentCreation.feature
+++ b/features/standard/ContentCreation.feature
@@ -78,7 +78,7 @@ Feature: Content items creation
 
   @javascript @common
   Scenario: Content can be previewed during edition
-    Given I navigate to content "Test Article edited" of type "Article" in root path
+    Given I open UDW and go to "root/Test Article edited"
     When I click on the edit action bar button "Edit"
     And I should be on "Content Update" "Test Article edited" page
     And I click on the edit action bar button "Preview"

--- a/features/standard/ContentTypeFields.feature
+++ b/features/standard/ContentTypeFields.feature
@@ -52,7 +52,7 @@ Feature: Content fields setting and editing
 
   @javascript @common @admin
   Scenario: Create an ImageAsset Content item and edit specified field
-    Given I create "Image" Content items in "/Media/Images/" in "eng-GB"
+    Given I create "image" Content items in "/Media/Images/" in "eng-GB"
       | name             | image                                                                              |
       | ImageAssetImage  | vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Images/small2.jpg  |
       And I create a 'Image Asset CT2' Content Type in "Content" with 'ImageAssetCT2' identifier

--- a/features/standard/ContentTypeFields.feature
+++ b/features/standard/ContentTypeFields.feature
@@ -72,7 +72,8 @@ Feature: Content fields setting and editing
   @javascript @common
   Scenario Outline: Edit content item with given field
     Given I am logged as "admin"
-      And I navigate to content "<oldContentItemName>" of type "<fieldName> CT" in root path
+      And I go to "Content structure" in "Content" tab
+      And I open UDW and go to "root/<oldContentItemName>"
     When I click on the edit action bar button "Edit"
       And I set content fields
         | label    | <label1> | <label2> | <label3> |

--- a/features/standard/SearchContent.feature
+++ b/features/standard/SearchContent.feature
@@ -4,7 +4,7 @@ Feature: Searching for a Content item
 
   @javascript @admin @common
   Scenario: Content can be searched for
-    Given I create "Folder" Content items in root in "eng-GB"
+    Given I create "folder" Content items in root in "eng-GB"
       | name              | short_name          |
       | Searched folder   | Searched folder     |
     And I am logged as "admin"

--- a/features/standard/Trash.feature
+++ b/features/standard/Trash.feature
@@ -61,7 +61,7 @@ Scenario: Element in trash can be restored under new location
 
 @javascript @common @admin
 Scenario: Content can be moved to trash from non-root location
-  Given I create "Folder" Content items in "/Media/Files/" in "eng-GB"
+  Given I create "folder" Content items in "/Media/Files/" in "eng-GB"
       | name               | short_name         |
       | TestFolderToRemove | TestFolderToRemove |
     And I navigate to content "TestFolderToRemove" of type "Folder" in "Media/Files"


### PR DESCRIPTION
Required for https://travis-ci.org/github/ezsystems/ezplatform/builds/715325679

Failing jobs on PostgreSQL: 
- https://travis-ci.org/github/ezsystems/ezplatform/jobs/715262666
- https://travis-ci.org/github/ezsystems/ezplatform/jobs/715325691

There are two types of errors in that build:
- Case sensitivity:
```
Given I create "Folder" Content items in "/Media/Files/" in "eng-GB"             # EzSystems\BehatBundle\Context\Object\ContentContext::createContentItems()

      | name               | short_name         |

      | TestFolderToRemove | TestFolderToRemove |

      eZ\Publish\Core\Persistence\Legacy\Exception\TypeNotFound: Could not find 'eZ\Publish\SPI\Persistence\Content\Type' with identifier 'ID: Folder, Status: 0' in vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php:264
```

The Content Type identifier is called `folder` - mysql handles `Folder`, but PostgreSQL does not.
- Order of limitations returned:
```
      PHPUnit\Framework\Exception: Policy "Content/Read" with limitation "Content Type: Article, Folder" not found on the "Test Role edited" policies list.
```
Screen: https://res.cloudinary.com/ezplatformtravis/image/upload/v1596655526/screenshots/5f2b07a5a37bf961140190-vendor_ezsystems_ezplatform-admin-ui_features_standard_roles_feature_168_bx3j5n.png

As you can see the we're searching for string `Content Type: Article, Folder`, but string `Content Type: Folder, Article` is present.

The code might look a bit complicated, basically what happens is:
we take the actual limitations (as a string, returned from Selenium):
```
Content Type: Article, Folder Subtree of Location: /Users/Anonymous Users State: Lock:Locked
```
then we search for all expected Limitation values in that string (`Article`, `Folder`) and save their positions. This allows us to reorder the expected limitation string from:
`Content Type: Article, Folder` into `Content Type: Folder, Article`, which is enough for us to verify that the expected limitations are present in actual (displayed) limitations.

- Unable to find an item in Subitems list:
```
  Given I navigate to content "Test Article edited" of type "Article" in root path # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\NavigationContext::iNavigateToContentInRoot()

      There's no subitem Test Article edited on Sub-item list

      Failed asserting that false is true.
```
I'm afraid something similar to https://github.com/ezsystems/ezplatform-admin-ui/pull/1184 is happening, I've applied the fix from that PR, but further investigation might be needed.

Passing build jobs on PostgreSQL: 
- https://travis-ci.org/github/ezsystems/ezplatform/builds/715442034 (bottom 5)
- https://travis-ci.org/github/ezsystems/ezplatform/builds/715567661 (bottom 5)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
