### PR TITLE
IBX-183: Fixed accessing Tabs with spaces and special characters

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -26,7 +26,7 @@
                     {% if grouped_fields is defined and grouped_fields|length > 1 %}
                         <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
                             {% for key, group in grouped_fields %}
-                                {% set sanitized_key = key|replace({' ': '-'}) %}
+                                {% set sanitized_key = key|slug %}
                                 <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ sanitized_key }}">
                                     <a href="#{{ sanitized_key }}" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
                                         {{ key|capitalize }}
@@ -38,7 +38,7 @@
 
                         <div class="tab-content px-3">
                             {% for key, group in grouped_fields %}
-                                {% set sanitized_key = key|replace({' ': '-'}) %}
+                                {% set sanitized_key = key|slug %}
                                 <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ sanitized_key }}">
                                     {% for field in group %}
                                         {% set formField = form.fieldsData[field] %}

--- a/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/base.html.twig
@@ -26,8 +26,9 @@
                     {% if grouped_fields is defined and grouped_fields|length > 1 %}
                         <ul class="nav nav-tabs ez-nav-tabs--content-edit ez-tabs" role="tablist">
                             {% for key, group in grouped_fields %}
-                                <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ key }}">
-                                    <a href="#{{ key }}" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
+                                {% set sanitized_key = key|replace({' ': '-'}) %}
+                                <li role="presentation" class="nav-item ez-tabs__nav-item" id="item-{{ sanitized_key }}">
+                                    <a href="#{{ sanitized_key }}" class="nav-link {{ loop.first ? 'active' }}" role="tab" data-toggle="tab">
                                         {{ key|capitalize }}
                                     </a>
                                     {% include '@ezdesign/ui/component/warning_icon.html.twig' %}
@@ -37,7 +38,8 @@
 
                         <div class="tab-content px-3">
                             {% for key, group in grouped_fields %}
-                                <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ key }}">
+                                {% set sanitized_key = key|replace({' ': '-'}) %}
+                                <div role="tabpanel" class="tab-pane {{ loop.first ? 'active' }}" id="{{ sanitized_key }}">
                                     {% for field in group %}
                                         {% set formField = form.fieldsData[field] %}
                                         


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-183](https://issues.ibexa.co/browse/IBX-183)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Tab ids coming from custom category names containing spaces make tabs inaccessible. The idea is to sanitize them by replacing spaces with hyphens to match current `item-` notation.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
