### PR TITLE
EZP-32210  objects multiple locations labels

### DIFF
--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -32,7 +32,7 @@
                             {{ form_widget(form_content_location_remove.locations[location.id], {'attr': {'disabled': not location.canDelete}}) }}
                         </td>
                         <td class="ez-table__cell align-middle">
-                            {% include '@ezdesign/parts/path.html.twig' with {'locations': location.pathLocations} %}
+                            {% include '@ezdesign/parts/path.html.twig' with {'locations': location.pathLocations, 'link_last_element': true} %}
                         </td>
                         <td class="ez-table__cell align-middle">{{ location.childCount }}</td>
                         <td class="ez-table__cell">


### PR DESCRIPTION
EZP-32210 - Allow to click on objects multiple locations labels (paths)

| Question      | Answer
| ------------- | ---
| Tickets       |  https://issues.ibexa.co/browse/EZP-32210
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
