### PR TITLE
IBX-808: As an Editor, I want to be able to reset starting location for ezobjectrelation FieldType

### DIFF
--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
@@ -1,5 +1,6 @@
 (function (global, doc, React, ReactDOM) {
-    const btns = doc.querySelectorAll('.btn--udw-relation-default-location');
+    const resetStartingLocationBtns = doc.querySelectorAll('.ez-reset-starting-location');
+    const udwBtns = doc.querySelectorAll('.btn--udw-relation-default-location');
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
     const siteaccess = doc.querySelector('meta[name="SiteAccess"]').content;
@@ -11,6 +12,11 @@
         const locationName = items[0].ContentInfo.Content.TranslatedName;
         const objectRelationListSettingsWrapper = btn.closest('.ezobjectrelationlist-settings');
         const objectRelationSettingsWrapper = btn.closest('.ezobjectrelation-settings');
+
+        toggleResetStartingLocationBtn(
+            btn.parentNode.querySelector('.ez-reset-starting-location'),
+            true
+        );
 
         if (objectRelationListSettingsWrapper) {
             objectRelationListSettingsWrapper.querySelector(btn.dataset.relationRootInputSelector).value = locationId;
@@ -35,6 +41,21 @@
             restInfo: { token, siteaccess }
         }, config)), udwContainer);
     };
