### PR TITLE
IBX-418: Skipped content name retrieve for the top node

### DIFF
--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -305,6 +305,7 @@ final class NodeFactory
         if ($node->contentId !== self::TOP_NODE_CONTENT_ID) {
             $node->name = $this->translationHelper->getTranslatedContentName($contentById[$node->contentId]);
         }
+        
         foreach ($node->children as $child) {
             $this->supplyTranslatedContentName($child, $contentById);
         }

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -305,7 +305,7 @@ final class NodeFactory
         if ($node->contentId !== self::TOP_NODE_CONTENT_ID) {
             $node->name = $this->translationHelper->getTranslatedContentName($contentById[$node->contentId]);
         }
-        
+
         foreach ($node->children as $child) {
             $this->supplyTranslatedContentName($child, $contentById);
         }

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -28,6 +28,7 @@ use EzSystems\EzPlatformAdminUi\REST\Value\ContentTree\Node;
  */
 final class NodeFactory
 {
+    private const TOP_NODE_CONTENT_ID = 0;
     private const SORT_CLAUSE_MAP = [
         'DatePublished' => SortClause\DatePublished::class,
         'ContentName' => SortClause\ContentName::class,
@@ -301,7 +302,9 @@ final class NodeFactory
      */
     private function supplyTranslatedContentName(Node $node, array $contentById): void
     {
-        $node->name = $this->translationHelper->getTranslatedContentName($contentById[$node->contentId]);
+        if ($node->contentId !== self::TOP_NODE_CONTENT_ID) {
+            $node->name = $this->translationHelper->getTranslatedContentName($contentById[$node->contentId]);
+        }
         foreach ($node->children as $child) {
             $this->supplyTranslatedContentName($child, $contentById);
         }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-418
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

The Tree View in UDW creates a node for the top location, which does not have content (`contentId === 0`).
This fix skips the content name retrieval for this node to avoid errors.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
