### PR TITLE
EZP-32033: Wrong caret icon size on Content Type Edit view

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
@@ -82,10 +82,10 @@
                         <div id="field-definition-{{ value.identifier }}" class="ez-card__header">
                             {% set name = value.names[language_code] ?? value.names[content_type.mainLanguageCode]  %}
                             <button class="ez-card__body-display-toggler btn">
-                                <svg class="ez-icon ez-icon--medium ez-icon--caret-down" aria-hidden="true">
+                                <svg class="ez-icon ez-icon--small ez-icon--caret-down" aria-hidden="true">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#caret-down"></use>
                                 </svg>
-                                <svg class="ez-icon ez-icon--medium ez-icon--caret-next" aria-hidden="true">
+                                <svg class="ez-icon ez-icon--small ez-icon--caret-next" aria-hidden="true">
                                     <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#caret-next"></use>
                                 </svg>
                             </button>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32033
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
