### PR TITLE
IBX-264: [Behat] Make sure date picker is loaded before interacting with it.

### DIFF
--- a/src/lib/Behat/Component/Fields/Date.php
+++ b/src/lib/Behat/Component/Fields/Date.php
@@ -34,6 +34,8 @@ class Date extends FieldTypeComponent
             ->build();
 
         $this->getHTMLPage()->find($fieldSelector)->click();
+
+        $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setDate(date_create($parameters['value']), self::DATE_FORMAT);
     }
 

--- a/src/lib/Behat/Component/Fields/DateAndTime.php
+++ b/src/lib/Behat/Component/Fields/DateAndTime.php
@@ -39,6 +39,7 @@ class DateAndTime extends FieldTypeComponent
 
         $time = explode(':', $parameters['time']);
 
+        $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setDate(date_create($parameters['date']));
         $this->dateAndTimePopup->setTime((int)$time[0], (int)$time[1]);
 

--- a/src/lib/Behat/Component/Fields/Time.php
+++ b/src/lib/Behat/Component/Fields/Time.php
@@ -37,6 +37,7 @@ class Time extends FieldTypeComponent
 
         $time = explode(':', $parameters['value']);
 
+        $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setTime((int)$time[0], (int)$time[1]);
 
         // This click is closing the date and time picker, to finally ensure that value is set up.


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-264

Example failure:
https://travis-ci.com/github/ezsystems/ezplatform-workflow/builds/232892471

```
     | ezdate               | Date                         |                                                                       | value     | 11/23/2019                                                                |            |                       |         |             | Saturday 23 November 2019 |
        Ibexa\Behat\Browser\Exception\TimeoutException: css selector 'dateSet': '.date-set' not found in 1 seconds. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php:65
        Stack trace:
        #0 vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php(86): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
        #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/DateAndTimePopup.php(63): Ibexa\Behat\Browser\Element\BaseElement->find()
        #2 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/Date.php(37): Ibexa\AdminUi\Behat\Component\DateAndTimePopup->setDate()
        #3 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Page/ContentUpdateItemPage.php(67): Ibexa\AdminUi\Behat\Component\Fields\Date->setValue()
        #4 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/BrowserContext/ContentUpdateContext.php(40): Ibexa\AdminUi\Behat\Page\ContentUpdateItemPage->fillFieldWithValue()
```

![obraz](https://user-images.githubusercontent.com/10993858/125912965-8551c886-5ed5-4789-9f24-8ae6f654450d.png)

At this point in tests the value should be already set in the Date picker, but as you can see in the screenshot it's not.

I believe this is caused by interacting with the picker too fast, hopefully making sure that it's visible before performing further actions will do the trick.