### PR TITLE
[Composer] Bumped BazingaJsTranslationBundle to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "babdev/pagerfanta-bundle": "^2.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "mck89/peast": "^1.9",
-        "willdurand/js-translation-bundle": "^3.0",
+        "willdurand/js-translation-bundle": "^4.0",
         "twig/twig": "^3.0",
         "twig/intl-extra": "^3.0",
         "twig/string-extra": "^3.0"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | yes
| **Doc needed**                       | yes

Bumped `willdurand/js-translation-bundle` package to ^4.0 to support Symfony 5.2.

Otherwise it would crash:
```
  - Configuring symfony/webpack-encore-bundle (>=1.6): From github.com/symfony/recipes:master
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In TranslationResourceFilesPass.php line 58:
!!
!!    Warning: array_merge(): Expected parameter 2 to be an array, object given
!!
!!
!!
Script @auto-scripts was called via post-update-cmd
```

#### Doc
3.3 Release Notes: we needed to bump BazingaJsTranslationBundle (`willdurand/js-translation-bundle`) to next major version 4.0.0 in order to support Symfony 5.2.

#### QA
UI Translation sanities (generating, availability)

#### TODO
- [x] See if there are any breaking changes for our use cases.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review