### PR TITLE
EZP-31896: CT - ezauthor - tooltips have different fonts between lines

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezauthor.js
@@ -117,6 +117,8 @@
 
             this.reinit();
             this.updateDisabledState(authorNode);
+            eZ.helpers.tooltips.parse(node);
+            eZ.helpers.tooltips.hideAll();
         }
 
         /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31896
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
