### PR TITLE
[Behat] Adjusted selectors to redesign

### DIFF
--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -47,7 +47,7 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
 
         if ($fieldDefinition->hasClass($this->getLocator('fieldCollapsed')->getSelector())) {
             // TODO: Convert to normal click once this page is redesigned
-            $this->getSession()->executeScript("document.querySelector('.ez-card--toggle-group:last-of-type .ez-card__body-display-toggler').click()");
+            $this->getSession()->executeScript("document.querySelector('.ibexa-card--toggle-group:last-of-type .ibexa-card__body-display-toggler').click()");
         }
     }
 


### PR DESCRIPTION
Follow up to https://github.com/ezsystems/ezplatform-admin-ui/pull/1825 and https://github.com/ezsystems/ezplatform-admin-ui/pull/1819 - the selectors were changed https://github.com/ezsystems/ezplatform-admin-ui/pull/1825 and need to be adjusted for the tests to pass.

Failing build:
https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/jobs/527374810
```
  And I set "Name" to "Country field" for "Country" field                      # Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext::iSetFieldDefinitionData()
      WebDriver\Exception\JavaScriptError: javascript error: Cannot read property 'click' of null
        (Session info: chrome=90.0.4430.85)
```