### PR TITLE
[Behat] Extracted Scenario emptying Trash

### DIFF
--- a/features/standard/CleanTrash.feature
+++ b/features/standard/CleanTrash.feature
@@ -1,0 +1,10 @@
+Feature: Trash management
+
+    @javascript @common
+    Scenario: Trash can be emptied
+    Given I am logged as "admin"
+        And I go to "Content structure" in "Content" tab
+        And I click on the left menu bar button "Trash"
+        And trash is not empty
+    When I empty the trash
+    Then trash is empty

--- a/features/standard/Trash.feature
+++ b/features/standard/Trash.feature
@@ -68,9 +68,3 @@ Scenario: Content can be moved to trash from non-root location
   When I send content to trash
   Then there's no "Folder" "TestFolderToRemove" on "Files" Sub-items list
     And going to trash there is "Folder" "TestFolderToRemove" on list
-
-@javascript @common
-Scenario: Trash can be emptied
-  Given I click on the left menu bar button "Trash"
-  When I empty the trash
-  Then trash is empty

--- a/src/lib/Behat/BusinessContext/TrashContext.php
+++ b/src/lib/Behat/BusinessContext/TrashContext.php
@@ -34,6 +34,18 @@ class TrashContext extends BusinessContext
     }
 
     /**
+     * @When trash is not empty
+     */
+    public function trashIsNotEmpty(): void
+    {
+        $trash = PageObjectFactory::createPage($this->utilityContext, TrashPage::PAGE_NAME);
+        Assert::assertFalse(
+            $trash->isTrashEmpty(),
+            'Trash is empty.'
+        );
+    }
+
+    /**
      * @When I empty the trash
      */
     public function iEmptyTrash(): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31796
| Bug fix?      | in tests?
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Failing build: https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/369564566

There are tests failing in nightly builds because they are checking that items are present in the Trash - this fails when the Trash is cleaned inbetween the Steps. (see JIRA ticket for more information)

I've decided to extract the Scenario emptying the Trash into a separate, single Feature - this causes it to run as the last one, which makes interference less likely.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
