### PR TITLE
EZP-32321: Added deleteTranslations target to fix 'content/remove' permission check

### DIFF
--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUser;
@@ -162,16 +163,19 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     ->build(),
             ]
         );
+        $translations = $content->getVersionInfo()->languageCodes;
+        $target = (new Target\Version())->deleteTranslations($translations);
         $canDelete = $this->permissionResolver->canUser(
             'content',
             'remove',
-            $content
+            $content,
+            [$target]
         );
         $canTrashLocation = $this->permissionResolver->canUser(
             'content',
             'remove',
             $location->getContentInfo(),
-            [$location]
+            [$location, $target]
         );
 
         $createAttributes = [

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -32,6 +32,7 @@ use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
+use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
@@ -234,6 +235,9 @@ class ValueFactory
      */
     public function createLocation(Location $location): UIValue\Content\Location
     {
+        $translations = $location->getContent()->getVersionInfo()->languageCodes;
+        $target = (new Target\Version())->deleteTranslations($translations);
+
         return new UIValue\Content\Location($location, [
             'childCount' => $this->locationService->getLocationChildCount($location),
             'pathLocations' => $this->pathService->loadPathLocations($location),
@@ -241,7 +245,7 @@ class ValueFactory
                 'content', 'manage_locations', $location->getContentInfo()
             ),
             'userCanRemove' => $this->permissionResolver->canUser(
-                'content', 'remove', $location->getContentInfo(), [$location]
+                'content', 'remove', $location->getContentInfo(), [$location, $target]
             ),
             'userCanEdit' => $this->permissionResolver->canUser(
                 'content', 'edit', $location->getContentInfo(), [$location]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32321
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| Related PR   | https://github.com/ezsystems/ezpublish-kernel/pull/3084
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


A bug occurs how long a policy `content/remove` has a language limitation. If 'initialLanguageCode' of content is the same as one of the allowed languages then the user can delete content. Because initial language code is set when content is edited in given language behavior is nondeterministic. To eliminate this bug additional "target" should be passed as an argument when the permission check I performed. After this change, if the user has `content/remove` policy with language limitations then he has to have access to all languages of content.

#### Documentation
After this change, if the user has `content/remove` policy with language limitations then he has to have access to all languages of content.
Below is an example of how a permission check could be achieved
```
$translations = $location->getContent()->getVersionInfo()->languageCodes;
$target = (new Target\Version())->deleteTranslations($translations);
$permissionResolver->canUser(
    'content', 'remove', $location->getContentInfo(), [$location, $target]
);
```

#### QA
- moving content to trash
- removing location
- removing content from trash

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
