### PR TITLE
Simplify login form view customization

### DIFF
--- a/src/bundle/Resources/views/themes/admin/account/login/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/login/index.html.twig
@@ -4,55 +4,66 @@
     <h2 class="ez-login__actions-headline">{{ 'base.sign_in'|trans|desc('Sign in to IBEXA DXP') }}</h2>
     <p class="ez-login__actions-subheadline">{{ 'base.enter_credentials'|trans|desc('Enter your login credentials below.') }}</p>
 
-    <form action="{{ path( 'login_check' ) }}" method="post" role="form">
-        <fieldset>
-            {% if error %}
-                <span class="ez-login__errors-container">{{ error.message|trans }}</span>
-            {% endif %}
-            <div class="form-group{% if error %} has-error{% endif %}">
-                <div class="ez-login__input-label-wrapper">
-                    <label class="ez-login__input-label" for="username">{{ 'authentication.username'|trans|desc('Username') }}</label>
-                </div>
-                <input
-                    type="text"
-                    id="username"
-                    class="form-control ez-login__input ez-login__input--username"
-                    name="_username"
-                    value="{{ last_username }}"
-                    required="required"
-                    autofocus="autofocus"
-                    autocomplete="on"
-                    tabindex="1"
-                />
-            </div>
-            <div class="form-group{% if error %} has-error{% endif %} position-relative">
-                <div class="ez-login__input-label-wrapper">
-                    <label class="ez-login__input-label" for="password">{{ 'authentication.password'|trans|desc('Password') }}</label>
-                    <a href="{{ path('ezplatform.user.forgot_password') }}" tabindex="4">{{ 'authentication.forgot_password'|trans|desc('Forgot password?') }}</a>
-                </div>
-                <input
-                    type="password"
-                    id="password"
-                    class="form-control ez-login__input ez-login__input--password"
-                    name="_password"
-                    required="required"
-                    tabindex="2"
-                />
-                <button type="button" class="ez-login__password-visibility-toggler" tabindex="5">
-                    <svg class="ez-icon ez-icon--medium ez-icon--dark ez-icon--view">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ ez_icon_path('view') }}"></use>
-                    </svg>
-                    <svg class="ez-icon ez-icon--medium ez-icon--dark ez-icon--view-hide d-none">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ ez_icon_path('view-hide') }}"></use>
-                    </svg>
-                </button>
-            </div>
+    {% block login_form %}
+        <form action="{{ path( 'login_check' ) }}" method="post" role="form">
+            <fieldset>
+                {% block login_form_errors %}
+                    {% if error %}
+                        <span class="ez-login__errors-container">{{ error.message|trans }}</span>
+                    {% endif %}
+                {% endblock %}
 
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token("authenticate") }}" />
+                {% block login_form_fields %}
+                    <div class="form-group{% if error %} has-error{% endif %}">
+                        <div class="ez-login__input-label-wrapper">
+                            <label class="ez-login__input-label" for="username">{{ 'authentication.username'|trans|desc('Username') }}</label>
+                        </div>
+                        <input
+                            type="text"
+                            id="username"
+                            class="form-control ez-login__input ez-login__input--username"
+                            name="_username"
+                            value="{{ last_username }}"
+                            required="required"
+                            autofocus="autofocus"
+                            autocomplete="on"
+                            tabindex="1"
+                        />
+                    </div>
+                    <div class="form-group{% if error %} has-error{% endif %} position-relative">
+                        <div class="ez-login__input-label-wrapper">
+                            <label class="ez-login__input-label" for="password">{{ 'authentication.password'|trans|desc('Password') }}</label>
+                            <a href="{{ path('ezplatform.user.forgot_password') }}" tabindex="4">{{ 'authentication.forgot_password'|trans|desc('Forgot password?') }}</a>
+                        </div>
+                        <input
+                            type="password"
+                            id="password"
+                            class="form-control ez-login__input ez-login__input--password"
+                            name="_password"
+                            required="required"
+                            tabindex="2"
+                        />
+                        <button type="button" class="ez-login__password-visibility-toggler" tabindex="5">
+                            <svg class="ez-icon ez-icon--medium ez-icon--dark ez-icon--view">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ ez_icon_path('view') }}"></use>
+                            </svg>
+                            <svg class="ez-icon ez-icon--medium ez-icon--dark ez-icon--view-hide d-none">
+                                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ ez_icon_path('view-hide') }}"></use>
+                            </svg>
+                        </button>
+                    </div>
 
-            <button type="submit" class="btn btn-primary ez-login__btn ez-login__btn--sign-in" tabindex="3">{{ 'authentication.sign_in'|trans|desc('Sign in') }}</button>
-        </fieldset>
-    </form>
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token("authenticate") }}" />
+                {% endblock %}
+
+                {% block login_form_buttons %}
+                    <button type="submit" class="btn btn-primary ez-login__btn ez-login__btn--sign-in" tabindex="3">
+                        {{ 'authentication.sign_in'|trans|desc('Sign in') }}
+                    </button>
+                {% endblock %}
+            </fieldset>
+        </form>
+    {% endblock %}
 
     {{ encore_entry_script_tags('ezplatform-admin-ui-login-js', null, 'ezplatform') }}
 {%- endblock content -%}

--- a/src/bundle/Resources/views/themes/admin/account/login/index.html.twig
+++ b/src/bundle/Resources/views/themes/admin/account/login/index.html.twig
@@ -5,6 +5,8 @@
     <p class="ez-login__actions-subheadline">{{ 'base.enter_credentials'|trans|desc('Enter your login credentials below.') }}</p>
 
     {% block login_form %}
+        {{ ez_render_component_group('login-form-before') }}
+
         <form action="{{ path( 'login_check' ) }}" method="post" role="form">
             <fieldset>
                 {% block login_form_errors %}
@@ -63,6 +65,8 @@
                 {% endblock %}
             </fieldset>
         </form>
+
+        {{ ez_render_component_group('login-form-after') }}
     {% endblock %}
 
     {{ encore_entry_script_tags('ezplatform-admin-ui-login-js', null, 'ezplatform') }}


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| Tickets | \- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Tests pass? | yes |
| Doc needed? | yes |
| License | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE) |

In order to simplify login form template (`src/bundle/Resources/views/themes/admin/account/login/index.html.twig`) customization:

*   Restructured template using blocks
*   Added `login-form-before` and `login-form-after` components groups

### Example use case

Assuming that as a Developer I would like to would like to add "Login via XYZ" button to login form. 

1.  Create  `/templates/login_via_oauth2.html.twig`

```twig
<div class="row mt-4">
    <div class="col">
        <p class="text-center">or</p>

        <div class="btn-group d-flex">
            <a href="#" class="btn btn-primary mr-1">
                Login via Google
            </a>

            <a href="#" class="btn btn-primary ml-1">
                Login via  Microsoft
            </a>
        </div>
    </div>
</div>
```

2\. Add component definition to `/config/services.yaml:`

```yaml
    app.components.login_via_aouth2:
        parent: EzSystems\EzPlatformAdminUi\Component\TwigComponent
        arguments:
            $template: 'login_via_oauth2.html.twig'
        tags:
            - { name: ezplatform.admin_ui.component, group: login-form-after }
```

3\. Done. 

![image](https://user-images.githubusercontent.com/211967/103289341-3deac080-49e7-11eb-88a7-d2a1e0e391dc.png)

#### Checklist:

*   [x] Coding standards (`$ composer fix-cs`)
*   [x] Ready for Code Review