### PR TITLE
IBX-947: Fixed draft deletion in Drafts module

### DIFF
--- a/src/bundle/Controller/ContentDraftController.php
+++ b/src/bundle/Controller/ContentDraftController.php
@@ -92,13 +92,18 @@ class ContentDraftController extends Controller
             $result = $this->submitHandler->handle($form, function (ContentRemoveData $data) {
                 foreach (array_keys($data->getVersions()) as $version) {
                     $versionId = VersionId::fromString($version);
+                    $contentInfo = $this->contentService->loadContentInfo($versionId->getContentId());
 
-                    $this->contentService->deleteVersion(
-                        $this->contentService->loadVersionInfoById(
-                            $versionId->getContentId(),
-                            $versionId->getVersionNo()
-                        )
-                    );
+                    if (1 === count($this->contentService->loadVersions($contentInfo))) {
+                        $this->contentService->deleteContent($contentInfo);
+                    } else {
+                        $this->contentService->deleteVersion(
+                            $this->contentService->loadVersionInfoById(
+                                $versionId->getContentId(),
+                                $versionId->getVersionNo()
+                            )
+                        );
+                    }
                 }
 
                 return $this->redirectToRoute('ezplatform.content_draft.list');


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-947](https://issues.ibexa.co/browse/IBX-947)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a result of this bug, some corrupted records have been left in the database, specifically in `ezcontentobject` table. They should be cleared to fix the original issue (so adding a field to CT). 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
