### PR TITLE
EZP-32003: Fix cancel editing redirect for root location

### DIFF
--- a/features/standard/ContentDraft.feature
+++ b/features/standard/ContentDraft.feature
@@ -115,7 +115,6 @@ Feature: Content items creation
     Given I navigate to content "Test Article draft edited3" of type "Article" in root path
       And I click on the edit action bar button "Edit"
       And I click on the close button
-      And I navigate to content "Test Article draft edited3" of type "Article"
     When I click on the edit action bar button "Edit"
       And I start editing draft with ID "4" from draft conflict modal
       And I set content fields

--- a/features/standard/ContentDraft.feature
+++ b/features/standard/ContentDraft.feature
@@ -79,7 +79,7 @@ Feature: Content items creation
         | Title | Test Article draft edited2 |
       And I set article main content field to "Test Article draft intro edited2"
       And I click on the close button
-    Then I should be on root container page in Content View
+    Then I should be on content container page "Test Article draft" of type "Article" in root path
 
   @javascript @common
   Scenario: Content edit draft can be saved

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -4,7 +4,7 @@
     {% if without_close_button is not defined or without_close_button != true %}
         <a
             class="ez-content-edit-container__close"
-            href="{{ path('_ez_content_view', { 'contentId': parent_location.contentId, 'locationId': parent_location.id}) }}"
+            href="{{ path('_ez_content_view', { 'contentId': max(parent_location.contentId, 1), 'locationId': max(parent_location.id, 2)}) }}"
             title="{{ 'tooltip.exit_label'|trans({}, 'content')|desc('Exit') }}"
         >
             <svg class="ez-icon ez-icon--small-medium ez-icon--primary">

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -2,9 +2,10 @@
 
 {% block close_button %}
     {% if without_close_button is not defined or without_close_button != true %}
+        {% set referrer_location = parent_location.id > 1 ? parent_location : location %}
         <a
             class="ez-content-edit-container__close"
-            href="{{ path('_ez_content_view', { 'contentId': max(parent_location.contentId, 1), 'locationId': max(parent_location.id, 2)}) }}"
+            href="{{ path('_ez_content_view', { 'contentId': referrer_location.contentId, 'locationId': referrer_location.id }) }}"
             title="{{ 'tooltip.exit_label'|trans({}, 'content')|desc('Exit') }}"
         >
             <svg class="ez-icon ez-icon--small-medium ez-icon--primary">

--- a/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/page_title_edit.html.twig
@@ -2,7 +2,7 @@
 
 {% block close_button %}
     {% if without_close_button is not defined or without_close_button != true %}
-        {% set referrer_location = parent_location.id > 1 ? parent_location : location %}
+        {% set referrer_location = is_published ? location : parent_location %}
         <a
             class="ez-content-edit-container__close"
             href="{{ path('_ez_content_view', { 'contentId': referrer_location.contentId, 'locationId': referrer_location.id }) }}"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32003](https://jira.ez.no/browse/EZP-32003)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

**Steps to reproduce:**
1. Start editing the root location in admin UI
2.  Click on the "cancel" button in the top left

**Expected result:**

User is redirected to the full view page

**Actual result:**

The following error is shown:
```
Return value of eZ\Publish\Core\Repository\Values\Content\Content::getContentType() must be an instance of eZ\Publish\API\Repository\Values\ContentType\ContentType, null returned
```


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
