### PR TITLE
[Behat] Fixed tab switching in Content View

### DIFF
--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -277,7 +277,7 @@ class ContentViewPage extends Page
             new VisibleCSSLocator('pageTitle', '.ez-page-title h1'),
             new VisibleCSSLocator('contentType', '.ez-page-title h4'),
             new VisibleCSSLocator('mainContainer', '.ibexa-tab-content #ibexa-tab-location-view-content'),
-            new VisibleCSSLocator('tab', '#ibexa-tab-label-location-view-locations'),
+            new VisibleCSSLocator('tab', '.ez-content-container .ibexa-tabs .ibexa-tabs__link'),
             new VisibleCSSLocator('addLocationButton', '#ibexa-tab-location-view-locations .ez-table-header__tools .ibexa-btn--udw-add'),
         ];
     }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-264

Failure:
https://travis-ci.com/github/ezsystems/ezplatform-page-fieldtype/jobs/524392449
```
    And I switch to "Submissions" tab in Content structure # Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext::switchTab()

      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'Submissions'. Found names: Locations instead. css locator 'tab': '#ibexa-tab-label-location-view-locations' in vendor/ezsystems/behatbundle/src/lib/Browser/Element/ElementCollection.php:53
```
The current CSS selector found only one tab, "Locations":
<img width="1680" alt="Zrzut ekranu 2021-07-14 o 15 43 24" src="https://user-images.githubusercontent.com/10993858/125632479-a46e302d-ecfb-41be-ad8e-e0901c44333c.png">

I've switched it to another one which finds all the tabs:
<img width="1680" alt="Zrzut ekranu 2021-07-14 o 15 44 04" src="https://user-images.githubusercontent.com/10993858/125632584-8ee9968e-f5c4-48dd-a6ef-3333b87f7660.png">
