### PR TITLE
IBX-154: Allowed to define if the alternative text for image field is required (2.5)

### DIFF
--- a/src/bundle/Controller/AssetController.php
+++ b/src/bundle/Controller/AssetController.php
@@ -84,7 +84,7 @@ class AssetController extends Controller
                             'path' => $file->getRealPath(),
                             'fileSize' => $file->getSize(),
                             'fileName' => $file->getClientOriginalName(),
-                            'alternativeText' => null,
+                            'alternativeText' => $file->getClientOriginalName(),
                         ]),
                         $data->getLanguageCode()
                     );

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimage.js
@@ -66,9 +66,12 @@
          * @memberof EzStringValidator
          */
         validateAltInput(event) {
-            const isRequired = event.target.required;
+            const fileField = this.fieldContainer.querySelector(SELECTOR_INPUT_FILE);
+            const dataContainer = this.fieldContainer.querySelector('.ez-field-edit__data');
+            const isFileFieldEmpty = fileField.files && !fileField.files.length && dataContainer && !dataContainer.hasAttribute('hidden');
+            const isRequired = event.target.dataset.isRequired;
             const isEmpty = !event.target.value;
-            const isError = isEmpty && isRequired;
+            const isError = isEmpty && isRequired && !isFileFieldEmpty;
             const label = event.target.closest(SELECTOR_ALT_WRAPPER).querySelector('.ez-data-source__label').innerHTML;
             const result = { isError };
 

--- a/src/bundle/Resources/public/scss/fieldType/edit/_ezimage.scss
+++ b/src/bundle/Resources/public/scss/fieldType/edit/_ezimage.scss
@@ -1,6 +1,6 @@
 .ez-field-edit--ezimage {
     .ez-field-edit-preview {
-        padding: 1.25rem 0 .75rem 1.25rem;
+        padding: 1.25rem 0 0.75rem 1.25rem;
 
         &__media {
             max-width: 100%;
@@ -11,12 +11,12 @@
 
         &__details {
             color: $ez-color-base-light;
-            font-size: .75rem;
-            padding-top: .5rem;
+            font-size: 0.75rem;
+            padding-top: 0.5rem;
         }
 
         .ez-field-edit-preview__image-alt {
-            margin-top: .5rem;
+            margin-top: 0.5rem;
         }
     }
 
@@ -25,7 +25,7 @@
             position: relative;
 
             &:before {
-                content : '!';
+                content: '!';
                 position: absolute;
                 top: 0;
                 left: -20px;
@@ -41,6 +41,10 @@
     }
 
     .ez-data-source__field--alternativeText {
+        .ez-data-source__label {
+            @include label-required();
+        }
+
         &.is-invalid {
             .ez-data-source__label-wrapper,
             .ez-data-source__label-wrapper .ez-field-edit__label {

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -84,6 +84,10 @@
     <div class="ezimage-validator max-file-size{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_row(form.maxSize, {'label_attr': {'class': 'ez-label'}}) -}}
     </div>
+
+    <div class="ezimage-validator is-alternative-text-required"{% if group_class is not empty %} {{ group_class }}{% endif %}>
+        {{ form_row(form.isAlternativeTextRequired, {'attr': {'class': 'ez-input ez-input--checkbox'}, 'label_attr': {'class': 'ez-label'}}) }}
+    </div>
 {% endblock %}
 
 {% block ezinteger_field_definition_edit %}

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -86,7 +86,7 @@
     </div>
 
     <div class="ezimage-validator is-alternative-text-required"{% if group_class is not empty %} {{ group_class }}{% endif %}>
-        {{ form_row(form.isAlternativeTextRequired, {'attr': {'class': 'ez-input ez-input--checkbox'}, 'label_attr': {'class': 'ez-label'}}) }}
+        {{ form_row(form.isAlternativeTextRequired, {'attr': {'class': 'ez-input ez-input--checkbox'}, 'label_attr': {'class': 'checkbox-inline ez-label'}}) }}
     </div>
 {% endblock %}
 

--- a/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
@@ -25,7 +25,7 @@
                 <span class="ez-field-edit-preview__file-size">{{ form.parent.vars.value.value.fileSize|ez_file_size(2) }}</span>
             </div>
             <div class="ez-field-edit-preview__image-alt">
-                {{ form_row(form.alternativeText) }}
+                {{ form_row(form.alternativeText, { attr: { 'data-is-required': form.vars.is_alternative_text_required }}) }}
             </div>
         </div>
         <div class="ez-field-edit-preview__actions">

--- a/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/fieldtypes/edit/ezimage.html.twig
@@ -25,7 +25,11 @@
                 <span class="ez-field-edit-preview__file-size">{{ form.parent.vars.value.value.fileSize|ez_file_size(2) }}</span>
             </div>
             <div class="ez-field-edit-preview__image-alt">
-                {{ form_row(form.alternativeText, { attr: { 'data-is-required': form.vars.is_alternative_text_required }}) }}
+                {% set alternative_text_label_class = form.vars.is_alternative_text_required ? 'required' : '' %}
+                {{ form_row(form.alternativeText, {
+                    attr: { 'data-is-required': form.vars.is_alternative_text_required },
+                    label_attr: { 'class': alternative_text_label_class }
+                }) }}
             </div>
         </div>
         <div class="ez-field-edit-preview__actions">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-154
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | ?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


https://github.com/ezsystems/ezplatform-admin-ui/pull/1777 for v2.5

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review