### PR TITLE
EZP-31923: [Trash] Restore's and Delete buttons are displayed too close to each other

### DIFF
--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -148,6 +148,10 @@
 
     &__tools {
         white-space: nowrap;
+
+        .btn {
+            margin: 0 calculateRem(5px);
+        }
     }
 
     &--bordered-bottom {

--- a/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/content_type_group/list.html.twig
@@ -24,7 +24,7 @@
     <section class="container ez-container">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'content_type_group.view.list.title'|trans|desc('Content Type groups') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_create %}
                     <a
                         title="{{ 'content_type_group.view.list.action.add'|trans|desc('Create a Content Type group') }}"

--- a/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/list.html.twig
@@ -7,7 +7,7 @@
 <section class="container ez-container">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">{{ 'content_type.view.list.title'|trans({ '%identifier%': content_type_group.identifier })|desc('Content Types in \'%identifier%\'') }}</div>
-        <div>
+        <div class="ez-table-header__tools">
             {% if can_create %}
                 <a
                     href="{{ path('ezplatform.content_type.add', {contentTypeGroupId: content_type_group.id}) }}"

--- a/src/bundle/Resources/views/themes/admin/language/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/index.html.twig
@@ -29,7 +29,7 @@
             <div class="ez-table-header__headline">
                 {{ 'language.information.header'|trans|desc('Language information') }}
             </div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_administrate %}
                     {{ form_start(deleteForm, {"action": path("ezplatform.language.delete", {"languageId": language.id, "redirectErrorsTo": "view"})}) }}
 

--- a/src/bundle/Resources/views/themes/admin/language/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/language/list.html.twig
@@ -26,7 +26,7 @@
     <section class="container ez-container">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'language.list'|trans|desc('Languages') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_administrate %}
                     <a
                         title="{{ 'language.new'|trans|desc('Create a new language') }}"

--- a/src/bundle/Resources/views/themes/admin/object_state/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/object_state/list.html.twig
@@ -6,7 +6,7 @@
     <section class="container ez-container">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state.view.list.title'|trans({'%count%': object_states|length})|desc('Object states (%count%)') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_administrate %}
                     <a
                         title="{{ 'object_state.new'|trans|desc('Create a new Object state') }}"

--- a/src/bundle/Resources/views/themes/admin/object_state/object_state_group/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/object_state/object_state_group/list.html.twig
@@ -26,7 +26,7 @@
     <section class="container ez-container">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'object_state_group.view.list.title'|trans|desc('Object state groups') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_administrate %}
                     <a
                         title="{{ 'object_state_group.new'|trans|desc('Create a new Object state group') }}"

--- a/src/bundle/Resources/views/themes/admin/section/assigned_content.html.twig
+++ b/src/bundle/Resources/views/themes/admin/section/assigned_content.html.twig
@@ -9,7 +9,7 @@
                 '%name%': section.name,
                 '%count%': pagerfanta.nbResults
             } )|desc('Content items in \'%name%\' (%count%)') }}
-        </div>
+        </div class="ez-table-header__tools">
         {% if can_assign %}
             {{ form_start(form_section_content_assign, {
                 'action': path("ezplatform.section.assign_content", {"sectionId": section.id}),

--- a/src/bundle/Resources/views/themes/admin/section/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/section/list.html.twig
@@ -25,7 +25,7 @@
     <section class="container ez-container">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'section.list.title'|trans|desc('Sections') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_add %}
                     <a
                         title="{{ 'section.new'|trans|desc('Create a new Section') }}"
@@ -82,9 +82,9 @@
                     <td class="ez-table__cell ez-table__cell--has-checkbox">
                         {% if can_edit %}
                             {{ form_widget(form_sections_delete.sections[section.id], {
-                                    "attr": { "class": "ez-input ez-input--checkbox" }, 
+                                    "attr": { "class": "ez-input ez-input--checkbox" },
                                     "disabled": not deletable[section.id]
-                                }) 
+                                })
                             }}
                         {% else %}
                             {% do form_sections_delete.sections.setRendered %}

--- a/src/bundle/Resources/views/themes/admin/section/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/section/view.html.twig
@@ -23,8 +23,7 @@
     <section class="container ez-container">
         <header class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'section.information.header'|trans|desc('Section information') }}</div>
-
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_edit %}
                     {% set modalDataAttributes = deletable ? 'data-toggle=modal data-target=#delete-section-modal' : '' %}
                     <button

--- a/src/bundle/Resources/views/themes/admin/url_wildcard/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/url_wildcard/list.html.twig
@@ -20,7 +20,7 @@
         <div class="ez-table-header__headline">
             {{ 'url_wildcard.list.title'|trans|desc('URL wildcards') }}
         </div>
-        <div>
+        <div class="ez-table-header__tools">
             {% set modal_create_data_target = 'create-wildcards-modal' %}
             <button
                 id="create-wildcards"

--- a/src/bundle/Resources/views/themes/admin/user/policy/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/policy/list.html.twig
@@ -5,7 +5,7 @@
 <section class="container ez-container">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">{{ 'policy.view.list.title.count'|trans({'%count%': role.policies|length})|desc('Policies (%count%)') }}</div>
-        <div>
+        <div class="ez-table-header__tools">
             {% if can_update %}
                 <a
                     title="{{ 'policy.view.list.action.add'|trans|desc('Add a new Policy') }}"

--- a/src/bundle/Resources/views/themes/admin/user/role/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/role/list.html.twig
@@ -28,7 +28,7 @@
         }) }}
         <div class="ez-table-header">
             <div class="ez-table-header__headline">{{ 'role.view.list.title'|trans|desc('Roles') }}</div>
-            <div>
+            <div class="ez-table-header__tools">
                 {% if can_create %}
                     <a
                         title="{{ 'role.view.list.action.add'|trans|desc('Create a Role') }}"

--- a/src/bundle/Resources/views/themes/admin/user/role_assignment/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/role_assignment/list.html.twig
@@ -5,7 +5,7 @@
 <section class="container ez-container">
     <div class="ez-table-header">
         <div class="ez-table-header__headline">{{ 'role_assignment.view.list.header'|trans|desc('Users and Groups') }}</div>
-        <div>
+        <div class="ez-table-header__tools">
             {% if can_assign %}
                 <a
                     href="{{ path('ezplatform.role_assignment.create', {roleId: role.id}) }}"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31923
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
