### PR TITLE
EZP-32047: Errors in forms should use danger color not primary

### DIFF
--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -129,6 +129,7 @@
 .ez-content-item__errors-wrapper {
     color: $ibexa-color-danger;
     font-size: calculateRem(14px);
+    padding: 0 calculateRem(6px);
 }
 
 .ez-header--content-edit {

--- a/src/bundle/Resources/public/scss/_content-edit.scss
+++ b/src/bundle/Resources/public/scss/_content-edit.scss
@@ -127,7 +127,7 @@
 }
 
 .ez-content-item__errors-wrapper {
-    color: $ibexa-color-primary;
+    color: $ibexa-color-danger;
     font-size: calculateRem(14px);
 }
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezrichtext.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezrichtext.scss
@@ -7,7 +7,7 @@
         .ez-data-source {
             &__richtext,
             .ez-richtext-tools {
-                border-left: calculateRem(3px) solid $ibexa-color-primary;
+                border-left: calculateRem(3px) solid $ibexa-color-danger;
             }
         }
     }

--- a/src/bundle/Resources/public/scss/mixins/_inputs.scss
+++ b/src/bundle/Resources/public/scss/mixins/_inputs.scss
@@ -6,18 +6,18 @@
 @mixin input-invalid {
     background: $ibexa-white;
     border-width: calculateRem(1px) calculateRem(1px) calculateRem(1px) calculateRem(3px);
-    border-color: $ibexa-color-base-dark $ibexa-color-base-dark $ibexa-color-base-dark $ibexa-color-primary;
+    border-color: $ibexa-color-base-dark $ibexa-color-base-dark $ibexa-color-base-dark $ibexa-color-danger;
 }
 
 @mixin area-invalid {
-    border-left: calculateRem(3px) solid $ibexa-color-primary;
+    border-left: calculateRem(3px) solid $ibexa-color-danger;
 }
 
 @mixin error-input {
     display: flex;
     font-size: calculateRem(14px);
     font-style: normal;
-    color: $ibexa-color-primary;
+    color: $ibexa-color-danger;
     align-items: center;
     box-sizing: border-box;
 
@@ -28,7 +28,7 @@
         width: calculateRem(14px);
         height: calculateRem(14px);
         color: $ibexa-white;
-        background: $ibexa-color-primary;
+        background: $ibexa-color-danger;
         border-radius: 50%;
         justify-content: center;
         align-items: center;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32047
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
