### PR TITLE
[Behat] Added sorting subitems by Modified date

### DIFF
--- a/src/lib/Behat/BusinessContext/ContentViewContext.php
+++ b/src/lib/Behat/BusinessContext/ContentViewContext.php
@@ -266,6 +266,7 @@ class ContentViewContext extends BusinessContext
         $pathSize = count($explodedPath);
 
         $contentItemPage = PageObjectFactory::createPage($this->utilityContext, ContentItemPage::PAGE_NAME, $explodedPath[$pathSize - 1]);
+        $contentItemPage->subItemList->sortBy('Modified', false);
 
         Assert::assertTrue(
             $contentItemPage->subItemList->table->isElementInTable($contentName),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Failing builds:
https://travis-ci.com/github/ezsystems/ezplatform/jobs/489625249 (v2)
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/490255179 (v3.3)

Error:
```
  @javascript @common
  Scenario: Element in trash can be restored                                               # vendor/ezsystems/ezplatform-admin-ui/features/standard/Trash.feature:41
    Given I click on the left menu bar button "Trash"                                      # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\LeftMenuContext::iClickLeftMenuBarButton()
    And there is "Folder" "Folder2" on trash list                                          # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\TrashContext::thereIsItemOnTrashList()
    When I restore item from trash                                                         # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\TrashContext::iRestoreItemFromTrash()
      | item    |
      | Folder2 |
    Then success notification that "Items restored under their original location." appears # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\NotificationContext::specificNotificationAppears()
    And there is no "Folder" "Folder2" on trash list                                       # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\TrashContext::thereIsNoItemOnTrashList()
    And going to root path there is "Folder2" "Folder" on Sub-items list                   # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\ContentViewContext::goingToRootTheresSubItem()
      Folder "Folder2" shouldn't be on eZ Platform Sub-items list
      Failed asserting that false is true.
    │
    │  JS Console errors:
    │  	 No logs for this section.
    │  Application logs:
    │  	[2021-03-10 07:14:14] Starting Step "I click on the edit action bar button "Publish"" 
    │  	[2021-03-10 07:14:15] Ending Step "I click on the edit action bar button "Publish"" 
    │  	[2021-03-10 07:14:15] Starting Step "success notification that "Content published." appears" 
    │  	[2021-03-10 07:14:17] Ending Step "success notification that "Content published." appears" 
    │  	[2021-03-10 07:14:17] Starting Step "I should be on content item page "binary2.txt" of type "File CT" in root path" 
    │  	[2021-03-10 07:14:17] Ending Step "I should be on content item page "binary2.txt" of type "File CT" in root path" 
    │  	[2021-03-10 07:14:17] Starting Step "content attributes equal" 
    │  	[2021-03-10 07:14:17] Ending Step "content attributes equal" 
    │  	[2021-03-10 07:14:17] Ending Scenario "| File                         | value     | binary2.txt.zip                           |            |                          |         |           | binary1.txt               | binary2.txt                  |" 
    │  	[2021-03-10 07:14:17] Starting Scenario "| Matrix                       | value     | col1:col2:col3,11:12:13,21:22:23,31:32:33 |            |                          |         |           | Matrix                    | Matrix                       |" 
    │  	[2021-03-10 07:14:17] Starting Step "I am logged as "admin"" 
    │  	[2021-03-10 07:14:18] Ending Step "I am logged as "admin"" 
    │  	[2021-03-10 07:14:18] Starting Step "I go to "Content structure" in "Content" tab" 
    │  	[2021-03-10 07:14:20] Ending Step "I go to "Content structure" in "Content" tab" 
    │  	[2021-03-10 07:14:20] Starting Step "I open UDW and go to "root/Matrix"" 
    │  	[2021-03-10 07:14:30] Ending Step "I open UDW and go to "root/Matrix"" 
    │  	[2021-03-10 07:14:30] Starting Step "I click on the edit action bar button "Edit"" 
    │  	[2021-03-10 07:14:30] Ending Step "I click on the edit action bar button "Edit"" 
    │  	[2021-03-10 07:14:30] Starting Step "I set content fields" 
    │  	[2021-03-10 07:14:32] Ending Step "I set content fields" 
    │  	[2021-03-10 07:14:32] Starting Step "I click on the edit action bar button "Publish"" 
    │  	[2021-03-10 07:14:32] Ending Step "I click on the edit action bar button "Publish"" 
    │  	[2021-03-10 07:14:32] Starting Step "success notification that "Content published." appears" 
    │  	[2021-03-10 07:14:35] Ending Step "going to root path there is "Folder2" "Folder" on Sub-items list" 
    │  	
    │  
    │
    └─ @AfterStep # EzSystems\EzPlatformAdminUi\Behat\Helper\Hooks::getLogsAfterFailedStep()
      Screenshot has been taken. Open image at https://res.cloudinary.com/ezplatformtravis/image/upload/v1615360475/screenshots/604871db4b9d9111498094-vendor_ezsystems_ezplatform-admin-ui_features_standard_trash_feature_41_kvhmir.png
```

The callstack is as follow:
1) https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/src/lib/Behat/BusinessContext/ContentViewContext.php#L279-L282
2) https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/src/lib/Behat/BusinessContext/ContentViewContext.php#L260-L274

As you can see it does not benefit from the change made in https://github.com/ezsystems/ezplatform-admin-ui/pull/1479 - the `goToSubItem` method is not called. I think that adding the sorting here will help as in did in the PR I've mentioned - less pagination less issues :)

During merge-up it needs to be changed to:
```
if ($contentItemPage->canBeSorted()) {
        $contentItemPage->subItemList->sortBy('Modified', false);
}
```

to take changes from https://github.com/ezsystems/ezplatform-admin-ui/pull/1481 into account.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
