### PR TITLE
IBX-385: Fixed error handling when composer files are corrupted

### DIFF
--- a/src/bundle/Resources/config/default_parameters.yml
+++ b/src/bundle/Resources/config/default_parameters.yml
@@ -25,6 +25,10 @@ parameters:
                 template: '@@ezdesign/admin/systeminfo/symfony_kernel.html.twig'
                 match:
                     SystemInfo\Identifier: 'symfony_kernel'
+            invalid:
+                template: '@@ezdesign/admin/systeminfo/invalid.html.twig'
+                match:
+                    SystemInfo\Identifier: 'invalid'
 
     ezsettings.default.content_type.about:
         thumbnail: '/bundles/ezplatformadminui/img/ez-icons.svg#about'

--- a/src/bundle/Resources/translations/systeminfo.en.xliff
+++ b/src/bundle/Resources/translations/systeminfo.en.xliff
@@ -61,6 +61,11 @@
         <target state="new">Hardware</target>
         <note>key: hardware</note>
       </trans-unit>
+      <trans-unit id="5a3d301a871855ae4b3809c19b76fcccdb65b8ce" resname="invalid.system_unable_to_fetch">
+        <source>System was unable to fetch corresponding data</source>
+        <target state="new">System was unable to fetch corresponding data</target>
+        <note>key: invalid.system_unable_to_fetch</note>
+      </trans-unit>
       <trans-unit id="81c5d49be9505089d8d248ea96f6d077fd0ab9bd" resname="memory">
         <source>Memory</source>
         <target state="new">Memory</target>

--- a/src/bundle/Resources/views/admin/systeminfo/invalid.html.twig
+++ b/src/bundle/Resources/views/admin/systeminfo/invalid.html.twig
@@ -1,0 +1,16 @@
+{% trans_default_domain "systeminfo" %}
+
+<table class="table ez-table--list">
+    <thead>
+    <tr>
+        <th class="ez-table__cell ez-table__cell--header" colspan="2">{{ 'invalid.system_unable_to_fetch'|trans|desc('System was unable to fetch corresponding data') }}</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr class="ez-table__row">
+            <td class="ez-table__cell" colspan="2">
+                {{ info.errorMessage }}
+            </td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-385](https://issues.ibexa.co/browse/IBX-385)
| Bug fix?      | no
| New feature?  | kinda (improvement)
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

>Currently, whenever composer.json or composer.lock files get accidentally corrupted, the system will return exceptions coming from ez-support-tools (where those files are parsed) which results in the system being unusable. The idea is to show some warnings in:
>- the dashboard,
> - the System Information tab,
> - ez-support-tools:dump-info
>if the composer files are either not accessible or don't contain valid data.

Given, we moved AdminUI part to `ez-support-tools` in v3, these changes won't be needed.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
