### PR TITLE
EZP-32395: Fixed location visibility due to kept BC

### DIFF
--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -74,7 +74,7 @@
                             'system_urls_pagination_params': system_urls_pagination_params,
                             'roles_pagination_params': roles_pagination_params,
                             'policies_pagination_params': policies_pagination_params,
-                            'is_location_visible': location.invisible,
+                            'is_location_visible': not location.invisible,
                         }, '@ezdesign/parts/tab/locationview.html.twig') }}
 
                         {% if contentType.isContainer %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-32395
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixes BC as `not` keyword was missing. Direct continuation of https://github.com/ezsystems/ezplatform-admin-ui/pull/1725.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
