### PR TITLE
EZEE-3486: Added AllowedContentTypes to default config as it was overridden by default empty value

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -172,7 +172,6 @@
                     onConfirm,
                     onCancel,
                     title,
-                    allowedContentTypes: [imageAssetMapping['contentTypeIdentifier']],
                     ...config,
                 }),
                 udwContainer

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber;
+
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
+
+class ImageAssetAllowedContentTypes implements EventSubscriberInterface
+{
+    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
+    private $assetMapper;
+
+    /**
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper $assetMapper
+     */
+    public function __construct(AssetMapper $assetMapper)
+    {
+        $this->assetMapper = $assetMapper;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConfigResolveEvent::NAME => ['onUdwConfigResolve'],
+        ];
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent $event
+     */
+    public function onUdwConfigResolve(ConfigResolveEvent $event): void
+    {
+        if ($event->getConfigName() !== 'image_asset') {
+            return;
+        }
+
+        $config = $event->getConfig();
+        $config['allowedContentTypes'][] = $this->assetMapper->getContentTypeIdentifier();
+
+        $event->setConfig($config);
+    }
+}

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
@@ -12,7 +12,7 @@ use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
 
-class ImageAssetAllowedContentTypes implements EventSubscriberInterface
+final class ImageAssetAllowedContentTypes implements EventSubscriberInterface
 {
     /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
     private $assetMapper;

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ImageAssetAllowedContentTypes.php
@@ -17,17 +17,11 @@ class ImageAssetAllowedContentTypes implements EventSubscriberInterface
     /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
     private $assetMapper;
 
-    /**
-     * @param \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper $assetMapper
-     */
     public function __construct(AssetMapper $assetMapper)
     {
         $this->assetMapper = $assetMapper;
     }
 
-    /**
-     * @return array
-     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -35,9 +29,6 @@ class ImageAssetAllowedContentTypes implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * @param \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent $event
-     */
     public function onUdwConfigResolve(ConfigResolveEvent $event): void
     {
         if ($event->getConfigName() !== 'image_asset') {


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZEE-3486
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This had nothing to do with unsplash, or dam connector.
From what I understand allowed CTs were passed here `ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js L178`

```
            ReactDOM.render(
                React.createElement(eZ.modules.UniversalDiscovery, {
                    onConfirm,
                    onCancel,
                    title,
                    allowedContentTypes: [imageAssetMapping['contentTypeIdentifier']],
                    ...config,
                }),
                udwContainer
            );
```

But since that key now exist with default value, this part is overridden by it.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
