### PR TITLE
EZP-31887: Added missing header informations in create/edit content/user

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -1,4 +1,4 @@
-(function (global, doc, eZ) {
+(function(global, doc, eZ) {
     const enterKeyCode = 13;
     const inputTypeToPreventSubmit = [
         'checkbox',

--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -22,8 +22,8 @@
         'url',
     ];
     const form = doc.querySelector('.ez-form-validate');
-    const itemAuthor = doc.querySelector('.ez-details-items__author-breadcrumbs');
-    const itemAuthorToggler = doc.querySelector('.ez-details-items__toggler');
+    const titleDetails = doc.querySelector('.ez-content-edit-page-title__details');
+    const titleDetailsToggler = doc.querySelector('.ez-content-edit-page-title__toggler');
     const submitBtns = form.querySelectorAll('[type="submit"]:not([formnovalidate])');
     const getValidationResults = (validator) => {
         const isValid = validator.isValid();
@@ -114,13 +114,12 @@
         btn.addEventListener('click', clickHandler, false);
     });
 
-    if (itemAuthorToggler) {
-        itemAuthorToggler.addEventListener('click', (event) => {
+    if (titleDetailsToggler) {
+        titleDetailsToggler.addEventListener('click', (event) => {
             event.preventDefault();
             eZ.helpers.tooltips.hideAll();
 
-            itemAuthorToggler.classList.toggle('ez-details-items__toggler--gray');
-            itemAuthor.classList.toggle('ez-details-items--collapsed');
+            titleDetails.classList.toggle('ez-content-edit-page-title__details--collapsed');
         });
     }
 })(window, window.document, window.eZ);

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -8,6 +8,7 @@
     }
 
     &__title {
+        margin-bottom: calculateRem(4px);
         font-size: calculateRem(26px);
     }
 

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -36,7 +36,8 @@
         text-decoration: none;
         color: $ibexa-color-base-dark;
         font-size: calculateRem(16px);
-
+        border: none;
+        
         &:hover {
             text-decoration: none;
         }

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -16,6 +16,31 @@
         font-size: calculateRem(14px);
         color: $ibexa-color-base-dark;
     }
+
+    &__details {
+        height: calculateRem(20px);
+        font-size: calculateRem(14px);
+        color: $ibexa-color-base-dark;
+        overflow: hidden;
+        transition: all 0.2s $ez-admin-transition;
+
+        &--collapsed {
+            height: 0;
+        }
+    }
+
+    &__toggler {
+        position: absolute;
+        top: calculateRem(10px);
+        right: 0;
+        text-decoration: none;
+        color: $ibexa-color-base-dark;
+        font-size: calculateRem(16px);
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
 }
 
 .ez-content-item {

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -33,14 +33,8 @@
         position: absolute;
         top: calculateRem(10px);
         right: 0;
-        text-decoration: none;
         color: $ibexa-color-base-dark;
-        font-size: calculateRem(16px);
         border: none;
-        
-        &:hover {
-            text-decoration: none;
-        }
     }
 }
 

--- a/src/bundle/Resources/public/scss/_header.scss
+++ b/src/bundle/Resources/public/scss/_header.scss
@@ -8,6 +8,7 @@
     }
 
     &--content-edit {
+        padding-top: calculateRem(24px);
         padding-bottom: calculateRem(24px);
         background: $ibexa-white;
         border-bottom: calculateRem(1px) solid $ibexa-color-base;

--- a/src/bundle/Resources/translations/content_create.en.xliff
+++ b/src/bundle/Resources/translations/content_create.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="ad4e9a4e42b99d945f972bab5a2eff694d283793" resname="creating">
+        <source>Creating</source>
+        <target state="new">Creating</target>
+        <note>key: creating</note>
+      </trans-unit>
       <trans-unit id="0f727a5b08f9dd958453e3fe685f22bb9a55a877" resname="creating_details">
         <source><![CDATA[
                         <span class="ez-details-items__connector">Creating:</span>

--- a/src/bundle/Resources/translations/content_edit.en.xliff
+++ b/src/bundle/Resources/translations/content_edit.en.xliff
@@ -36,33 +36,6 @@
         <target state="new">Editing</target>
         <note>key: editing</note>
       </trans-unit>
-      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
-        <source><![CDATA[
-                        <span class="ez-details-items__connector">Editing:</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
-                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
-                            <use xlink:href="%icon%"></use>
-                        </svg>
-                        %content_type_name%
-                        </span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></source>
-        <target state="new"><![CDATA[
-                        <span class="ez-details-items__connector">Editing:</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
-                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
-                            <use xlink:href="%icon%"></use>
-                        </svg>
-                        %content_type_name%
-                        </span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>]]></target>
-        <note>key: editing_details</note>
-      </trans-unit>
       <trans-unit id="669edeb37bec7cf4ec99288b90b02ba65e84b4cf" resname="errors.in.the.form">
         <source>Cannot save the form. Check required Fields or validation errors.</source>
         <target state="new">Cannot save the form. Check required Fields or validation errors.</target>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -176,6 +176,11 @@
         <target state="new">Delete</target>
         <note>key: custom_url_alias_add_form.remove</note>
       </trans-unit>
+      <trans-unit id="750bead6705b295c7b7d66c27b2768c1b9329ed5" resname="editing_details">
+        <source><![CDATA[<b>in</b> %language_name% <b>under</b> %location_name%]]></source>
+        <target state="new"><![CDATA[<b>in</b> %language_name% <b>under</b> %location_name%]]></target>
+        <note>key: editing_details</note>
+      </trans-unit>
       <trans-unit id="7cb40cbc703336ab1285e81ebf100b82b05a0e27" resname="error.page.403.actions">
         <source><![CDATA[Please contact your Administrator to request access to this content or modify your profile.<br/>Otherwise, go back to <a class="error-page__link" href="%dashboard%">dashboard</a> or <a class="error-page__link" href="%search%">search</a> for another Content item.]]></source>
         <target state="new"><![CDATA[Please contact your Administrator to request access to this content or modify your profile.<br/>Otherwise, go back to <a class="error-page__link" href="%dashboard%">dashboard</a> or <a class="error-page__link" href="%search%">search</a> for another Content item.]]></target>

--- a/src/bundle/Resources/translations/user_edit.en.xliff
+++ b/src/bundle/Resources/translations/user_edit.en.xliff
@@ -17,8 +17,8 @@
         <note>key: created_by</note>
       </trans-unit>
       <trans-unit id="f34946beab1da2af6535a8e4a88145e9557de0aa" resname="editing">
-        <source>Editing a(n) %contentType%</source>
-        <target state="new">Editing a(n) %contentType%</target>
+        <source>Editing</source>
+        <target state="new">Editing</target>
         <note>key: editing</note>
       </trans-unit>
       <trans-unit id="876d7bdba03c72251ec4c2dc827fc54af7889091" resname="location_id">

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -10,8 +10,6 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -5,17 +5,16 @@
 {% block meta %}
     <meta name="LanguageCode" content="{{ language.languageCode }}"/>
 {% endblock %}
-{% block page_title %}
-    {% include '@ezdesign/ui/breadcrumbs.html.twig' with { items: [
-            { value: 'Structure > Admin / Content types / Content / all !!!!!!!!! TO DO' }
-    ] } %}
 
+{% block page_title %}
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        description: content_type.description
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
+
 {% block details %}{% endblock %}
 
 {% block form_fields %}

--- a/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/create/create.html.twig
@@ -10,6 +10,7 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -6,8 +6,6 @@
     <meta name="LanguageCode" content="{{ language.languageCode }}"/>
 {% endblock %}
 
-{% block breadcrumbs %}{% endblock %}
-
 {% block page_title %}
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -10,6 +10,7 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -6,23 +6,18 @@
     <meta name="LanguageCode" content="{{ language.languageCode }}"/>
 {% endblock %}
 
-{% block breadcrumbs %}
-    {% include '@ezdesign/ui/breadcrumbs.html.twig' with { items: [
-        { value: content_type.name }
-    ]} %}
-{% endblock %}
+{% block breadcrumbs %}{% endblock %}
 
 {% block page_title %}
-    {% set content_name = content ? content.name : 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') %}
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),
-        title: content_name,
-        description: content_type.description
+        title: content.name,
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 
-{% block details %}
-{% endblock %}
+{% block details %}{% endblock %}
 
 {% block form_fields %}
     <section class="container">

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -10,8 +10,6 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -15,12 +15,18 @@
         <div class="ez-content-edit-page-title__action">{{ action_name }}</div>
         <div class="ez-content-edit-page-title__title">{{ title }}</div>
         <div class="ez-content-edit-page-title__description">
-            {{ 'editing_details'|trans({
-                '%language_name%': language.name,
-                '%location_name%': parent_location.contentInfo.name})
-                |desc('<b>in</b> %language_name% <b>under</b> %location_name%')|raw
-            }}
+            {% if content_type.description %}
+                <div class="my-1">{{ content_type.description }}</div>
+            {% endif %}
+            <div>
+                {{ 'editing_details'|trans({
+                    '%language_name%': language.name,
+                    '%location_name%': parent_location.contentInfo.name})
+                    |desc('<b>in</b> %language_name% <b>under</b> %location_name%')|raw
+                }}
+            </div>
         </div>
+
         {% if content is defined %}
             <a class="ez-content-edit-page-title__toggler" href="#">?</a>
             <div class="ez-content-edit-page-title__details ez-content-edit-page-title__details--collapsed">

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -16,10 +16,25 @@
         <div class="ez-content-edit-page-title__title">{{ title }}</div>
         <div class="ez-content-edit-page-title__description">
             {{ 'editing_details'|trans({
-                '%language_name%': language_name,
-                '%location_name%': location_name})
+                '%language_name%': language.name,
+                '%location_name%': parent_location.contentInfo.name})
                 |desc('<b>in</b> %language_name% <b>under</b> %location_name%')|raw
             }}
         </div>
+        {% if content is defined %}
+            <a class="ez-content-edit-page-title__toggler" href="#">?</a>
+            <div class="ez-content-edit-page-title__details ez-content-edit-page-title__details--collapsed">
+                {% if creator is defined %}
+                    {{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }}/
+                {% endif %}
+                {{ content.versionInfo.contentInfo.publishedDate|ez_full_datetime }}/
+                {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
+                {% if is_published == false %}
+                    {{ 'parent_location_id'|trans({'%locationId%': parent_location.id})|desc('Parent Location ID: %locationId%') }}
+                {% else %}
+                    {{ 'location_id'|trans({'%locationId%': location.id})|desc('Location ID: %locationId%') }}
+                {% endif %}
+            </div>
+        {% endif %}
     </div>
 {% endif %}

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -14,6 +14,12 @@
     <div class="ez-content-edit-page-title {{ class is defined ? class }}">
         <div class="ez-content-edit-page-title__action">{{ action_name }}</div>
         <div class="ez-content-edit-page-title__title">{{ title }}</div>
-        <div class="ez-content-edit-page-title__description">{{ description }}</div>
+        <div class="ez-content-edit-page-title__description">
+            {{ 'editing_details'|trans({
+                '%language_name%': language_name,
+                '%location_name%': location_name})
+                |desc('<b>in</b> %language_name% <b>under</b> %location_name%')|raw
+            }}
+        </div>
     </div>
 {% endif %}

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -18,7 +18,7 @@
             {% if description is defined %}
                 <div class="my-1">{{ description }}</div>
             {% endif %}
-            
+
             <div>
                 {{ 'editing_details'|trans({
                     '%language_name%': language.name,
@@ -29,7 +29,7 @@
         </div>
 
         {% if content is defined %}
-            <a class="ez-content-edit-page-title__toggler" href="#">?</a>
+            <button class="ez-content-edit-page-title__toggler" href="#">?</button>
             <div class="ez-content-edit-page-title__details ez-content-edit-page-title__details--collapsed">
                 {% if creator is defined %}
                     {{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }}/

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -15,9 +15,10 @@
         <div class="ez-content-edit-page-title__action">{{ action_name }}</div>
         <div class="ez-content-edit-page-title__title">{{ title }}</div>
         <div class="ez-content-edit-page-title__description">
-            {% if content_type.description %}
-                <div class="my-1">{{ content_type.description }}</div>
+            {% if description is defined %}
+                <div class="my-1">{{ description }}</div>
             {% endif %}
+            
             <div>
                 {{ 'editing_details'|trans({
                     '%language_name%': language.name,

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -29,7 +29,7 @@
         </div>
 
         {% if content is defined %}
-            <button class="ez-content-edit-page-title__toggler" href="#">?</button>
+            <button class="ez-content-edit-page-title__toggler">?</button>
             <div class="ez-content-edit-page-title__details ez-content-edit-page-title__details--collapsed">
                 {% if creator is defined %}
                     {{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }}/

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -7,18 +7,12 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@ezdesign/ui/breadcrumbs.html.twig' with { 
-        class: 'breadcrumb--increased-left-margin',
-        items: [
-            { value: 'Structure > Admin / Content types / Content / all TO DO' }
-        ] 
-    } %}
-
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        description: content_type.description
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -11,6 +11,7 @@
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/create_on_the_fly.html.twig
@@ -11,8 +11,6 @@
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'creating'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -11,8 +11,6 @@
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -6,66 +6,20 @@
     <meta name="LanguageCode" content="{{ language.languageCode }}" />
 {% endblock %}
 
-{% block details %}
-    <div class="ez-edit-header ez-edit-header--edit-on-the-fly">
-        <div class="ez-edit-header__content-type-name">
-            {% block close_button %}{% endblock %}
-            <div class="container px-5">
-                {% set content_name = content ? content.name : 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%') %}
-                <div class="ez-content-item__name" title="{{ content_name }}">
-                    {{ content_name }}
-                </div>
-            </div>
-        </div>
-        <div class="ez-edit-header__details">
-            <div class="container ez-details-items">
-                {{ 'editing_details'|trans({
-                    '%icon%': ez_content_type_icon(content_type.identifier),
-                    '%content_type_name%': content_type.name,
-                    '%language_name%': language.name,
-                    '%location_name%': parent_location.contentInfo.name})
-                    |desc('
-                        <span class="ez-details-items__connector">Editing:</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--content-type">
-                        <svg class="ez-icon ez-icon--small ez-icon-%identifier%">
-                            <use xlink:href="%icon%"></use>
-                        </svg>
-                        %content_type_name%
-                        </span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">in</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--language">%language_name%</span>
-                        <span class="ez-details-items__connector ez-details-items__connector--small">under</span>
-                        <span class="ez-badge ez-badge--small ez-details-items__pill ez-details-items__pill--location">%location_name%</span>')
-                    |raw
-                }}
-                <a class="ez-details-items__toggler ez-details-items__toggler--gray" href="#">?</a>
-            </div>
-            <div class="container ez-details-items ez-details-items--collapsed ez-details-items__author-breadcrumbs">
-                {{ content_type.name }}/
-                {% if creator is not null %}
-                    {{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }}/
-                {% endif %}
-                {{ content.versionInfo.contentInfo.publishedDate|ez_full_datetime }}/
-                {{ 'content_id'|trans({'%contentId%': content.id})|desc('Content ID: %contentId%') }},
-                {% if is_published == false %}
-                    {{ 'parent_location_id'|trans({'%locationId%': parent_location.id})|desc('Parent Location ID: %locationId%') }}
-                {% else %}
-                    {{ 'location_id'|trans({'%locationId%': location.id})|desc('Location ID: %locationId%') }}
-                {% endif %}
-            </div>
-        </div>
-        <div class="ez-content-item__errors-wrapper" hidden>
-            {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
-        </div>
-        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-        {% if content_type.descriptions is not empty %}
-            <div class="small text-muted">{{ content_type.description }}</div>
-        {% endif %}
-    </div>
+{% block page_title %}
+    {% include '@ezdesign/content/page_title_edit.html.twig' with { 
+        class: 'ez-content-edit-page-title--increased-left-margin',
+        action_name: 'editing'|trans|desc('Editing'),
+        title: content.name,
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
+    } %}
 {% endblock %}
 
+{% block details %}{% endblock %}
+
 {% block form_fields %}
-    <section class="container mt-4 mb-5 px-5">
+    <section class="container ez-container">
         <div class="card ez-card ez-card--light">
             <div class="card-body">
                 {{ parent() }}

--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -11,6 +11,7 @@
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/user/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/create.html.twig
@@ -2,8 +2,6 @@
 
 {% trans_default_domain 'user_create' %}
 
-{% block breadcrumbs %}{% endblock %}
-
 {% block page_title %}
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'Create'|trans|desc('Creating'),

--- a/src/bundle/Resources/views/themes/admin/user/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/create.html.twig
@@ -2,22 +2,18 @@
 
 {% trans_default_domain 'user_create' %}
 
-{% block breadcrumbs %}
-    {% include '@ezdesign/ui/breadcrumbs.html.twig' with { items: [
-        { value: content_type.name ~ '/' ~ 'group_id'|trans({'%groupId%': parent_group.id})|desc('Group ID: %groupId%') }
-    ]} %}
-{% endblock %}
+{% block breadcrumbs %}{% endblock %}
 
 {% block page_title %}
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'Create'|trans|desc('Creating'),
-        title: content_type.name,
-        description: content_type.description
+        title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 
-{% block details %}
-{% endblock %}
+{% block details %}{% endblock %}
 
 {% block form_fields %}
     <section class="container">

--- a/src/bundle/Resources/views/themes/admin/user/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/create.html.twig
@@ -6,6 +6,7 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'Create'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/user/create.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/create.html.twig
@@ -6,8 +6,6 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'Create'|trans|desc('Creating'),
         title: 'new_content_item'|trans({'%contentType%': content_type.name})|desc('New %contentType%'),
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/user/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/edit.html.twig
@@ -7,8 +7,6 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),
         title: content_type.name,
-        language_name: language.name,
-        location_name: parent_location.contentInfo.name
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/user/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/edit.html.twig
@@ -7,6 +7,7 @@
     {% include '@ezdesign/content/page_title_edit.html.twig' with { 
         action_name: 'editing'|trans|desc('Editing'),
         title: content_type.name,
+        description: content_type.description
     } %}
 {% endblock %}
 

--- a/src/bundle/Resources/views/themes/admin/user/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/user/edit.html.twig
@@ -2,43 +2,17 @@
 
 {% trans_default_domain 'user_edit' %}
 
-{% block details %}
-    {% block close_button %}
-        <a 
-            class="ez-content-edit-container__close" 
-            href="{{ path('_ez_content_view', {'contentId': user.id, 'locationId': user.versionInfo.contentInfo.mainLocationId}) }}"
-            title="{{ 'tooltip.exit_label'|trans({}, 'content')|desc('Exit') }}"
-        >
-            <svg class="ez-icon ez-icon--small-medium ez-icon--primary">
-                <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#discard"></use>
-            </svg>
-        </a>
-    {% endblock %}
 
-    <div class="container mt-5 px-5">
-        <h4 class="ez-content-item-status">{{ 'editing'|trans({'%contentType%': content_type.name})|desc('Editing a(n) %contentType%') }}</h4>
-        <h1>
-            <svg class="ez-icon ez-icon-{{ content_type.identifier }}">
-                <use xlink:href="{{ ez_content_type_icon(content_type.identifier) }}"></use>
-            </svg>
-            {{ user.name }}
-        </h1>
-
-        <div class="small">
-            {{ content_type.name }} /
-            {% if creator is not null %}{{ 'created_by'|trans({'%name%': ez_content_name(creator)})|desc('Created by %name%') }} /{% endif %}
-            {{ user.versionInfo.contentInfo.publishedDate|ez_full_datetime }} /
-            {{ 'content_id'|trans({'%contentId%': user.id})|desc('Content ID: %contentId%') }}{% if user.versionInfo.contentInfo.mainLocationId %}, {{ 'location_id'|trans({'%locationId%': user.versionInfo.contentInfo.mainLocationId})|desc('Location ID: %locationId%') }}{% endif %}
-        </div>
-        <div class="ez-content-item__errors-wrapper" hidden>
-            {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}
-        </div>
-        {# @todo remove if statement once getDescription() bug is resolved in kernel #}
-        {% if content_type.descriptions is not empty %}
-            <div class="small text-muted">{{ content_type.description }}</div>
-        {% endif %}
-    </div>
+{% block page_title %}
+    {% include '@ezdesign/content/page_title_edit.html.twig' with { 
+        action_name: 'editing'|trans|desc('Editing'),
+        title: content_type.name,
+        language_name: language.name,
+        location_name: parent_location.contentInfo.name
+    } %}
 {% endblock %}
+
+{% block details %}{% endblock %}
 
 {% block form_fields %}
     <section class="container mt-4 mb-5 px-5">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31887 
|| https://jira.ez.no/browse/EZP-31846
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

![Screenshot from 2020-09-24 12-52-42](https://user-images.githubusercontent.com/24355391/94136558-65b90e00-fe65-11ea-97e0-4c60b23c6364.png)
![Screenshot from 2020-09-24 12-52-30](https://user-images.githubusercontent.com/24355391/94136561-6651a480-fe65-11ea-8df2-06d76acc828a.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
