### PR TITLE
EZP-31875: Added request matcher to recognize REST requests executed in AdminUI context

### DIFF
--- a/src/bundle/Resources/config/services/rest.yaml
+++ b/src/bundle/Resources/config/services/rest.yaml
@@ -38,7 +38,6 @@ services:
       tags:
           - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root }
 
-  # RequestMatcher for JWT
-  EzSystems\EzPlatformAdminUi\REST\Security\AdminRESTRequestMatcher:
+  EzSystems\EzPlatformAdminUi\REST\Security\NonAdminRESTRequestMatcher:
       arguments:
           $siteAccessGroups: '%ezpublish.siteaccess.groups%'

--- a/src/bundle/Resources/config/services/rest.yaml
+++ b/src/bundle/Resources/config/services/rest.yaml
@@ -37,3 +37,8 @@ services:
       parent: ezpublish_rest.output.value_object_visitor.base
       tags:
           - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Root }
+
+  # RequestMatcher for JWT
+  EzSystems\EzPlatformAdminUi\REST\Security\AdminRESTRequestMatcher:
+      arguments:
+          $siteAccessGroups: '%ezpublish.siteaccess.groups%'

--- a/src/lib/REST/Security/AdminRESTRequestMatcher.php
+++ b/src/lib/REST/Security/AdminRESTRequestMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformAdminUi\REST\Security;
+
+use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+final class AdminRESTRequestMatcher implements RequestMatcherInterface
+{
+    /** @var string[][] */
+    private $siteAccessGroups;
+
+    public function __construct(array $siteAccessGroups)
+    {
+        $this->siteAccessGroups = $siteAccessGroups;
+    }
+
+    public function matches(Request $request): bool
+    {
+        return
+            $request->attributes->get('is_rest_request') &&
+            !$this->isAdminSiteAccess($request);
+    }
+
+    private function isAdminSiteAccess(Request $request): bool
+    {
+        return (new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($request->attributes->get('siteaccess'));
+    }
+}

--- a/src/lib/REST/Security/NonAdminRESTRequestMatcher.php
+++ b/src/lib/REST/Security/NonAdminRESTRequestMatcher.php
@@ -4,13 +4,15 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformAdminUi\REST\Security;
 
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
-final class AdminRESTRequestMatcher implements RequestMatcherInterface
+final class NonAdminRESTRequestMatcher implements RequestMatcherInterface
 {
     /** @var string[][] */
     private $siteAccessGroups;

--- a/src/lib/Tests/REST/Security/NonAdminRESTRequestMatcherTest.php
+++ b/src/lib/Tests/REST/Security/NonAdminRESTRequestMatcherTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\REST\Security;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use EzSystems\EzPlatformAdminUi\REST\Security\NonAdminRESTRequestMatcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class NonAdminRESTRequestMatcherTest extends TestCase
+{
+    public function testMatchRESTRequestInAdminContext(): void
+    {
+        $siteAccessMock = $this->createMock(SiteAccess::class);
+        $siteAccessMock->name = 'admin';
+        $adminRESTRequestMatcher = new NonAdminRESTRequestMatcher(
+            [
+                'admin_group' => [
+                    'admin',
+                ],
+            ]
+        );
+
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
+
+        $request->attributes
+            ->expects(self::at(0))
+            ->method('get')
+            ->with('is_rest_request')
+            ->willReturn(true);
+
+        $request->attributes
+            ->expects(self::at(1))
+            ->method('get')
+            ->with('siteaccess')
+            ->willReturn($siteAccessMock);
+
+        self::assertFalse($adminRESTRequestMatcher->matches($request));
+    }
+
+    public function testMatchNonRESTRequest(): void
+    {
+        $adminRESTRequestMatcher = new NonAdminRESTRequestMatcher([]);
+
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
+
+        $request->attributes
+            ->expects(self::at(0))
+            ->method('get')
+            ->with('is_rest_request')
+            ->willReturn(false);
+
+        self::assertFalse($adminRESTRequestMatcher->matches($request));
+    }
+
+    public function testMatchRESTRequestNotInAdminContext(): void
+    {
+        $siteAccessMock = $this->createMock(SiteAccess::class);
+        $siteAccessMock->name = 'admin';
+        $nonAdminSiteAccessMock = $this->createMock(SiteAccess::class);
+        $nonAdminSiteAccessMock->name = 'ibexa';
+        $adminRESTRequestMatcher = new NonAdminRESTRequestMatcher(
+            [
+                'admin_group' => [
+                    'admin',
+                ],
+                'another_group' => [
+                    'ibexa',
+                ],
+            ]
+        );
+
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
+
+        $request->attributes
+            ->expects(self::at(0))
+            ->method('get')
+            ->with('is_rest_request')
+            ->willReturn(true);
+
+        $request->attributes
+            ->expects(self::at(1))
+            ->method('get')
+            ->with('siteaccess')
+            ->willReturn($nonAdminSiteAccessMock);
+
+        self::assertTrue($adminRESTRequestMatcher->matches($request));
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31875](https://jira.ez.no/browse/EZP-31875)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR introduces a `RequestMatcher` that is needed for https://github.com/ezsystems/ezplatform-rest/pull/54.

I'm happy to change the class name if someone has any better ideas. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
