### PR TITLE
[Behat] Added verification of existence and closing of the notificati…

### DIFF
--- a/features/standard/Roles.feature
+++ b/features/standard/Roles.feature
@@ -145,6 +145,7 @@ Feature: Roles management
     When I start creating new "Policy" in "Test Role edited"
       And I select policy "Content / Read"
       And I click on the edit action bar button "Create"
+      And success notification that "Now you can set Limitations for the Policy." appears
       And I select limitation for "Content Type"
         | option  |
         | File    |


### PR DESCRIPTION
…on during Limitation creation

| Question      | Answer
| ------------- | ---
| Tickets       | Followup to https://jira.ez.no/browse/EZP-32010
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Failing build: https://travis-ci.com/github/ezsystems/ezcommerce-shop/jobs/402360743
Screen: https://res.cloudinary.com/ezplatformtravis/image/upload/v1603184150/screenshots/5f8ea616314a8006130920-vendor_ezsystems_ezplatform-admin-ui_features_standard_roles_feature_142_p3qqxw.png
Error:
```
 Exception: element click intercepted: Element <li data-value="12" class="ez-custom-dropdown__item">...</li> is not clickable at point (234, 931). Other element would receive the click: <div class="alert alert-success alert-dismissible fade show">...</div>
```

This step makes sure that notification is visible and closes it before selecting Limitation details.
Note: notification is visible only when Limitation is created, but not when it's edited.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
