### PR TITLE
Added ext-json to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "ext-json": "*",
         "symfony/symfony": "^3.4",
         "jms/translation-bundle": "^1.3.2",
         "ezsystems/ezpublish-kernel": "^7.5.6@dev",


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

UDW, Sub-items list and config provider use json_* functions so ext-json should be declared as dependency. 

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
