### PR TITLE
EZP-32056: Wrong margin for Search button in the URL management list

### DIFF
--- a/src/bundle/Resources/views/themes/admin/link_manager/list.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/list.html.twig
@@ -10,7 +10,7 @@
                     'placeholder': 'url.search.placeholder'|trans,
                 }}) }}
 
-                <button class="btn btn-primary">
+                <button class="btn btn-primary ml-2">
                     {{ 'url.search'|trans|desc("Search") }}
                 </button>
             </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32056
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
