### PR TITLE
IBX-862: Fixed translation action originating from non-main Location

### DIFF
--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -86,6 +86,7 @@ class TranslationController extends Controller
 
                 return new RedirectResponse($this->generateUrl('ezplatform.content.translate', [
                     'contentId' => $contentInfo->id,
+                    'locationId' => $location->id,
                     'fromLanguageCode' => null !== $baseLanguage ? $baseLanguage->languageCode : null,
                     'toLanguageCode' => $language->languageCode,
                 ]));

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -84,7 +84,7 @@ class TranslationController extends Controller
                 $language = $data->getLanguage();
                 $baseLanguage = $data->getBaseLanguage();
 
-                return new RedirectResponse($this->generateUrl('ezplatform.content.translate', [
+                return new RedirectResponse($this->generateUrl('ezplatform.content.translate_with_location', [
                     'contentId' => $contentInfo->id,
                     'locationId' => $location->id,
                     'fromLanguageCode' => null !== $baseLanguage ? $baseLanguage->languageCode : null,

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -84,7 +84,7 @@ class TranslationController extends Controller
                 $language = $data->getLanguage();
                 $baseLanguage = $data->getBaseLanguage();
 
-                return new RedirectResponse($this->generateUrl('ezplatform.content.translate_with_location', [
+                return new RedirectResponse($this->generateUrl('ibexa.content.translate_with_location', [
                     'contentId' => $contentInfo->id,
                     'locationId' => $location->id,
                     'fromLanguageCode' => null !== $baseLanguage ? $baseLanguage->languageCode : null,

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -574,7 +574,7 @@ ibexa.content.translate_with_location:
     path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
     defaults:
-        _controller: 'EzPlatformAdminUiBundle:ContentEdit:translate'
+        _controller: '\EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
         fromLanguageCode: ~
 
 ezplatform.content.check_edit_permission:

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -574,7 +574,7 @@ ibexa.content.translate_with_location:
     path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
     defaults:
-        _controller: '\EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
+        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
         fromLanguageCode: ~
 
 ezplatform.content.check_edit_permission:

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -564,7 +564,14 @@ ezplatform.content.preview:
         locationId: ~
 
 ezplatform.content.translate:
-    path: /content/{contentId}/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
+    path: /content/{contentId}/translate/{toLanguageCode}/{fromLanguageCode}
+    methods: ['GET', 'POST']
+    defaults:
+        _controller: 'EzPlatformAdminUiBundle:ContentEdit:translate'
+        fromLanguageCode: ~
+
+ezplatform.content.translate_with_location:
+    path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
     defaults:
         _controller: 'EzPlatformAdminUiBundle:ContentEdit:translate'

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -564,7 +564,7 @@ ezplatform.content.preview:
         locationId: ~
 
 ezplatform.content.translate:
-    path: /content/{contentId}/translate/{toLanguageCode}/{fromLanguageCode}
+    path: /content/{contentId}/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
     defaults:
         _controller: 'EzPlatformAdminUiBundle:ContentEdit:translate'

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -570,7 +570,7 @@ ezplatform.content.translate:
         _controller: 'EzPlatformAdminUiBundle:ContentEdit:translate'
         fromLanguageCode: ~
 
-ezplatform.content.translate_with_location:
+ibexa.content.translate_with_location:
     path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
     defaults:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-862](https://issues.ibexa.co/browse/IBX-862)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


The `locationId`  parameter has been added to translate action in order for redirect after the translation to work properly.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
