### PR TITLE
EZP-32308: Passed mandatory Location into LocationLimitation

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -371,7 +371,8 @@ class ContentViewController extends Controller
                     $this->permissionResolver,
                     $contentInfo,
                     $this->lookupLimitationsTransformer,
-                    $languageCodes
+                    $languageCodes,
+                    $this->locationService
                 ),
             ]
         );

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
@@ -85,7 +85,7 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
                 $this->contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($this->contentInfo->mainLocationId)
+                    $this->locationService->loadLocation($this->contentInfo->mainLocationId),
                 ],
                 [Limitation::LANGUAGE]
             );

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader;
 
 use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
@@ -33,6 +34,9 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
     /** @var \EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer */
     private $lookupLimitationsTransformer;
 
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
     /**
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
@@ -45,13 +49,15 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
         PermissionResolver $permissionResolver,
         ?ContentInfo $contentInfo,
         LookupLimitationsTransformer $lookupLimitationsTransformer,
-        array $languageCodes
+        array $languageCodes,
+        LocationService $locationService
     ) {
         $this->languageService = $languageService;
         $this->permissionResolver = $permissionResolver;
         $this->contentInfo = $contentInfo;
         $this->languageCodes = $languageCodes;
         $this->lookupLimitationsTransformer = $lookupLimitationsTransformer;
+        $this->locationService = $locationService;
     }
 
     /**
@@ -77,7 +83,10 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
                 'content',
                 'edit',
                 $this->contentInfo,
-                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(), $this->contentInfo->getMainLocation()],
+                [
+                    (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
+                    $this->locationService->loadLocation($this->contentInfo->mainLocationId)
+                ],
                 [Limitation::LANGUAGE]
             );
 

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
@@ -77,7 +77,7 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
                 'content',
                 'edit',
                 $this->contentInfo,
-                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build()],
+                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(), $this->contentInfo->getMainLocation()],
                 [Limitation::LANGUAGE]
             );
 

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -197,7 +197,10 @@ class TranslationAddType extends AbstractType
                 'content',
                 'edit',
                 $contentInfo,
-                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(), $contentInfo->getMainLocation()],
+                [
+                    (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
+                    $this->locationService->loadLocation($contentInfo->mainLocationId)
+                ],
                 [Limitation::LANGUAGE]
             );
 

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -197,7 +197,7 @@ class TranslationAddType extends AbstractType
                 'content',
                 'edit',
                 $contentInfo,
-                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build()],
+                [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(), $contentInfo->getMainLocation()],
                 [Limitation::LANGUAGE]
             );
 

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -199,7 +199,7 @@ class TranslationAddType extends AbstractType
                 $contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($contentInfo->mainLocationId)
+                    $this->locationService->loadLocation($contentInfo->mainLocationId),
                 ],
                 [Limitation::LANGUAGE]
             );

--- a/src/lib/Tab/LocationView/TranslationsTab.php
+++ b/src/lib/Tab/LocationView/TranslationsTab.php
@@ -132,7 +132,7 @@ class TranslationsTab extends AbstractEventDispatchingTab implements OrderedTabI
             'content',
             'edit',
             $location->getContentInfo(),
-            [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build()]
+            [(new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(), $location]
         );
 
         $viewParameters = [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-32308
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Based on:
https://github.com/ezsystems/ezpublish-kernel/pull/3083
At least one valid `Location` object is needed to properly solve LocationLimitation (content/edit).


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
