### PR TITLE
EZP-31984: Create/Edit on the fly footer is still visible after canceling by X button

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/on_the_fly/edit_on_the_fly.html.twig
@@ -7,11 +7,12 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@ezdesign/content/page_title_edit.html.twig' with { 
+    {% include '@ezdesign/content/page_title_edit.html.twig' with {
         class: 'ez-content-edit-page-title--increased-left-margin',
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
-        description: content_type.description
+        description: content_type.description,
+        without_close_button: true
     } %}
 {% endblock %}
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31984
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
