### PR TITLE
Revert "[Composer] Set metarepo branch for tests and requirements for master branch"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/asset": "^5.0",
         "symfony/yaml": "^5.0",
         "jms/translation-bundle": "^1.5",
-        "ezsystems/ezplatform-kernel": "^1.3@dev",
+        "ezsystems/ezplatform-kernel": "~1.2.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
         "ezsystems/ezplatform-user": "^2.0@dev",
@@ -58,10 +58,10 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "3.2",
         "branch-alias": {
-            "dev-tmp_ci_branch": "2.3.x-dev",
-            "dev-master": "2.3.x-dev"
+            "dev-tmp_ci_branch": "2.2.x-dev",
+            "dev-master": "2.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | sort of
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This reverts commit 2a57e16bc20f3e6847673419c9e8370b37bbea86.

Reverting changes from https://github.com/ezsystems/ezplatform-admin-ui/pull/1629 that should not land in 2.2 branch (they are meant for master only).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