+    const toggleResetStartingLocationBtn = (button, isEnabled) => {
+        isEnabled ? button.removeAttribute('disabled') : button.setAttribute('disabled', true);
+    };
+    const resetStartingLocation = (event) => {
+        const button = event.target.closest('button');
+        const buttonDataset = button.dataset;
+        const relationRootInputSelector = buttonDataset.relationRootInputSelector;
+        const relationSelectedRootNameSelector = buttonDataset.relationSelectedRootNameSelector;
 
-    btns.forEach(btn => btn.addEventListener('click', openUDW, false));
+        doc.querySelector(relationRootInputSelector).value = '';
+        doc.querySelector(relationSelectedRootNameSelector).innerHTML = '';
+
+        toggleResetStartingLocationBtn(button, false);
+    };
+
+    udwBtns.forEach(btn => btn.addEventListener('click', openUDW, false));
+    resetStartingLocationBtns.forEach(btn => btn.addEventListener('click', resetStartingLocation, false));
 })(window, window.document, window.React, window.ReactDOM);

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
@@ -44,7 +44,7 @@
     };
     const toggleResetStartingLocationBtn = (button, isEnabled) => {
         if (isEnabled) {
-            button.removeAttribute('disabled')
+            button.removeAttribute('disabled');
         } else {
             button.setAttribute('disabled', true);
         }

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
@@ -1,6 +1,6 @@
 (function (global, doc, React, ReactDOM) {
-    const RESET_STARTING_LOCATION_BTN_SELECTOR = '.ez-btn--reset-starting-location';
-    const resetStartingLocationBtns = doc.querySelectorAll(RESET_STARTING_LOCATION_BTN_SELECTOR);
+    const SELECTOR_RESET_STARTING_LOCATION_BTN = '.ez-btn--reset-starting-location';
+    const resetStartingLocationBtns = doc.querySelectorAll(SELECTOR_RESET_STARTING_LOCATION_BTN);
     const udwBtns = doc.querySelectorAll('.btn--udw-relation-default-location');
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
@@ -15,7 +15,7 @@
         const objectRelationSettingsWrapper = btn.closest('.ezobjectrelation-settings');
 
         toggleResetStartingLocationBtn(
-            btn.parentNode.querySelector(RESET_STARTING_LOCATION_BTN_SELECTOR),
+            btn.parentNode.querySelector(SELECTOR_RESET_STARTING_LOCATION_BTN),
             true
         );
 
@@ -51,7 +51,7 @@
     };
     const resetStartingLocation = (event) => {
         const button = event.currentTarget;
-        const {relationRootInputSelector, relationSelectedRootNameSelector} = button.dataset;
+        const { relationRootInputSelector, relationSelectedRootNameSelector } = button.dataset;
 
         doc.querySelector(relationRootInputSelector).value = '';
         doc.querySelector(relationSelectedRootNameSelector).innerHTML = '';

--- a/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
+++ b/src/bundle/Resources/public/js/scripts/admin.contenttype.relation.default.location.js
@@ -1,5 +1,6 @@
 (function (global, doc, React, ReactDOM) {
-    const resetStartingLocationBtns = doc.querySelectorAll('.ez-reset-starting-location');
+    const RESET_STARTING_LOCATION_BTN_SELECTOR = '.ez-btn--reset-starting-location';
+    const resetStartingLocationBtns = doc.querySelectorAll(RESET_STARTING_LOCATION_BTN_SELECTOR);
     const udwBtns = doc.querySelectorAll('.btn--udw-relation-default-location');
     const udwContainer = doc.getElementById('react-udw');
     const token = doc.querySelector('meta[name="CSRF-Token"]').content;
@@ -14,7 +15,7 @@
         const objectRelationSettingsWrapper = btn.closest('.ezobjectrelation-settings');
 
         toggleResetStartingLocationBtn(
-            btn.parentNode.querySelector('.ez-reset-starting-location'),
+            btn.parentNode.querySelector(RESET_STARTING_LOCATION_BTN_SELECTOR),
             true
         );
 
@@ -42,13 +43,15 @@
         }, config)), udwContainer);
     };
     const toggleResetStartingLocationBtn = (button, isEnabled) => {
-        isEnabled ? button.removeAttribute('disabled') : button.setAttribute('disabled', true);
+        if (isEnabled) {
+            button.removeAttribute('disabled')
+        } else {
+            button.setAttribute('disabled', true);
+        }
     };
     const resetStartingLocation = (event) => {
-        const button = event.target.closest('button');
-        const buttonDataset = button.dataset;
-        const relationRootInputSelector = buttonDataset.relationRootInputSelector;
-        const relationSelectedRootNameSelector = buttonDataset.relationSelectedRootNameSelector;
+        const button = event.currentTarget;
+        const {relationRootInputSelector, relationSelectedRootNameSelector} = button.dataset;
 
         doc.querySelector(relationRootInputSelector).value = '';
         doc.querySelector(relationSelectedRootNameSelector).innerHTML = '';

--- a/src/bundle/Resources/translations/ezrepoforms_content_type.en.xliff
+++ b/src/bundle/Resources/translations/ezrepoforms_content_type.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Select a starting location for browsing for relation</target>
         <note>key: field_definition.ezobjectrelation.selection_root_udw_title</note>
       </trans-unit>
+      <trans-unit id="58fa0150fbbe5c094880333e871c71ff7b9ee19b" resname="field_definition.ezobjectrelationlist.selection_root_reset_title">
+        <source>Reset starting location</source>
+        <target state="new">Reset starting location</target>
+        <note>key: field_definition.ezobjectrelationlist.selection_root_reset_title</note>
+      </trans-unit>
       <trans-unit id="1592c36df8d445c3154d1f639027f97a90739856" resname="field_definition.ezobjectrelationlist.selection_root_udw_button">
         <source>Select location</source>
         <target state="new">Select location</target>

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -4,7 +4,7 @@
  # - \EzSystems\RepositoryForms\Data\FieldDefinitionData data Data object for current fieldDefinition.
  # - \Symfony\Component\Form\FormView form Field definition form.
  # - string languageCode
- #}
+#}
 
 {# @var data \EzSystems\RepositoryForms\Data\FieldDefinitionData #}
 {# @var form \Symfony\Component\Form\FormView #}
@@ -142,6 +142,19 @@
             >{{ "field_definition.ezobjectrelation.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select item") }}</button>
+            <button type="button"
+                title="{{ "field_definition.ezobjectrelationlist.selection_root_reset_title"
+                |trans({}, "ezrepoforms_content_type")
+                |desc('Reset starting location') }}"
+                class="ez-reset-starting-location btn btn-danger"
+                data-relation-root-input-selector="#{{ form.selectionRoot.vars.id }}"
+                data-relation-selected-root-name-selector="#{{ form.selectionRoot.vars.id }}-selected-root-name"
+                {% if form.selectionRoot.vars.destination_location is null %} disabled {% endif %}
+            >
+                <svg class="ez-icon ez-icon--medium ez-icon--light">
+                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                </svg>
+            </button>
         </div>
         <div id="{{ form.selectionRoot.vars.id }}-selected-root-name">
             {% if form.selectionRoot.vars.destination_location is not null %}
