### PR TITLE
[Behat] Fixed PHPUnit 9 deprecations and class usage casing

### DIFF
--- a/src/lib/Behat/BrowserContext/NotificationContext.php
+++ b/src/lib/Behat/BrowserContext/NotificationContext.php
@@ -59,7 +59,7 @@ class NotificationContext implements Context
     {
         $this->notification->verifyIsLoaded();
         $this->notification->verifyAlertFailure();
-        Assert::assertContains($message, $this->notification->getMessage());
+        Assert::assertStringContainsString($message, $this->notification->getMessage());
         $this->notification->closeAlert();
     }
 }

--- a/src/lib/Behat/Component/ContentItemAdminPreview.php
+++ b/src/lib/Behat/Component/ContentItemAdminPreview.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component;
 
+use Behat\Mink\Session;
 use Ibexa\Behat\Browser\Component\Component;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
-use Behat\Mink\Session;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Traversable;
 
@@ -44,6 +44,20 @@ class ContentItemAdminPreview extends Component
         }
     }
 
+    public function verifyIsLoaded(): void
+    {
+    }
+
+    protected function specifyLocators(): array
+    {
+        return [
+            new VisibleCSSLocator('nthFieldContainer', 'div.ez-content-field:nth-of-type(%s)'),
+            new VisibleCSSLocator('fieldName', '.ez-content-field-name'),
+            new VisibleCSSLocator('fieldValue', '.ez-content-field-value'),
+            new VisibleCSSLocator('fieldValueContainer', ':first-child'),
+        ];
+    }
+
     private function getFieldPosition(string $fieldLabel): int
     {
         $searchText = sprintf('%s:', $fieldLabel);
@@ -60,35 +74,22 @@ class ContentItemAdminPreview extends Component
         }
     }
 
