### PR TITLE
RFC: Added information to Symfony's profiler "performance" tab for component rendering

### DIFF
--- a/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformAdminUiExtension.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Yaml\Yaml;
 
 class EzPlatformAdminUiExtension extends Extension implements PrependExtensionInterface
@@ -39,6 +40,8 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
         if ($environment === 'behat') {
             $loader->load('services/feature_contexts.yaml');
         }
+
+        $this->registerDebugConfiguration($container, $loader);
     }
 
     /**
@@ -142,5 +145,14 @@ class EzPlatformAdminUiExtension extends Extension implements PrependExtensionIn
                 ],
             ],
         ]);
+    }
+
+    private function registerDebugConfiguration(ContainerBuilder $container, YamlFileLoader $loader): void
+    {
+        $debug = $container->getParameter('kernel.debug');
+
+        if ($debug && class_exists(Stopwatch::class)) {
+            $loader->load('services.debug.yaml');
+        }
     }
 }

--- a/src/bundle/Resources/config/services.debug.yaml
+++ b/src/bundle/Resources/config/services.debug.yaml
@@ -1,0 +1,7 @@
+services:
+    EzSystems\EzPlatformAdminUi\Component\Renderer\TraceableRenderer:
+        decorates: EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface
+        public: false
+        arguments:
+            - '@.inner'
+            - '@debug.stopwatch'

--- a/src/bundle/Resources/config/services/components.yaml
+++ b/src/bundle/Resources/config/services/components.yaml
@@ -36,5 +36,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\Component\Renderer\DefaultRenderer:
         public: false
+        calls:
+            - setRenderer: ['@EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface']
 
     EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface: '@EzSystems\EzPlatformAdminUi\Component\Renderer\DefaultRenderer'

--- a/src/bundle/Templating/Twig/ComponentExtension.php
+++ b/src/bundle/Templating/Twig/ComponentExtension.php
@@ -8,22 +8,17 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
 
-use EzSystems\EzPlatformAdminUi\Component\Registry as ComponentRegistry;
 use EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class ComponentExtension extends AbstractExtension
 {
-    protected $registry;
-
     protected $renderer;
 
     public function __construct(
-        ComponentRegistry $registry,
         RendererInterface $renderer
     ) {
-        $this->registry = $registry;
         $this->renderer = $renderer;
     }
 

--- a/src/lib/Component/Renderer/DefaultRenderer.php
+++ b/src/lib/Component/Renderer/DefaultRenderer.php
@@ -16,14 +16,24 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class DefaultRenderer implements RendererInterface
 {
+    /** @var \EzSystems\EzPlatformAdminUi\Component\Registry */
     protected $registry;
 
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
     protected $eventDispatcher;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface */
+    protected $renderer;
 
     public function __construct(Registry $registry, EventDispatcherInterface $eventDispatcher)
     {
         $this->registry = $registry;
         $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function setRenderer(RendererInterface $renderer): void
+    {
+        $this->renderer = $renderer;
     }
 
     public function renderGroup(string $groupName, array $parameters = []): array
@@ -38,7 +48,7 @@ class DefaultRenderer implements RendererInterface
 
         $rendered = [];
         foreach ($components as $id => $component) {
-            $rendered[] = $this->renderSingle($id, $groupName, $parameters);
+            $rendered[] = $this->renderer->renderSingle($id, $groupName, $parameters);
         }
 
         return $rendered;

--- a/src/lib/Component/Renderer/TraceableRenderer.php
+++ b/src/lib/Component/Renderer/TraceableRenderer.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUi\Component\Renderer;
+
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class TraceableRenderer implements RendererInterface
+{
+
+    /** @var \EzSystems\EzPlatformAdminUi\Component\Renderer\RendererInterface */
+    private $decorated;
+
+    /** @var \Symfony\Component\Stopwatch\Stopwatch */
+    private $stopwatch;
+
+    public function __construct(RendererInterface $decorated, Stopwatch $stopwatch)
+    {
+        $this->decorated = $decorated;
+        $this->stopwatch = $stopwatch;
+    }
+
+    public function renderGroup(string $groupName, array $parameters = []): array
+    {
+        $event = $this->stopwatch->start(sprintf('%s', $groupName), 'admin-ui');
+
+        try {
+            $rendered = $this->decorated->renderGroup($groupName, $parameters);
+        } finally {
+            if ($event->isStarted()) {
+                $event->stop();
+            }
+        }
+
+        return $rendered;
+    }
+
+    public function renderSingle(string $name, $groupName, array $parameters = []): string
+    {
+        $event = $this->stopwatch->start(sprintf('%s - %s', $groupName, $name), 'admin-ui');
+
+        try {
+            $rendered = $this->decorated->renderSingle($name, $groupName, $parameters);
+        } finally {
+            if ($event->isStarted()) {
+                $event->stop();
+            }
+        }
+
+        return $rendered;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR adds dev mode decoration for one the services, which adds `debug.stopwatch` around the method calls to add them into performance tab in Symfony's profiler.

This also changes the renderer to emit both group and single events, when iterating over group components for rendering.

![image](https://user-images.githubusercontent.com/3183926/117417793-005ced80-af1b-11eb-8328-241745b2f559.png)

WDYT?

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
