### PR TITLE
EZP-31966: Added underline and ibexa-color-primary for hover breadcrumb in UDW

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_breadcrumbs.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_breadcrumbs.scss
@@ -89,7 +89,20 @@
             .c-breadcrumbs__list-item-text {
                 cursor: not-allowed;
                 color: $ibexa-color-font-pale;
+                text-decoration: none;
+
+                &:hover {
+                    color: $ibexa-color-font-pale;
+                }
             }
+        }
+    }
+
+    &__list-item-text {
+        text-decoration: underline;
+
+        &:hover {
+            color: $ibexa-color-primary;
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31966
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
