### PR TITLE
EZP-32223: Certain Back Office languages can break pager labels

### DIFF
--- a/src/bundle/Resources/public/scss/_pagination.scss
+++ b/src/bundle/Resources/public/scss/_pagination.scss
@@ -21,10 +21,18 @@
 
         .page-item.prev {
             @include pagination-prev-btn();
+
+            .page-link {
+                padding-left: calculateRem(20px);
+            }
         }
 
         .page-item.next {
             @include pagination-next-btn();
+
+            .page-link {
+                padding-right: calculateRem(20px);
+            }
         }
 
         .page-item.prev,
@@ -37,7 +45,7 @@
             }
 
             .page-link {
-                width: calculateRem(60px);
+                width: initial;
                 border-radius: 0;
             }
         }

--- a/src/bundle/Resources/public/scss/ui/modules/sub-items-list/_main.scss
+++ b/src/bundle/Resources/public/scss/ui/modules/sub-items-list/_main.scss
@@ -83,10 +83,18 @@
 
             .c-pagination-button.prev {
                 @include pagination-prev-btn();
+
+                .page-link {
+                    padding-left: calculateRem(20px);
+                }
             }
 
             .c-pagination-button.next {
                 @include pagination-next-btn();
+
+                .page-link {
+                    padding-right: calculateRem(20px);
+                }
             }
 
             .c-pagination-button.prev,
@@ -99,7 +107,7 @@
                 }
 
                 .page-link {
-                    width: calculateRem(60px);
+                    width: initial;
                     border-radius: 0;
                 }
             }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32223
| Bug fix?      | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Ready for Code Review
