### PR TITLE
EZP-31776: Resolved Contents' Locations in Dashboard

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/all_content.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/all_content.html.twig
@@ -23,7 +23,7 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">
+                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.resolvedLocation.id }) }}">
                         {{ row.name }}
                     </a>
                 </td>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/all_media.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/all_media.html.twig
@@ -23,7 +23,7 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">
+                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.resolvedLocation.id }) }}">
                         {{ row.name }}
                     </a>
                 </td>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_content.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_content.html.twig
@@ -22,7 +22,7 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">
+                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.resolvedLocation.id }) }}">
                         {{ row.name }}
                     </a>
                 </td>

--- a/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_media.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/dashboard/tab/my_media.html.twig
@@ -22,7 +22,7 @@
                     </svg>
                 </td>
                 <td class="ez-table__cell ez-table__cell--name ez-table__cell--after-icon">
-                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">
+                    <a href="{{ url('_ez_content_view', { 'contentId': row.contentId, 'locationId': row.resolvedLocation.id }) }}">
                         {{ row.name }}
                     </a>
                 </td>

--- a/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
+++ b/src/lib/Tab/Dashboard/PagerContentToDataMapper.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
 use EzSystems\EzPlatformAdminUi\Pagination\Mapper\AbstractPagerContentToDataMapper;
 use Pagerfanta\Pagerfanta;
 
@@ -27,6 +28,9 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
 
     /** @var \eZ\Publish\API\Repository\UserService */
     protected $userService;
+
+    /** @var \eZ\Publish\Core\Repository\LocationResolver\LocationResolver */
+    protected $locationResolver;
 
     /**
      * @param \eZ\Publish\API\Repository\ContentService $contentService
@@ -42,11 +46,13 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
         UserService $userService,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
         TranslationHelper $translationHelper,
-        LanguageService $languageService
+        LanguageService $languageService,
+        LocationResolver $locationResolver
     ) {
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->userService = $userService;
+        $this->locationResolver = $locationResolver;
 
         parent::__construct(
             $contentTypeService,
@@ -85,6 +91,7 @@ class PagerContentToDataMapper extends AbstractPagerContentToDataMapper
                 'initialLanguageCode' => $content->versionInfo->initialLanguageCode,
                 'content_is_user' => $this->isContentIsUser($content),
                 'available_enabled_translations' => $this->getAvailableTranslations($content, true),
+                'resolvedLocation' => $this->locationResolver->resolveLocation($contentInfo),
             ];
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31776
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Dashboard Content should have resolved `LocationId` attribute passed to `_ez_content_view` path.

This PR is a direct follow up of https://github.com/ezsystems/ezplatform-admin-ui/pull/1443 but for v3.1

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
