### PR TITLE
[EZP-32397] Removed logic from ezdate.html.twig

### DIFF
--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,5 +7,7 @@
             </svg>
         </button>
     </div>
+    {% set action_type = isEditView ? 'edit' : 'create' %}
+    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden', 'data-action-type': action_type}) %}
     {{ block('form_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,7 +7,10 @@
             </svg>
         </button>
     </div>
-    {% set action_type = app.request.attributes.get('_route') is same as('ez_content_draft_edit') ? 'edit' : 'create' %}
+    {% set action_type =
+        app.request.attributes.get('_route') is same as('ez_content_draft_edit') or
+        app.request.attributes.get('_route') is same as('ezplatform.content.translate') ? 'edit' : 'create'
+    %}
     {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden', 'data-action-type': action_type}) %}
     {{ block('form_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,10 +7,6 @@
             </svg>
         </button>
     </div>
-    {% set action_type =
-        app.request.attributes.get('_route') is same as('ez_content_draft_edit') or
-        app.request.attributes.get('_route') is same as('ezplatform.content.translate') ? 'edit' : 'create'
-    %}
-    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden', 'data-action-type': action_type}) %}
+    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden'}) %}
     {{ block('form_widget') }}
 {% endblock %}

--- a/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig
@@ -7,6 +7,5 @@
             </svg>
         </button>
     </div>
-    {% set attr = attr|merge({'class': 'ez-data-source__input', 'hidden': 'hidden'}) %}
     {{ block('form_widget') }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32397
| Bugfix?      | yes
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR requires: https://github.com/ezsystems/repository-forms/pull/344

This PR removes logic from the template https://github.com/ezsystems/ezplatform-admin-ui/blob/v1.5.17/src/bundle/Resources/views/fieldtypes/edit/ezdate.html.twig#L10  as it is no longer needed (see https://github.com/ezsystems/repository-forms/pull/344)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
