### PR TITLE
IBX-340: Prevented multiple count operations when attempting to paginate URL tab

### DIFF
--- a/src/lib/Pagination/Pagerfanta/URLSearchAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/URLSearchAdapter.php
@@ -56,6 +56,7 @@ class URLSearchAdapter implements AdapterInterface
         $query = clone $this->query;
         $query->offset = $offset;
         $query->limit = $length;
+        $query->performCount = false;
 
         return $this->urlService->findUrls($query)->items;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-340](https://issues.ibexa.co/browse/IBX-340)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


See / depends on https://github.com/ezsystems/ezplatform-kernel/pull/180.
**Without it, calling the URL Management page will result in an error (!)**

Should we change the `composer.json` requirements?

> Prevent multiple database count queries when paginating URL lists.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
