### PR TITLE
EZP-32117: [UI][UX] Content Field validation error is not auto-scrolled to when it occurs on a non-focused tab

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.edit.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.edit.js
@@ -47,6 +47,15 @@
 
         fields.forEach((field) => field.removeAttribute('tabindex'));
         invalidFields.forEach((field) => field.setAttribute('tabindex', '-1'));
+
+        invalidTab = invalidFields[0].closest('.tab-pane');
+
+        if (invalidTab) {
+            const invalidTabLink = doc.querySelector(`a[href="#${invalidTab.id}"]`);
+
+            invalidTabLink.click();
+        }
+
         invalidFields[0].focus();
 
         doc.querySelector('.ez-content-item__errors-wrapper').removeAttribute('hidden');
@@ -98,8 +107,7 @@
     };
 
     const isAutosaveEnabled = () => {
-        return eZ.adminUiConfig.autosave.enabled
-            && form.querySelector('[name="ezplatform_content_forms_content_edit[autosave]"]');
+        return eZ.adminUiConfig.autosave.enabled && form.querySelector('[name="ezplatform_content_forms_content_edit[autosave]"]');
     };
 
     if (isAutosaveEnabled()) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32117
| Bug fix?      | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Ready for Code Review
