### PR TITLE
EZP-31844: Trash Management screen - Display creator name and not ID in the table

### DIFF
--- a/src/bundle/Resources/views/themes/admin/trash/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/trash/list.html.twig
@@ -207,7 +207,7 @@
                                         <td class="ez-table__cell">{{ trash_item.contentType.name }}</td>
                                         <td class="ez-table__cell">
                                             {{ trash_item.creator is not empty
-                                                ? trash_item.creator.login :
+                                                ? ez_content_name(trash_item.creator.content) :
                                                 'trash.item.deleted_user'|trans|desc('Deleted user')
                                             }}
                                         </td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31844
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
