### PR TITLE
EZP-31602: Moving to trash confirmation modal is not updated after sub-items bulk move

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -7,6 +7,7 @@
     const sortContainer = doc.querySelector('[data-sort-field][data-sort-order]');
     const sortField = sortContainer.getAttribute('data-sort-field');
     const sortOrder = sortContainer.getAttribute('data-sort-order');
+    const contentName = doc.querySelector('.ez-sil').dataset.contentName;
     const mfuAttrs = {
         adminUiConfig: Object.assign({}, eZ.adminUiConfig, {
             token,
@@ -118,6 +119,35 @@
 
         $(SELECTOR_MODAL_BULK_ACTION_FAIL).modal('show');
     };
+    const refreshTrashModal = (event) => {
+        const { numberOfSubitems } = event.detail;
+        const sendToTrashModal = document.querySelector('.ez-modal--trash-location');
+        const modalBody = sendToTrashModal.querySelector('.modal-body');
+        const modalSendToTrashButton = sendToTrashModal.querySelector('.modal-footer .ez-modal-button--send-to-trash');
+
+        if (numberOfSubitems) {
+            const message = Translator.trans(
+                /*@Desc("Sending '%content_name%' and its %children_count% Content item(s) to Trash will also send the sub-items of this Location to Trash.")*/ 'trash_container.modal.message_main',
+                {
+                    content_name: contentName,
+                    children_count: numberOfSubitems,
+                },
+                'content'
+            );
+
+            modalBody.querySelector('.ez-modal__option-description').innerHTML = message;
+        } else {
+            const message = Translator.trans(
+                /*@Desc("Are you sure you want to send this Content item to Trash?")*/ 'trash.modal.message',
+                {},
+                'content'
+            );
+
+            modalBody.innerHTML = message;
+            modalSendToTrashButton.toggleAttribute('disabled', false);
+            modalSendToTrashButton.classList.toggle('disabled', false);
+        }
+    };
 
     listContainers.forEach((container) => {
         const subItemsList = JSON.parse(container.dataset.items).SubitemsList;
@@ -166,4 +196,5 @@
             container
         );
     });
+    doc.body.addEventListener('ez-trash-modal-refresh', refreshTrashModal, false);
 })(window, window.document, window.jQuery, window.React, window.ReactDOM, window.eZ, window.Routing, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -118,36 +118,6 @@
 
         $(SELECTOR_MODAL_BULK_ACTION_FAIL).modal('show');
     };
-    const refreshTrashModal = (event) => {
-        const { numberOfSubitems } = event.detail;
-        const sendToTrashModal = document.querySelector('.ez-modal--trash-location');
-        const modalBody = sendToTrashModal.querySelector('.modal-body');
-        const modalSendToTrashButton = sendToTrashModal.querySelector('.modal-footer .ez-modal-button--send-to-trash');
-        const { contentName } = sendToTrashModal.dataset;
-
-        if (numberOfSubitems) {
-            const message = Translator.trans(
-                /*@Desc("Sending '%content_name%' and its %children_count% Content item(s) to Trash will also send the sub-items of this Location to Trash.")*/ 'trash_container.modal.message_main',
-                {
-                    content_name: contentName,
-                    children_count: numberOfSubitems,
-                },
-                'content'
-            );
-
-            modalBody.querySelector('.ez-modal__option-description').innerHTML = message;
-        } else {
-            const message = Translator.trans(
-                /*@Desc("Are you sure you want to send this Content item to Trash?")*/ 'trash.modal.message',
-                {},
-                'content'
-            );
-
-            modalBody.innerHTML = message;
-            modalSendToTrashButton.removeAttribute('disabled');
-            modalSendToTrashButton.classList.remove('disabled');
-        }
-    };
 
     listContainers.forEach((container) => {
         const subItemsList = JSON.parse(container.dataset.items).SubitemsList;
@@ -196,5 +166,4 @@
             container
         );
     });
