### PR TITLE
Limited subtree results to 0 in IsWithinCopySubtreeLimit::isSatisfiedBy

### DIFF
--- a/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
+++ b/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
@@ -52,6 +52,7 @@ class IsWithinCopySubtreeLimit extends AbstractSpecification
 
         $query = new LocationQuery([
             'filter' => new Criterion\Subtree($item->pathString),
+            'limit' => 0,
         ]);
 
         $searchResults = $this->searchService->findLocations($query);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

We only need size of the subtree, not actual search results, to check if given subtree is within copy subtree limit in `EzSystems\EzPlatformAdminUi\Specification\Location\IsWithinCopySubtreeLimit::isSatisfiedBy`

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
