### PR TITLE
Temporary fix content position by added right margin, needed for tests

### DIFF
--- a/src/bundle/Resources/public/scss/_general.scss
+++ b/src/bundle/Resources/public/scss/_general.scss
@@ -214,3 +214,7 @@ select {
         padding: 0;
     }
 }
+
+.ez-content-view .ez-content-container {
+    margin-right: calculateRem(80px); // TODO: Please delete after redsign context menu on content view
+}


### PR DESCRIPTION
Example failure: https://travis-ci.com/github/ezsystems/ezplatform-form-builder/jobs/524856789

```
   Examples:
      | label             | value        | expectedSubmissionCount |
      | Single line input | test value 1 | 1                       |
        Exception: element click intercepted: Element <a href="#" data-toggle="modal" data-target="#submission-details-modal" data-submission-values="
                <tr class='ez-table__row'>
                <td class='ez-table__cell'>
                    Single line input
                </td>
                <td class='ez-table__cell'>
                    test value 1
                </td>
            </tr>
            " class="btn ibexa-btn ibexa-btn--ghost ibexa-btn--no-text ibexa-btn--content-submission-view mx-3" title="" data-original-title="View submission">...</a> is not clickable at point (1340, 425). Other element would receive the click: <button class="ibexa-btn--udw-copy-subtree btn ibexa-btn ibexa-btn--primary" data-udw-config="{&quot;multiple&quot;:false,&quot;multipleItemsLimit&quot;:0,&quot;rootLocationId&quot;:1,&quot;startingLocationId&quot;:1,&quot;containersOnly&quot;:true,&quot;allowedContentTypes&quot;:null,&quot;activeSortClause&quot;:&quot;DatePublished&quot;,&quot;activeSortOrder&quot;:&quot;ascending&quot;,&quot;activeTab&quot;:&quot;browse&quot;,&quot;activeView&quot;:&quot;finder&quot;,&quot;allowRedirects&quot;:false,&quot;allowConfirmation&quot;:true,&quot;contentOnTheFly&quot;:{&quot;allowedLanguages&quot;:null,&quot;allowedLocations&quot;:null,&quot;preselectedLanguage&quot;:null,&quot;preselectedContentType&quot;:null,&quot;hidden&quot;:false,&quot;autoConfirmAfterPublish&quot;:true},&quot;tabsConfig&quot;:{&quot;search&quot;:{&quot;itemsPerPage&quot;:50,&quot;priority&quot;:10,&quot;hidden&quot;:false},&quot;bookmarks&quot;:{&quot;itemsPerPage&quot;:50,&quot;priority&quot;:20,&quot;hidden&quot;:false},&quot;browse&quot;:{&quot;itemsPerPage&quot;:50,&quot;priority&quot;:30}}}" data-root-location="1" id="content__sidebar_right__copy_subtree-tab">...</button>
```

Right context menu with actions is covering the buttons related to form submissions (delete, preview).
https://recordit.co/JeGvKcvkZa

After this change it's displayed properly:
![obraz](https://user-images.githubusercontent.com/10993858/125927839-0e517a7a-b9ea-4813-a02e-d6abb191fe5a.png)

The menu will be further redesigned, so this PR is created as a temporary fix to keep tests passing. This change has been made with @lucasOsti's blessing 😄 (by him, actually).