### PR TITLE
EZP-31783: Fixed RichTextEmbedAllowedContentTypes subscriber implementation

### DIFF
--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypesTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\UniversalDiscovery\Event\Subscriber;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\RichTextEmbedAllowedContentTypes;
+use PHPUnit\Framework\TestCase;
+
+final class RichTextEmbedAllowedContentTypesTest extends TestCase
+{
+    private const EXAMPLE_LIMITATIONS = [/* Some limitations */];
+
+    private const SUPPORTED_CONFIG_NAMES = ['richtext_embed', 'richtext_embed_image'];
+
+    private const ALLOWED_CONTENT_TYPES_IDS = [2, 4];
+    private const ALLOWED_CONTENT_TYPES = ['article', 'folder'];
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionResolver;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionChecker;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentTypeService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\RichTextEmbedAllowedContentTypes */
+    private $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->permissionChecker = $this->createMock(PermissionCheckerInterface::class);
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+
+        $this->subscriber = new RichTextEmbedAllowedContentTypes(
+            $this->permissionResolver,
+            $this->permissionChecker,
+            $this->contentTypeService
+        );
+    }
+
+    public function testUdwConfigResolveOnUnsupportedConfigName(): void
+    {
+        $this->permissionResolver->expects($this->never())->method('hasAccess');
+        $this->permissionChecker->expects($this->never())->method('getRestrictions');
+        $this->contentTypeService->expects($this->never())->method('loadContentTypeList');
+
+        $event = $this->createConfigResolveEvent('unsupported_config_name');
+
+        $this->subscriber->onUdwConfigResolve($event);
+
+        $this->assertEquals([], $event->getConfig());
+    }
+
+    /**
+     * @dataProvider dataProviderForUdwConfigResolveWhenThereIsNoContentReadLimitations
+     */
+    public function testUdwConfigResolveWhenThereIsNoContentReadLimitations(bool $hasAccess): void
+    {
+        $this->permissionResolver->method('hasAccess')->with('content', 'read')->willReturn($hasAccess);
+        $this->permissionChecker->expects($this->never())->method('getRestrictions');
+        $this->contentTypeService->expects($this->never())->method('loadContentTypeList');
+
+        $this->assertConfigurationResolvingResult([
+            'allowed_content_types' => null,
+        ]);
+    }
+
+    public function dataProviderForUdwConfigResolveWhenThereIsNoContentReadLimitations(): iterable
+    {
+        return [
+            ['hasAccess' => false],
+            ['hasAccess' => true],
+        ];
+    }
+
+    public function testUdwConfigResolveWhenThereAreContentReadLimitations(): void
+    {
+        $this->permissionResolver
+            ->method('hasAccess')
+            ->with('content', 'read')
+            ->willReturn(self::EXAMPLE_LIMITATIONS);
+
+        $this->permissionChecker
+            ->method('getRestrictions')
+            ->with(self::EXAMPLE_LIMITATIONS, ContentTypeLimitation::class)
+            ->willReturn(self::ALLOWED_CONTENT_TYPES_IDS);
+
+        $this->contentTypeService
+            ->method('loadContentTypeList')
+            ->with(self::ALLOWED_CONTENT_TYPES_IDS)
+            ->willReturn($this->createContentTypeListMock(self::ALLOWED_CONTENT_TYPES));
+
+        $this->assertConfigurationResolvingResult([
+            'allowed_content_types' => self::ALLOWED_CONTENT_TYPES,
+        ]);
+    }
+
+    private function assertConfigurationResolvingResult(?array $expectedConfiguration): void
+    {
+        foreach (self::SUPPORTED_CONFIG_NAMES as $configName) {
+            $event = $this->createConfigResolveEvent($configName);
+
+            $this->subscriber->onUdwConfigResolve($event);
+
+            $this->assertEquals(
+                $expectedConfiguration,
+                $event->getConfig()
+            );
+        }
+    }
+
+    private function createConfigResolveEvent(string $configName = 'richtext_embed'): ConfigResolveEvent
+    {
+        $event = new ConfigResolveEvent();
+        $event->setConfigName($configName);
+
+        return $event;
+    }
+
+    private function createContentTypeListMock(array $identifiers): array
+    {
+        return array_map(function (string $identifier) {
+            $contentType = $this->createMock(ContentType::class);
+            $contentType->method('__get')->with('identifier')->willReturn($identifier);
+
+            return $contentType;
+        }, $identifiers);
+    }
+}

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -12,16 +12,16 @@ use Symfony\Component\EventDispatcher\Event;
 
 class ConfigResolveEvent extends Event
 {
-    const NAME = 'udw.resolve.config';
+    public const NAME = 'udw.resolve.config';
 
     /** @var string */
     protected $configName;
 
     /** @var array */
-    protected $config;
+    protected $config = [];
 
     /** @var array */
-    protected $context;
+    protected $context = [];
 
     /**
      * @return string


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31783
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Follow up for https://github.com/ezsystems/ezplatform-admin-ui/pull/1441. Fixed few issues in previous implementation:

* Accessing unexciting `restrictedContentTypesIdentifier` property (see https://github.com/ezsystems/ezplatform-admin-ui/commit/81de433dd0f310461fd73c61e522d1e2b15d6f9f#diff-9dd2d0d839357c185ad9fc0a1d78a44aR99)
* "TypeError: Argument 1 passed to iterator_to_array() must implement interface Traversable, array given"  throw in https://github.com/ezsystems/ezplatform-admin-ui/commit/81de433dd0f310461fd73c61e522d1e2b15d6f9f#diff-9dd2d0d839357c185ad9fc0a1d78a44aR73  (also reported as https://jira.ez.no/browse/EC-250)
* Accessing repository data in class constructor 

Additionally provided basic unit tests for `\EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\RichTextEmbedAllowedContentTypes`

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
