### PR TITLE
EZP-31946: Added missing 'Admin' to breadcrumbs and set correct margin for URL Management

### DIFF
--- a/src/bundle/Resources/views/themes/admin/link_manager/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/view.html.twig
@@ -4,6 +4,7 @@
 
 {%- block breadcrumbs -%}
     {% include '@ezdesign/ui/breadcrumbs.html.twig' with { items: [
+        { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },
         { value: 'url.breadcrumb.list'|trans|desc('URL management'), url: path('ezplatform.url_management') },
         { value: 'url.breadcrumb.detail'|trans|desc('Link details') }
     ]} %}
@@ -23,7 +24,7 @@
 {% block body_class %}ez-link-manager-view{% endblock %}
 
 {%- block content -%}
-    <section class="container ez-container mt-5">
+    <section class="container ez-container">
         <table class="ez-table table ez-table--list">
             <thead>
                 <tr>

--- a/src/bundle/Resources/views/themes/admin/url_management/url_management.html.twig
+++ b/src/bundle/Resources/views/themes/admin/url_management/url_management.html.twig
@@ -23,9 +23,9 @@
 {% endblock %}
 
 {% block content %}
-    <div>
+    <section class="container ez-container">
         {{ ez_render_component_group('link-manager-block') }}
-    </div>
+    </section>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31946
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
