### PR TITLE
EZEE-3280: Added reset input .ez-data-source__destination-source-id when user remove image from image asset field

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -2,6 +2,7 @@
     const SELECTOR_FIELD = '.ez-field-edit--ezimageasset';
     const SELECTOR_INPUT_FILE = 'input[type="file"]';
     const SELECTOR_INPUT_DESTINATION_CONTENT_ID = '.ez-data-source__destination-content-id';
+    const SELECTOR_INPUT_SOURCE_ID = '.ez-data-source__destination-source-id';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const showErrorNotification = eZ.helpers.notification.showErrorNotification;
@@ -209,6 +210,7 @@
             super.resetInputField();
 
             this.inputDestinationContentId.value = '';
+            this.inputSourcetId.value = '';
         }
 
         /**
@@ -222,6 +224,7 @@
             this.btnSelect = this.fieldContainer.querySelector('.ez-data-source__btn-select');
             this.btnSelect.addEventListener('click', this.openUDW.bind(this), false);
             this.inputDestinationContentId = this.fieldContainer.querySelector(SELECTOR_INPUT_DESTINATION_CONTENT_ID);
+            this.inputSourcetId = this.fieldContainer.querySelector(SELECTOR_INPUT_SOURCE_ID);
         }
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3280
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
