### PR TITLE
EZP-31964: Set smaller (50%) padding between title and edit meta information button in UDW

### DIFF
--- a/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_content.meta.preview.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/universal-discovery/_content.meta.preview.scss
@@ -41,7 +41,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: calculateRem(42px);
+        margin-bottom: calculateRem(21px);
     }
 
     &__toggle-bookmark-button {
@@ -63,7 +63,7 @@
     &__actions {
         display: flex;
         justify-content: space-between;
-        margin-bottom: calculateRem(42px);
+        margin-bottom: calculateRem(21px);
     }
 
     &__edit-button,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31964
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


![Screenshot from 2020-09-30 11-53-18](https://user-images.githubusercontent.com/24355391/94671017-97255400-0313-11eb-8db8-dd9ae5058f07.png)



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
