### PR TITLE
EZP-31888: Bookmarks page header and item placement are not adjusted to other page views

### DIFF
--- a/src/bundle/Resources/views/themes/admin/account/bookmarks/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/bookmarks/list.html.twig
@@ -12,14 +12,10 @@
             {{ parent() }}
         {% endblock left_sidebar %}
         
-        <div class="container ml-0">
-            <div class="ez-header mt-3">
-                <div class="container">
-                    {% include '@ezdesign/ui/page_title.html.twig' with { title: 'bookmark.headline'|trans|desc('Bookmarks'), icon_name: 'bookmark-manager' } %}
-                </div>
-            </div>
+        <div class="px-0 ez-content-container">
+            <section class="container mt-5">
+                {% include '@ezdesign/ui/page_title.html.twig' with { title: 'bookmark.headline'|trans|desc('Bookmarks'), icon_name: 'bookmark-manager' } %}
 
-            <div class="container ez-content-container">
                 {{ form_start(form_remove, {
                     'action': path('ezplatform.bookmark.remove'),
                     'attr': { 'class': 'ez-toggle-btn-state', 'data-toggle-button-id': '#bookmark_remove_remove' }
@@ -110,7 +106,7 @@
                         {{ pagerfanta(pager, 'ez') }}
                     </div>
                 {% endif %}
-            </div>
+            </section>
         </div>
 
         {{ form_start(form_edit, {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31888
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
