### PR TITLE
EZP-32395: Sort out Locations tab info on visibility

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -168,7 +168,6 @@ class ContentViewController extends Controller
             $this->supplyPathLocations($view);
             $this->subitemsContentViewParameterSupplier->supply($view);
             $this->supplyContentActionForms($view);
-            $this->supplyIsLocationInvisible($view);
             $this->supplyContentReverseRelations($view);
             $this->supplyContentTreeParameters($view);
         }
@@ -565,23 +564,5 @@ class ContentViewController extends Controller
         );
 
         $view->addParameters(['content_has_reverse_relations' => \count($relations) > 0]);
-    }
-
-    /**
-     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
-     */
-    private function supplyIsLocationInvisible(ContentView $view)
-    {
-        $location = $view->getLocation();
-        $parentLocation = $this->permissionResolver->sudo(
-            function (Repository $repository) use ($location) {
-                return $repository->getLocationService()->loadLocation($location->parentLocationId);
-            },
-            $this->repository
-        );
-        $isLocationVisible = !($parentLocation->hidden || $parentLocation->invisible);
-
-        // Location is invisible when parent location is not visible.
-        $view->addParameters(['is_location_visible' => $isLocationVisible]);
     }
 }

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -63,6 +63,7 @@
                 </div>
                 <div class="panel panel-primary">
                     <div class="panel-body">
+                        {# 'is_location_visible': location.invisible - param deprecated since EZP-32395 #}
                         {{ ez_platform_tabs('location-view', {
                             'content': content,
                             'location': location,
@@ -73,6 +74,7 @@
                             'system_urls_pagination_params': system_urls_pagination_params,
                             'roles_pagination_params': roles_pagination_params,
                             'policies_pagination_params': policies_pagination_params,
+                            'is_location_visible': location.invisible,
                         }, '@ezdesign/parts/tab/locationview.html.twig') }}
 
                         {% if contentType.isContainer %}

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -73,7 +73,6 @@
                             'system_urls_pagination_params': system_urls_pagination_params,
                             'roles_pagination_params': roles_pagination_params,
                             'policies_pagination_params': policies_pagination_params,
-                            'is_location_visible': is_location_visible,
                         }, '@ezdesign/parts/tab/locationview.html.twig') }}
 
                         {% if contentType.isContainer %}

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -51,7 +51,7 @@
                                     {% if not can_hide[location.id] %} disabled="disabled"{% endif %}
                                     value="{{ location.id }}"/>
                             </label>
-                            {% if location.invisible or location.hidden %}
+                            {% if location.invisible %}
                                 <span class="ml-2">
                                     {{ 'tab.locations.hidden_content_or_superior'|trans()|desc('Content or superior is hidden') }}
                                 </span>

--- a/src/bundle/Resources/views/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/content/tab/locations/tab.html.twig
@@ -51,7 +51,7 @@
                                     {% if not can_hide[location.id] %} disabled="disabled"{% endif %}
                                     value="{{ location.id }}"/>
                             </label>
-                            {% if location.contentInfo.isHidden or not is_location_visible %}
+                            {% if location.invisible or location.hidden %}
                                 <span class="ml-2">
                                     {{ 'tab.locations.hidden_content_or_superior'|trans()|desc('Content or superior is hidden') }}
                                 </span>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32395
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`supplyIsLocationInvisible` method is not really necessary, we can easily check if the `Location` is hidden in the twig itself + it shows invalid data as it only accounts for a single `Location`.  A small performance increase is an upside as well.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
