### PR TITLE
EZEE-3239: Added additional event to show asset preview

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
@@ -20,6 +20,7 @@
             const dataMaxSize = +this.inputField.dataset.maxFileSize;
 
             this.maxFileSize = parseInt(dataMaxSize, 10);
+            this.showPreviewEventName = 'ez-base:show-preview';
         }
 
         /**
@@ -270,7 +271,7 @@
             window.addEventListener('drop', this.preventDefaultAction, false);
             window.addEventListener('dragover', this.preventDefaultAction, false);
 
-            this.fieldContainer.addEventListener('ez-show-preview', () => this.showPreview());
+            this.fieldContainer.addEventListener(this.showPreviewEventName, () => this.showPreview());
 
             this.initializeDropZone();
             this.initializePreview();

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-preview-field.js
@@ -270,6 +270,8 @@
             window.addEventListener('drop', this.preventDefaultAction, false);
             window.addEventListener('dragover', this.preventDefaultAction, false);
 
+            this.fieldContainer.addEventListener('ez-show-preview', () => this.showPreview());
+
             this.initializeDropZone();
             this.initializePreview();
 

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -252,7 +252,5 @@
         previewField.init();
 
         eZ.addConfig('fieldTypeValidators', [validator], true);
-        eZ.addConfig('EzImageAssetPreviewField', EzImageAssetPreviewField);
-        eZ.addConfig('EzImageAssetFieldValidator', EzImageAssetFieldValidator);
     });
 })(window, window.document, window.eZ, window.React, window.ReactDOM, window.Translator, window.Routing);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -10,6 +10,11 @@
     const imageAssetMapping = eZ.adminUiConfig.imageAssetMapping;
 
     class EzImageAssetPreviewField extends eZ.BasePreviewField {
+        constructor(props) {
+            super(props);
+
+            this.showPreviewEventName = 'ez-image-asset:show-preview';
+        }
         /**
          * Creates a new Image Asset
          *

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -252,5 +252,7 @@
         previewField.init();
 
         eZ.addConfig('fieldTypeValidators', [validator], true);
+        eZ.addConfig('EzImageAssetPreviewField', EzImageAssetPreviewField);
+        eZ.addConfig('EzImageAssetFieldValidator', EzImageAssetFieldValidator);
     });
 })(window, window.document, window.eZ, window.React, window.ReactDOM, window.Translator, window.Routing);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3239
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Unless there is different way to do this, I need those here:
https://github.com/ezsystems/ezplatform-connector-dam/pull/4


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
