### PR TITLE
EZEE-3316: Disabled button should have opacity 0.3 not 1

### DIFF
--- a/src/bundle/Resources/public/scss/_buttons.scss
+++ b/src/bundle/Resources/public/scss/_buttons.scss
@@ -78,7 +78,6 @@
     }
 }
 
-
 .btn-icon {
     padding: 0;
 }
@@ -131,8 +130,8 @@
 }
 
 .ez-context-menu {
-    .btn.disabled,
-    .btn[disabled] {
+    .ez-sticky-container > .btn.disabled,
+    .ez-sticky-container > .btn[disabled] {
         opacity: 1;
         color: rgba($ibexa-white, 0.5);
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZEE-3316
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
