### PR TITLE
[Behat] Fixed inline date picker interactions

### DIFF
--- a/src/lib/Behat/Component/DateAndTimePopup.php
+++ b/src/lib/Behat/Component/DateAndTimePopup.php
@@ -19,7 +19,9 @@ class DateAndTimePopup extends Component
 
     private const SETTING_SCRIPT_FORMAT = "document.querySelector('%s %s')._flatpickr.setDate('%s', true, '%s')";
 
-    private const ADD_CALLBACK_TO_DATEPICKER_SCRIPT_FORMAT = 'var fi = document.querySelector(\'%s .flatpickr-input.active\');
+    private const CALENDAR_CONTAINER_CLASSES_SCRIPT = "document.querySelector('%s %s')._flatpickr.calendarContainer.attributes.class.textContent";
+
+    private const ADD_CALLBACK_TO_DATEPICKER_SCRIPT_FORMAT = 'var fi = document.querySelector(\'%s .flatpickr-input\');
                 const onChangeOld = fi._flatpickr.config.onChange;
                 const onChangeNew = (dates, dateString, flatpickInstance) => {
                 flatpickInstance.input.classList.add("date-set");
@@ -67,7 +69,13 @@ class DateAndTimePopup extends Component
 
     public function setTime(int $hour, int $minute): void
     {
-        $isTimeOnly = $this->getHTMLPage()->find($this->parentLocator)->findAll($this->getLocator('timeOnly'))->any();
+        $calendarContainerClassesScript = sprintf(
+            self::CALENDAR_CONTAINER_CLASSES_SCRIPT,
+            $this->parentLocator->getSelector(),
+            $this->getLocator('flatpickrSelector')->getSelector()
+        );
+
+        $isTimeOnly = strpos($this->getSession()->evaluateScript($calendarContainerClassesScript), 'noCalendar') !== false;
 
         if (!$isTimeOnly) {
             // get current date as it's not possible to set time without setting date
@@ -105,11 +113,9 @@ class DateAndTimePopup extends Component
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('calendarSelectorInline', '.flatpickr-calendar.inline'),
             new VisibleCSSLocator('calendarSelector', '.flatpickr-calendar'),
-            new VisibleCSSLocator('flatpickrSelector', '.flatpickr-input.active'),
+            new VisibleCSSLocator('flatpickrSelector', '.flatpickr-input'),
             new VisibleCSSLocator('dateSet', '.date-set'),
-            new VisibleCSSLocator('timeOnly', '.flatpickr-calendar.noCalendar'),
         ];
     }
 }

--- a/src/lib/Behat/Component/Fields/Date.php
+++ b/src/lib/Behat/Component/Fields/Date.php
@@ -35,6 +35,7 @@ class Date extends FieldTypeComponent
 
         $this->getHTMLPage()->find($fieldSelector)->click();
 
+        $this->dateAndTimePopup->setParentLocator($this->parentLocator);
         $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setDate(date_create($parameters['value']), self::DATE_FORMAT);
     }

--- a/src/lib/Behat/Component/Fields/DateAndTime.php
+++ b/src/lib/Behat/Component/Fields/DateAndTime.php
@@ -39,6 +39,7 @@ class DateAndTime extends FieldTypeComponent
 
         $time = explode(':', $parameters['time']);
 
+        $this->dateAndTimePopup->setParentLocator($this->parentLocator);
         $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setDate(date_create($parameters['date']));
         $this->dateAndTimePopup->setTime((int)$time[0], (int)$time[1]);

--- a/src/lib/Behat/Component/Fields/Time.php
+++ b/src/lib/Behat/Component/Fields/Time.php
@@ -37,6 +37,7 @@ class Time extends FieldTypeComponent
 
         $time = explode(':', $parameters['value']);
 
+        $this->dateAndTimePopup->setParentLocator($this->parentLocator);
         $this->dateAndTimePopup->verifyIsLoaded();
         $this->dateAndTimePopup->setTime((int)$time[0], (int)$time[1]);
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-264
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes 🎉 
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Reverting the change from https://github.com/ezsystems/ezplatform-admin-ui/pull/1820, as the `active` class is not present when the datepicker is inlined, for example when using Publish Later:
![obraz](https://user-images.githubusercontent.com/10993858/126465405-bb35bd75-09d1-4202-940a-fbb3b80f0033.png)

This time the solution is different:
1) We set the parent locator so that the tests interact with the correct date picker input
2) We use JS to get the CSS classes that are related to our input field and based on that we detect if it's a time only calendar (we can't use the current solution because the calendar is not a child element of our parent element - it's attached to the root of the HTML page).
3) Removed unused selectors

Build with all tests passing on v3.3:
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/525863902
(PR: https://github.com/ezsystems/ezplatform-page-builder/pull/795)

Build with all tests passing on v4.0:
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/525864322
(PRs: [AdminUI merge-up](https://github.com/ezsystems/ezplatform-admin-ui/pull/1823/files)), [Page Builder](https://github.com/ezsystems/ezplatform-page-builder/pull/796) )


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
