### PR TITLE
EZP-31814: Self owner limitation in a security role breaks the UDW

### DIFF
--- a/src/lib/Permission/PermissionChecker.php
+++ b/src/lib/Permission/PermissionChecker.php
@@ -210,14 +210,14 @@ class PermissionChecker implements PermissionCheckerInterface
 
     public function getContentUpdateLimitations(Location $location): LookupLimitationResult
     {
-        $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
+        $contentInfo = $location->getContentInfo();
 
         $versionBuilder = new VersionBuilder();
         $versionBuilder->translateToAnyLanguageOf($this->getActiveLanguageCodes());
         $versionBuilder->createFromAnyContentTypeOf($this->getContentTypeIds());
 
         return $this->permissionResolver->lookupLimitations('content', 'edit',
-            $contentUpdateStruct,
+            $contentInfo,
             [$versionBuilder->build(), $location],
             [Limitation::CONTENTTYPE, Limitation::LANGUAGE]
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31814
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Users with "Content/Edit, Limitation: Owner" security role are unable to use the UDW.
More details: https://jira.ez.no/browse/EZP-31814

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review