### PR TITLE
IBX-792: Implemented group_by filter for Twig

### DIFF
--- a/src/bundle/Resources/config/services/twig.yaml
+++ b/src/bundle/Resources/config/services/twig.yaml
@@ -19,3 +19,7 @@ services:
             - '@EzSystems\EzPlatformAdminUi\Limitation\Templating\LimitationBlockRenderer'
         tags:
             - { name: twig.extension }
+
+    EzSystems\EzPlatformAdminUiBundle\Templating\Twig\GroupByExtension:
+        tags:
+            - { name: twig.extension }

--- a/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/edit.html.twig
@@ -75,51 +75,54 @@
             {% include '@ezdesign/content_type/modal/delete_confirmation.html.twig' with {'form': form} %}
 
             <div class="card-body ibexa-card__body ibexa-card__body--incresed-margin">
-                {% for field_definition in form.fieldDefinitionsData %}
-                    {% set value = field_definition.vars.value %}
+                {% for field_group, field_definitions in form.fieldDefinitionsData|group_by((field) => field.vars.data.fieldGroup) %}
+                    <h2>{{ field_group }}</h2>
+                    {% for field_definition in field_definitions %}
+                        {% set value = field_definition.vars.value %}
 
-                    <div class="card ibexa-card ibexa-card--toggle-group ibexa-card--collapsed">
-                        <div id="field-definition-{{ value.identifier }}" class="ibexa-card__header">
-                            {% set name = value.names[language_code] ?? value.names[content_type.mainLanguageCode]  %}
-                            <button class="ibexa-card__body-display-toggler btn">
-                                <svg class="ibexa-icon ibexa-icon--small ibexa-icon--caret-down" aria-hidden="true">
-                                    <use xlink:href="{{ ibexa_icon_path('caret-down') }}"></use>
-                                </svg>
-                                <svg class="ibexa-icon ibexa-icon--small ibexa-icon--caret-next" aria-hidden="true">
-                                    <use xlink:href="{{ ibexa_icon_path('caret-next') }}"></use>
-                                </svg>
-                            </button>
-                            {{ form_widget(field_definition.selected, {
-                                'label': '%s (%s)'|format(name, value.fieldTypeIdentifier),
-                                'attr': {'class': 'mr-1'}
-                            }) }}
+                        <div class="card ibexa-card ibexa-card--toggle-group ibexa-card--collapsed">
+                            <div id="field-definition-{{ value.identifier }}" class="ibexa-card__header">
+                                {% set name = value.names[language_code] ?? value.names[content_type.mainLanguageCode]  %}
+                                <button class="ibexa-card__body-display-toggler btn">
+                                    <svg class="ibexa-icon ibexa-icon--small ibexa-icon--caret-down" aria-hidden="true">
+                                        <use xlink:href="{{ ibexa_icon_path('caret-down') }}"></use>
+                                    </svg>
+                                    <svg class="ibexa-icon ibexa-icon--small ibexa-icon--caret-next" aria-hidden="true">
+                                        <use xlink:href="{{ ibexa_icon_path('caret-next') }}"></use>
+                                    </svg>
+                                </button>
+                                {{ form_widget(field_definition.selected, {
+                                    'label': '%s (%s)'|format(name, value.fieldTypeIdentifier),
+                                    'attr': {'class': 'mr-1'}
+                                }) }}
+                            </div>
+
+                            <div class="ibexa-card__body">
+                                {{ form_row(field_definition.name) }}
+                                {{ form_row(field_definition.identifier) }}
+                                {{ form_row(field_definition.position) }}
+                                {{ form_row(field_definition.description) }}
+                                {{ form_row(field_definition.isRequired) }}
+                                {{ form_row(field_definition.isSearchable) }}
+                                {{ form_row(field_definition.isTranslatable) }}
+                                {{ form_row(field_definition.isThumbnail) }}
+                                {{ form_row(field_definition.fieldGroup) }}
+
+                                {# Field type specific fields below #}
+                                {{ ez_render_field_definition_edit(value, {
+                                    'languageCode': language_code,
+                                    'form': field_definition,
+                                    'group_class': value.group_class|default(''),
+                                    'is_translation': is_translation,
+                                }) }}
+
+                                {# Default rendering #}
+                                {% for child in field_definition|filter(child => child.isRendered() == false) %}
+                                    {{ form_row(child) }}
+                                {% endfor %}
+                            </div>
                         </div>
-
-                        <div class="ibexa-card__body">
-                            {{ form_row(field_definition.name) }}
-                            {{ form_row(field_definition.identifier) }}
-                            {{ form_row(field_definition.position) }}
-                            {{ form_row(field_definition.description) }}
-                            {{ form_row(field_definition.isRequired) }}
-                            {{ form_row(field_definition.isSearchable) }}
-                            {{ form_row(field_definition.isTranslatable) }}
-                            {{ form_row(field_definition.isThumbnail) }}
-                            {{ form_row(field_definition.fieldGroup) }}
-
-                            {# Field type specific fields below #}
-                            {{ ez_render_field_definition_edit(value, {
-                                'languageCode': language_code,
-                                'form': field_definition,
-                                'group_class': value.group_class|default(''),
-                                'is_translation': is_translation,
-                            }) }}
-
-                            {# Default rendering #}
-                            {% for child in field_definition|filter(child => child.isRendered() == false) %}
-                                {{ form_row(child) }}
-                            {% endfor %}
-                        </div>
-                    </div>
+                    {% endfor %}
                 {% endfor %}
             </div>
         </div>

--- a/src/bundle/Templating/Twig/GroupByExtension.php
+++ b/src/bundle/Templating/Twig/GroupByExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig;
+
+use EzSystems\EzPlatformAdminUiBundle\Templating\Twig\Values\Group;
+use LogicException;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class GroupByExtension extends AbstractExtension
+{
+    /**
+     * @return \Twig\TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('group_by', [$this, 'groupBy']),
+        ];
+    }
+
+    public function groupBy(iterable $values, callable $arrow): iterable
+    {
+        /** @var array<string|int,Group> $groups */
+        $groups = [];
+
+        foreach ($values as $value) {
+            $key = $arrow($value);
+
+            $hash = $this->getHashFromKey($key);
+            if (!isset($groups[$hash])) {
+                $groups[$hash] = new Group($key);
+            }
+
+            $groups[$hash]->entries[] = $value;
+        }
+
+        foreach ($groups as $group) {
+            yield $group->key => $group->entries;
+        }
+    }
+
+    /**
+     * @return int|string
+     */
+    private function getHashFromKey($value)
+    {
+        if (is_object($value)) {
+            return spl_object_hash($value);
+        }
+
+        if (is_string($value) || is_int($value)) {
+            return $value;
+        }
+
+        throw new LogicException('Invalid key type');
+    }
+}

--- a/src/bundle/Templating/Twig/Values/Group.php
+++ b/src/bundle/Templating/Twig/Values/Group.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformAdminUiBundle\Templating\Twig\Values;
+
+/**
+ * @internal
+ *
+ * @see \EzSystems\EzPlatformAdminUiBundle\Templating\Twig\GroupByExtension
+ */
+final class Group
+{
+    /** @var string|int|object */
+    public $key;
+
+    /** @var array<mixed> */
+    public $entries;
+
+    /**
+     * @param string|int|object
+     */
+    public function __construct($key)
+    {
+        $this->key = $key;
+        $this->entries = [];
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-792
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Implemented `group_by` filter for Twig. Usage is similar to https://twig.symfony.com/doc/3.x/filters/filter.htmll function:

```twig
{% set groups = data|group_by((item) => item.group) %}

{% for key, group in groups %}
    {# "key" is a group key #}
    <h1>{{ key }}</h1>
    
    <ul>
    {% for item in group %}
        <li>{{ item.name }}</li>
    {% endfor %}
    </ul>
{% endfor %}
```

### Limitations

Group key needs to be an integer, string or object.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [ ] Implement tests
- [ ] Ready for Code Review
