### PR TITLE
IBX-792: Fixed class using new namespace registered via resource

### DIFF
--- a/src/bundle/Resources/config/services/forms.yaml
+++ b/src/bundle/Resources/config/services/forms.yaml
@@ -18,6 +18,7 @@ services:
 
     EzSystems\EzPlatformAdminUi\Form\Type\:
         resource: '../../../lib/Form/Type'
+        exclude: '../../../lib/Form/Type/ContentType/{FieldDefinitionsCollectionType}.php'
 
     EzSystems\EzPlatformAdminUi\Form\EventListener\:
         resource: '../../../lib/Form/EventListener'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | IBX-792
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ~yes/no~
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Attempts to fix an issue that occurs irregularly, causing failure to compile service container due to loading of a new class (with new namespace) via `resource` declaration.

Error reported:
```
In FileLoader.php line 174:
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
 Expected to find class "EzSystems\EzPlatformAdminUi\Form\Type\ContentType\FieldDefinitionsCollectionType" in file "/var/www/vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentType/FieldDefinitionsCollectionType.php" while importing services from resource "../../../lib/Form/Type", but it was not found! Check the namespace prefix used with the resource in /var/www/vendor/ezsystems/ezplatform-admin-ui/src/bundle/DependencyInjection/../Resources/config/services/forms.yaml (which is being imported from "/var/www/vendor/ezsystems/ezplatform-admin-ui/src/bundle/DependencyInjection/../Resources/config/services.yaml").  

Expected to find class "EzSystems\EzPlatformAdminUi\Form\Type\ContentType\FieldDefinitionsCollectionType" in file "/var/www/vendor/ezsystems/ezplatform-admin-ui/src/lib/Form/Type/ContentType/FieldDefinitionsCollectionType.php" while importing services from resource "../../../lib/Form/Type", but it was not found! Check the namespace prefix used with the resource. 
```

Follow up for #1835.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
