### PR TITLE
[Behat] Adapted tests to the redesign

### DIFF
--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -276,7 +276,7 @@ class ContentViewPage extends Page
         return [
             new VisibleCSSLocator('pageTitle', '.ez-page-title h1'),
             new VisibleCSSLocator('contentType', '.ez-page-title h4'),
-            new VisibleCSSLocator('mainContainer', '#ez-tab-list-content-location-view'),
+            new VisibleCSSLocator('mainContainer', '.ibexa-tab-content #ibexa-tab-location-view-content'),
             new VisibleCSSLocator('tab', '#ibexa-tab-label-location-view-locations'),
             new VisibleCSSLocator('addLocationButton', '#ibexa-tab-location-view-locations .ez-table-header__tools .ibexa-btn--udw-add'),
         ];

--- a/src/lib/Behat/Page/DashboardPage.php
+++ b/src/lib/Behat/Page/DashboardPage.php
@@ -54,7 +54,9 @@ class DashboardPage extends Page
     public function verifyIsLoaded(): void
     {
         $this->getHTMLPage()->find($this->getLocator('pageTitle'))->assert()->textEquals('My dashboard');
-        $this->getHTMLPage()->find($this->getLocator('table'))->assert()->isVisible();
+        $this->getHTMLPage()->findAll($this->getLocator('tableTitle'))
+            ->getByCriterion(new ElementTextCriterion('My content'))
+            ->assert()->isVisible();
     }
 
     public function getName(): string

--- a/src/lib/Behat/Page/ObjectStateGroupPage.php
+++ b/src/lib/Behat/Page/ObjectStateGroupPage.php
@@ -15,7 +15,7 @@ use Ibexa\Behat\Browser\Page\Page;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\Dialog;
 use Ibexa\AdminUi\Behat\Component\Table\TableBuilder;
-use PHPUnit\Framework\Assert;
+use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 
 class ObjectStateGroupPage extends Page
 {
@@ -107,10 +107,11 @@ class ObjectStateGroupPage extends Page
 
     public function verifyIsLoaded(): void
     {
-        Assert::assertEquals(
-            sprintf('Object state group: %s', $this->expectedObjectStateGroupName),
-            $this->getHTMLPage()->find($this->getLocator('pageTitle'))->getText()
-        );
+        $this->getHTMLPage()
+            ->setTimeout(3)
+            ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('objectStatesTable')))
+            ->find($this->getLocator('pageTitle'))
+            ->assert()->textEquals(sprintf('Object state group: %s', $this->expectedObjectStateGroupName));
     }
 
     public function getName(): string
@@ -122,8 +123,8 @@ class ObjectStateGroupPage extends Page
     {
         return [
             new VisibleCSSLocator('pageTitle', '.ez-page-title h1'),
-            new VisibleCSSLocator('propertiesTable', '.ez-container:nth-of-type(1)'),
-            new VisibleCSSLocator('objectStatesTable', '.ez-container:nth-of-type(2)'),
+            new VisibleCSSLocator('propertiesTable', '.ez-container > .ez-table'),
+            new VisibleCSSLocator('objectStatesTable', '[name="object_states_delete"]'),
             new VisibleCSSLocator('createButton', '.ibexa-icon--create'),
             new VisibleCSSLocator('deleteButton', '.ibexa-icon--trash'),
         ];

--- a/src/lib/Behat/Page/SectionPage.php
+++ b/src/lib/Behat/Page/SectionPage.php
@@ -15,7 +15,7 @@ use Ibexa\Behat\Browser\Page\Page;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\AdminUi\Behat\Component\Dialog;
 use Ibexa\AdminUi\Behat\Component\Table\TableBuilder;
-use PHPUnit\Framework\Assert;
+use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 
 class SectionPage extends Page
 {
@@ -125,10 +125,11 @@ class SectionPage extends Page
 
     public function verifyIsLoaded(): void
     {
-        Assert::assertEquals(
-            sprintf('Section: %s', $this->expectedSectionName),
-            $this->getHTMLPage()->find($this->getLocator('pageTitle'))->getText()
-        );
+        $this->getHTMLPage()
+            ->setTimeout(3)
+            ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('contentItemsTable')))
+            ->find($this->getLocator('pageTitle'))
+            ->assert()->textEquals(sprintf('Section: %s', $this->expectedSectionName));
     }
 
     public function getName(): string
@@ -140,9 +141,9 @@ class SectionPage extends Page
     {
         return [
             new VisibleCSSLocator('pageTitle', '.ez-page-title h1'),
-            new VisibleCSSLocator('contentItemsTable', '.ez-container:nth-of-type(2)'),
+            new VisibleCSSLocator('contentItemsTable', '.ez-container ~ .ez-container'),
             new VisibleCSSLocator('assignButton', '#section_content_assign_locations_select_content'),
-            new VisibleCSSLocator('sectionInfoTable', '.ez-container:nth-of-type(1)'),
+            new VisibleCSSLocator('sectionInfoTable', '.ez-container > .ez-table'),
             new VisibleCSSLocator('deleteButton', 'button[data-original-title="Delete Section"]'),
         ];
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-264
| Bug fix?      | yes (in tests)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Adapting the tests for the design changes in master.
For some reason the CSS selectors with `nth-of-type` can't be found, I've switched to others so that tests can pass.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
