### PR TITLE
EZP-31852: Fixed selectedLocations prop in UDW

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
@@ -162,7 +162,11 @@ const UniversalDiscoveryModule = (props) => {
             return;
         }
 
-        loadLocationsWithPermissions({ locationIds: props.selectedLocations.join(',') }, addPermissionsToSelectedLocations);
+        findLocationsById({ ...restInfo, id: props.selectedLocations.join(',') }, (locations) => {
+            const mappedLocation = locations.map((location) => ({ location }));
+
+            dispatchSelectedLocationsAction({ type: 'REPLACE_SELECTED_LOCATIONS', locations: mappedLocation });
+        });
     }, [props.selectedLocations]);
 
     useEffect(() => {

--- a/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
@@ -163,7 +163,11 @@ const UniversalDiscoveryModule = (props) => {
         }
 
         findLocationsById({ ...restInfo, id: props.selectedLocations.join(',') }, (locations) => {
-            const mappedLocation = locations.map((location) => ({ location }));
+            const mappedLocation = props.selectedLocations.map((locationId) => {
+                const location = locations.find((location) => location.id === parseInt(locationId, 10));
+
+                return { location };
+            });
 
             dispatchSelectedLocationsAction({ type: 'REPLACE_SELECTED_LOCATIONS', locations: mappedLocation });
         });


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31852
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Now UDW should have already selected locations when user is returning to collection block settings.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
