### PR TITLE
[Behat] Adapted tests for the new System Information tab

### DIFF
--- a/features/standard/SystemInfo.feature
+++ b/features/standard/SystemInfo.feature
@@ -8,6 +8,11 @@ Feature: System info verification
       And I go to "System Information" in "Admin" tab
 
   @javascript @common
+  Scenario: Check My Ibexa Information
+    When I go to "My Ibexa" tab in System Information
+    Then I see "Product" system information table
+
+  @javascript @common
   Scenario: Check Composer System Information
     When I go to "Composer" tab in System Information
     Then I see "Composer" system information table

--- a/features/standard/SystemInfo.feature
+++ b/features/standard/SystemInfo.feature
@@ -1,3 +1,4 @@
+@systemInformation
 Feature: System info verification
   As an administrator
   In order to customize my eZ installation

--- a/src/lib/Behat/PageObject/SystemInfoPage.php
+++ b/src/lib/Behat/PageObject/SystemInfoPage.php
@@ -20,11 +20,6 @@ class SystemInfoPage extends Page
     public const PAGE_NAME = 'System Information';
 
     /**
-     * @var AdminList[]
-     */
-    public $adminLists;
-
-    /**
      * @var NavLinkTabs
      */
     public $navLinkTabs;
@@ -37,9 +32,6 @@ class SystemInfoPage extends Page
     public function __construct(BrowserContext $context)
     {
         parent::__construct($context);
-        $this->adminLists['Packages'] = ElementFactory::createElement($this->context, AdminList::ELEMENT_NAME, 'Packages', SimpleTable::ELEMENT_NAME, '.ez-main-container .tab-pane.active');
-        $this->adminLists['Bundles'] = ElementFactory::createElement($this->context, AdminList::ELEMENT_NAME, 'Bundles', SimpleTable::ELEMENT_NAME, '.ez-main-container .tab-pane.active');
-        $this->systemInfoTable = ElementFactory::createElement($context, SystemInfoTable::ELEMENT_NAME, '.ez-main-container .active .ez-fieldgroup:nth-of-type(1)');
         $this->navLinkTabs = ElementFactory::createElement($context, NavLinkTabs::ELEMENT_NAME);
         $this->siteAccess = 'admin';
         $this->route = '/systeminfo';
@@ -50,18 +42,20 @@ class SystemInfoPage extends Page
     public function verifyElements(): void
     {
         $this->navLinkTabs->verifyVisibility();
-        $this->adminLists['Packages']->verifyVisibility();
+        $this->verifySystemInfoTable('Product');
     }
 
     public function verifySystemInfoTable(string $tabName): void
     {
-        $this->systemInfoTable->verifyHeader($tabName);
+        $systemInfoTable = ElementFactory::createElement($this->context, SystemInfoTable::ELEMENT_NAME, '.ez-main-container .active .ez-fieldgroup:nth-of-type(1)');
+        $systemInfoTable->verifyHeader($tabName);
     }
 
     public function verifySystemInfoRecords(string $tableName, array $records): void
     {
-        $this->adminLists[$tableName]->verifyVisibility();
-        $tableHash = $this->adminLists[$tableName]->table->getTableHash();
+        $tab = ElementFactory::createElement($this->context, AdminList::ELEMENT_NAME, $tableName, SimpleTable::ELEMENT_NAME, '.ez-main-container .tab-pane.active');
+        $tab->verifyVisibility();
+        $tableHash = $tab->table->getTableHash();
 
         foreach ($records as $desiredRecord) {
             $found = false;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32097
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

In https://github.com/ezsystems/ez-support-tools/pull/69 the default tab opened when accessing "System Information" changed - it used to be the "Composer" tab, now it's "My Ibexa".
Adapted the tests for that and added a simple test that makes sure the tab is displayed. Also adding a `systemInformation` tab so we can run these tests only (used by https://github.com/ezsystems/ez-support-tools/pull/72)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
