### PR TITLE
EZP-32396: Content tree doesn't expand to current location

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.content.tree.js
+++ b/src/bundle/Resources/public/js/scripts/admin.content.tree.js
@@ -51,7 +51,7 @@
         React.createElement(eZ.modules.ContentTree, {
             userId,
             currentLocationPath,
-            rootLocationId: treeRootLocationId,
+            rootLocationId: parseInt(treeRootLocationId, 10),
             restInfo: { token, siteaccess },
         }),
         contentTreeWrapper


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | EZP-32396
| Bug fix?      | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Ready for Code Review
