### PR TITLE
[Composer] Bumped ezplatform-kernel require to ~1.2.8@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/asset": "^5.0",
         "symfony/yaml": "^5.0",
         "jms/translation-bundle": "^1.5",
-        "ezsystems/ezplatform-kernel": "~1.2.0@dev",
+        "ezsystems/ezplatform-kernel": "~1.2.8@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
         "ezsystems/ezplatform-user": "^2.0@dev",


### PR DESCRIPTION
Fixes issues visible in https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/jobs/510343428 :
tests are failing because Composer downloads incorrect dependencies:
```
  - Locking ezsystems/ezplatform-kernel (v1.2.7)
```
where kernel ~1.2.8 is required (it's the first version containing changes from https://github.com/ezsystems/ezplatform-kernel/pull/180).

It's most likely caused by https://github.com/ezsystems/ezplatform-kernel/pull/192 - Composer doesn't know what to do (install Symfony higher than 5.1 and Kernel 1.2.7 or Symfony 5.1.x and Kernel 1.2.8-dev - the first option is chosen).

Bumping the kernel requirement makes Composer choose correctly.
