### PR TITLE
[Behat] Corrected error message for missing user notification

### DIFF
--- a/src/lib/Behat/Component/UserNotificationPopup.php
+++ b/src/lib/Behat/Component/UserNotificationPopup.php
@@ -34,7 +34,7 @@ class UserNotificationPopup extends Component
             return;
         }
 
-        throw new Exception(sprintf('Notification of type: %s with description: %d not found', $type, $description));
+        throw new Exception(sprintf('Notification of type: %s with description: %d not found', $expectedType, $expectedDescription));
     }
 
     public function verifyIsLoaded(): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Example error on Travis:
https://app.travis-ci.com/ezsystems/ezplatform-workflow/builds/236969700?utm_source=slack&utm_medium=notification

```
    And I go to user notification with details:                                       # Ibexa\AdminUi\Behat\BrowserContext\UserNotificationContext::iGoToUserNotificationWithDetails()
      | Type                   | Description                               |
      | Content review request | From: Creator Workflow Please have a look |
      Notice: Undefined variable: type in vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/UserNotificationPopup.php line 37
```

The error message generation contains a mistake - in the error message we should be using the expected values, not the ones that we found (which can be missing).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
