### PR TITLE
IBX-264: [Behat] Fixed entering values in AdminUI forms

### DIFF
--- a/src/lib/Behat/Page/AdminUpdateItemPage.php
+++ b/src/lib/Behat/Page/AdminUpdateItemPage.php
@@ -46,7 +46,14 @@ class AdminUpdateItemPage extends Page
 
     public function fillFieldWithValue(string $fieldName, $value): void
     {
-        $this->getField($fieldName)->setValue($value);
+        $field = $this->getField($fieldName);
+        $fieldType = $field->getAttribute('type');
+
+        $this->getHTMLPage()->setTimeout(3)->waitUntil(function () use ($field, $fieldType, $value) {
+            $field->setValue($value);
+
+            return $fieldType !== 'text' || $value === $field->getValue();
+        }, sprintf('Failed to set correct value in input field. Expected: %s. Actual: %s', $value, $field->getValue()));
     }
 
     public function clickButton(string $label): void


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-264

Example failure:
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/232829581

Screen:
https://res.cloudinary.com/ezplatformtravis/image/upload/v1626346210/screenshots/60f012e285380609399926-vendor_ezsystems_ezplatform-admin-ui_features_standard_objectstates_feature_23_k4gmwo.png

The value is not always correctly entered into input fields in AdminUI part.

The solution was already present in the previous code:
https://github.com/ezsystems/ezplatform-admin-ui/blob/1.5/src/lib/Behat/PageElement/Fields/DefaultFieldElement.php#L36-L40

I must've removed it during refactoring, trusting that `setValue` is really doing it's job 😄 
