### PR TITLE
[Behat] Changed ContentDraft tests to use article Content Type

### DIFF
--- a/features/standard/ContentDraft.feature
+++ b/features/standard/ContentDraft.feature
@@ -1,4 +1,4 @@
-@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce @richtext
 Feature: Content items creation
   As an administrator
   In order to manage content to my site
@@ -10,21 +10,22 @@ Feature: Content items creation
   @javascript
   Scenario: Content draft can be saved
     Given I'm on Content view Page for root
-    When I start creating a new content "Folder"
+    When I start creating a new content "Article"
       And I set content fields
-        | label | value             |
-        | Name  | Test Folder Draft |
+        | label       | value              |
+        | Title       | Test Article draft |
+        | Short title | Test Article draft |
       And I click on the edit action bar button "Save"
     Then success notification that "Content draft saved." appears
-      And I should be on Content update page for "Test Folder Draft"
+      And I should be on Content update page for "Test Article draft"
       And I open the "Dashboard" page in admin SiteAccess
-      And there's draft "Test Folder Draft" on Dashboard list
+      And there's draft "Test Article draft" on Dashboard list
 
   @javascript @APIUser:admin
   Scenario: Content draft can be deleted
-    Given I create "folder" Content drafts
-      | name      | short_name | parentPath | language |
-      | TestDraft | TestDraft  | root       | eng-GB   |
+    Given I create "article" Content drafts
+      | title     | short_title | parentPath | language |
+      | TestDraft | TestDraft   | root        | eng-GB   |
       And I open the "Dashboard" page in admin SiteAccess
       And there's draft "TestDraft" on Dashboard list
     When I start editing content draft "TestDraft"
@@ -36,20 +37,22 @@ Feature: Content items creation
   @javascript
   Scenario: Content draft can be saved and then published
     Given I'm on Content view Page for root
-      And I start creating a new content "Folder"
+      And I start creating a new content "Article"
       And I set content fields
-        | label | value                 |
-        | Name  | TestFolderSavePublish |
+        | label       | value                  |
+        | Title       | TestArticleSavePublish |
+        | Short title | TestArticleSavePublish |
+        | Intro       | TestArticleIntro       |
       When I click on the edit action bar button "Save"
-      And I should be on Content update page for "TestFolderSavePublish"
+      And I should be on Content update page for "TestArticleSavePublish"
       And I click on the edit action bar button "Publish"
     Then success notification that "Content published." appears
-    And I should be on Content view Page for "TestFolderSavePublish"
+    And I should be on Content view Page for "TestArticleSavePublish"
 
   @javascript @APIUser:admin
   Scenario: Content draft edition can be closed
-    Given I create "folder" Content drafts
-      | name                   | short_name             | parentPath | language |
+    Given I create "article" Content drafts
+      | title                  | short_title            | parentPath | language |
       | TestDraftDashboardEdit | TestDraftDashboardEdit | root       | eng-GB   |
     And I open the "Dashboard" page in admin SiteAccess
     And there's draft "TestDraftDashboardEdit" on Dashboard list
@@ -60,44 +63,46 @@ Feature: Content items creation
 
   @javascript @APIUser:admin
   Scenario: Content draft can be created and published through draft list modal
-    Given I create "folder" Content items
-      | name                 | short_name           | parentPath        | language |
-      | ContentDraftConflict | ContentDraftConflict | root              | eng-GB   |
+    Given I create "article" Content items
+      | title                | short_title          | parentPath | language |
+      | ContentDraftConflict | ContentDraftConflict | root       | eng-GB   |
     And I create a new Draft for "ContentDraftConflict" Content item in "eng-GB"
-      | name                         | short_name                   |
+      | title                         | short_title                 |
       | ContentDraftConflictVersion1 | ContentDraftConflictVersion2 |
     And I'm on Content view Page for "ContentDraftConflict"
     When I click on the edit action bar button "Edit"
       And I start creating new draft from draft conflict modal
       And I set content fields
         | label       | value                        |
-        | Short name  | ContentDraftConflictVersion2 |
+        | Title       | ContentDraftConflictVersion2 |
+        | Short title | ContentDraftConflictVersion2 |
       And I click on the edit action bar button "Publish"
     Then success notification that "Content published." appears
       And I should be on Content view Page for ContentDraftConflictVersion2
       And content attributes equal
         | label      | value                        |
-        | Name       | ContentDraftConflict         |
-        | Short name | ContentDraftConflictVersion2 |
+        | Title       | ContentDraftConflictVersion2 |
+        | Short title | ContentDraftConflictVersion2 |
 
   @javascript @APIUser:admin
   Scenario: Content draft from draft list modal can be published
-    Given I create "folder" Content items
-      | name                            | short_name                      | parentPath        | language |
+    Given I create "article" Content items
+      | title                           | short_title                     | parentPath        | language |
       | ContentDraftConflictFromTheList | ContentDraftConflictFromTheList | root              | eng-GB   |
     And I create a new Draft for "ContentDraftConflictFromTheList" Content item in "eng-GB"
-      | name                                    | short_name                              |
+      | title                                   | short_title                             |
       | ContentDraftConflictFromTheListVersion2 | ContentDraftConflictFromTheListVersion2 |
     And I'm on Content view Page for "ContentDraftConflictFromTheList"
     When I click on the edit action bar button "Edit"
       And I start editing draft with version number "2" from draft conflict modal
       And I set content fields
-        | label      | value                                         |
-        | Short name | ContentDraftConflictFromTheListVersion2Edited |
+        | label  | value                                         |
+        | Intro  | ContentDraftConflictFromTheListVersion2Edited |
       And I click on the edit action bar button "Publish"
     Then success notification that "Content published." appears
-      And I should be on Content view Page for ContentDraftConflictFromTheListVersion2Edited
+      And I should be on Content view Page for ContentDraftConflictFromTheListVersion2
       And content attributes equal
-        | label      | value                                         |
-        | Name       | ContentDraftConflictFromTheListVersion2       |
-        | Short name | ContentDraftConflictFromTheListVersion2Edited |
+        | label       | value                                         |
+        | Title       | ContentDraftConflictFromTheListVersion2       |
+        | Short title | ContentDraftConflictFromTheListVersion2       |
+        | Intro       | ContentDraftConflictFromTheListVersion2Edited |


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-264

Added a `@richtext` tag that will be run in ezsystems/ezplatform-richtext (https://github.com/ezsystems/ezplatform-richtext/pull/197)

As I've changed the Content Item used to Folder during refactoring I've switched it back to Article, which contains a richtext fields that is required and needs to be set.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
