### PR TITLE
IBX-93: [Behat] Fixed calculating Richtext button positions

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\AdminUi\Behat\Component\Fields;
 
+use Behat\Mink\Session;
+use EzSystems\EzPlatformRichText\Configuration\Provider\CustomStyle;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
@@ -26,6 +28,15 @@ class RichText extends FieldTypeComponent
         'Heading 5' => 'h5',
         'Heading 6' => 'h6',
     ];
+
+    /** @var \EzSystems\EzPlatformRichText\Configuration\Provider\CustomStyle */
+    private $customStyleProvider;
+
+    public function __construct(Session $session, CustomStyle $customStyleProvider)
+    {
+        parent::__construct($session);
+        $this->customStyleProvider = $customStyleProvider;
+    }
 
     private function getFieldInput(): ElementInterface
     {
@@ -124,22 +135,16 @@ class RichText extends FieldTypeComponent
 
     public function clickEmbedInlineButton(): void
     {
+        $buttonPosition = 22 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
-        $this->getHTMLPage()
-            ->find($this->getLocator('additionalToolbar'))
-            ->findAll($this->getLocator('toolbarElement'))
-            ->toArray()[16]
-            ->click();
+        $this->clickElementsToolbarButton($buttonPosition);
     }
 
     public function clickEmbedButton(): void
     {
+        $buttonPosition = 20 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
-        $this->getHTMLPage()
-            ->find($this->getLocator('additionalToolbar'))
-            ->findAll($this->getLocator('toolbarElement'))
-            ->toArray()[14]
-            ->click();
+        $this->clickElementsToolbarButton($buttonPosition);
     }
 
     public function equalsEmbedInlineItem($itemName): bool
@@ -180,6 +185,23 @@ class RichText extends FieldTypeComponent
             $this->getLocator('fieldInput')->getSelector(),
             $commandName
         );
+        $this->getSession()->executeScript($script);
+    }
+
+    private function getCustomStylesOffset(): int
+    {
+        return count($this->customStyleProvider->getConfiguration());
+    }
+
+    private function clickElementsToolbarButton(int $buttonPosition): void
+    {
+        $script = sprintf(
+            "document.querySelectorAll('%s %s')[%d].click()",
+            $this->getLocator('additionalToolbar')->getSelector(),
+            $this->getLocator('toolbarElement')->getSelector(),
+            $buttonPosition,
+        );
+
         $this->getSession()->executeScript($script);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-93
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Failing build:
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/233724638

You can see that this job fails:
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/527021180
but this job passes:
https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/527021181

Even though they both include the same test (TextBlock test in Blocks.feature).

The difference is in setups: the second job has none related to Richtext, but the first one adds a custom style from https://github.com/ezsystems/BehatBundle/tree/master/features/setup/richtextConfiguration.
Normal setup:
<img width="1680" alt="Zrzut ekranu 2021-07-27 o 11 18 51" src="https://user-images.githubusercontent.com/10993858/127129528-90aa1d93-912a-4e15-81ed-edbc11fa6663.png">
Extended setup:
<img width="1680" alt="Zrzut ekranu 2021-07-27 o 11 20 05" src="https://user-images.githubusercontent.com/10993858/127129713-5e1a4409-1b75-4bb2-8119-6e790cb88253.png">

Adding new buttons to the toolbar causes the tests to invoke the wrong button.

I've changed how the button position is calculated - now it's not a constant value but it's calculated based on the number of buttons. This is not a great solution, but I don't see any other way as of now (there are no classes we can rely on to select the right button).

I've also had to change the clicking action to a JS one. For some reason Selenium can't reliably find all the buttons in opened CKEditor toolbar and sometimes finds only some of them, examples:
![obraz](https://user-images.githubusercontent.com/10993858/127818547-b78a5da1-2aaf-48fb-bf8a-8e56ec785ecb.png)
![obraz](https://user-images.githubusercontent.com/10993858/127818603-dcc64416-d9f3-45d7-afee-c2ade992b1ae.png)

Proof that it works:
[Test PR](https://github.com/ezsystems/ezplatform-page-builder/pull/800)
[Build](https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/234147843)
All job types are passing.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
