### PR TITLE
IBX-952: Added chosen Location to Translation Choice form

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -327,7 +327,8 @@ class ContentViewController extends Controller
                     $contentInfo,
                     $this->lookupLimitationsTransformer,
                     $languageCodes,
-                    $this->locationService
+                    $this->locationService,
+                    $location
                 ),
             ]
         );

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\SPI\Limitation\Target;
 use EzSystems\EzPlatformAdminUi\Permission\LookupLimitationsTransformer;
@@ -37,6 +38,9 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location|null */
+    private $location;
+
     /**
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
@@ -50,7 +54,8 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
         ?ContentInfo $contentInfo,
         LookupLimitationsTransformer $lookupLimitationsTransformer,
         array $languageCodes,
-        LocationService $locationService
+        LocationService $locationService,
+        ?Location $location
     ) {
         $this->languageService = $languageService;
         $this->permissionResolver = $permissionResolver;
@@ -58,6 +63,7 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
         $this->languageCodes = $languageCodes;
         $this->lookupLimitationsTransformer = $lookupLimitationsTransformer;
         $this->locationService = $locationService;
+        $this->location = $location;
     }
 
     /**
@@ -85,7 +91,7 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
                 $this->contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($this->contentInfo->mainLocationId),
+                    $this->locationService->loadLocation($this->location->id),
                 ],
                 [Limitation::LANGUAGE]
             );

--- a/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
+++ b/src/lib/Form/Type/ChoiceList/Loader/ContentEditTranslationChoiceLoader.php
@@ -91,7 +91,11 @@ class ContentEditTranslationChoiceLoader extends BaseChoiceLoader
                 $this->contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($this->location->id),
+                    $this->locationService->loadLocation(
+                        $this->location !== null
+                            ? $this->location->id
+                            : $this->contentInfo->mainLocationId
+                    ),
                 ],
                 [Limitation::LANGUAGE]
             );

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -121,7 +121,7 @@ class TranslationAddType extends AbstractType
             $contentLanguages = $versionInfo->languageCodes;
         }
 
-        $this->addLanguageFields($form, $contentLanguages, $contentInfo);
+        $this->addLanguageFields($form, $contentLanguages, $contentInfo, $location);
     }
 
     /**
@@ -142,6 +142,7 @@ class TranslationAddType extends AbstractType
         $form = $event->getForm();
         $data = $event->getData();
 
+        $location = null;
         if (isset($data['location'])) {
             try {
                 $location = $this->locationService->loadLocation((int)$data['location']);
@@ -156,7 +157,7 @@ class TranslationAddType extends AbstractType
             }
         }
 
-        $this->addLanguageFields($form, $contentLanguages, $contentInfo);
+        $this->addLanguageFields($form, $contentLanguages, $contentInfo, $location);
     }
 
     /**
@@ -201,7 +202,11 @@ class TranslationAddType extends AbstractType
                 $contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($location->id),
+                    $this->locationService->loadLocation(
+                        $location !== null
+                            ? $location->id
+                            : $contentInfo->mainLocationId
+                    ),
                 ],
                 [Limitation::LANGUAGE]
             );

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -190,7 +190,7 @@ class TranslationAddType extends AbstractType
         FormInterface $form,
         array $contentLanguages,
         ?ContentInfo $contentInfo,
-        ?Location $location
+        ?Location $location = null
     ): void {
         $languagesCodes = array_column($this->languageService->loadLanguages(), 'languageCode');
 

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\SPI\Limitation\Target;
 use EzSystems\EzPlatformAdminUi\Form\Data\Content\Translation\TranslationAddData;
@@ -179,12 +180,17 @@ class TranslationAddType extends AbstractType
      * @param \Symfony\Component\Form\FormInterface $form
      * @param string[] $contentLanguages
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo|null $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Location|null $location
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    public function addLanguageFields(FormInterface $form, array $contentLanguages, ?ContentInfo $contentInfo): void
-    {
+    public function addLanguageFields(
+        FormInterface $form,
+        array $contentLanguages,
+        ?ContentInfo $contentInfo,
+        ?Location $location
+    ): void {
         $languagesCodes = array_column($this->languageService->loadLanguages(), 'languageCode');
 
         $limitationLanguageCodes = [];
@@ -195,7 +201,7 @@ class TranslationAddType extends AbstractType
                 $contentInfo,
                 [
                     (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf($languagesCodes)->build(),
-                    $this->locationService->loadLocation($contentInfo->mainLocationId),
+                    $this->locationService->loadLocation($location->id),
                 ],
                 [Limitation::LANGUAGE]
             );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-952](https://issues.ibexa.co/browse/IBX-952)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

We should consider the `Location` we are actually in to load the required languages as the user might not have access to main `Location` but have access to secondary one.

Related `ezplatform-page-builder` PR: https://github.com/ezsystems/ezplatform-page-builder/pull/826.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
