### PR TITLE
EZP-31915: CT - ezimageasset - tooltips font too large

### DIFF
--- a/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_base-preview.scss
@@ -29,6 +29,7 @@
             &--filesize {
                 color: $ibexa-color-base-dark;
                 margin-top: calculateRem(24px);
+                font-size: calculateRem(14px);
             }
         }
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31915
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
