### PR TITLE
EZP-31924: Bookmarks barely fit in the left side menu

### DIFF
--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -80,12 +80,13 @@
 .ez-side-menu,
 .ez-context-menu {
     .ez-sticky-container > .btn {
-        width: calculateRem(80px);
+        width: 100%;
         height: calculateRem(80px);
-        padding: calculateRem(2px);
+        padding: calculateRem(2px) calculateRem(4px);
         border: 0;
         border-radius: 0;
         text-decoration: none;
+        font-size: calculateRem(13px);
         line-height: calculateRem(18px);
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31924
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
