### PR TITLE
EZP-31782: PermissionChecker caches policy limitations incorrectly

### DIFF
--- a/src/lib/Permission/PermissionChecker.php
+++ b/src/lib/Permission/PermissionChecker.php
@@ -38,9 +38,6 @@ class PermissionChecker implements PermissionCheckerInterface
     /** @var \eZ\Publish\API\Repository\UserService */
     private $userService;
 
-    /** @var array */
-    private $flattenArrayOfLimitations;
-
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
@@ -239,7 +236,7 @@ class PermissionChecker implements PermissionCheckerInterface
             }
         }
 
-        return $this->flattenArrayOfLimitations[$currentUserId] = $limitations;
+        return $limitations;
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31782
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

PermissionChecker caches policy limitations incorrectly. Please note https://github.com/ezsystems/ezplatform-admin-ui/pull/1441 depends on this PR.

More info:
- https://jira.ez.no/browse/EZP-31782
- https://github.com/ezsystems/ezplatform-admin-ui/security/advisories/GHSA-w355-8mff-w525

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
