### PR TITLE
[CI] Added job for wrong target branch detection

### DIFF
--- a/.github/workflows/pr_check.yaml
+++ b/.github/workflows/pr_check.yaml
@@ -1,0 +1,45 @@
+name: PR check
+on:
+  pull_request:
+    types: 
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  test-base-branch:
+    name: Pull Request base branch verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Get PR's composer.json
+        id: pr
+        with:
+          branch: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          route: /repos/{repository}/contents/composer.json?ref={branch}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: octokit/request-action@v2.x
+        name: Get base's composer.json
+        id: base
+        with:
+          branch: ${{ github.event.pull_request.base.ref }}
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          route: /repos/{repository}/contents/composer.json?ref={branch}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify base branch
+        run: |
+          PR_BRANCH_ALIAS=$(echo $PR_DATA | jq -r '.["content"]' | base64 --decode | jq -r '.["extra"]["branch-alias"] | flatten | .[0]')
+          BASE_BRANCH_ALIAS=$(echo $BASE_DATA | jq -r '.["content"]' | base64 --decode | jq -r '.["extra"]["branch-alias"] | flatten | .[0]')
+          if [ "$PR_BRANCH_ALIAS" != "$BASE_BRANCH_ALIAS" ]; then 
+            echo "Base branch has different branch-alias than PR."
+            echo "Pull Request: $PR_BRANCH_ALIAS"
+            echo "Base branch: $BASE_BRANCH_ALIAS"
+            exit 1; 
+          fi
+        env:
+          PR_DATA: ${{ steps.pr.outputs.data }}
+          BASE_DATA: ${{ steps.base.outputs.data }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-754
| Bug fix?      | no
| New feature?  | yes (CI)
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR adds a new Github Action that verifies base branch for Pull Request for PHP packages.

1) I've decided to base this solution on the `branch-alias` property in composer.json, which exists in every branch in our packages and has a different value for each stable branch. 
2) At first I've experiemented with using the `checkout` action to get the file contents, but then I've decided it's better to get a single file instead of performing a (shallow) clone of the whole repo
3) I'm using the `octocit/request-action` (https://github.com/octokit/request-action) to hit the `repos/.../contents` endpoint (https://docs.github.com/en/rest/reference/repos#get-repository-content) and get the composer.json file I need
4) In the jq part I couldn't use the key name - it can be `dev-master`, `dev-main`, the current way avoids addressing it.
5) I've added the `edited` event type to the list of events that triggers this action - this means that the action will be rerun after the base is changed. The drawback is that it will also be run after the PR title or descriptions are edited.
6) I've tested it with forks and private packages in (https://github.com/ezsystems/ezplatform-admin-ui/pull/1892 and https://github.com/ezsystems/ezplatform-page-builder/pull/830 )

Passing on Github Actions (when base is 1.5): https://github.com/ezsystems/ezplatform-admin-ui/runs/3619248590?check_suite_focus=true
Failing on Github Actions (when base is 2.3): https://github.com/ezsystems/ezplatform-admin-ui/runs/3587109785?check_suite_focus=true

Tested locally (with https://github.com/nektos/act) with payloads:
### payload_correct.json
```json
{
  "pull_request": {
    "base": {
      "ref": "1.5",
      "repo": {
        "full_name": "ezsystems/ezplatform-admin-ui"
      }
    },
    "head": {
      "ref": "add-target-checking-action",
      "repo": {
        "full_name": "ezsystems/ezplatform-admin-ui"
      }
    }
  }
}
```

### payload_incorrect.json
```json
{
  "pull_request": {
    "base": {
      "ref": "2.3",
      "repo": {
        "full_name": "ezsystems/ezplatform-admin-ui"
      }
    },
    "head": {
      "ref": "add-target-checking-action",
      "repo": {
        "full_name": "ezsystems/ezplatform-admin-ui"
      }
    }
  }
}
```

### Correct PR
```
MacBook-Pro:ezplatform-admin-ui mareknocon$ act pull_request -j test-base-branch -e payload_correct.json  -s GITHUB_TOKEN=X
[Pull Request base branch verification/test-base-branch]   ✅  Success - Verify base branch
```

### Incorrect PR
```
MacBook-Pro:ezplatform-admin-ui mareknocon$ act pull_request -j test-base-branch -e payload_incorrect.json  -s GITHUB_TOKEN=X
[Pull Request base branch verification/test-base-branch]   ✅  Success - Get base's composer.json
[Pull Request base branch verification/test-base-branch] ⭐  Run Verify base branch
[Pull Request base branch verification/test-base-branch]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/mareknocon/Desktop/repos/ga_actions/ezplatform-admin-ui/workflow/2] user=
| Base branch has different branch-alias than PR.
| Pull Request: 1.5.x-dev
| Base branch: 2.3.x-dev
[Pull Request base branch verification/test-base-branch]   ❌  Failure - Verify base branch
Error: exit with `FAILURE`: 1
```

If you'd like to test it - feel free to change the base branch of this PR (it's supposed to go into 1.5).


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review