### PR TITLE
IBX-186: The top button of side menus gets hidden at the bottom of the page (mergeup fix)

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -67,6 +67,7 @@
 
                 if (!actions.classList.contains(CLASS_HIDDEN)) {
                     doc.body.addEventListener('click', detectClickOutside, false);
+                    setContainerHeight();
                     addContainerHeightListeners();
                 } else {
                     doc.body.removeEventListener('click', detectClickOutside);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | IBX-186
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Without it initial height isn't set, only after resizing/scrolling


#### Checklist:
- [x] Ready for Code Review
