### PR TITLE
EZP-32038: Move System information tab to ez-support-tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,8 +52,7 @@
         "phpunit/phpunit": "^8.1",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
-        "ezsystems/ezplatform-code-style": "^0.1.0",
-        "ezsystems/ez-support-tools": "dev-ezp-32038-sys-info-tab-moved as 2.2.x-dev"
+        "ezsystems/ezplatform-code-style": "^0.1.0"
     },
     "scripts": {
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "phpunit/phpunit": "^8.1",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
-        "ezsystems/ezplatform-code-style": "^0.1.0"
+        "ezsystems/ezplatform-code-style": "^0.1.0",
+        "ezsystems/ez-support-tools": "dev-ezp-32038-sys-info-tab-moved as 2.2.x-dev"
     },
     "scripts": {
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"

--- a/src/lib/Menu/MainMenuBuilder.php
+++ b/src/lib/Menu/MainMenuBuilder.php
@@ -30,7 +30,6 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
 
     /* Main Menu / Admin */
     const ITEM_ADMIN = 'main_admin';
-    const ITEM_ADMIN__SYSTEMINFO = 'main__admin__systeminfo';
     const ITEM_ADMIN__SECTIONS = 'main__admin__sections';
     const ITEM_ADMIN__ROLES = 'main__admin__roles';
     const ITEM_ADMIN__LANGUAGES = 'main__admin__languages';
@@ -40,12 +39,6 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
     const ITEM_ADMIN__URL_MANAGEMENT = 'main__admin__url_management';
 
     public const ITEM_ADMIN_OPTIONS = [
-        self::ITEM_ADMIN__SYSTEMINFO => [
-            'route' => 'ezplatform.systeminfo',
-            'extras' => [
-                'orderNumber' => 10,
-            ],
-        ],
         self::ITEM_ADMIN__SECTIONS => [
             'route' => 'ezplatform.section.list',
             'extras' => [
@@ -230,13 +223,6 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
     {
         $menuItems = [];
 
-        if ($this->permissionResolver->hasAccess('setup', 'system_info')) {
-            $menuItems[self::ITEM_ADMIN__SYSTEMINFO] = $this->createMenuItem(
-                self::ITEM_ADMIN__SYSTEMINFO,
-                self::ITEM_ADMIN_OPTIONS[self::ITEM_ADMIN__SYSTEMINFO]
-            );
-        }
-
         if ($this->permissionResolver->hasAccess('section', 'view') !== false) {
             $menuItems[self::ITEM_ADMIN__SECTIONS] = $this->createMenuItem(
                 self::ITEM_ADMIN__SECTIONS,
@@ -303,7 +289,6 @@ class MainMenuBuilder extends AbstractBuilder implements TranslationContainerInt
             (new Message(self::ITEM_CONTENT__CONTENT_STRUCTURE, 'menu'))->setDesc('Content structure'),
             (new Message(self::ITEM_CONTENT__MEDIA, 'menu'))->setDesc('Media'),
             (new Message(self::ITEM_ADMIN, 'menu'))->setDesc('Admin'),
-            (new Message(self::ITEM_ADMIN__SYSTEMINFO, 'menu'))->setDesc('System Information'),
             (new Message(self::ITEM_ADMIN__SECTIONS, 'menu'))->setDesc('Sections'),
             (new Message(self::ITEM_ADMIN__ROLES, 'menu'))->setDesc('Roles'),
             (new Message(self::ITEM_ADMIN__LANGUAGES, 'menu'))->setDesc('Languages'),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32038](https://jira.ez.no/browse/EZP-32038)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Excerpt from JIRA:
>System information tab should be moved from MainMenuBuilder.php to the dedicated listener within ez-support-tools to be aligned with other bundles practices.


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
