### PR TITLE
EZP-32333: Hidden duplicated 'change password' menu item

### DIFF
--- a/src/lib/Menu/UserMenuBuilder.php
+++ b/src/lib/Menu/UserMenuBuilder.php
@@ -76,10 +76,6 @@ class UserMenuBuilder extends AbstractBuilder implements TranslationContainerInt
         $token = $this->tokenStorage->getToken();
         if (null !== $token && is_object($token->getUser())) {
             $menu->addChild(
-                $this->createMenuItem(self::ITEM_CHANGE_PASSWORD, ['route' => 'ezplatform.user_profile.change_password'])
-            );
-
-            $menu->addChild(
                 $this->createMenuItem(self::ITEM_USER_SETTINGS, ['route' => 'ezplatform.user_settings.list'])
             );
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32333](https://jira.ez.no/browse/EZP-32333)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This fragment is not needed here as this menu item is generated in `ezplatform-user` package nevertheless:  https://github.com/ezsystems/ezplatform-user/blob/1.0/src/lib/EventListener/UserMenuListener.php#L49

Related `ezplatform-user` PR: https://github.com/ezsystems/ezplatform-user/pull/92

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
