### PR TITLE
EZP-32387: Fixed text block toolbar alignment

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
@@ -42,6 +42,17 @@ export default class EzConfigBase {
             range.selectNodeContents(positionReference.$);
             left = range.getBoundingClientRect().left + scrollLeft;
 
+            if (window.frameElement) {
+                const blockLeftMargin = block.$.offsetLeft;
+                const blockWidth = block.$.offsetWidth;
+                const toolbarWidth = document.querySelector('.ae-toolbar-floating').offsetWidth;
+                const maxLeft = blockWidth - toolbarWidth;
+
+                if (left > maxLeft) {
+                    left = maxLeft + blockLeftMargin;
+                }
+            }
+
             if (empty) {
                 positionReference.remove();
             }

--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
@@ -39,18 +39,16 @@ export default class EzConfigBase {
 
             const range = document.createRange();
             const scrollLeft = parseInt(block.$.scrollLeft, 10);
+            const blockLeftMargin = block.$.offsetLeft;
+            const blockWidth = block.$.offsetWidth;
+            const toolbarWidth = document.querySelector('.ae-toolbar-floating').offsetWidth;
+            const maxLeft = blockWidth - toolbarWidth;
+
             range.selectNodeContents(positionReference.$);
             left = range.getBoundingClientRect().left + scrollLeft;
 
-            if (window.frameElement) {
-                const blockLeftMargin = block.$.offsetLeft;
-                const blockWidth = block.$.offsetWidth;
-                const toolbarWidth = document.querySelector('.ae-toolbar-floating').offsetWidth;
-                const maxLeft = blockWidth - toolbarWidth;
-
-                if (left > maxLeft) {
-                    left = maxLeft + blockLeftMargin;
-                }
+            if (left > maxLeft) {
+                left = maxLeft + blockLeftMargin;
             }
 
             if (empty) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-32387](https://issues.ibexa.co/browse/EZP-32387)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

JIRA excerpt:
>When editing a Page Builder, the Rich text inside a Text block is unconfortable to use in certain cases. Sometimes, impossible to use. When you click on align right on the toolbar inside the Text Block, the toolbar aligns itself to the right as well. But the toolbar collapses and a part of it is hidden. Also a scrollbar appears on the bottom of the window, but impossible to scroll.

>Steps to reproduce:
>1. Install a clean version of Ibexa V.3.3
>2. Edit a landing page
>3. Add a text bloc inside the landing page(drag and drop)
>4. click on the content block of the Text Block and see the toolbar appears
>5. click on align right button
>6. You will notice that a part of the toolbar is missing and the window has a scrollbar on its bottom. Try to use that scrollbar. You cannot.

PR for 3.x (targetting `ezplatform-richtext`) will be created once this solution is approved.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
