### PR TITLE
EZEE-3419: Fixed providing empty object instead of empty array when no data set

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -126,6 +126,7 @@
          */
         updateData(destinationContentId, destinationContentName, destinationLocationId, image) {
             const preview = this.fieldContainer.querySelector('.ez-field-edit__preview');
+            const previewVisual = preview.querySelector('.ez-field-edit-preview__visual');
             const previewImg = preview.querySelector('.ez-field-edit-preview__media');
             const previewAlt = preview.querySelector('.ez-field-edit-preview__image-alt input');
             const previewActionPreview = preview.querySelector('.ez-field-edit-preview__action--preview');
@@ -134,7 +135,9 @@
                 contentId: destinationContentId,
                 locationId: destinationLocationId,
             });
+            const additionalData = Array.isArray(image.additionalData) ? '{}' : JSON.stringify(image.additionalData);
 
+            previewVisual.setAttribute('data-additional-data', additionalData);
             previewImg.setAttribute('src', image ? image.uri : '//:0');
             previewImg.classList.toggle('d-none', image === null);
             previewAlt.value = image.alternativeText;

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -90,8 +90,10 @@
         {% set additional_data = ez_field_value(destination_content, ez_content_field_identifier_image_asset()).additionalData %}
     {% endif %}
 
+    {% set has_additional_data = additional_data is not null and additional_data is not empty %}
+
     <div class="ez-field-edit-preview">
-        <div class="ez-field-edit-preview__visual" data-additional-data="{{ additional_data is not null ? additional_data|json_encode(): '{}' }}">
+        <div class="ez-field-edit-preview__visual" data-additional-data="{{ has_additional_data ? additional_data|json_encode(): '{}' }}">
             <div class="ez-field-edit-preview__media-wrapper">
                 <div class="ez-field-edit-preview__actions">
                     <button


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | EZEE-3419
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
