### PR TITLE
EZP-32051: Remove icon is not centered in trash filter

### DIFF
--- a/src/bundle/Resources/public/scss/_trash-search-form.scss
+++ b/src/bundle/Resources/public/scss/_trash-search-form.scss
@@ -82,7 +82,7 @@
         display: none;
         position: absolute;
         right: calculateRem(5px);
-        bottom: calculateRem(6px);
+        bottom: calculateRem(9px);
     }
 
     &__range-wrapper {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32051
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | /no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
