### PR TITLE
EZEE-3465: Made SiteaccessPreviewVoter repository aware

### DIFF
--- a/src/lib/Menu/ContentRightSidebarBuilder.php
+++ b/src/lib/Menu/ContentRightSidebarBuilder.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 use EzSystems\EzPlatformAdminUi\Specification\ContentType\ContentTypeIsUser;
@@ -162,16 +163,19 @@ class ContentRightSidebarBuilder extends AbstractBuilder implements TranslationC
                     ->build(),
             ]
         );
+        $translations = $content->getVersionInfo()->languageCodes;
+        $target = (new Target\Version())->deleteTranslations($translations);
         $canDelete = $this->permissionResolver->canUser(
             'content',
             'remove',
-            $content
+            $content,
+            [$target]
         );
         $canTrashLocation = $this->permissionResolver->canUser(
             'content',
             'remove',
             $location->getContentInfo(),
-            [$location]
+            [$location, $target]
         );
 
         $createAttributes = [

--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -54,7 +54,7 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
         $siteaccessRepository = $siteaccessRepository ?: $this->repositoryConfigurationProvider->pullDefaultRepository();
         $currentRepository = $this->repositoryConfigurationProvider->getRepositoryConfig()['alias'];
 
-        if (!in_array($languageCode, $siteaccessLanguages) || $siteaccessRepository !== $currentRepository) {
+        if (!in_array($languageCode, $siteaccessLanguages, true) || $siteaccessRepository !== $currentRepository) {
             return false;
         }
 

--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Siteaccess;
 
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterInterface
@@ -15,13 +16,15 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     protected $configResolver;
 
-    /**
-     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
-     */
+    /** @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider */
+    protected $repositoryConfigurationProvider;
+
     public function __construct(
-        ConfigResolverInterface $configResolver
+        ConfigResolverInterface $configResolver,
+        RepositoryConfigurationProvider $repositoryConfigurationProvider
     ) {
         $this->configResolver = $configResolver;
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
 
     /**
@@ -43,7 +46,15 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
             null,
             $siteaccess
         );
-        if (!in_array($languageCode, $siteaccessLanguages)) {
+        $siteaccessRepository = $this->configResolver->getParameter(
+            'repository',
+            null,
+            $siteaccess
+        );
+        $siteaccessRepository = $siteaccessRepository ?: $this->repositoryConfigurationProvider->pullDefaultRepository();
+        $currentRepository = $this->repositoryConfigurationProvider->getRepositoryConfig()['alias'];
+
+        if (!in_array($languageCode, $siteaccessLanguages) || $siteaccessRepository !== $currentRepository) {
             return false;
         }
 

--- a/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
+++ b/src/lib/Siteaccess/AbstractSiteaccessPreviewVoter.php
@@ -41,20 +41,17 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
             return false;
         }
 
+        if (!$this->validateRepositoryMatch($siteaccess)) {
+            return false;
+        }
+
         $siteaccessLanguages = $this->configResolver->getParameter(
             'languages',
             null,
             $siteaccess
         );
-        $siteaccessRepository = $this->configResolver->getParameter(
-            'repository',
-            null,
-            $siteaccess
-        );
-        $siteaccessRepository = $siteaccessRepository ?: $this->repositoryConfigurationProvider->pullDefaultRepository();
-        $currentRepository = $this->repositoryConfigurationProvider->getRepositoryConfig()['alias'];
 
-        if (!in_array($languageCode, $siteaccessLanguages, true) || $siteaccessRepository !== $currentRepository) {
+        if (!in_array($languageCode, $siteaccessLanguages, true)) {
             return false;
         }
 
@@ -67,6 +64,21 @@ abstract class AbstractSiteaccessPreviewVoter implements SiteaccessPreviewVoterI
         }
 
         return true;
+    }
+
+    protected function validateRepositoryMatch(string $siteaccess): bool
+    {
+        $siteaccessRepository = $this->configResolver->getParameter(
+            'repository',
+            null,
+            $siteaccess
+        );
+
+        // If SA does not have a repository configured we should obtain the default one, which is used as a fallback.
+        $siteaccessRepository = $siteaccessRepository ?: $this->repositoryConfigurationProvider->getDefaultRepositoryAlias();
+        $currentRepository = $this->repositoryConfigurationProvider->getCurrentRepositoryAlias();
+
+        return $siteaccessRepository === $currentRepository;
     }
 
     /**

--- a/src/lib/Tests/Siteaccess/AdminSiteaccessPreviewVoterTest.php
+++ b/src/lib/Tests/Siteaccess/AdminSiteaccessPreviewVoterTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class AdminSiteaccessPreviewVoterTest extends TestCase
 {
-    public const LANGUAGE_CODE = 'eng-GB';
+    private const LANGUAGE_CODE = 'eng-GB';
 
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;

--- a/src/lib/Tests/Siteaccess/AdminSiteaccessPreviewVoterTest.php
+++ b/src/lib/Tests/Siteaccess/AdminSiteaccessPreviewVoterTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Tests\Siteaccess;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPlatformAdminUi\Siteaccess\AdminSiteaccessPreviewVoter;
+use EzSystems\EzPlatformAdminUi\Siteaccess\SiteaccessPreviewVoterContext;
+use PHPUnit\Framework\TestCase;
+
+class AdminSiteaccessPreviewVoterTest extends TestCase
+{
+    public const LANGUAGE_CODE = 'eng-GB';
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider */
+    private $repositoryConfigurationProvider;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Siteaccess\AdminSiteaccessPreviewVoter */
+    private $adminSiteaccessPreviewVoter;
+
+    public function setUp(): void
+    {
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->repositoryConfigurationProvider = $this->createMock(RepositoryConfigurationProvider::class);
+
+        $this->adminSiteaccessPreviewVoter = new AdminSiteaccessPreviewVoter(
+            $this->configResolver,
+            $this->repositoryConfigurationProvider
+        );
+    }
+
+    public function testVoteWithInvalidPath(): void
+    {
+        $languageCode = self::LANGUAGE_CODE;
+        $location = new Location(['id' => 1234, 'path' => [1]]);
+        $versionInfo = new VersionInfo([
+            'contentInfo' => new ContentInfo(['mainLanguageCode' => $languageCode]),
+        ]);
+        $siteaccess = 'site';
+
+        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, $languageCode);
+
+        $this->mockConfigMethods($context);
+
+        $this->assertFalse($this->adminSiteaccessPreviewVoter->vote($context));
+    }
+
+    /**
+     * @dataProvider dataProviderForSiteaccessPreviewVoterContext
+     */
+    public function testVoteWithInvalidLanguageMatch(SiteaccessPreviewVoterContext $context): void
+    {
+        $this->mockConfigMethods($context);
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(0))
+            ->method('getDefaultRepositoryAlias')
+            ->willReturn('default');
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(1))
+            ->method('getCurrentRepositoryAlias')
+            ->willReturn('default');
+
+        $this->configResolver
+            ->expects($this->at(3))
+            ->method('getParameter')
+            ->with('repository', null, $context->getSiteaccess())
+            ->willReturn(null);
+
+        $this->configResolver
+            ->expects($this->at(4))
+            ->method('getParameter')
+            ->with('languages', null, $context->getSiteaccess())
+            ->willReturn(['ger-DE']);
+
+        $this->assertFalse($this->adminSiteaccessPreviewVoter->vote($context));
+    }
+
+    /**
+     * @dataProvider dataProviderForSiteaccessPreviewVoterContext
+     */
+    public function testVoteWithInvalidRepositoryMatch(SiteaccessPreviewVoterContext $context): void
+    {
+        $this->mockConfigMethods($context);
+
+        $this->configResolver
+            ->expects($this->at(3))
+            ->method('getParameter')
+            ->with('repository', null, $context->getSiteaccess())
+            ->willReturn(null);
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(0))
+            ->method('getDefaultRepositoryAlias')
+            ->willReturn('default');
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(1))
+            ->method('getCurrentRepositoryAlias')
+            ->willReturn('main');
+
+        $this->assertFalse($this->adminSiteaccessPreviewVoter->vote($context));
+    }
+
+    /**
+     * @dataProvider dataProviderForSiteaccessPreviewVoterContext
+     */
+    public function testVoteWithValidRepositoryAndLanguageMatch(SiteaccessPreviewVoterContext $context): void
+    {
+        $this->mockConfigMethods($context);
+
+        $this->configResolver
+            ->expects($this->at(3))
+            ->method('getParameter')
+            ->with('repository', null, $context->getSiteaccess())
+            ->willReturn(null);
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(0))
+            ->method('getDefaultRepositoryAlias')
+            ->willReturn('default');
+
+        $this->repositoryConfigurationProvider
+            ->expects($this->at(1))
+            ->method('getCurrentRepositoryAlias')
+            ->willReturn('default');
+
+        $this->configResolver
+            ->expects($this->at(4))
+            ->method('getParameter')
+            ->with('languages', null, $context->getSiteaccess())
+            ->willReturn(['eng-GB', 'fre-FR']);
+
+        $this->assertTrue($this->adminSiteaccessPreviewVoter->vote($context));
+    }
+
+    private function mockConfigMethods(SiteaccessPreviewVoterContext $context): void
+    {
+        $this->configResolver
+            ->expects($this->at(0))
+            ->method('getParameter')
+            ->with('content.tree_root.location_id', null, $context->getSiteaccess())
+            ->willReturn(2);
+
+        $this->configResolver
+            ->expects($this->at(1))
+            ->method('getParameter')
+            ->with('location_ids.media', null, $context->getSiteaccess())
+            ->willReturn(43);
+
+        $this->configResolver
+            ->expects($this->at(2))
+            ->method('getParameter')
+            ->with('location_ids.users', null, $context->getSiteaccess())
+            ->willReturn(5);
+    }
+
+    public function dataProviderForSiteaccessPreviewVoterContext(): array
+    {
+        $languageCode = self::LANGUAGE_CODE;
+        $location = new Location(['id' => 123456, 'path' => [1, 2]]);
+        $versionInfo = new VersionInfo([
+            'contentInfo' => new ContentInfo(['mainLanguageCode' => $languageCode]),
+        ]);
+        $siteaccess = 'site';
+
+        $context = new SiteaccessPreviewVoterContext($location, $versionInfo, $siteaccess, $languageCode);
+
+        return [
+            [
+                $context,
+            ],
+        ];
+    }
+}

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -32,6 +32,7 @@ use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
+use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use EzSystems\EzPlatformAdminUi\Specification\UserExists;
 use EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory;
@@ -234,6 +235,9 @@ class ValueFactory
      */
     public function createLocation(Location $location): UIValue\Content\Location
     {
+        $translations = $location->getContent()->getVersionInfo()->languageCodes;
+        $target = (new Target\Version())->deleteTranslations($translations);
+
         return new UIValue\Content\Location($location, [
             'childCount' => $this->locationService->getLocationChildCount($location),
             'pathLocations' => $this->pathService->loadPathLocations($location),
@@ -241,7 +245,7 @@ class ValueFactory
                 'content', 'manage_locations', $location->getContentInfo()
             ),
             'userCanRemove' => $this->permissionResolver->canUser(
-                'content', 'remove', $location->getContentInfo(), [$location]
+                'content', 'remove', $location->getContentInfo(), [$location, $target]
             ),
             'userCanEdit' => $this->permissionResolver->canUser(
                 'content', 'edit', $location->getContentInfo(), [$location]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZEE-3465
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As the title states.

Required `ezpublish-kernel` PR: https://github.com/ezsystems/ezpublish-kernel/pull/3085

Regression suite: https://github.com/ezsystems/ezplatform-page-builder/pull/726

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
