### PR TITLE
IBX-354: Used fullsized thumbnails if svg is provided

### DIFF
--- a/src/bundle/ui-dev/src/modules/sub-items/components/grid-view/grid.view.item.component.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/components/grid-view/grid.view.item.component.js
@@ -10,19 +10,18 @@ const GridViewItemComponent = ({ item, generateLink }) => {
     let image = null;
     let contentTypeIcon = null;
 
-    if (content._thumbnail) {
+    if (content._thumbnail === null || content._thumbnail.mimeType === 'image/svg+xml') {
+        image = (
+            <div className={`${imageClassName} ${imageClassName}--none`}>
+                <Icon customPath={contentTypeIconUrl} extraClasses="ez-icon--extra-large" />
+            </div>
+        );
+    } else {
         const { uri, alternativeText } = content._thumbnail;
-
         image = <img className={imageClassName} src={uri} alt={alternativeText} />;
         contentTypeIcon = (
             <div className="c-grid-view-item__content-type">
                 <Icon customPath={contentTypeIconUrl} extraClasses="ez-icon--small" />
-            </div>
-        );
-    } else {
-        image = (
-            <div className={`${imageClassName} ${imageClassName}--none`}>
-                <Icon customPath={contentTypeIconUrl} extraClasses="ez-icon--extra-large" />
             </div>
         );
     }

--- a/src/bundle/ui-dev/src/modules/sub-items/components/grid-view/grid.view.item.component.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/components/grid-view/grid.view.item.component.js
@@ -18,6 +18,7 @@ const GridViewItemComponent = ({ item, generateLink }) => {
         );
     } else {
         const { uri, alternativeText } = content._thumbnail;
+
         image = <img className={imageClassName} src={uri} alt={alternativeText} />;
         contentTypeIcon = (
             <div className="c-grid-view-item__content-type">

--- a/src/bundle/ui-dev/src/modules/sub-items/services/sub.items.service.js
+++ b/src/bundle/ui-dev/src/modules/sub-items/services/sub.items.service.js
@@ -58,6 +58,7 @@ export const loadLocation = ({ token, siteaccess }, { locationId = 2, limit = 10
                                 _thumbnail {
                                     uri
                                     alternativeText
+                                    mimeType
                                 }
                                 _name
                                 _info {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-354
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

https://github.com/ezsystems/ezplatform-graphql/pull/101

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