@@ -174,6 +187,19 @@
             >{{ "field_definition.ezobjectrelationlist.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select location") }}</button>
+            <button type="button"
+                title="{{ "field_definition.ezobjectrelationlist.selection_root_reset_title"
+                |trans({}, "ezrepoforms_content_type")
+                |desc('Reset starting location') }}"
+                class="ez-reset-starting-location btn btn-danger"
+                data-relation-root-input-selector="#{{ form.selectionDefaultLocation.vars.id }}"
+                data-relation-selected-root-name-selector="#{{ form.selectionDefaultLocation.vars.id }}-selected-root-name"
+                {% if form.selectionDefaultLocation.vars.destination_location is null %} disabled {% endif %}
+            >
+                <svg class="ez-icon ez-icon--medium ez-icon--light">
+                    <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#trash"></use>
+                </svg>
+            </button>
         </div>
         <div id="{{ form.selectionDefaultLocation.vars.id }}-selected-root-name">
             {% if form.selectionDefaultLocation.vars.destination_location is not null %}

--- a/src/bundle/Resources/views/admin/content_type/field_types.html.twig
+++ b/src/bundle/Resources/views/admin/content_type/field_types.html.twig
@@ -142,11 +142,12 @@
             >{{ "field_definition.ezobjectrelation.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select item") }}</button>
-            <button type="button"
+            <button
+                type="button"
                 title="{{ "field_definition.ezobjectrelationlist.selection_root_reset_title"
                 |trans({}, "ezrepoforms_content_type")
                 |desc('Reset starting location') }}"
-                class="ez-reset-starting-location btn btn-danger"
+                class="ez-btn--reset-starting-location btn btn-danger"
                 data-relation-root-input-selector="#{{ form.selectionRoot.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionRoot.vars.id }}-selected-root-name"
                 {% if form.selectionRoot.vars.destination_location is null %} disabled {% endif %}
@@ -187,11 +188,12 @@
             >{{ "field_definition.ezobjectrelationlist.selection_root_udw_button"
                 |trans({}, "ezrepoforms_content_type")
                 |desc("Select location") }}</button>
-            <button type="button"
+            <button
+                type="button"
                 title="{{ "field_definition.ezobjectrelationlist.selection_root_reset_title"
                 |trans({}, "ezrepoforms_content_type")
                 |desc('Reset starting location') }}"
-                class="ez-reset-starting-location btn btn-danger"
+                class="ez-btn--reset-starting-location btn btn-danger"
                 data-relation-root-input-selector="#{{ form.selectionDefaultLocation.vars.id }}"
                 data-relation-selected-root-name-selector="#{{ form.selectionDefaultLocation.vars.id }}-selected-root-name"
                 {% if form.selectionDefaultLocation.vars.destination_location is null %} disabled {% endif %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-808](https://issues.ibexa.co/browse/IBX-808)
| Bugfix?      | no
| Improvement? | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Excerpt from JIRA:
>Currently, after selecting "Starting Location" in ezobjectrelation settings, there is no way to reset it. This might get problematic when, for some reason, the initial content is not visible in UDW due to tree_root parameter usage or associated user permissions.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
