### PR TITLE
IBX-154: Allowed to define if the alternative text for image field is required

### DIFF
--- a/src/bundle/Controller/AssetController.php
+++ b/src/bundle/Controller/AssetController.php
@@ -84,7 +84,7 @@ class AssetController extends Controller
                             'path' => $file->getRealPath(),
                             'fileSize' => $file->getSize(),
                             'fileName' => $file->getClientOriginalName(),
-                            'alternativeText' => null,
+                            'alternativeText' => $file->getClientOriginalName(),
                         ]),
                         $data->getLanguageCode()
                     );

--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -636,6 +636,11 @@
         <target state="new">Maximum file size (MB)</target>
         <note>key: field_definition.ezimage.max_file_size</note>
       </trans-unit>
+      <trans-unit id="d2474547af649be4af884989e0af3e003125291e" resname="field_definition.ezimage.is_alternative_text_required">
+        <source>Alternative text is required</source>
+        <target state="new">Alternative text is required</target>
+        <note>key: field_definition.ezimage.is_alternative_text_required</note>
+      </trans-unit>
       <trans-unit id="8a95f664895f9c72e5ca52ea43908ad3d54c8966" resname="field_definition.ezinteger.default_value">
         <source>Default value</source>
         <target state="new">Default value</target>

--- a/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/field_types.html.twig
@@ -84,6 +84,10 @@
     <div class="ezimage-validator max-file-size{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_row(form.maxSize, {'label_attr': {'class': 'ez-label'}}) -}}
     </div>
+
+    <div class="ezimage-validator is-alternative-text-required"{% if group_class is not empty %} {{ group_class }}{% endif %}>
+        {{ form_row(form.isAlternativeTextRequired, {'attr': {'class': 'ez-input ez-input--checkbox'}, 'label_attr': {'class': 'ez-label'}}) }}
+    </div>
 {% endblock %}
 
 {% block ezinteger_field_definition_edit %}

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -142,11 +142,23 @@ const prepareStruct = ({ parentInfo, config, languageCode }, data) => {
         .then((response) => response.json())
         .catch(() => window.eZ.helpers.notification.showErrorNotification('Cannot get content type by identifier'))
         .then((response) => {
+            const fileValue = {
+                fileName: data.file.name,
+                data: data.fileReader.result.replace(/^.*;base64,/, ''),
+            }
+
+            if (data.file.type.startsWith('image/')) {
+                fileValue.alternativeText = data.file.name;
+            }
+
             const fields = [
-                { fieldDefinitionIdentifier: mapping.nameFieldIdentifier, fieldValue: data.file.name },
+                {
+                    fieldDefinitionIdentifier: mapping.nameFieldIdentifier,
+                    fieldValue: data.file.name
+                },
                 {
                     fieldDefinitionIdentifier: mapping.contentFieldIdentifier,
-                    fieldValue: { fileName: data.file.name, data: data.fileReader.result.replace(/^.*;base64,/, '') },
+                    fieldValue: fileValue
                 },
             ];
 

--- a/src/lib/FieldType/Mapper/ImageFormMapper.php
+++ b/src/lib/FieldType/Mapper/ImageFormMapper.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\FieldTypeService;
 use EzSystems\EzPlatformAdminUi\Form\Data\FieldDefinitionData;
 use EzSystems\EzPlatformAdminUi\FieldType\FieldDefinitionFormMapperInterface;
 use EzSystems\EzPlatformContentForms\ConfigResolver\MaxUploadSize;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Exception\AccessException;
@@ -44,6 +45,12 @@ class ImageFormMapper implements FieldDefinitionFormMapperInterface
                     'min' => 0,
                     'max' => $this->maxUploadSize->get(MaxUploadSize::MEGABYTES),
                 ],
+                'disabled' => $isTranslation,
+            ])
+            ->add('isAlternativeTextRequired', CheckboxType::class, [
+                'required' => false,
+                'property_path' => 'validatorConfiguration[AlternativeTextValidator][required]',
+                'label' => /** @Desc("Alternative text is required") */ 'field_definition.ezimage.is_alternative_text_required',
                 'disabled' => $isTranslation,
             ]);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-154
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | ?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
