### PR TITLE
IBX-824: Fixed triggering closing link popup on formatted text

### DIFF
--- a/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/buttons/ez-btn-linkedit.js
@@ -473,6 +473,7 @@ export default class EzBtnLinkEdit extends Component {
             'data-ez-temporary-link': this.state.isTemporary ? true : null,
         };
         const modifySelection = { advance: true };
+        const caretToEndMovingElements = ['strong', 'u', 'em'];
 
         if (this.state.linkHref) {
             linkAttrs.href = this.state.linkHref;
@@ -482,8 +483,13 @@ export default class EzBtnLinkEdit extends Component {
                 editor.fire('actionPerformed', this);
 
                 const pathElement = editor.elementPath().lastElement;
+                const pathElementName = pathElement.getName();
 
-                if (pathElement.getName() === 'br') {
+                if (caretToEndMovingElements.includes(pathElementName)) {
+                    editor.eZ.moveCaretToElementEnd(editor, pathElement.getParent());
+                }
+
+                if (pathElementName === 'br') {
                     const parent = pathElement.getParent();
 
                     if (parent.getName() === 'td' || parent.getName() === 'th') {

--- a/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-caret.js
+++ b/src/bundle/Resources/public/js/alloyeditor/src/plugins/ez-caret.js
@@ -16,6 +16,18 @@
     }
 
     /**
+     * Moves caret to the end of the element.
+     *
+     * @method moveCaretToElementEnd
+     */
+    const moveCaretToElementEnd = (editor, element) => {
+        const range = editor.createRange();
+
+        range.moveToPosition(element, CKEDITOR.POSITION_AFTER_END);
+        editor.getSelection().selectRanges([range]);
+    }
+
+    /**
      * Finds caret element.
      *
      * @method findCaretElement
@@ -50,6 +62,15 @@
              * @param {CKEDITOR.dom.element} element
              */
             editor.eZ.moveCaretToElement = moveCaretToElement;
+
+            /**
+             * Moves the caret in the editor to the end of the given element
+             *
+             * @method eZ.moveCaretToElementEnd
+             * @param {CKEDITOR.editor} editor
+             * @param {CKEDITOR.dom.element} element
+             */
+            editor.eZ.moveCaretToElementEnd = moveCaretToElementEnd;
 
             /**
              * Finds the "caret element" for the given element. For some elements,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-824](https://issues.ibexa.co/browse/IBX-824)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

It seems that text formatted with bold, italic, or underline doesn't trigger popup closing after adding a link. I added proper condition ensuring that and implemented a method for moving the caret to the end of the text element. This aims to preserve the consistency with the behavior observed for the non-formatted text when the link is associated. Otherwise, the caret will be moved to the beginning of bold/italic/underline each time which might be inconvenient for the editors.

PR targetting v3 will be done once this solution gets approval.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
