### PR TITLE
EZP-32400: Fixed displaying anchors for tables

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -1,5 +1,7 @@
 (function(global) {
     const eZ = (global.eZ = global.eZ || {});
+    const TABLE_TAG_NAME = 'table';
+    const SVG_TAG_NAME = 'svg';
     const HTML_NODE = 1;
     const TEXT_NODE = 3;
     const notInitializeElements = ['strong', 'em', 'u', 'sup', 'sub', 's'];
@@ -170,8 +172,14 @@
 
         clearAnchor(element) {
             const icon = element.querySelector('.ez-icon--anchor');
+            const elementPreviousSibling = element.previousSibling;
+            const isTableWithAnchor =
+                element.tagName.toLowerCase() === TABLE_TAG_NAME &&
+                elementPreviousSibling.tagName.toLowerCase() === SVG_TAG_NAME;
 
-            if (icon) {
+            if (isTableWithAnchor) {
+                elementPreviousSibling.remove();
+            } else if (icon) {
                 icon.remove();
             } else {
                 element.classList.remove('ez-has-anchor');

--- a/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/base/base-rich-text.js
@@ -175,6 +175,7 @@
             const elementPreviousSibling = element.previousSibling;
             const isTableWithAnchor =
                 element.tagName.toLowerCase() === TABLE_TAG_NAME &&
+                elementPreviousSibling &&
                 elementPreviousSibling.tagName.toLowerCase() === SVG_TAG_NAME;
 
             if (isTableWithAnchor) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32400](https://issues.ibexa.co/browse/EZP-32400)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

SVG icon representing anchor is placed outside table by the AlloyEditor, hence is not saved alongside with the content. Therefore the icon is not presented in the edit mode. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
