### PR TITLE
EZP-32034: Draft list view has a wrong padding for container and table

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/draft/draft_list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/draft/draft_list.html.twig
@@ -16,8 +16,8 @@
             {{ parent() }}
         {% endblock left_sidebar %}
 
-        <div class="container ml-0">
-            <div class="ez-header mt-3">
+        <div class="container ez-content-container">
+            <div class="ez-header mt-5">
                 <div class="container">
                     {% include '@ezdesign/ui/page_title.html.twig' with {
                         title: 'drafts.list'|trans|desc('Drafts'),
@@ -26,7 +26,7 @@
                 </div>
             </div>
 
-            <div class="container ez-content-container">
+            <div class="container ez-container">
                 {{ form_start(form_remove, {
                     'action': path('ezplatform.content_draft.remove'),
                     'attr': {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32034
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
