### PR TITLE
EC-277: Components notification message is not aligned to the left

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/component/preview_unavailable.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/component/preview_unavailable.html.twig
@@ -1,11 +1,13 @@
 {% trans_default_domain 'content_edit_component_preview_unavailable' %}
 
-<section class="container mt-3 px-5">
-    <div class="alert alert-info ez-alert ez-alert--info" role="alert">
-        <svg class="ez-icon ez-icon--small ez-icon-warning">
-            <use xlink:href="{{ ez_icon_path('warning') }}"></use>
-        </svg>
+<section class="container mt-3">
+    <div class="px-3">
+        <div class="alert alert-info ez-alert ez-alert--info" role="alert">
+            <svg class="ez-icon ez-icon--small ez-icon-warning">
+                <use xlink:href="{{ ez_icon_path('warning') }}"></use>
+            </svg>
 
-        {{ 'preview_unavailable'|trans|desc('You cannot preview this translation because there is no site available for this language. Contact your Administrator.') }}
+            {{ 'preview_unavailable'|trans|desc('You cannot preview this translation because there is no site available for this language. Contact your Administrator.') }}
+        </div>
     </div>
 </section>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EC-277
| Bug fix?      | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Ready for Code Review
