### PR TITLE
EZP-32053: Missing hover state in content meta preview button in UDW

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-edit-button/content.edit.button.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-edit-button/content.edit.button.js
@@ -111,7 +111,7 @@ const ContentEditButton = ({ version, location, isDisabled }) => {
                 onClick={toggleTranslationSelectorVisibility}
                 data-tooltip-container-selector=".c-udw-tab"
                 title={editLabel}>
-                <Icon name="edit" extraClasses="ez-icon--small-medium ez-icon--dark" />
+                <Icon name="edit" extraClasses="ez-icon--small-medium ez-icon--secondary" />
             </button>
             {renderTranslationSelector()}
         </div>

--- a/src/bundle/ui-dev/src/modules/universal-discovery/content.meta.preview.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/content.meta.preview.module.js
@@ -59,11 +59,11 @@ const ContentMetaPreview = () => {
     const renderActions = () => {
         const previewButton = allowRedirects ? (
             <button
-                className="c-content-meta-preview__preview-button btn"
+                className="c-content-meta-preview__preview-button btn btn-icon"
                 onClick={previewContent}
                 data-tooltip-container-selector=".c-udw-tab"
                 title={previewLabel}>
-                <Icon name="view" extraClasses="ez-icon--small-medium ez-icon--dark" />
+                <Icon name="view" extraClasses="ez-icon--small-medium ez-icon--secondary" />
             </button>
         ) : null;
         const hasAccess = permissions && permissions.edit.hasAccess;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32053
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
