### PR TITLE
EZP-32287: Wrong size of a Save tile on the URL management edit page

### DIFF
--- a/src/bundle/Resources/views/themes/admin/link_manager/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/link_manager/edit.html.twig
@@ -41,11 +41,13 @@
             </div>
         </div>
         <div class="ez-context-menu">
-            {% set url_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.url_edit.sidebar_right', [], {'url': url}) %}
+            <div class="ez-sticky-container">
+                {% set url_create_sidebar_right = knp_menu_get('ezplatform_admin_ui.menu.url_edit.sidebar_right', [], {'url': url}) %}
 
-            {{ knp_menu_render(url_create_sidebar_right, {
-                'template': '@ezdesign/ui/menu/sidebar_right.html.twig'
-            }) }}
+                {{ knp_menu_render(url_create_sidebar_right, {
+                    'template': '@ezdesign/ui/menu/sidebar_right.html.twig'
+                }) }}
+            </div>
         </div>
     </div>
 {%- endblock -%}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32287
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added missing html container `.ez-sticky-container`

![Screenshot from 2021-01-15 14-59-17](https://user-images.githubusercontent.com/24355391/104735761-4874bc00-5742-11eb-9331-061e843a0d27.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
