### PR TITLE
IBX-759: Fixed wrong class taken to calculate toolbar's width

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/toolbars/config/base.js
@@ -41,7 +41,7 @@ export default class EzConfigBase {
             const scrollLeft = parseInt(block.$.scrollLeft, 10);
             const blockLeftMargin = block.$.offsetLeft;
             const blockWidth = block.$.offsetWidth;
-            const toolbarWidth = document.querySelector('.ae-toolbar-floating').offsetWidth;
+            const toolbarWidth = document.querySelector('.ae-toolbar-styles').offsetWidth;
             const maxLeft = blockWidth - toolbarWidth;
 
             range.selectNodeContents(positionReference.$);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-759](https://issues.ibexa.co/browse/IBX-759)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Followup for https://github.com/ezsystems/ezplatform-richtext/pull/196 targetting eZ Platform 2.5.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
