### PR TITLE
EZP-32311: Dropdown bottom options become inaccessible inside modals

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -131,21 +131,21 @@
             this.sourceInput.dispatchEvent(new CustomEvent(EVENT_VALUE_CHANGED));
         }
 
-        getItemsContainerHeight(isItemsContainerTop) {
+        getItemsContainerHeight(isItemsContainerAbove) {
             const DROPDOWN_MARGIN = 16;
-            const MODAL_SELECTOR = '.modal[aria-modal=true]';
+            const SELECTOR_MODAL = '.modal[aria-modal=true]';
             const documentElementHeight = document.documentElement.getBoundingClientRect().height;
-            const itemsContainerHeight = this.itemsContainer.getBoundingClientRect().top;
+            const itemsContainerTop = this.itemsContainer.getBoundingClientRect().top;
 
-            if (isItemsContainerTop) {
+            if (isItemsContainerAbove) {
                 return this.container.querySelector(SELECTOR_SELECTION_INFO).getBoundingClientRect().top - DROPDOWN_MARGIN;
             }
 
-            if (this.itemsContainer.closest(MODAL_SELECTOR)) {
-                return itemsContainerHeight - DROPDOWN_MARGIN;
+            if (this.itemsContainer.closest(SELECTOR_MODAL)) {
+                return itemsContainerTop - DROPDOWN_MARGIN;
             }
 
-            return documentElementHeight - itemsContainerHeight - DROPDOWN_MARGIN;
+            return documentElementHeight - itemsContainerTop - DROPDOWN_MARGIN;
         }
 
         onInputClick(event) {
@@ -161,10 +161,10 @@
             if (isListHidden) {
                 const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
                 const { top } = this.itemsContainer.getBoundingClientRect();
-                const isItemsContainerTop = top + ITEMS_LIST_MAX_HEIGHT > viewportHeight;
-                const itemsListMethodName = isItemsContainerTop ? 'add' : 'remove';
+                const isItemsContainerAbove = top + ITEMS_LIST_MAX_HEIGHT > viewportHeight;
+                const itemsListMethodName = isItemsContainerAbove ? 'add' : 'remove';
 
-                this.itemsContainer.style['max-height'] = `${this.getItemsContainerHeight(isItemsContainerTop)}px`;
+                this.itemsContainer.style['max-height'] = `${this.getItemsContainerHeight(isItemsContainerAbove)}px`;
                 this.itemsContainer.classList[itemsListMethodName](CLASS_ITEMS_POSITION_TOP);
             }
 

--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -133,14 +133,19 @@
 
         getItemsContainerHeight(isItemsContainerTop) {
             const DROPDOWN_MARGIN = 16;
+            const MODAL_SELECTOR = '.modal[aria-modal=true]';
+            const documentElementHeight = document.documentElement.getBoundingClientRect().height;
+            const itemsContainerHeight = this.itemsContainer.getBoundingClientRect().top;
 
             if (isItemsContainerTop) {
                 return this.container.querySelector(SELECTOR_SELECTION_INFO).getBoundingClientRect().top - DROPDOWN_MARGIN;
             }
 
-            return (
-                document.documentElement.getBoundingClientRect().height - this.itemsContainer.getBoundingClientRect().top - DROPDOWN_MARGIN
-            );
+            if (this.itemsContainer.closest(MODAL_SELECTOR)) {
+                return itemsContainerHeight - DROPDOWN_MARGIN;
+            }
+
+            return documentElementHeight - itemsContainerHeight - DROPDOWN_MARGIN;
         }
 
         onInputClick(event) {

--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -134,7 +134,7 @@
         getItemsContainerHeight(isItemsContainerAbove) {
             const DROPDOWN_MARGIN = 16;
             const SELECTOR_MODAL = '.modal[aria-modal=true]';
-            const documentElementHeight = document.documentElement.getBoundingClientRect().height;
+            const documentElementHeight = doc.documentElement.getBoundingClientRect().height;
             const itemsContainerTop = this.itemsContainer.getBoundingClientRect().top;
 
             if (isItemsContainerAbove) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32311](https://issues.ibexa.co/browse/EZP-32311)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


JIRA excerpt:
>When a Create a new translation window is shown and more than 6 Languages are defined, some of them won't be visible in the "Select a language for the new translation" field.

The idea is to check whether any of the dropdown parents is a modal (not to break dropdowns outside popups) and reduce the dropdown's height to not exceed the modal's height. Thanks to that, a scroll will appear allowing the user to select bottom options that are currently being covered by the modal itself.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
