### PR TITLE
Boosted performance of NodeFactory

### DIFF
--- a/src/bundle/Resources/config/services/modules/content_tree.yaml
+++ b/src/bundle/Resources/config/services/modules/content_tree.yaml
@@ -6,6 +6,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\UI\Module\ContentTree\NodeFactory:
         arguments:
+            $contentService: '@ezpublish.api.service.content'
             $translationHelper: '@ezpublish.translation_helper'
             $configResolver: '@ezpublish.config.resolver'
 

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -256,7 +256,7 @@ final class NodeFactory
             : 0;
 
         $children = [];
-        if ($depth < $this->getSetting('tree_max_depth') && $loadChildren) {
+        if ($loadChildren && $depth < $this->getSetting('tree_max_depth')) {
             $searchResult = $this->findSubitems($location, $limit, $offset, $sortClause, $sortOrder);
             $totalChildrenCount = $searchResult->totalCount;
 

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -72,7 +72,7 @@ final class NodeFactory
         string $sortOrder = Query::SORT_ASC
     ): Node {
         $contentInfoList = new ArrayObject();
-        $node = $this->buildNode($location, $loadSubtreeRequestNode, $loadChildren, $depth, $sortClause, $sortOrder, $contentInfoList);
+        $node = $this->buildNode($location, $contentInfoList, $loadSubtreeRequestNode, $loadChildren, $depth, $sortClause, $sortOrder);
         $contentById = $this->contentService->loadContentListByContentInfo((array) $contentInfoList);
         $this->supplyTranslatedContentName($node, $contentById);
 
@@ -226,20 +226,18 @@ final class NodeFactory
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo[] $contentInfoList
      *
-     * @return \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     private function buildNode(
         Location $location,
+        ArrayObject $contentInfoList,
         ?LoadSubtreeRequestNode $loadSubtreeRequestNode = null,
         bool $loadChildren = false,
         int $depth = 0,
         ?string $sortClause = null,
-        string $sortOrder = Query::SORT_ASC,
-        ArrayObject $contentInfoList = null
+        string $sortOrder = Query::SORT_ASC
     ): Node {
         $contentInfo = $location->getContentInfo();
         $contentId = $location->contentId;
@@ -270,12 +268,12 @@ final class NodeFactory
 
                 $children[] = $this->buildNode(
                     $childLocation,
+                    $contentInfoList,
                     $childLoadSubtreeRequestNode,
                     null !== $childLoadSubtreeRequestNode,
                     $depth + 1,
                     null,
-                    Query::SORT_ASC,
-                    $contentInfoList
+                    Query::SORT_ASC
                 );
             }
         } else {
@@ -289,7 +287,7 @@ final class NodeFactory
             $depth,
             $location->id,
             $location->contentId,
-            '',
+            '', // node name will be provided later by `supplyTranslatedContentName` method
             $contentType ? $contentType->identifier : '',
             $contentType ? $contentType->isContainer : true,
             $location->invisible || $location->hidden,
@@ -300,7 +298,6 @@ final class NodeFactory
     }
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node $node
      * @param \eZ\Publish\API\Repository\Values\Content\Content[] $contentById
      */
     private function supplyTranslatedContentName(Node $node, array $contentById): void

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -71,9 +71,9 @@ final class NodeFactory
         ?string $sortClause = null,
         string $sortOrder = Query::SORT_ASC
     ): Node {
-        $contentInfoList = new ArrayObject();
-        $node = $this->buildNode($location, $contentInfoList, $loadSubtreeRequestNode, $loadChildren, $depth, $sortClause, $sortOrder);
-        $contentById = $this->contentService->loadContentListByContentInfo((array) $contentInfoList);
+        $uninitializedContentInfoList = [];
+        $node = $this->buildNode($location, $uninitializedContentInfoList, $loadSubtreeRequestNode, $loadChildren, $depth, $sortClause, $sortOrder);
+        $contentById = $this->contentService->loadContentListByContentInfo($uninitializedContentInfoList);
         $this->supplyTranslatedContentName($node, $contentById);
 
         return $node;
@@ -224,7 +224,7 @@ final class NodeFactory
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo[] $contentInfoList
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo[] $uninitializedContentInfoList
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
@@ -232,7 +232,7 @@ final class NodeFactory
      */
     private function buildNode(
         Location $location,
-        ArrayObject $contentInfoList,
+        array &$uninitializedContentInfoList,
         ?LoadSubtreeRequestNode $loadSubtreeRequestNode = null,
         bool $loadChildren = false,
         int $depth = 0,
@@ -241,8 +241,8 @@ final class NodeFactory
     ): Node {
         $contentInfo = $location->getContentInfo();
         $contentId = $location->contentId;
-        if (!isset($this->contentInfoList[$contentId])) {
-            $contentInfoList[$contentId] = $contentInfo;
+        if (!isset($uninitializedContentInfoList[$contentId])) {
+            $uninitializedContentInfoList[$contentId] = $contentInfo;
         }
 
         // Top Level Location (id = 1) does not have a Content Type
@@ -268,7 +268,7 @@ final class NodeFactory
 
                 $children[] = $this->buildNode(
                     $childLocation,
-                    $contentInfoList,
+                    $uninitializedContentInfoList,
                     $childLoadSubtreeRequestNode,
                     null !== $childLoadSubtreeRequestNode,
                     $depth + 1,

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\UI\Module\ContentTree;
 
-use ArrayObject;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\SearchService;


### PR DESCRIPTION
The `load-subtree` endpoint can become very slow in big projects when there are multiple Content Tree nodes expanded.
With every new tree expanded, the load time grows significantly. 

Reasons behind the slowness:
1. Counting child number for every single visible node using `SearchService::findLocations` with `$searchQuery->performCount = true;`
2. Initialization of Content Proxy objects - when for example 1000 nodes are displayed in the tree, every single node is loaded separately from SPI.

This PR optimizes `NodeFactory` to improve the overall response times for `load-subtree` endpoint by limiting `countSubitems` action to only those Nodes, that ContentType is a container (reducing unnecessary `countSubitems` calls), by relying on `$location->getContentInfo();` instead of `$location->getContent` when possible (`ContentInfo` is already initialised, therefore no additional call to SPI is made) and loading all Content in bulk instead of one-by-one initialisation.

The mentioned changes result in 60-70% response time reduction for `load-subtree` in large projects (10s -> 3-4s).

The `countSubitems` method can still be further optimized introducing further improvements in performance by using Aggregation, but it will be subject to a separate PR.

