### PR TITLE
[Behat] Added check that session is started before browser logs are accessed

### DIFF
--- a/src/lib/Behat/Helper/TestLogProvider.php
+++ b/src/lib/Behat/Helper/TestLogProvider.php
@@ -38,6 +38,12 @@ class TestLogProvider
 
     public function getBrowserLogs(): array
     {
+        $driver = $this->session->getDriver();
+
+        if (!$this->session->isStarted() || !($driver instanceof Selenium2Driver)) {
+            return [];
+        }
+
         if ($this->hasCachedLogs()) {
             $logs = $this->getCachedLogs();
             $this->clearCachedLogs();
@@ -45,16 +51,11 @@ class TestLogProvider
             return $logs;
         }
 
-        $driver = $this->session->getDriver();
-        if ($driver instanceof Selenium2Driver) {
-            $logs = $driver->getWebDriverSession()->log(LogType::BROWSER) ?? [];
-            $parsedLogs = $this->parseBrowserLogs($logs);
-            $this->cacheLogs($parsedLogs);
+        $logs = $driver->getWebDriverSession()->log(LogType::BROWSER) ?? [];
+        $parsedLogs = $this->parseBrowserLogs($logs);
+        $this->cacheLogs($parsedLogs);
 
-            return $parsedLogs;
-        }
-
-        return [];
+        return $parsedLogs;
     }
 
     public function getApplicationLogs(): array


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31836
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

More details in JIRA issue, but we simply need to check whether the session is started before browser logs can be accessed.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
