### PR TITLE
IBX-148: Skipped deleted Relation fieldtypes when generating Relations tab

### DIFF
--- a/src/lib/UI/Dataset/RelationListDataset.php
+++ b/src/lib/UI/Dataset/RelationListDataset.php
@@ -54,6 +54,10 @@ final class RelationListDataset
             $this->contentService->loadRelations($versionInfo)
         );
 
+        $this->relations = array_filter($this->relations, function (Relation $relation) {
+            return $relation->sourceFieldDefinitionIdentifier !== null;
+        });
+
         return $this;
     }
 

--- a/src/lib/UI/Dataset/ReverseRelationListDataset.php
+++ b/src/lib/UI/Dataset/ReverseRelationListDataset.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\RelationList\Item\RelationListItem;
 use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface;
 use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
 
@@ -54,6 +55,10 @@ final class ReverseRelationListDataset
             $offset,
             $limit
         )->items;
+
+        $reverseRelationListItems = array_filter($reverseRelationListItems, function (RelationListItem $relation) {
+            return $relation->getRelation()->sourceFieldDefinitionIdentifier !== null;
+        });
 
         $this->reverseRelations = array_map(
             function (RelationListItemInterface $relationListItem) use ($content) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-148
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As the title states.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
