### PR TITLE
IBX-695: Added ignore to trans id 'interval.format.%s'

### DIFF
--- a/src/bundle/Templating/Twig/FormatIntervalExtension.php
+++ b/src/bundle/Templating/Twig/FormatIntervalExtension.php
@@ -49,6 +49,7 @@ class FormatIntervalExtension extends AbstractExtension implements TranslationCo
         foreach (self::INTERVAL_PARTS as $part => $name) {
             if ($interval->$part > 0) {
                 $parts[] = $this->translator->trans(
+                    /** @ignore */
                     sprintf('interval.format.%s', $name),
                     ['%count%' => $interval->$part],
                     'time_diff'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-695](https://issues.ibexa.co/browse/IBX-695)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

JMS Translation extractor has to ignore dynamic labels that are translated by Format Interval Extension twig. Otherwise, it will display the error described in the JIRA issue.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
