### PR TITLE
[Behat] Adapted Behat tests for PostgreSQL

### DIFF
--- a/src/lib/Behat/PageElement/Fields/Keywords.php
+++ b/src/lib/Behat/PageElement/Fields/Keywords.php
@@ -13,7 +13,22 @@ class Keywords extends EzFieldElement
 {
     /** @var string Name by which Element is recognised */
     public const ELEMENT_NAME = 'Keywords';
-    private $setKeywordsValueScript = 'document.getElementById(\'%s\').value = \'%s\';';
+    private $setKeywordsValueScript = <<<SCRIPT
+const SELECTOR_TAGGIFY = '.ez-data-source__taggify';
+const taggifyContainer = document.querySelector(SELECTOR_TAGGIFY);
+const taggify = new window.Taggify({
+    containerNode: taggifyContainer,
+    displayLabel: false,
+    displayInputValues: false,
+});
+
+const tags = [%s];
+var list = tags.map(function (item) {
+    return {id: item, label: item};
+});
+
+taggify.updateTags(list);
+SCRIPT;
 
     public function __construct(UtilityContext $context, string $locator, string $label)
     {
@@ -26,14 +41,15 @@ class Keywords extends EzFieldElement
         $fieldInput = $this->context->findElement(
             sprintf('%s %s', $this->fields['fieldContainer'], $this->fields['fieldInput'])
         );
-
         Assert::assertNotNull($fieldInput, sprintf('Input for field %s not found.', $this->label));
 
-        $keywordInputId = $fieldInput->getAttribute('id');
-        $fieldInput->focus();
-        $this->context->getSession()->getDriver()->executeScript(sprintf($this->setKeywordsValueScript, $keywordInputId, ''));
-        $this->context->getSession()->getDriver()->executeScript(sprintf($this->setKeywordsValueScript, $keywordInputId, $parameters['value']));
-        $fieldInput->blur();
+        $parsedValue = implode(',', array_map(
+            function (string $element) {
+                return sprintf('"%s"', trim($element));
+            }, explode(',', $parameters['value'])
+        ));
+
+        $this->context->getSession()->getDriver()->executeScript(sprintf($this->setKeywordsValueScript, $parsedValue));
     }
 
     public function getValue(): array


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3235
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


Passing 5 PostreSQL jobs: https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/builds/718918387
Another 5 PostgreSQL jobs passing: https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/builds/718941332

Failure this PR is trying to solve: https://travis-ci.org/github/ezsystems/ezplatform/jobs/717786184
```
       Wrong page title.
        Failed asserting that two strings are equal.
        --- Expected
        +++ Actual
        @@ @@
        -'first keyword, second, edit'
        +'second, first keyword, edit'
```

When editing a Keyword Content Item the keywords were in incorrect order. This has been caused by two things:
1) already present keywords are not ordered when loaded from the database
2) the code clearing existing keywords didn't work

So, instead of setting "first keyword, second, edit", it appended keywords to the already existing ones (loaded in random order) and then appended duplicates would be removed, resulting in reordering of already existing keywords.

I've decided to change the JS code responsible for setting the value, using the JS library we use under the hood (Taggify).
More info about it:
- https://github.com/sunpietro/taggify
- also had to take this issue into account: https://github.com/sunpietro/taggify/issues/4

Now the new keywords are set correctly and there is no reordering.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
