### PR TITLE
EZP-31890: CT - ezrichtext field takes too much space

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezrichtext.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezrichtext.scss
@@ -5,10 +5,10 @@
         }
 
         &__richtext {
-            min-height: calculateRem(400px);
+            min-height: calculateRem(100px);
             border-radius: $ibexa-border-radius $ibexa-border-radius 0 0;
             border-color: $ibexa-color-base-dark;
-            border-width: calculateRem(1px) calculateRem(1px) 0 calculateRem(1px); 
+            border-width: calculateRem(1px) calculateRem(1px) 0 calculateRem(1px);
         }
 
         .ez-richtext-tools {
@@ -16,7 +16,7 @@
             align-items: center;
             height: calculateRem(40px);
             border: calculateRem(1px) solid $ibexa-color-base-dark;
-            border-width: 0 calculateRem(1px) calculateRem(1px) calculateRem(1px); 
+            border-width: 0 calculateRem(1px) calculateRem(1px) calculateRem(1px);
         }
 
         .ez-elements-path,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31890
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
