### PR TITLE
EZP-31462: Added particular message when reset password reason in migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
-        "_ezplatform_branch_for_behat_tests": "3.1",
+        "_ezplatform_branch_for_behat_tests": "fix/EZP-31462-handle-users-with-unsupported-password-hash-types",
         "branch-alias": {
             "dev-tmp_ci_branch": "2.1.x-dev",
             "dev-master": "2.1.x-dev"

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -231,6 +231,11 @@
         <target state="new">Remove author</target>
         <note>key: ezauthor.action.delete</note>
       </trans-unit>
+      <trans-unit id="8c3f0606ebb870dd8113cca42da7510414c5a0a8" resname="ezplatform.forgot_password.reset_your_password.reason.migration">
+        <source>Your password has expired, change it!</source>
+        <target state="new">Your password has expired, change it!</target>
+        <note>key: ezplatform.forgot_password.reset_your_password.reason.migration</note>
+      </trans-unit>
       <trans-unit id="f73d03811ba3033d6b44986d55ca728c5a88b168" resname="ezplatform.forgot_user_password.contact_administrator">
         <source>If you do not remember your login, contact your Administrator.</source>
         <target state="new">If you do not remember your login, contact your Administrator.</target>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -232,8 +232,8 @@
         <note>key: ezauthor.action.delete</note>
       </trans-unit>
       <trans-unit id="8c3f0606ebb870dd8113cca42da7510414c5a0a8" resname="ezplatform.forgot_password.reset_your_password.reason.migration">
-        <source>Your password has expired, change it!</source>
-        <target state="new">Your password has expired, change it!</target>
+        <source>Your password has expired, change it.</source>
+        <target state="new">Your password has expired, change it.</target>
         <note>key: ezplatform.forgot_password.reset_your_password.reason.migration</note>
       </trans-unit>
       <trans-unit id="f73d03811ba3033d6b44986d55ca728c5a88b168" resname="ezplatform.forgot_user_password.contact_administrator">

--- a/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
@@ -3,7 +3,10 @@
 {% form_theme form_forgot_user_password '@ezdesign/account/form_fields.html.twig'  %}
 
 {%- block content -%}
-    <h2 class="ez-login__header">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>
+    <h2 class="ez-login__actions-headline">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>
+    {% if reason is defined and reason == userForgotPasswordReasonMigration %}
+        <p>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</p>
+    {% endif %}
     {% if form_forgot_user_password is defined %}
         {{ form_start(form_forgot_user_password, {'attr': {'class': 'ez-form-validate'}}) }}
         <fieldset>

--- a/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
@@ -4,7 +4,7 @@
 
 {%- block content -%}
     <h2 class="ez-login__actions-headline">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>
-    {% if reason is defined and reason == userForgotPasswordReasonMigration %}
+    {% if reason == userForgotPasswordReasonMigration %}
         <p>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</p>
     {% endif %}
     {% if form_forgot_user_password is defined %}

--- a/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/forgot_password/index.html.twig
@@ -5,7 +5,7 @@
 {%- block content -%}
     <h2 class="ez-login__actions-headline">{{ 'authentication.reset_your_password'|trans|desc('Reset your password') }}</h2>
     {% if reason == userForgotPasswordReasonMigration %}
-        <p>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</p>
+        <p>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it.') }}</p>
     {% endif %}
     {% if form_forgot_user_password is defined %}
         {{ form_start(form_forgot_user_password, {'attr': {'class': 'ez-form-validate'}}) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31462](https://jira.ez.no/browse/EZP-31462)
| Required by  | ezsystems/ezplatform-user#75 ezsystems/ezplatform#593
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


In order to have better UX, when a user needs to reset password  because of unsupported password hash type, there was  added a message on route `admin/user/forgot-password/migration` analogous to `user/forgot-password/migration`


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
