### PR TITLE
Added location parameter to ez_render_field

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig
@@ -25,7 +25,7 @@
                                             {% if ez_field_is_empty(content, field_definition.identifier) and field_definition.fieldTypeIdentifier is not same as('ezboolean') %}
                                                 <em>{{ 'fieldview.field.empty'|trans({}, 'fieldview')|desc('This field is empty') }}</em>
                                             {% else %}
-                                                {{ ez_render_field(content, field_definition.identifier) }}
+                                                {{ ez_render_field(content, field_definition.identifier, {location: location}) }}
                                             {% endif %}
                                         </div>
                                     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31659](https://issues.ibexa.co/browse/EZP-31659)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Adds the location as an extra parameter to `ez_render_field`. Used by the query field (ezsystems/ezplatform-query-fieldtype#38) to render the results for the current location, but may also apply to other fields who depend on it.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
