### PR TITLE
EZP-31039: Remove unnecessary sorting params when updating Location priority

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/services/sub.items.service.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/services/sub.items.service.js
@@ -142,8 +142,6 @@ export const updateLocationPriority = ({ priority, pathString, token, siteaccess
         body: JSON.stringify({
             LocationUpdate: {
                 priority: priority,
-                sortField: 'PATH',
-                sortOrder: 'ASC',
             },
         }),
     });


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31039
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As the title states.

Related `ezplatform-rest` PR: https://github.com/ezsystems/ezplatform-rest

Parent `ezplatform-admin-ui-modules` PR: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/287

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
