### PR TITLE
IBX-375: Fixed setting 2nd menu level active

### DIFF
--- a/src/bundle/Resources/views/parts/menu/top_menu_2nd_level.html.twig
+++ b/src/bundle/Resources/views/parts/menu/top_menu_2nd_level.html.twig
@@ -6,7 +6,7 @@
     <div class="tab-content mx-4">
         {% for child in currentItem.children %}
             <div role="tabpanel"
-                 class="tab-pane fade{{ matcher.isAncestor(child, options.matchingDepth) ? ' show active' }}"
+                 class="tab-pane fade{{ matcher.isAncestor(child, options.matchingDepth) or matcher.isCurrent(child) ? ' show active' }}"
                  id="{{ child.name }}">
                 <div class="container-fluid">
                     <div class="collapse navbar-collapse">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-375
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When working on IBX-375 we noticed there is a problem with 2nd level menu. Even though you set `extras.routes` on first level element and it matches, the second level menu won't be displayed unless there is a match on a child. In some cases you still want to display 2nd level menu, for example Page Builder submenu when there is no siteaccess match.


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
