### PR TITLE
[Behat] Adjusted title in UserCreationPage

### DIFF
--- a/src/lib/Behat/PageObject/UserCreationPage.php
+++ b/src/lib/Behat/PageObject/UserCreationPage.php
@@ -33,7 +33,7 @@ class UserCreationPage extends Page
         parent::__construct($context);
         $this->contentUpdateForm = ElementFactory::createElement($this->context, ContentUpdateForm::ELEMENT_NAME);
         $this->rightMenu = ElementFactory::createElement($this->context, RightMenu::ELEMENT_NAME);
-        $this->pageTitleLocator = '.ez-content-item-status';
+        $this->pageTitleLocator = '.ez-content-edit-page-title__title';
     }
 
     public function verifyElements(): void
@@ -44,7 +44,7 @@ class UserCreationPage extends Page
 
     public function verifyTitle(): void
     {
-        $expectedPageTitles = ['Creating a(n) User', 'Editing a(n) User'];
+        $expectedPageTitles = ['New User', 'User'];
         Assert::assertContains($this->getPageTitle(), $expectedPageTitles);
     }
 


### PR DESCRIPTION
Upstream changes for https://github.com/ezsystems/ezplatform-admin-ui/pull/1652 :
The title page (also selector used to find it) is different after the redesign (3.2).

Failing build: https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/206551935