### PR TITLE
[Behat] Fixed test stability during deletion of content type

### DIFF
--- a/src/lib/Behat/Page/ContentTypeGroupPage.php
+++ b/src/lib/Behat/Page/ContentTypeGroupPage.php
@@ -10,6 +10,7 @@ namespace Ibexa\AdminUi\Behat\Page;
 
 use Behat\Mink\Session;
 use eZ\Publish\API\Repository\ContentTypeService;
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Routing\Router;
 use Ibexa\Behat\Browser\Page\Page;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
@@ -71,6 +72,12 @@ class ContentTypeGroupPage extends Page
 
     public function delete(string $contentTypeName)
     {
+        $contentTypeLabelLocator = $this->getLocator('contentTypeLabel');
+        $listElement = $this->getHTMLPage()
+            ->findAll($contentTypeLabelLocator)
+            ->getByCriterion(new ElementTextCriterion($contentTypeName));
+        usleep(1000000); //TODO : refactor after redesign
+        $listElement->mouseOver();
         $this->table->getTableRow(['Name' => $contentTypeName])->select();
         $this->getHTMLPage()->find($this->getLocator('deleteButton'))->click();
         $this->dialog->verifyIsLoaded();
@@ -125,6 +132,7 @@ class ContentTypeGroupPage extends Page
             new VisibleCSSLocator('tableContainer', '.ez-container'),
             new VisibleCSSLocator('deleteButton', '.ibexa-icon--trash,button[data-bs-original-title^="Delete"]'),
             new VisibleCSSLocator('tableItem', '.ez-main-container tbody tr'),
+            new VisibleCSSLocator('contentTypeLabel', '.ibexa-table__cell > a'),
         ];
     }
 }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-835

Similar PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1863

This PR improves tests stability during deletion of content type. MouseOver() function is used to scroll down so a certain element may be visible.

![pobrane](https://user-images.githubusercontent.com/59650405/129873929-5ff25286-cfbe-4e97-b08a-8109357f8fb6.png)
