### PR TITLE
EZP-31094: Fixed unnecessary ":" in Content Type translations

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -87,13 +87,13 @@
         <note>key: content_type.default_sort</note>
       </trans-unit>
       <trans-unit id="b29f5d9c32e10776ec9fd36c35c4aefc96732cb2" resname="content_type.default_sort_field">
-        <source>Sort children by default by:</source>
-        <target state="new">Sort children by default by:</target>
+        <source>Sort children by default by</source>
+        <target state="new">Sort children by default by</target>
         <note>key: content_type.default_sort_field</note>
       </trans-unit>
       <trans-unit id="7a67ffefca1339a9e4c5224d773378c2e5f6f378" resname="content_type.default_sort_order">
-        <source>Sort children by default in order:</source>
-        <target state="new">Sort children by default in order:</target>
+        <source>Sort children by default in order</source>
+        <target state="new">Sort children by default in order</target>
         <note>key: content_type.default_sort_order</note>
       </trans-unit>
       <trans-unit id="be2f64eb4557a3af16a2f32f5e0185c591d3ca8f" resname="content_type.delete">

--- a/src/lib/Form/Type/ContentType/ContentTypeUpdateType.php
+++ b/src/lib/Form/Type/ContentType/ContentTypeUpdateType.php
@@ -90,11 +90,11 @@ class ContentTypeUpdateType extends AbstractType
                 'disabled' => $isTranslation,
             ])
             ->add('defaultSortField', SortFieldChoiceType::class, [
-                'label' => /** @Desc("Sort children by default by:") */ 'content_type.default_sort_field',
+                'label' => /** @Desc("Sort children by default by") */ 'content_type.default_sort_field',
                 'disabled' => $isTranslation,
             ])
             ->add('defaultSortOrder', SortOrderChoiceType::class, [
-                'label' => /** @Desc("Sort children by default in order:") */ 'content_type.default_sort_order',
+                'label' => /** @Desc("Sort children by default in order") */ 'content_type.default_sort_order',
                 'disabled' => $isTranslation,
             ])
             ->add('defaultAlwaysAvailable', CheckboxType::class, [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31904
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
