### PR TITLE
EZP-32294: Location removal removes all children silently and unreversable

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -494,7 +494,7 @@ class LocationController extends Controller
 
                 foreach ($data->getLocations() as $locationId => $selected) {
                     $location = $this->locationService->loadLocation($locationId);
-                    $this->locationService->deleteLocation($location);
+                    $this->trashService->trash($location);
 
                     $this->notificationHandler->success(
                         $this->translator->trans(

--- a/src/bundle/Resources/public/scss/_modals.scss
+++ b/src/bundle/Resources/public/scss/_modals.scss
@@ -42,6 +42,7 @@
         .ez-modal-body__explanation {
             margin-bottom: 0;
             color: $ez-black;
+            white-space: initial;
         }
     }
 

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -202,8 +202,8 @@
         <note>key: tab.locations.main</note>
       </trans-unit>
       <trans-unit id="e704444c07d73c053f58f427ebcc0b6b2042c63d" resname="tab.locations.modal.message">
-        <source>Do you want to delete Location?</source>
-        <target state="new">Do you want to delete Location?</target>
+        <source>Do you want to delete Location? All its subitems will be trashed.</source>
+        <target state="new">Do you want to delete Location? All its subitems will be trashed.</target>
         <note>key: tab.locations.modal.message</note>
       </trans-unit>
       <trans-unit id="7514a2a1e82c82fa3a197dc3da8be56a9c68f136" resname="tab.locations.path">

--- a/src/bundle/Resources/translations/locationview.en.xliff
+++ b/src/bundle/Resources/translations/locationview.en.xliff
@@ -202,8 +202,8 @@
         <note>key: tab.locations.main</note>
       </trans-unit>
       <trans-unit id="e704444c07d73c053f58f427ebcc0b6b2042c63d" resname="tab.locations.modal.message">
-        <source>Do you want to delete Location? All its subitems will be trashed.</source>
-        <target state="new">Do you want to delete Location? All its subitems will be trashed.</target>
+        <source>Do you want to delete the Location? All its sub-items will be sent to Trash.</source>
+        <target state="new">Do you want to delete the Location? All its sub-items will be sent to Trash.</target>
         <note>key: tab.locations.modal.message</note>
       </trans-unit>
       <trans-unit id="7514a2a1e82c82fa3a197dc3da8be56a9c68f136" resname="tab.locations.path">

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -110,7 +110,7 @@
     </button>
     {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
         'id': modal_data_target,
-        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Location? All its subitems will be trashed.'),
+        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete the Location? All its sub-items will be sent to Trash.'),
         'data_click': '#' ~ form_remove.remove.vars.id,
     } %}
 {% endmacro %}

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -110,7 +110,7 @@
     </button>
     {% include '@ezdesign/bulk_delete_confirmation_modal.html.twig' with {
         'id': modal_data_target,
-        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Location?'),
+        'message': 'tab.locations.modal.message'|trans|desc('Do you want to delete Location? All its subitems will be trashed.'),
         'data_click': '#' ~ form_remove.remove.vars.id,
     } %}
 {% endmacro %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32294](https://issues.ibexa.co/browse/EZP-32294)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


JIRA excerpt:
>When removing a location of an object, all child nodes will be removed, too. This happens silently and without going to the trash.

The frontend (CSS) part relates to modals' content: when the text is too long, it overflows the modal. This remark applies only to 2.5 so this change will be dropped on merge-up.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
