### PR TITLE
EZEE-3455: [Image upload] no validation message for files bigger than 2mb

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-file-field.js
@@ -27,10 +27,14 @@
             }
 
             if (!isEmpty && maxFileSize > 0 && input.files[0] && input.files[0].size > maxFileSize) {
-                result = this.showFileSizeError();
+                result = this.validateFileSize(event);
             }
 
             return result;
+        }
+
+        validateFileSize(event) {
+            return this.showFileSizeError();
         }
 
         /**

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezbinaryfile.js
@@ -1,6 +1,7 @@
-(function (global, doc, eZ) {
+(function(global, doc, eZ) {
     const SELECTOR_FIELD = '.ez-field-edit--ezbinaryfile';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
+    const SELECTOR_FILESIZE_NOTICE = '.ez-data-source__message--filesize';
 
     class EzBinaryFilePreviewField extends eZ.BasePreviewField {
         /**
@@ -24,8 +25,18 @@
         }
     }
 
+    class EzBinaryFileFieldValidator extends eZ.BaseFileFieldValidator {
+        validateFileSize(event) {
+            event.currentTarget.dispatchEvent(new CustomEvent('ez-invalid-file-size'));
+
+            return {
+                isError: false,
+            };
+        }
+    }
+
     doc.querySelectorAll(SELECTOR_FIELD).forEach((fieldContainer) => {
-        const validator = new eZ.BaseFileFieldValidator({
+        const validator = new EzBinaryFileFieldValidator({
             classInvalid: 'is-invalid',
             fieldContainer,
             eventsMap: [
@@ -40,7 +51,7 @@
                     selector: `input[type="file"]`,
                     eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
-                    errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
+                    errorNodeSelectors: [SELECTOR_FILESIZE_NOTICE],
                 },
             ],
         });

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -2,6 +2,7 @@
     const SELECTOR_FIELD = '.ez-field-edit--ezimage';
     const SELECTOR_INPUT_FILE = 'input[type="file"]';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
+    const SELECTOR_FILESIZE_NOTICE = '.ez-data-source__message--filesize';
     const SELECTOR_ALT_WRAPPER = '.ez-field-edit-preview__image-alt';
     const SELECTOR_INPUT_ALT = '.ez-field-edit-preview__image-alt .ez-data-source__input';
     const EVENT_CANCEL_ERROR = 'ez-cancel-errors';
@@ -52,10 +53,18 @@
         toggleInvalidState(isError, config, input) {
             super.toggleInvalidState(isError, config, input);
 
-            const container = input.closest('.ez-field-edit--ezimage');
+            const container = this.getFieldTypeContainer(input.closest(this.fieldSelector));
             const method = !!container.querySelector(`.${this.classInvalid}`) ? 'add' : 'remove';
 
             container.classList[method](this.classInvalid);
+        }
+
+        validateFileSize(event) {
+            event.currentTarget.dispatchEvent(new CustomEvent('ez-invalid-file-size'));
+
+            return {
+                isError: false,
+            };
         }
 
         /**
@@ -104,7 +113,7 @@
                     selector: `${SELECTOR_INPUT_FILE}`,
                     eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
-                    errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
+                    errorNodeSelectors: [SELECTOR_FILESIZE_NOTICE],
                 },
                 {
                     isValueValidator: false,

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -3,6 +3,7 @@
     const SELECTOR_INPUT_FILE = 'input[type="file"]';
     const SELECTOR_INPUT_DESTINATION_CONTENT_ID = '.ez-data-source__destination-content-id';
     const SELECTOR_LABEL_WRAPPER = '.ez-field-edit__label-wrapper';
+    const SELECTOR_FILESIZE_NOTICE = '.ez-data-source__message--filesize';
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const showErrorNotification = eZ.helpers.notification.showErrorNotification;
     const showSuccessNotification = eZ.helpers.notification.showSuccessNotification;
@@ -228,7 +229,15 @@
         }
     }
 
-    class EzImageAssetFieldValidator extends eZ.BaseFileFieldValidator {}
+    class EzImageAssetFieldValidator extends eZ.BaseFileFieldValidator {
+        validateFileSize(event) {
+            event.currentTarget.dispatchEvent(new CustomEvent('ez-invalid-file-size'));
+
+            return {
+                isError: false,
+            };
+        }
+    }
 
     doc.querySelectorAll(SELECTOR_FIELD).forEach((fieldContainer) => {
         const validator = new EzImageAssetFieldValidator({
@@ -246,7 +255,7 @@
                     selector: `${SELECTOR_INPUT_FILE}`,
                     eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
-                    errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
+                    errorNodeSelectors: [SELECTOR_FILESIZE_NOTICE],
                 },
             ],
         });

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezmedia.js
@@ -7,8 +7,17 @@
     const SELECTOR_MEDIA_WRAPPER = '.ez-field-edit-preview__media-wrapper';
     const SELECTOR_INPUT_FILE = 'input[type="file"]';
     const CLASS_MEDIA_WRAPPER_LOADING = 'ez-field-edit-preview__media-wrapper--loading';
+    const SELECTOR_FILESIZE_NOTICE = '.ez-data-source__message--filesize';
 
     class EzMediaValidator extends eZ.BaseFileFieldValidator {
+        validateFileSize(event) {
+            event.currentTarget.dispatchEvent(new CustomEvent('ez-invalid-file-size'));
+
+            return {
+                isError: false,
+            };
+        }
+
         /**
          * Validates the dimensions inputs
          *
@@ -144,7 +153,7 @@
                     selector: SELECTOR_INPUT_FILE,
                     eventName: 'ez-invalid-file-size',
                     callback: 'showFileSizeError',
-                    errorNodeSelectors: [SELECTOR_LABEL_WRAPPER],
+                    errorNodeSelectors: [SELECTOR_FILESIZE_NOTICE],
                 },
                 {
                     selector: '.ez-field-edit-preview__dimensions .form-control',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZEE-3455
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

![Screenshot from 2021-01-28 13-59-36](https://user-images.githubusercontent.com/24355391/106141922-18c9a900-6171-11eb-9cdf-dd7c3e9ec9a5.png)



- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
