### PR TITLE
EZP-32173: Fixed UDW 'allowed_content_types' configuration

### DIFF
--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypesTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypesTest.php
@@ -64,12 +64,9 @@ final class RichTextEmbedAllowedContentTypesTest extends TestCase
         $this->assertEquals([], $event->getConfig());
     }
 
-    /**
-     * @dataProvider dataProviderForUdwConfigResolveWhenThereIsNoContentReadLimitations
-     */
-    public function testUdwConfigResolveWhenThereIsNoContentReadLimitations(bool $hasAccess): void
+    public function testUdwConfigResolveWhenThereIsNoContentReadLimitations(): void
     {
-        $this->permissionResolver->method('hasAccess')->with('content', 'read')->willReturn($hasAccess);
+        $this->permissionResolver->method('hasAccess')->with('content', 'read')->willReturn(true);
         $this->permissionChecker->expects($this->never())->method('getRestrictions');
         $this->contentTypeService->expects($this->never())->method('loadContentTypeList');
 
@@ -78,12 +75,15 @@ final class RichTextEmbedAllowedContentTypesTest extends TestCase
         ]);
     }
 
-    public function dataProviderForUdwConfigResolveWhenThereIsNoContentReadLimitations(): iterable
+    public function testUdwConfigResolveWhenThereIsNoContentReadLimitationsAndNoAccess(): void
     {
-        return [
-            ['hasAccess' => false],
-            ['hasAccess' => true],
-        ];
+        $this->permissionResolver->method('hasAccess')->with('content', 'read')->willReturn(false);
+        $this->permissionChecker->expects($this->never())->method('getRestrictions');
+        $this->contentTypeService->expects($this->never())->method('loadContentTypeList');
+
+        $this->assertConfigurationResolvingResult([
+            'allowed_content_types' => [null],
+        ]);
     }
 
     public function testUdwConfigResolveWhenThereAreContentReadLimitations(): void

--- a/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
@@ -45,13 +45,13 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
     private function getAllowedContentTypesIdentifiers(array $contentTypesAllowedViaConfig): ?array
     {
         $access = $this->permissionResolver->hasAccess('content', 'read');
-        if (!\is_array($access)) {
-            return count($contentTypesAllowedViaConfig) ? $contentTypesAllowedViaConfig : null;
+        if (!\is_array($access) && $access) {
+            return $contentTypesAllowedViaConfig ?: null;
         }
 
         $restrictedContentTypesIds = $this->permissionChecker->getRestrictions($access, ContentTypeLimitation::class);
         if (empty($restrictedContentTypesIds)) {
-            return count($contentTypesAllowedViaConfig) ? $contentTypesAllowedViaConfig : null;
+            return $contentTypesAllowedViaConfig ?: null;
         }
 
         $allowedContentTypesIdentifiers = [];
@@ -66,7 +66,7 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
             : $allowedContentTypesIdentifiers;
 
         //hacky, but as of now null or empty array means UDW allows all Content Types, which shouldn't be the case
-        return empty($allowedContentTypesIdentifiers) ? [microtime()] : array_values($allowedContentTypesIdentifiers);
+        return empty($allowedContentTypesIdentifiers) ? [null] : array_values($allowedContentTypesIdentifiers);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
@@ -45,8 +45,8 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
     private function getAllowedContentTypesIdentifiers(array $contentTypesAllowedViaConfig): ?array
     {
         $access = $this->permissionResolver->hasAccess('content', 'read');
-        if (!\is_array($access) && $access) {
-            return $contentTypesAllowedViaConfig ?: null;
+        if (!\is_array($access)) {
+            return $access ? ($contentTypesAllowedViaConfig ?: null) : [null];
         }
 
         $restrictedContentTypesIds = $this->permissionChecker->getRestrictions($access, ContentTypeLimitation::class);
@@ -87,7 +87,7 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
             $this->allowedContentTypesIdentifiers = $this->getAllowedContentTypesIdentifiers($config['allowed_content_types'] ?? []);
         }
 
-        $config['allowed_content_types'] = $this->allowedContentTypesIdentifiers ?: null;
+        $config['allowed_content_types'] = $this->allowedContentTypesIdentifiers;
 
         $event->setConfig($config);
     }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
@@ -42,16 +42,16 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    private function getAllowedContentTypesIdentifiers(): array
+    private function getAllowedContentTypesIdentifiers(array $contentTypesAllowedViaConfig): ?array
     {
         $access = $this->permissionResolver->hasAccess('content', 'read');
         if (!\is_array($access)) {
-            return [];
+            return count($contentTypesAllowedViaConfig) ? $contentTypesAllowedViaConfig : null;
         }
 
         $restrictedContentTypesIds = $this->permissionChecker->getRestrictions($access, ContentTypeLimitation::class);
         if (empty($restrictedContentTypesIds)) {
-            return [];
+            return count($contentTypesAllowedViaConfig) ? $contentTypesAllowedViaConfig : null;
         }
 
         $allowedContentTypesIdentifiers = [];
@@ -61,7 +61,12 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
             $allowedContentTypesIdentifiers[] = $contentType->identifier;
         }
 
-        return $allowedContentTypesIdentifiers;
+        $allowedContentTypesIdentifiers = count($contentTypesAllowedViaConfig)
+            ? array_intersect($contentTypesAllowedViaConfig, $allowedContentTypesIdentifiers)
+            : $allowedContentTypesIdentifiers;
+
+        //hacky, but as of now null or empty array means UDW allows all Content Types, which shouldn't be the case
+        return empty($allowedContentTypesIdentifiers) ? [microtime()] : array_values($allowedContentTypesIdentifiers);
     }
 
     public static function getSubscribedEvents(): array
@@ -80,10 +85,10 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
         }
 
         if ($this->allowedContentTypesIdentifiers === null) {
-            $this->allowedContentTypesIdentifiers = $this->getAllowedContentTypesIdentifiers();
+            $this->allowedContentTypesIdentifiers = $this->getAllowedContentTypesIdentifiers($config['allowed_content_types'] ?? []);
         }
 
-        $config['allowed_content_types'] = !empty($this->allowedContentTypesIdentifiers) ? $this->allowedContentTypesIdentifiers : null;
+        $config['allowed_content_types'] = $this->allowedContentTypesIdentifiers ?: null;
 
         $event->setConfig($config);
     }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/RichTextEmbedAllowedContentTypes.php
@@ -65,7 +65,6 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
             ? array_intersect($contentTypesAllowedViaConfig, $allowedContentTypesIdentifiers)
             : $allowedContentTypesIdentifiers;
 
-        //hacky, but as of now null or empty array means UDW allows all Content Types, which shouldn't be the case
         return empty($allowedContentTypesIdentifiers) ? [null] : array_values($allowedContentTypesIdentifiers);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32173
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When 'allowed_content_types' was specified in the .yml config it wasn't taken into consideration. This has been fixed in this PR.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
