### PR TITLE
EZP-31814: Fixed PermissionChecker for content/edit policy

### DIFF
--- a/src/lib/Permission/PermissionChecker.php
+++ b/src/lib/Permission/PermissionChecker.php
@@ -210,14 +210,12 @@ class PermissionChecker implements PermissionCheckerInterface
 
     public function getContentUpdateLimitations(Location $location): LookupLimitationResult
     {
-        $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
-
         $versionBuilder = new VersionBuilder();
         $versionBuilder->translateToAnyLanguageOf($this->getActiveLanguageCodes());
         $versionBuilder->createFromAnyContentTypeOf($this->getContentTypeIds());
 
         return $this->permissionResolver->lookupLimitations('content', 'edit',
-            $contentUpdateStruct,
+            $location->getContentInfo(),
             [$versionBuilder->build(), $location],
             [Limitation::CONTENTTYPE, Limitation::LANGUAGE]
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31814
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Invalid target was passed to `content/edit` policy which caused exception instead of resolving the permission itself.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
