### PR TITLE
Fixed issues in test PHP namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "autoload-dev": {
         "psr-4": {
             "EzSystems\\EzPlatformAdminUi\\Tests\\": "src/lib/Tests",
-            "Ibexa\\AdminUi\\Tests\\": "tests/lib"
+            "Ibexa\\Tests\\AdminUi\\": "tests/lib"
         }
     },
     "require": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,7 @@
         <testsuite name="EzSystems\EzPlatformAdminUiBundle">
             <directory>src/bundle/Tests/</directory>
         </testsuite>
-        <testsuite name="Ibexa\AdminUi">
+        <testsuite name="Ibexa\Tests\AdminUi">
             <directory>tests/lib/</directory>
         </testsuite>
     </testsuites>

--- a/tests/lib/REST/Input/ContentType/FieldDefinitionCreateTest.php
+++ b/tests/lib/REST/Input/ContentType/FieldDefinitionCreateTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\AdminUi\Tests\REST\Input\ContentType;
+namespace Ibexa\Tests\AdminUi\REST\Input\ContentType;
 
 use EzSystems\EzPlatformAdminUi\REST\Value\ContentType\FieldDefinitionCreate as FieldDefinitionCreateValue;
 use EzSystems\EzPlatformRest\Exceptions;

--- a/tests/lib/REST/Input/ContentType/FieldDefinitionDeleteTest.php
+++ b/tests/lib/REST/Input/ContentType/FieldDefinitionDeleteTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\AdminUi\Tests\REST\Input\ContentType;
+namespace Ibexa\Tests\AdminUi\REST\Input\ContentType;
 
 use EzSystems\EzPlatformAdminUi\REST\Value\ContentType\FieldDefinitionDelete as FieldDefinitionDeleteValue;
 use EzSystems\EzPlatformRest\Exceptions;

--- a/tests/lib/REST/Input/ContentType/FieldDefinitionReorderTest.php
+++ b/tests/lib/REST/Input/ContentType/FieldDefinitionReorderTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\AdminUi\Tests\REST\Input\ContentType;
+namespace Ibexa\Tests\AdminUi\REST\Input\ContentType;
 
 use EzSystems\EzPlatformAdminUi\REST\Value\ContentType\FieldDefinitionReorder as FieldDefinitionReorderValue;
 use EzSystems\EzPlatformRest\Exceptions;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Fixes wrong PHP namespace added in #1835.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
