### PR TITLE
Fixed wrong enclosing tag in location_view.html.twig

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/location_view.html.twig
@@ -103,7 +103,7 @@
                         </svg>
                     {% endif %}
                     {{ content_type_name }}
-                </h4>
+                </span>
             {% endif %}
         {% endblock %}
     {% endembed %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

It's probably merge conflict resolving issue.

https://github.com/ezsystems/ezplatform-admin-ui/blob/dcec45ad8cb9e7e875db3276d6ae47222a54858a/src/bundle/Resources/views/themes/admin/content/location_view.html.twig#L95-L106


#### Checklist:
- [X] Coding standards (`$ composer fix-cs`)
- [X] Ready for Code Review
