### PR TITLE
[Behat] Added sorting subitems by Modified date before navigating

### DIFF
--- a/src/lib/Behat/PageElement/SubItemsList.php
+++ b/src/lib/Behat/PageElement/SubItemsList.php
@@ -36,4 +36,10 @@ class SubItemsList extends Element
     {
         $this->context->waitUntilElementIsVisible($this->fields['list']);
     }
+
+    public function sortBy(string $columnName, bool $ascending): void
+    {
+        $this->table->sortBy($columnName, $ascending);
+        $this->verifyVisibility();
+    }
 }

--- a/src/lib/Behat/PageElement/Tables/SubItemsTable.php
+++ b/src/lib/Behat/PageElement/Tables/SubItemsTable.php
@@ -19,10 +19,13 @@ class SubItemsTable extends Table
     public function __construct(UtilityContext $context, $containerLocator)
     {
         parent::__construct($context, $containerLocator);
+        $this->fields['tableHead'] = 'thead.c-table-view__head';
         $this->fields['horizontalHeaders'] = $this->fields['list'] . ' .c-table-view__cell--head';
         $this->fields['listElement'] = $this->fields['list'] . ' .c-table-view-item__link';
         $this->fields['nthListElement'] = $this->fields['list'] . ' tr:nth-child(%d) .c-table-view-item__link';
         $this->fields['listElementType'] = $this->fields['list'] . ' tr:nth-child(%d) .c-table-view-item__cell--content-type';
+        $this->fields['sortingOrderAscending'] = '.c-table-view__head--sort-asc';
+        $this->fields['sortingOrderDescending'] = '.c-table-view__head--sort-desc';
         $this->fields['editButton'] = $this->fields['list'] . ' .c-table-view-item__btn--edit';
         $this->fields['noItems'] = $this->fields['list'] . ' .c-no-items';
     }
@@ -39,6 +42,23 @@ class SubItemsTable extends Table
         );
 
         return $this->getCellValue($rowPosition, $columnPosition);
+    }
+
+    public function sortBy(string $columnName, bool $ascending): void
+    {
+        $this->context->getElementByText($columnName, $this->fields['horizontalHeaders'])->click();
+
+        $isSortedAscending = $this->context->isElementVisible(sprintf('%s%s', $this->fields['tableHead'], $this->fields['sortingOrderAscending']));
+
+        if ($ascending !== $isSortedAscending) {
+            $this->context->getElementByText($columnName, $this->fields['horizontalHeaders'])->click();
+        }
+
+        $verificationSelector = $ascending ?
+                                sprintf('%s%s', $this->fields['tableHead'], $this->fields['sortingOrderAscending']) :
+                                sprintf('%s%s', $this->fields['tableHead'], $this->fields['sortingOrderDescending']);
+
+        $this->context->waitUntilElementIsVisible($verificationSelector);
     }
 
     /**

--- a/src/lib/Behat/PageObject/ContentItemPage.php
+++ b/src/lib/Behat/PageObject/ContentItemPage.php
@@ -86,6 +86,7 @@ class ContentItemPage extends Page
     public function goToSubItem(string $contentName, string $contentType): void
     {
         $contentPage = PageObjectFactory::createPage($this->context, self::PAGE_NAME, $contentName);
+        $contentPage->subItemList->sortBy('Modified', false);
         $contentPage->subItemList->table->clickListElement($contentName, $contentType);
         $contentPage->verifyIsLoaded();
         $contentPage->verifyContentType($contentType);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://jira.ez.no/browse/EZP-31839
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Please see Jira issue for a list of failing builds.

Sometimes our tests are unable to find a Content Item when navigating through subitems - I suspect this is a similar issue to https://github.com/ezsystems/ezplatform-admin-ui/pull/1184 , where the list of Subitems is modified by Scenarios running in parallel.

This solution sorts the Subitems by Modification date (descending), hoping that the item the tests are looking for is created recently and will be displayed on the first page - and when it's on the first page of results then any modifications are not able to interfere with it, as it's already displayed.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
