### PR TITLE
EZP-31983: Catched exception thrown by empty tab group

### DIFF
--- a/src/lib/Tab/Event/Subscriber/ConditionalTabSubscriber.php
+++ b/src/lib/Tab/Event/Subscriber/ConditionalTabSubscriber.php
@@ -11,15 +11,13 @@ namespace EzSystems\EzPlatformAdminUi\Tab\Event\Subscriber;
 use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
 use EzSystems\EzPlatformAdminUi\Tab\Event\TabEvents;
 use EzSystems\EzPlatformAdminUi\Tab\Event\TabGroupEvent;
-use EzSystems\EzPlatformAdminUi\Tab\OrderedTabInterface;
 use EzSystems\EzPlatformAdminUi\UI\Service\TabService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Reorders tabs according to their Order value (Tabs implementing OrderedTabInterface).
- * Tabs without order specified are pushed to the end of the group.
+ * Evaluates if tabs should be visible (Tabs implementing ConditionalTabInterface).
  *
- * @see OrderedTabInterface
+ * @see ConditionalTabInterface
  */
 class ConditionalTabSubscriber implements EventSubscriberInterface
 {
@@ -51,7 +49,11 @@ class ConditionalTabSubscriber implements EventSubscriberInterface
         $tabGroup = $tabGroupEvent->getData();
         $tabGroupIdentifier = $tabGroupEvent->getData()->getIdentifier();
         $parameters = $tabGroupEvent->getParameters();
-        $tabs = $this->tabService->getTabGroup($tabGroupIdentifier)->getTabs();
+        try {
+            $tabs = $this->tabService->getTabGroup($tabGroupIdentifier)->getTabs();
+        } catch (\InvalidArgumentException $invalidArgumentException) {
+            $tabs = [];
+        }
 
         foreach ($tabs as $tab) {
             if (!$tab instanceof ConditionalTabInterface || $tab->evaluate($parameters)) {

--- a/src/lib/Tab/Event/Subscriber/ConditionalTabSubscriber.php
+++ b/src/lib/Tab/Event/Subscriber/ConditionalTabSubscriber.php
@@ -12,6 +12,7 @@ use EzSystems\EzPlatformAdminUi\Tab\ConditionalTabInterface;
 use EzSystems\EzPlatformAdminUi\Tab\Event\TabEvents;
 use EzSystems\EzPlatformAdminUi\Tab\Event\TabGroupEvent;
 use EzSystems\EzPlatformAdminUi\UI\Service\TabService;
+use InvalidArgumentException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -51,7 +52,7 @@ class ConditionalTabSubscriber implements EventSubscriberInterface
         $parameters = $tabGroupEvent->getParameters();
         try {
             $tabs = $this->tabService->getTabGroup($tabGroupIdentifier)->getTabs();
-        } catch (\InvalidArgumentException $invalidArgumentException) {
+        } catch (InvalidArgumentException $e) {
             $tabs = [];
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31983
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