-    doc.body.addEventListener('ez-trash-modal-refresh', refreshTrashModal, false);
 })(window, window.document, window.jQuery, window.React, window.ReactDOM, window.eZ, window.Routing, window.Translator);

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -144,8 +144,8 @@
             );
 
             modalBody.innerHTML = message;
-            modalSendToTrashButton.toggleAttribute('disabled', false);
-            modalSendToTrashButton.classList.toggle('disabled', false);
+            modalSendToTrashButton.removeAttribute('disabled');
+            modalSendToTrashButton.classList.remove('disabled');
         }
     };
 

--- a/src/bundle/Resources/public/js/scripts/admin.location.view.js
+++ b/src/bundle/Resources/public/js/scripts/admin.location.view.js
@@ -7,7 +7,6 @@
     const sortContainer = doc.querySelector('[data-sort-field][data-sort-order]');
     const sortField = sortContainer.getAttribute('data-sort-field');
     const sortOrder = sortContainer.getAttribute('data-sort-order');
-    const contentName = doc.querySelector('.ez-sil').dataset.contentName;
     const mfuAttrs = {
         adminUiConfig: Object.assign({}, eZ.adminUiConfig, {
             token,
@@ -124,6 +123,7 @@
         const sendToTrashModal = document.querySelector('.ez-modal--trash-location');
         const modalBody = sendToTrashModal.querySelector('.modal-body');
         const modalSendToTrashButton = sendToTrashModal.querySelector('.modal-footer .ez-modal-button--send-to-trash');
+        const { contentName } = sendToTrashModal.dataset;
 
         if (numberOfSubitems) {
             const message = Translator.trans(

--- a/src/bundle/Resources/public/js/scripts/admin.trash.js
+++ b/src/bundle/Resources/public/js/scripts/admin.trash.js
@@ -11,6 +11,38 @@
         button.disabled = true;
         button.classList.add('disabled');
     };
+    const refreshTrashModal = (event) => {
+        const { numberOfSubitems } = event.detail;
+        const sendToTrashModal = document.querySelector('.ez-modal--trash-location');
+        const modalBody = sendToTrashModal.querySelector('.modal-body');
+        const modalSendToTrashButton = sendToTrashModal.querySelector('.modal-footer .ez-modal-button--send-to-trash');
+        const { contentName } = sendToTrashModal.dataset;
+
+        if (numberOfSubitems) {
+            const message = Translator.trans(
+                /*@Desc("Sending '%content_name%' and its %children_count% Content item(s) to Trash will also send the sub-items of this Location to Trash.")*/ 'trash_container.modal.message_main',
+                {
+                    content_name: contentName,
+                    children_count: numberOfSubitems,
+                },
+                'content'
+            );
+
+            modalBody.querySelector('.ez-modal__option-description').innerHTML = message;
+        } else {
+            const message = Translator.trans(
+                /*@Desc("Are you sure you want to send this Content item to Trash?")*/ 'trash.modal.message',
+                {},
+                'content'
+            );
+
+            modalBody.innerHTML = message;
+            modalSendToTrashButton.removeAttribute('disabled');
+            modalSendToTrashButton.classList.remove('disabled');
+        }
+    };
+
+    doc.body.addEventListener('ez-trash-modal-refresh', refreshTrashModal, false);
 
     if (!confirmCheckbox) {
         enableButton(submitButton);

--- a/src/bundle/Resources/translations/content.en.xliff
+++ b/src/bundle/Resources/translations/content.en.xliff
@@ -51,6 +51,16 @@
         <target state="new">Content '%name%' has been revealed.</target>
         <note>key: content.reveal.success</note>
       </trans-unit>
+      <trans-unit id="2720e3018fc8b1158cb728b1d5dc377ef7293b57" resname="trash.modal.message">
+        <source>Are you sure you want to send this Content item to Trash?</source>
+        <target state="new">Are you sure you want to send this Content item to Trash?</target>
+        <note>key: trash.modal.message</note>
+      </trans-unit>
+      <trans-unit id="1e6a1d97cca01a288e47d2d14479274b90e6c6c1" resname="trash_container.modal.message_main">
+        <source>Sending '%content_name%' and its %children_count% Content item(s) to Trash will also send the sub-items of this Location to Trash.</source>
+        <target state="new">Sending '%content_name%' and its %children_count% Content item(s) to Trash will also send the sub-items of this Location to Trash.</target>
+        <note>key: trash_container.modal.message_main</note>
+      </trans-unit>
       <trans-unit id="4492a79e25635e7612f98971e02b4d0e6a408394" resname="user.delete.success">
         <source>User with login '%login%' deleted.</source>
         <target state="new">User with login '%login%' deleted.</target>

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -84,6 +84,7 @@
                                 <h2 class="ez-fieldgroup__name">{{ 'content.view.subitems'|trans|desc('Sub-items') }}</h2>
                                 <div class="ez-sil"
                                     data-location="{{ location.id }}"
+                                    data-content-name="{{ content.name }}"
                                     data-mfu-create-permissions-config="{{ subitems_module.content_create_permissions_for_mfu|json_encode() }}"
                                     data-items="{{ subitems_module.items }}"
                                     data-content-types="{{ subitems_module.content_type_info_list }}"

--- a/src/bundle/Resources/views/content/locationview.html.twig
+++ b/src/bundle/Resources/views/content/locationview.html.twig
@@ -84,7 +84,6 @@
                                 <h2 class="ez-fieldgroup__name">{{ 'content.view.subitems'|trans|desc('Sub-items') }}</h2>
                                 <div class="ez-sil"
                                     data-location="{{ location.id }}"
-                                    data-content-name="{{ content.name }}"
                                     data-mfu-create-permissions-config="{{ subitems_module.content_create_permissions_for_mfu|json_encode() }}"
                                     data-items="{{ subitems_module.items }}"
                                     data-content-types="{{ subitems_module.content_type_info_list }}"
@@ -113,7 +112,10 @@
                 </div>
             </div>
             {%  if form_location_trash is defined and form_user_delete is not defined %}
-                {% include '@ezdesign/content/modal_location_trash.html.twig' with {'form': form_location_trash} only %}
+                {% include '@ezdesign/content/modal_location_trash.html.twig' with {
+                    'form': form_location_trash,
+                    'content_name': ez_content_name(content)
+                } only %}
             {% endif %}
             {%  if form_user_delete is defined %}
                 {% include '@ezdesign/content/modal_user_delete.html.twig' with {'form': form_user_delete} only %}

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -5,7 +5,7 @@
     id="trash-location-modal"
     tabindex="-1"
     role="dialog"
-    data-content-name="{{ content_name }}"
+    data-content-name="{{ content_name|default('') }}"
 >
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -44,7 +44,7 @@
                     {{ 'trash.form.cancel'|trans|desc('Cancel') }}
                 </button>
                 {{ form_widget(form.trash,
-                    {'attr': {'class': 'btn-danger font-weight-bold disabled', 'disabled': true}})
+                    {'attr': {'class': 'btn-danger font-weight-bold disabled ez-modal-button ez-modal-button--send-to-trash', 'disabled': true}})
                 }}
             </div>
             {{ form_end(form) }}

--- a/src/bundle/Resources/views/content/modal_location_trash.html.twig
+++ b/src/bundle/Resources/views/content/modal_location_trash.html.twig
@@ -1,6 +1,12 @@
 {% form_theme form '@ezdesign/form_fields.html.twig' %}
 
-<div class="modal fade ez-modal ez-modal--send-to-trash ez-modal--trash-location" id="trash-location-modal" tabindex="-1" role="dialog">
+<div
+    class="modal fade ez-modal ez-modal--send-to-trash ez-modal--trash-location"
+    id="trash-location-modal"
+    tabindex="-1"
+    role="dialog"
+    data-content-name="{{ content_name }}"
+>
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/EZP-31602
| Related to | https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/289
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review