### PR TITLE
EZP-32252: Wrong documentation link in login screen

### DIFF
--- a/src/bundle/Resources/views/themes/admin/account/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/base.html.twig
@@ -13,7 +13,7 @@
                     <div class="ez-login__support-wrapper">
                         <h2 class="ez-login__support-headline">{{ 'base.need_assistance'|trans|desc('Get to know Ibexa DXP') }}</h2>
                         <span class="ez-login__support-content">{{ 'base.visit_support'|trans({
-                                '%ez_documentation_link%': '<a class="ez-link ez-link--light" href="https://ezplatform.com/documentation-center">https://ezplatform.com/documentation-center</a>',
+                                '%ez_documentation_link%': '<a class="ez-link ez-link--light" href="https://developers.ibexa.co/documentation-hub">https://developers.ibexa.co/documentation-hub</a>',
                                 '%ez_contact_link%': '<a class="ez-link ez-link--light" href="https://www.ibexa.co/about-ibexa/contact-us">https://www.ibexa.co/about-ibexa/contact-us</a>'
                               })| desc('Visit the official documentation %ez_documentation_link%<br/>or get in touch with us: %ez_contact_link%')|raw }}</span>
                     </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32252
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
