### PR TITLE
IBX-648: Added styles for backported landing page FT settings

### DIFF
--- a/src/bundle/Resources/public/scss/_custom.scss
+++ b/src/bundle/Resources/public/scss/_custom.scss
@@ -28,6 +28,10 @@ $ez-color-base-medium-hover: darken($ez-color-base-medium, 15%);
 $ez-color-base-dark: #555;
 $ez-black: #333;
 
+$ez-color-font-danger: #d92d42;
+$ez-color-font-pale: #878b90;
+$ez-color-base: #e0e0e8;
+
 $ez-secondary-ground-pale: #e1f5ff;
 $ez-ground-primary: #a8c8d5;
 $ez-secondary-ground: #2b84b1;
@@ -156,3 +160,6 @@ $pagination-border-color: transparent;
 
 // Modals
 $modal-content-bg: $ez-ground-base-medium;
+
+//Border
+$ez-border-radius: calculateRem(10px);


### PR DESCRIPTION
(cherry picked from commit c6245ee23cfe8206f9916fe12209d3ef417a433b)

https://issues.ibexa.co/browse/IBX-648

Related to:
https://github.com/ezsystems/ezplatform-page-builder/pull/769
https://github.com/ezsystems/ezplatform-page-fieldtype/pull/185

I have also added colors that were used in the design, but were missing from 2.5 file. Maybe they are already there but under different name but I am not sure if changing the templates to match it is no bigger fuss then adding them here.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
