### PR TITLE
EZP-31907: Link details view in URL Management is not properly styled

### DIFF
--- a/src/bundle/Resources/public/scss/_tables.scss
+++ b/src/bundle/Resources/public/scss/_tables.scss
@@ -259,3 +259,15 @@
         margin-bottom: 0;
     }
 }
+
+.ez-link-manager-view {
+    .ez-table__row {
+        .ez-table__cell {
+            &--has-action-btns {
+                display: flex;
+                justify-content: space-between;
+                width: auto;
+            }
+        }
+    }
+}

--- a/src/bundle/Resources/views/themes/admin/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/view.html.twig
@@ -23,7 +23,7 @@
 {% block body_class %}ez-link-manager-view{% endblock %}
 
 {%- block content -%}
-    <section class="container mt-5">
+    <section class="container ez-container mt-5">
         <table class="ez-table table ez-table--list">
             <thead>
                 <tr>
@@ -72,7 +72,7 @@
         </table>
     </section>
 
-    <section class="container mt-5">
+    <section class="container ez-container mt-5">
         <div class="ez-table-header">
             <div class="ez-table-header__headline">
                 {{ 'url.tab.usages'|trans({'%count%': usages.nbResults })|desc('Content item(s) using this URL') }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31907
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
