### PR TITLE
[Behat] Use standard mode for setup phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,20 +41,20 @@ matrix:
       name: "Admin UI tests using different personas"
       env:
         - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-        - SETUP_BEHAT_OPTS="--profile=setup --suite=personas -c=behat_ibexa_oss.yaml"
+        - SETUP_BEHAT_OPTS="--profile=setup --suite=personas -c=behat_ibexa_oss.yaml --mode=standard"
         - BEHAT_OPTS="--profile=browser --suite=personas -c=behat_ibexa_oss.yaml"
     # Nightly or triggered jobs
     - if: type in (cron) OR commit_message =~ /(Run regression)/
       name: "[PHP 7.4/PostgreSQL/Varnish/Redis/Multirepository] Ibexa OSS regression suite"
       env:
         - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
-        - SETUP_BEHAT_OPTS="--profile=regression --suite=setup-oss -c=behat_ibexa_oss.yaml"
+        - SETUP_BEHAT_OPTS="--profile=regression --suite=setup-oss -c=behat_ibexa_oss.yaml --mode=standard"
         - BEHAT_OPTS="--profile=regression --suite=oss --tags=~@broken -c=behat_ibexa_oss.yaml"
         - MULTIREPOSITORY=1
       name: "[PHP 7.3/Multirepository] Ibexa OSS regression suite"
       env: 
         - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-        - SETUP_BEHAT_OPTS="--profile=regression --suite=setup-oss -c=behat_ibexa_oss.yaml"
+        - SETUP_BEHAT_OPTS="--profile=regression --suite=setup-oss -c=behat_ibexa_oss.yaml --mode=standard"
         - BEHAT_OPTS="--profile=regression --suite=oss -c=behat_ibexa_oss.yaml"
         - MULTIREPOSITORY=1    
 


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-264

Example failure:
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/jobs/524369717
```
 3 test classes into the queue.
- Will be consumed by 2 parallel Processes.
1/3	✘	2 s 323 ms	/var/www/vendor/ezsystems/behatbundle/features/personas/subtree_editor.feature
2/3	✔	3 s 381 ms	/var/www/vendor/ezsystems/behatbundle/features/personas/add_location.feature
3/3	✔	1 s 341 ms	/var/www/vendor/ezsystems/behatbundle/features/personas/change_password.feature
[2] /var/www/vendor/ezsystems/behatbundle/features/personas/subtree_editor.featureFeature: Editor that has access only to a Subtree of Content Structure
  @admin @setup @subtreeEditor
  Scenario: Create a Role and assign policies with limitations to it                                          # vendor/ezsystems/behatbundle/features/personas/subtree_editor.feature:4
    Given I create a "DedicatedFolder" Content Type in "Content" with "dedicatedFolder" identifier            # EzSystems\Behat\API\Context\ContentTypeContext::iCreateAContentTypeWithIdentifier()
      | Field Type | Name       | Identifier | Required | Searchable | Translatable |
      | Text line  | Name       | name       | yes      | yes        | yes          |
      | Text line  | Short name | short_name | yes      | no         | yes          |
    And I create "dedicatedFolder" Content items in root in "eng-GB"                                          # EzSystems\Behat\API\Context\ContentContext::createContentItems()
      | name              | short_name        |
      | FolderGrandParent | FolderGrandParent |
    And I create "dedicatedFolder" Content items in "FolderGrandParent" in "eng-GB"                           # EzSystems\Behat\API\Context\ContentContext::createContentItems()
      | name         | short_name   |
      | FolderParent | FolderParent |
    And I create "dedicatedFolder" Content items in "FolderGrandParent/FolderParent" in "eng-GB"              # EzSystems\Behat\API\Context\ContentContext::createContentItems()
      | name         | short_name   |
      | FolderChild1 | FolderChild1 |
      | FolderChild2 | FolderChild2 |
    And I create "dedicatedFolder" Content items in "FolderGrandParent/FolderParent/FolderChild1" in "eng-GB" # EzSystems\Behat\API\Context\ContentContext::createContentItems()
      | name          | short_name    |
      | ContentToMove | ContentToMove |
    And I create a user group "SubtreeEditorsGroup"                                                           # EzSystems\Behat\API\Context\UserContext::createUseGroup()
    And I create a user "SubtreeEditor" with last name "Subtree Editor" in group "SubtreeEditorsGroup"        # EzSystems\Behat\API\Context\UserContext::createUserInGroup()
    And I create a role "BasicRole" with policies                                                             # EzSystems\Behat\API\Context\RoleContext::createRoleWithPolicies()
      | module | function |
      | user   | login    |
      | site   | view     |
    And I create a user "ThisUserIsAReviewer" with last name "Test" in group "SubtreeEditorsGroup"            # EzSystems\Behat\API\Context\UserContext::createUserInGroup()
    And I add policy "content" "read" to "BasicRole" with limitations                                         # EzSystems\Behat\API\Context\RoleContext::addPolicyToRoleWithLimitation()
      | limitationType | limitationValue                                    |
      | Location       | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test |
    And I create a role "SubtreeEditorsRole" with policies                                                    # EzSystems\Behat\API\Context\RoleContext::createRoleWithPolicies()
      | module  | function           |
      | content | read               |
      | content | create             |
      | content | publish            |
      | content | remove             |
      | content | edit               |
      | section | view               |
      | content | versionread        |
      | content | reverserelatedlist |
      eZ\Publish\Core\Base\Exceptions\DatabaseException: Database error in vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Base/Exceptions/DatabaseException.php:26
      Stack trace:
      #0 vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php(167): eZ\Publish\Core\Base\Exceptions\DatabaseException::wrap()
      #1 vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Persistence/Legacy/User/Handler.php(465): eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\ExceptionConversion->publishRoleDraft()
      #2 var/cache/behat/ContainerVnbQ9Qh/Handler_65f7bf7.php(170): eZ\Publish\Core\Persistence\Legacy\User\Handler->publishRoleDraft()
      #3 vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Persistence/Cache/UserHandler.php(469): ContainerVnbQ9Qh\Handler_65f7bf7->publishRoleDraft()
      #4 vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Repository/RoleService.php(580): eZ\Publish\Core\Persistence\Cache\UserHandler->publishRoleDraft()
      #5 var/cache/behat/ContainerVnbQ9Qh/RoleService_e7c21a9.php(100): eZ\Publish\Core\Repository\RoleService->publishRoleDraft()
      #6 vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Event/RoleService.php(277): ContainerVnbQ9Qh\RoleService_e7c21a9->publishRoleDraft()
      #7 vendor/ezsystems/behatbundle/src/lib/API/Facade/RoleFacade.php(50): eZ\Publish\Core\Event\RoleService->publishRoleDraft()
      #8 vendor/ezsystems/behatbundle/src/lib/API/Context/RoleContext.php(54): EzSystems\Behat\API\Facade\RoleFacade->addPolicyToRole()
```
Looks like running the setups steps in parallel is not a good idea, because they can conflict with each other.

Changing the mode to `standard` disables parallelism and run them sequencially.