### PR TITLE
IBX-93: [Behat] Switched to JS script for invoking CKEditor toolbar

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -64,11 +64,10 @@ class RichText extends FieldTypeComponent
     {
         $this->focusFieldInput();
         $this->getHTMLPage()
-            ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('mainToolbar')))
-            ->findAll($this->getLocator('toolbarElement'))
-            ->last()
-            ->click();
-        $this->getHTMLPage()->find($this->getLocator('additionalToolbar'))->assert()->isVisible();
+            ->waitUntilCondition(new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('mainToolbar')));
+
+        $script = "document.querySelector('.ck-toolbar__grouped-dropdown > .ck-dropdown__button').click()";
+        $this->getSession()->executeScript($script);
     }
 
     public function changeStyle(string $style): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-93
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Similar as in https://github.com/ezsystems/ezplatform-admin-ui/pull/1829, using standard Selenium actions fails when interacting with CKEditor - it's not stable enough.

Example failure:
```
   And I set up block "Text" "Text" with default testing configuration                                                                # Ibexa\PageBuilder\Tests\Behat\Context\PageBuilderContext::addBlockWithDefaultTestingConfiguration()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Collection created with CSS locator 'toolbarElement': '.ck-button' is empty. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/ElementCollection.php:95
      Stack trace:
      #0 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/RichText.php(69): Ibexa\Behat\Browser\Element\ElementCollection->last()
      #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/RichText.php(146): Ibexa\AdminUi\Behat\Component\Fields\RichText->openElementsToolbar()
```

Even though the button is clearly visible on the screen:
![obraz](https://user-images.githubusercontent.com/10993858/128701344-1bdc6f6a-4dcb-4906-8f3a-41236a79e40a.png)

By switching to Java Script the tests should be more stable.

Proof that is passes on Travis:
https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/529983765

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