-    public function verifyIsLoaded(): void
-    {
-    }
-
-    protected function specifyLocators(): array
-    {
-        return [
-            new VisibleCSSLocator('nthFieldContainer', 'div.ez-content-field:nth-of-type(%s)'),
-            new VisibleCSSLocator('fieldName', '.ez-content-field-name'),
-            new VisibleCSSLocator('fieldValue', '.ez-content-field-value'),
-            new VisibleCSSLocator('fieldValueContainer', ':first-child'),
-        ];
-    }
-
     private function detectFieldTypeIdentifier(CSSLocator $fieldValueLocator)
     {
         $fieldClass = $this->getHTMLPage()
             ->find(CSSLocatorBuilder::base($fieldValueLocator)->withDescendant($this->getLocator('fieldValueContainer'))->build())
-            ->getAttribute('class');
+            ->getAttribute('class')
+        ;
 
-        if ($fieldClass === 'ez-scrollable-table-wrapper mb-0') {
+        if ('ez-scrollable-table-wrapper mb-0' === $fieldClass) {
             return 'ezuser';
         }
 
-        if (strpos($fieldClass, 'ez-scrollable-table-wrapper') !== false) {
+        if (false !== strpos($fieldClass, 'ez-scrollable-table-wrapper')) {
             return 'ezmatrix';
         }
 
-        if ($fieldClass === '') {
+        if ('' === $fieldClass) {
             return 'ezboolean';
         }
 

--- a/src/lib/Behat/Component/Fields/Authors.php
+++ b/src/lib/Behat/Component/Fields/Authors.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/Checkbox.php
+++ b/src/lib/Behat/Component/Fields/Checkbox.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/ContentQuery.php
+++ b/src/lib/Behat/Component/Fields/ContentQuery.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/ContentRelationMultiple.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationMultiple.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Behat\Mink\Session;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\Table\TableBuilder;
 use Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget;

--- a/src/lib/Behat/Component/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationSingle.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Behat\Mink\Session;
 use Ibexa\AdminUi\Behat\Component\Table\TableBuilder;

--- a/src/lib/Behat/Component/Fields/Date.php
+++ b/src/lib/Behat/Component/Fields/Date.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Behat\Mink\Session;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\DateAndTimePopup;
 use PHPUnit\Framework\Assert;

--- a/src/lib/Behat/Component/Fields/DateAndTime.php
+++ b/src/lib/Behat/Component/Fields/DateAndTime.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Behat\Mink\Session;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\DateAndTimePopup;
 use PHPUnit\Framework\Assert;

--- a/src/lib/Behat/Component/Fields/FieldTypeComponent.php
+++ b/src/lib/Behat/Component/Fields/FieldTypeComponent.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Component\Component;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/File.php
+++ b/src/lib/Behat/Component/Fields/File.php
@@ -11,7 +11,7 @@ namespace Ibexa\AdminUi\Behat\Component\Fields;
 use Behat\Mink\Session;
 use Ibexa\Behat\Browser\FileUpload\FileUploadHelper;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -41,7 +41,7 @@ class File extends FieldTypeComponent
     {
         $filename = str_replace('.zip', '', $values['value']);
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Image has wrong file name'
@@ -51,7 +51,7 @@ class File extends FieldTypeComponent
             ->withDescendant($this->getLocator('file'))
             ->build();
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->find($fileFieldSelector)->getAttribute('href'),
             'File has wrong href'

--- a/src/lib/Behat/Component/Fields/Image.php
+++ b/src/lib/Behat/Component/Fields/Image.php
@@ -11,7 +11,7 @@ namespace Ibexa\AdminUi\Behat\Component\Fields;
 use Behat\Mink\Session;
 use Ibexa\Behat\Browser\FileUpload\FileUploadHelper;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -51,7 +51,7 @@ class Image extends FieldTypeComponent
     {
         $filename = str_replace('.zip', '', $values['value']);
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Image has wrong file name'
@@ -61,7 +61,7 @@ class Image extends FieldTypeComponent
             ->withDescendant($this->getLocator('image'))
             ->build();
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->setTimeout(5)->find($fileFieldSelector)->getAttribute('src'),
             'Image has wrong source'

--- a/src/lib/Behat/Component/Fields/ImageAsset.php
+++ b/src/lib/Behat/Component/Fields/ImageAsset.php
@@ -11,7 +11,7 @@ namespace Ibexa\AdminUi\Behat\Component\Fields;
 use Behat\Mink\Session;
 use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\FileUpload\FileUploadHelper;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\Notification;
 use Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget;

--- a/src/lib/Behat/Component/Fields/Keywords.php
+++ b/src/lib/Behat/Component/Fields/Keywords.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\ElementInterface;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/MapLocation.php
+++ b/src/lib/Behat/Component/Fields/MapLocation.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/Matrix.php
+++ b/src/lib/Behat/Component/Fields/Matrix.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
@@ -94,7 +94,7 @@ class Matrix extends FieldTypeComponent
 
     private function internalSetValue(int $rowIndex, string $column, $value): void
     {
-        $matrixCellSelector = CssLocatorBuilder::combine(
+        $matrixCellSelector = CSSLocatorBuilder::combine(
             $this->getLocator('matrixCellSelectorFormat')->getSelector(),
             new VisibleCSSLocator('rowIndex', (string) $rowIndex),
             new VisibleCSSLocator('columnIndex', $column),

--- a/src/lib/Behat/Component/Fields/Media.php
+++ b/src/lib/Behat/Component/Fields/Media.php
@@ -11,7 +11,7 @@ namespace Ibexa\AdminUi\Behat\Component\Fields;
 use Behat\Mink\Session;
 use Ibexa\Behat\Browser\FileUpload\FileUploadHelper;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -40,13 +40,13 @@ class Media extends FieldTypeComponent
     {
         $filename = str_replace('.zip', '', $values['value']);
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Media has wrong file name'
         );
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $filename,
             $this->getHTMLPage()->find(
                 CSSLocatorBuilder::base($this->parentLocator)

--- a/src/lib/Behat/Component/Fields/NonEditableField.php
+++ b/src/lib/Behat/Component/Fields/NonEditableField.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
 abstract class NonEditableField extends FieldTypeComponent

--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -80,7 +80,7 @@ class RichText extends FieldTypeComponent
 
         $selector = CSSLocatorBuilder::base($this->getLocator('fieldInput'))->withDescendant(new VisibleCSSLocator('style', $style))->build();
 
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             sprintf('%s%s</%s>', $value, '<br>', $style),
             $this->getHTMLPage()->find($selector)->getOuterHtml()
         );

--- a/src/lib/Behat/Component/Fields/Selection.php
+++ b/src/lib/Behat/Component/Fields/Selection.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
 class Selection extends FieldTypeComponent

--- a/src/lib/Behat/Component/Fields/Time.php
+++ b/src/lib/Behat/Component/Fields/Time.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Behat\Mink\Session;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\DateAndTimePopup;
 use PHPUnit\Framework\Assert;

--- a/src/lib/Behat/Component/Fields/URL.php
+++ b/src/lib/Behat/Component/Fields/URL.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Component/Fields/User.php
+++ b/src/lib/Behat/Component/Fields/User.php
@@ -7,7 +7,7 @@
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
-use Ibexa\Behat\Browser\Locator\CssLocatorBuilder;
+use Ibexa\Behat\Browser\Locator\CSSLocatorBuilder;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 

--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -216,7 +216,7 @@ class ContentViewPage extends Page
     {
         $this->getHTMLPage()->find($this->getLocator('mainContainer'))->assert()->isVisible();
         $this->rightMenu->verifyIsLoaded();
-        Assert::assertContains(
+        Assert::assertStringContainsString(
             $this->expectedContentName,
             $this->breadcrumb->getBreadcrumb(),
             'Breadcrumb shows invalid path'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-264
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

1) Using `assertContains` for string works in PHPUnit 8, but it's deprecated:
https://github.com/sebastianbergmann/phpunit/blob/8.5/src/Framework/Assert.php#L209-L214
changed usages to `assertStringContainsString` where it's applicable.
1) In some classes bad casing was used: `CssLocatorBuilder` instead of `CSSLocatorBuilder`. The class is called `CSSLocatorBuilder`: https://github.com/ezsystems/BehatBundle/blob/master/src/lib/Browser/Locator/CSSLocatorBuilder.php It works, but it's not the best practice.
1) Ordering changes were made by CS Fixer.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
