### PR TITLE
[Behat] Adjusted tab CSS selector on the Dashboard

### DIFF
--- a/src/lib/Behat/Page/DashboardPage.php
+++ b/src/lib/Behat/Page/DashboardPage.php
@@ -74,7 +74,7 @@ class DashboardPage extends Page
         return [
             new VisibleCSSLocator('tableSelector', '.ez-card'),
             new VisibleCSSLocator('tableTitle', '.ez-card__title'),
-            new VisibleCSSLocator('tableTab', '.ez-tabs .nav-item'),
+            new VisibleCSSLocator('tableTab', '.ibexa-tabs .nav-item'),
             new VisibleCSSLocator('pageTitle', '.ez-header h1'),
             new VisibleCSSLocator('table', '#ibexa-tab-dashboard-my-my-drafts'),
         ];


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-264

Required by: https://github.com/ezsystems/ezplatform-workflow/pull/197

Adjusting Dashboard tab locator:
on v3 it can be used to select Dashboard tabs:
<img width="1680" alt="Zrzut ekranu 2021-07-15 o 14 02 18" src="https://user-images.githubusercontent.com/10993858/125784840-586b5cc2-b721-481f-b0e6-e6fffbb15ee8.png">

But on v4 it has to be changed:
<img width="1680" alt="Zrzut ekranu 2021-07-15 o 14 02 58" src="https://user-images.githubusercontent.com/10993858/125784909-fd70c4ae-89ec-4371-a267-f9057111a53c.png">

