### PR TITLE
[Behat] Changed flatpickr locator to a more specific one

### DIFF
--- a/src/lib/Behat/Component/DateAndTimePopup.php
+++ b/src/lib/Behat/Component/DateAndTimePopup.php
@@ -19,7 +19,7 @@ class DateAndTimePopup extends Component
 
     private const SETTING_SCRIPT_FORMAT = "document.querySelector('%s %s')._flatpickr.setDate('%s', true, '%s')";
 
-    private const ADD_CALLBACK_TO_DATEPICKER_SCRIPT_FORMAT = 'var fi = document.querySelector(\'%s .flatpickr-input\');
+    private const ADD_CALLBACK_TO_DATEPICKER_SCRIPT_FORMAT = 'var fi = document.querySelector(\'%s .flatpickr-input.active\');
                 const onChangeOld = fi._flatpickr.config.onChange;
                 const onChangeNew = (dates, dateString, flatpickInstance) => {
                 flatpickInstance.input.classList.add("date-set");
@@ -107,7 +107,7 @@ class DateAndTimePopup extends Component
         return [
             new VisibleCSSLocator('calendarSelectorInline', '.flatpickr-calendar.inline'),
             new VisibleCSSLocator('calendarSelector', '.flatpickr-calendar'),
-            new VisibleCSSLocator('flatpickrSelector', '.flatpickr-input'),
+            new VisibleCSSLocator('flatpickrSelector', '.flatpickr-input.active'),
             new VisibleCSSLocator('dateSet', '.date-set'),
             new VisibleCSSLocator('timeOnly', '.flatpickr-calendar.noCalendar'),
         ];


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://issues.ibexa.co/browse/IBX-264
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Example failure:
https://app.travis-ci.com/ezsystems/ezplatform-page-builder/builds/233099716?utm_source=slack&utm_medium=notification

```
      | ezdate               | Date                         |                                                                       | value     | 11/23/2019                                                                |            |                       |         |             | Saturday 23 November 2019 |
        Ibexa\Behat\Browser\Exception\TimeoutException: css selector 'flatpickrSelector': '.flatpickr-input' not found in 1 seconds. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php:65
        Stack trace:
        #0 vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php(86): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
        #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/DateAndTimePopup.php(102): Ibexa\Behat\Browser\Element\BaseElement->find()
        #2 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/Date.php(38): Ibexa\AdminUi\Behat\Component\DateAndTimePopup->verifyIsLoaded()
        #3 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Page/ContentUpdateItemPage.php(67): Ibexa\AdminUi\Behat\Component\Fields\Date->setValue()
        #4 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/BrowserContext/ContentUpdateContext.php(40): Ibexa\AdminUi\Behat\Page\ContentUpdateItemPage->fillFieldWithValue()
```

Tests on master are failing because of the redesign - the input selector for Flatpicker is not specific enough and when there are more than two calendars on the same page (for example: ezdatetime field and "Publish later") the inactive one is used - this has changed with the redesign, as the "hidden" calendar is found first there, but the fix is valid for this branch as well.

Short movies showing the behaviour on v3.3 and v4:
https://recordit.co/WyVGY1IkHK
https://recordit.co/9N0iPuSw5b

And proof that the tests are passing with this change (tested on Ibexa Experience):

<img width="1124" alt="Zrzut ekranu 2021-07-20 o 13 12 29" src="https://user-images.githubusercontent.com/10993858/126314637-6bbe10ca-c83d-47e9-8cbc-420c8a7e1b5a.png">

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
