### PR TITLE
IBX-725: CredentialsExpiredListener makes it impossible to render a content from using CLI

### DIFF
--- a/src/lib/EventListener/CredentialsExpiredListener.php
+++ b/src/lib/EventListener/CredentialsExpiredListener.php
@@ -44,7 +44,8 @@ final class CredentialsExpiredListener implements EventSubscriberInterface
 
     public function onPreContentView(PreContentViewEvent $event): void
     {
-        if (!$this->isAdminSiteAccess($this->requestStack->getCurrentRequest())) {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest === null || !$this->isAdminSiteAccess($currentRequest)) {
             return;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-725
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`\EzSystems\EzPlatformAdminUi\EventListener\CredentialsExpiredListener::onPreContentView` throws TypeError when view is rendered in CLI env. 

#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
