### PR TITLE
Removed unnecessary height attribute from ez-sticky-container class

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -150,7 +150,6 @@ select {
     position: -webkit-sticky;
     position: sticky;
     top: calculateRem(16px);
-    height: 100vh;
 
     > .btn {
         .ez-icon {


### PR DESCRIPTION
Fixes: https://issues.ibexa.co/browse/IBX-186

The unnecessary `height` attribute on the `ez-sticky-container` made right side menu not sticky enough (there was a bottom padding added to the body for the footer, which caused the issue). Removing the `height: 100vh` attribute resolved the issue and I couldn't find anything broken (my guess is that this `height` attribute is a leftover when the right menu had a background from top to bottom), therefore this PR.