### PR TITLE
[Behat] Fixed Richtext button positions after widget redesign

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -104,10 +104,7 @@ class RichText extends FieldTypeComponent
     public function addUnorderedList(array $listElements): void
     {
         $this->focusFieldInput();
-        $this->getHTMLPage()
-            ->findAll($this->getLocator('toolbarDropdown'))
-            ->toArray()[2]
-            ->click();
+        $this->executeCommand('bulletedList');
 
         foreach ($listElements as $listElement) {
             $this->insertLine($listElement);
@@ -130,14 +127,14 @@ class RichText extends FieldTypeComponent
 
     public function clickEmbedInlineButton(): void
     {
-        $buttonPosition = 22 + $this->getCustomStylesOffset();
+        $buttonPosition = 32 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }
 
     public function clickEmbedButton(): void
     {
-        $buttonPosition = 20 + $this->getCustomStylesOffset();
+        $buttonPosition = 30 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Test failure:
```
      | TextBlock             | Text              |

        Notice: Undefined offset: 2 in vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/RichText.php line 109
```

Somewhere during the redesign the default layout of CKEditor widget changed. It used to look like this:
![obraz](https://user-images.githubusercontent.com/10993858/131800035-31cb2be1-1d7e-4d08-9f25-f4d6c4c06b50.png)
(the unordered list button is visible all the time).

Now it looks like this:
<img width="1680" alt="Zrzut ekranu 2021-09-2 o 09 20 14" src="https://user-images.githubusercontent.com/10993858/131800121-9c01d8de-c390-41b0-9e1e-2f1c4abc18d7.png">

The buttons previously visible are now available only after the additional menu is expanded.

I've:
1) fixed adding unordere lists
2) adjusted the Embed button positions to take the additional buttons into account

Proof that it works:
https://github.com/ezsystems/ezplatform-workflow/pull/215
(Workflow uses Text block in the Scenarios as well).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
