### PR TITLE
IBX-431: Allowed interception of canceling the draft version edit

### DIFF
--- a/src/bundle/Controller/ContentEditController.php
+++ b/src/bundle/Controller/ContentEditController.php
@@ -98,9 +98,6 @@ class ContentEditController extends Controller
             )
         )->getResponse();
 
-        return $response ?? $this->redirectToRoute('_ez_content_view', [
-            'contentId' => $referrerlocation->contentId,
-            'locationId' => $referrerlocation->id,
-        ]);
+        return $response ?? $this->redirectToLocation($referrerlocation);
     }
 }

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -587,6 +587,11 @@ ezplatform.content.draft.edit:
     options:
         expose: true
 
+ezplatform.content.draft.edit.cancel:
+    path: /content/edit/draft/{contentId}/{versionNo}/{languageCode}/{referrerLocationId}/cancel
+    defaults:
+        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::cancelEditVersionDraftAction'
+
 ezplatform.content.draft.create:
     path: /content/create/draft/{contentId}/{fromVersionNo}/{fromLanguage}/{toLanguage}
     defaults:

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -587,7 +587,7 @@ ezplatform.content.draft.edit:
     options:
         expose: true
 
-ezplatform.content.draft.edit.cancel:
+ibexa.content.draft.edit.cancel:
     path: /content/edit/draft/{contentId}/{versionNo}/{languageCode}/{referrerLocationId}/cancel
     defaults:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::cancelEditVersionDraftAction'

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -16,7 +16,7 @@
         {% block close_button %}
             {% if without_close_button is not defined or without_close_button != true %}
                 {% set referrer_location = is_published ? location : parent_location %}
-                {% set cancel_path = path('ezplatform.content.draft.edit.cancel', {
+                {% set cancel_path = path('ibexa.content.draft.edit.cancel', {
                     'contentId': content.id,
                     'referrerLocationId': referrer_location.id,
                     'versionNo': content.versionInfo.versionNo,

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -7,11 +7,31 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include '@ezdesign/content/page_title_edit.html.twig' with { 
+    {% embed '@ezdesign/content/page_title_edit.html.twig' with {
         action_name: 'editing'|trans|desc('Editing'),
         title: content.name,
+        content: content,
         description: content_type.description
     } %}
+        {% block close_button %}
+            {% if without_close_button is not defined or without_close_button != true %}
+                {% set referrer_location = is_published ? location : parent_location %}
+                <a class="ez-content-edit-container__close"
+                   href="{{ path('ezplatform.content.draft.edit.cancel', {
+                       'contentId': content.id,
+                       'referrerLocationId': referrer_location.id,
+                       'versionNo': content.versionInfo.versionNo,
+                       'languageCode': language.languageCode
+                   }) }}"
+                   title="{{ 'tooltip.exit_label'|trans({}, 'content')|desc('Exit') }}"
+                >
+                    <svg class="ez-icon ez-icon--small ez-icon--primary">
+                        <use xlink:href="{{ ez_icon_path('discard') }}"></use>
+                    </svg>
+                </a>
+            {% endif %}
+        {% endblock %}
+    {% endembed %}
 
     <div class="ez-content-item__errors-wrapper" hidden>
         {{ 'errors.in.the.form'|trans({},'content_edit')|desc('Cannot save the form. Check required Fields or validation errors.') }}

--- a/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/edit/edit.html.twig
@@ -16,13 +16,14 @@
         {% block close_button %}
             {% if without_close_button is not defined or without_close_button != true %}
                 {% set referrer_location = is_published ? location : parent_location %}
+                {% set cancel_path = path('ezplatform.content.draft.edit.cancel', {
+                    'contentId': content.id,
+                    'referrerLocationId': referrer_location.id,
+                    'versionNo': content.versionInfo.versionNo,
+                    'languageCode': language.languageCode
+                }) %}
                 <a class="ez-content-edit-container__close"
-                   href="{{ path('ezplatform.content.draft.edit.cancel', {
-                       'contentId': content.id,
-                       'referrerLocationId': referrer_location.id,
-                       'versionNo': content.versionInfo.versionNo,
-                       'languageCode': language.languageCode
-                   }) }}"
+                   href="{{ cancel_path }}"
                    title="{{ 'tooltip.exit_label'|trans({}, 'content')|desc('Exit') }}"
                 >
                     <svg class="ez-icon ez-icon--small ez-icon--primary">

--- a/src/lib/Event/CancelEditVersionDraftEvent.php
+++ b/src/lib/Event/CancelEditVersionDraftEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Event;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class CancelEditVersionDraftEvent extends Event
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $content;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    private $referrerLocation;
+
+    /** @var \Symfony\Component\HttpFoundation\Response|null */
+    private $response;
+
+    public function __construct(
+        Content $content,
+        Location $referrerLocation
+    ) {
+        $this->content = $content;
+        $this->referrerLocation = $referrerLocation;
+    }
+
+    public function getContent(): Content
+    {
+        return $this->content;
+    }
+
+    public function getReferrerLocation(): Location
+    {
+        return $this->referrerLocation;
+    }
+
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+
+    public function setResponse(?Response $response): void
+    {
+        $this->response = $response;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-431
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Rebase with 2.3 after merging: ~https://github.com/ezsystems/ezplatform-admin-ui/pull/1878~ Done.

There cancel button (`X`) was a plain link and it was not possible to intercept and react to the action on the backend side.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
