### PR TITLE
EZEE-3459: Cannot use image editor in product content type

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -56,7 +56,7 @@
             <div class="ez-field-edit-preview__image-alt">
                 {{ form_row(form.alternativeText) }}
             </div>
-            {{ form_widget(form.additionalData) }}
+            {{ form_widget(form.additionalData, {attr: {class: 'ez-field-edit-preview__additional-data'}}) }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZEE-3459
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
