### PR TITLE
EZP-32135: Twig helper to to display interval in a human readable format

### DIFF
--- a/src/bundle/Resources/translations/time_diff.en.xliff
+++ b/src/bundle/Resources/translations/time_diff.en.xliff
@@ -71,6 +71,36 @@
         <target state="new">in 1 second|in %count% seconds</target>
         <note>key: diff.in.year</note>
       </trans-unit>
+      <trans-unit id="2be7d1806c256f914b7451252c1d296346de0a03" resname="interval.format.days">
+        <source>1 day|%count% days</source>
+        <target state="new">1 day|%count% days</target>
+        <note>key: interval.format.days</note>
+      </trans-unit>
+      <trans-unit id="503ce7acdefad28e853f8ad5ecd796a8d4606b10" resname="interval.format.hours">
+        <source>1 hour|%count% hours</source>
+        <target state="new">1 hour|%count% hours</target>
+        <note>key: interval.format.hours</note>
+      </trans-unit>
+      <trans-unit id="b750144898737792d14f52d60c5516e9914be0af" resname="interval.format.minutes">
+        <source>1 minute|%count% minutes</source>
+        <target state="new">1 minute|%count% minutes</target>
+        <note>key: interval.format.minutes</note>
+      </trans-unit>
+      <trans-unit id="63d7fb24b0d482fb88797a437884606e988557fe" resname="interval.format.months">
+        <source>1 month|%count% months</source>
+        <target state="new">1 month|%count% months</target>
+        <note>key: interval.format.months</note>
+      </trans-unit>
+      <trans-unit id="9f20c9da2ac282bd80ccce255fee64c00913ee94" resname="interval.format.seconds">
+        <source>1 second|%count% seconds</source>
+        <target state="new">1 second|%count% seconds</target>
+        <note>key: interval.format.seconds</note>
+      </trans-unit>
+      <trans-unit id="bdf61f7e2d4eeddf834a9fe4a96a8b95bbc05fca" resname="interval.format.years">
+        <source>1 year|%count% years</source>
+        <target state="new">1 year|%count% years</target>
+        <note>key: interval.format.years</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Templating/Twig/FormatIntervalExtension.php
+++ b/src/bundle/Templating/Twig/FormatIntervalExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
+
+use DateInterval;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class FormatIntervalExtension extends AbstractExtension implements TranslationContainerInterface
+{
+    private const INTERVAL_PARTS = [
+        'y' => 'years',
+        'm' => 'months',
+        'd' => 'days',
+        'h' => 'hours',
+        'i' => 'minutes',
+        's' => 'seconds',
+    ];
+
+    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('format_interval', [$this, 'formatInterval']),
+        ];
+    }
+
+    public function formatInterval(string $periodFormat)
+    {
+        $interval = new DateInterval($periodFormat);
+        $parts = [];
+
+        foreach (self::INTERVAL_PARTS as $part => $name) {
+            if ($interval->$part > 0) {
+                $parts[] = $this->translator->trans(
+                    sprintf('interval.format.%s', $name),
+                    ['%count%' => $interval->$part],
+                    'time_diff'
+                );
+            }
+        }
+
+        return implode(' ', $parts);
+    }
+
+    public static function getTranslationMessages(): array
+    {
+        return [
+            (new Message('interval.format.seconds', 'time_diff'))->setDesc('1 second|%count% seconds'),
+            (new Message('interval.format.minutes', 'time_diff'))->setDesc('1 minute|%count% minutes'),
+            (new Message('interval.format.hours', 'time_diff'))->setDesc('1 hour|%count% hours'),
+            (new Message('interval.format.days', 'time_diff'))->setDesc('1 day|%count% days'),
+            (new Message('interval.format.months', 'time_diff'))->setDesc('1 month|%count% months'),
+            (new Message('interval.format.years', 'time_diff'))->setDesc('1 year|%count% years'),
+        ];
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32135
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

PHP:
```php
$someDateInterval = new DateInterval('P1Y3DT10M');
```
Twig: `{{ some_date_interval|format_interval }}`
Result: `1 year 3 days 10 minutes`

Translatable.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
