### PR TITLE
EZEE-3397: Added fieldDefId & contentId to image editor button

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -35,7 +35,13 @@
                             <use xlink:href="{{ ez_icon_path('open-newtab') }}"></use>
                         </svg>
                     </a>
-                    {{ ez_render_component_group('image-edit-actions-after') }}
+                    {{ ez_render_component_group(
+                        'image-edit-actions-after',
+                        {
+                            'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
+                            'contentId' : app.request.get('contentId')
+                        }
+                    ) }}
                 </div>
                 <img
                     class="ez-field-edit-preview__media"

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -113,7 +113,13 @@
                             <use xlink:href="{{ ez_icon_path('open-newtab') }}"></use>
                         </svg>
                     </a>
-                    {{ ez_render_component_group('image-edit-actions-after') }}
+                    {{ ez_render_component_group(
+                        'image-edit-actions-after',
+                        {
+                            'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
+                            'contentId' : app.request.get('contentId')
+                        }
+                    ) }}
                 </div>
                 <img
                     class="ez-field-edit-preview__media {{ image_uri ? '' : 'd-none' }}"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZEE-3397
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
