### PR TITLE
IBX-662: Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null at setContainerHeight

### DIFF
--- a/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
+++ b/src/bundle/Resources/public/js/scripts/sidebar/extra.actions.js
@@ -12,7 +12,7 @@
     const haveHiddenPart = (element) => element.classList.contains(CLASS_HIDDEN) && !element.classList.contains(CLASS_PREVENT_SHOW);
     const setContainerHeight = () => {
         const container = doc.querySelector('.ez-extra-actions:not(.ez-extra-actions--hidden)');
-        const bottomPosition = Math.min(footer.getBoundingClientRect().top, global.innerHeight);
+        const bottomPosition = footer ? Math.min(footer.getBoundingClientRect().top, global.innerHeight) : global.innerHeight;
         const containerHeight = bottomPosition - container.getBoundingClientRect().top - ACTIONS_CONTAINER_MARGIN;
 
         container.style.height = `${containerHeight}px`;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-662
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
