### PR TITLE
[Behat] Fixed test stability during role deletion

### DIFF
--- a/src/lib/Behat/Page/RolesPage.php
+++ b/src/lib/Behat/Page/RolesPage.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Page;
 
 use Behat\Mink\Session;
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use Ibexa\Behat\Browser\Page\Page;
 use Ibexa\Behat\Browser\Routing\Router;
@@ -62,6 +63,12 @@ class RolesPage extends Page
 
     public function deleteRole(string $roleName)
     {
+        $roleLabelLocator = $this->getLocator('roleLabel');
+        $listElement = $this->getHTMLPage()
+            ->findAll($roleLabelLocator)
+            ->getByCriterion(new ElementTextCriterion($roleName));
+        usleep(1000000); //TODO : refactor after redesign
+        $listElement->mouseOver();
         $this->table->getTableRow(['Name' => $roleName])->select();
         $this->getHTMLPage()->find($this->getLocator('deleteRoleButton'))->click();
         $this->dialog->verifyIsLoaded();
@@ -92,6 +99,7 @@ class RolesPage extends Page
             new VisibleCSSLocator('createButton', '.ibexa-icon--create'),
             new VisibleCSSLocator('pageTitle', '.ez-page-title h1'),
             new VisibleCSSLocator('deleteRoleButton', '#delete-roles'),
+            new VisibleCSSLocator('roleLabel', '.ibexa-table__cell--close-left > a'),
         ];
     }
 }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-835

This PR improves stability of Roles.feature tests; it seems that during role deletion behat is unable to select policy which is meant to be deleted. This policy, due to behat constraints (size of window in which tests are performed) is not visible on screen; to mitigate this problem mouseOver() function will be used. The idea is that by scrolling down it will be possible to see the desirable policy.

```
When I delete Role "Test Role edited"                               # Ibexa\AdminUi\Behat\BrowserContext\RolesContext::deleteRoleNamed()
      Exception: element click intercepted: Element is not clickable at point (344, 994)
```
![611ab4754238a211500405-vendor_ezsystems_ezplatform-admin-ui_features_standard_roles_feature_217_e2ewnq](https://user-images.githubusercontent.com/59650405/129704722-fe42a925-1791-4a34-8bec-462a4aec5b37.png)
