### PR TITLE
[Behat] Added reloading of the page when Content Type is not present in picker

### DIFF
--- a/src/lib/Behat/PageElement/ContentTypePicker.php
+++ b/src/lib/Behat/PageElement/ContentTypePicker.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformAdminUi\Behat\PageElement;
 
+use Behat\Mink\Element\NodeElement;
 use EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext;
 
 class ContentTypePicker extends Element
@@ -24,5 +25,17 @@ class ContentTypePicker extends Element
     public function select(string $contentType): void
     {
         $this->context->getElementByText($contentType, $this->fields['contentTypeSelector'])->click();
+    }
+
+    public function isContentTypeVisible(string $contentTypeName): bool
+    {
+        return $this->context->getElementByText($contentTypeName, $this->fields['contentTypeSelector']) !== null;
+    }
+
+    public function getDisplayedContentTypes(): array
+    {
+        return array_map(function (NodeElement $element) {
+            return $element->getText();
+        }, $this->context->findAllElements($this->fields['contentTypeSelector']));
     }
 }

--- a/src/lib/Behat/PageObject/ContentItemPage.php
+++ b/src/lib/Behat/PageObject/ContentItemPage.php
@@ -51,14 +51,20 @@ class ContentItemPage extends Page
      *
      * @param string $contentType
      */
-    public function startCreatingContent(string $contentType): ContentUpdateItemPage
+    public function startCreatingContent(string $contentTypeName): ContentUpdateItemPage
     {
         $this->rightMenu->clickButton('Create');
 
         $contentTypePicker = ElementFactory::createElement($this->context, ContentTypePicker::ELEMENT_NAME);
-        $contentTypePicker->select($contentType);
+        $contentTypePicker->verifyVisibility();
 
-        $contentUpdatePage = PageObjectFactory::createPage($this->context, ContentUpdateItemPage::PAGE_NAME, $contentType);
+        if (!$contentTypePicker->isContentTypeVisible($contentTypeName)) {
+            $this->handleMissingContentType($contentTypeName);
+        }
+
+        ElementFactory::createElement($this->context, ContentTypePicker::ELEMENT_NAME)->select($contentTypeName);
+
+        $contentUpdatePage = PageObjectFactory::createPage($this->context, ContentUpdateItemPage::PAGE_NAME, $contentTypeName);
         $contentUpdatePage->verifyIsLoaded();
 
         return $contentUpdatePage;
@@ -109,5 +115,33 @@ class ContentItemPage extends Page
                 $contentPage->subItemList->table->clickListElement($pathArray[$i]);
             }
         }
+    }
+
+    protected function handleMissingContentType(string $contentTypeName): void
+    {
+        $contentTypePicker = ElementFactory::createElement($this->context, ContentTypePicker::ELEMENT_NAME);
+        $displayedContentTypesBeforeReload = $contentTypePicker->getDisplayedContentTypes();
+
+        $this->context->getSession()->reload();
+
+        $rightMenu = ElementFactory::createElement($this->context, RightMenu::ELEMENT_NAME);
+        $rightMenu->clickButton('Create');
+
+        $contentTypePicker = ElementFactory::createElement($this->context, ContentTypePicker::ELEMENT_NAME);
+        $displayedContentTypesAfterReload = $contentTypePicker->getDisplayedContentTypes();
+
+        $this->printContentTypes('Content Types before reload:', $displayedContentTypesBeforeReload);
+        $this->printContentTypes('Content Types after reload:', $displayedContentTypesAfterReload);
+
+        Assert::fail(sprintf('Content Type: %s was not detected the first time', $contentTypeName));
+    }
+
+    protected function printContentTypes(string $initiaMessage, array $contentTypes): void
+    {
+        foreach ($contentTypes as $contentType) {
+            $initiaMessage .= PHP_EOL . $contentType;
+        }
+
+        echo $initiaMessage;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31856
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

See JIRA ticket for failing builds.

This is our most common issue in tests - the Content Type created by the API is not visible in Content Type picker. This is a highly random issue, because all of our Content Types in tests are created the same way. Most of the time everything is correct, but sometimes some Content Types are not loaded by the Content Type picker.

This PR does not solve the issue, but may help us get more data about it so we can make further improvements.

Since this looks like a cache issue and there is very little data about this PR does to things:
1) Adds more debugging info: displays the available Content Types in the picker so we can have a bit more data about the state of the Page when the issue happens
2) Tries if reloading the Page fixes the issue

Even if reloading helps we still fail the tests to get a notification about it on Slack and be able to look at the build.

Example debug output will look like this: (simulated, based on https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/jobs/726981397 - if I could reproduce the issue locally then it would be a different story 😉 )
```
      | FolderParent          | root/FolderGrandParent              | NewContent1 | root/FolderGrandParent/FolderParent              |
        │ Content Types before reload:
        │ Article
        │ Folder
        │ User
        │ User group
        │ File
        │ Image
        │ 
        │ 
        │ Content Types after reload:
        │ Article
        │ DedicatedFolder
        │ Folder
        │ User
        │ User group
        │ File
        │ Image
        │ 
        │ 
        │ 
        Content Type: DedicatedFolder was not detected the first time
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
