### PR TITLE
EZP-31777: Added resolved 'locationId' to '_ez_content_view' path in Search module

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/list_item.html.twig
@@ -8,6 +8,7 @@
         {% if row.mainLocationId is not null %}
             <a href="{{ path('_ez_content_view', {
                 'contentId': row.contentId,
+                'locationId': row.resolvedLocation.id,
                 'languageCode': row.translation_language_code,
             }) }}">{{ row.name }}</a>
         {% else %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31777](https://jira.ez.no/browse/EZP-31777)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR is a direct follow up of v2.5 PR but for v3.1: https://github.com/ezsystems/ezplatform-admin-ui/pull/1443

Required PR: https://github.com/ezsystems/ezplatform-search/pull/9

Regression suite: https://github.com/ezsystems/ezplatform-page-builder/pull/637

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
