### PR TITLE
Fixed content always being translated using a base translation

### DIFF
--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -548,20 +548,6 @@ ezplatform.content.preview:
         languageCode: ~
         locationId: ~
 
-ezplatform.content.translate:
-    path: /content/{contentId}/translate/{toLanguageCode}/{fromLanguageCode}
-    methods: ['GET', 'POST']
-    defaults:
-        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
-        fromLanguageCode: ~
-
-ibexa.content.translate_with_location:
-    path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
-    methods: ['GET', 'POST']
-    defaults:
-        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
-        fromLanguageCode: ~
-
 ezplatform.content.translate.proxy:
     path: /content/{contentId}/translate/proxy/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']
@@ -574,6 +560,20 @@ ibexa.content.translate_with_location.proxy:
     methods: ['GET', 'POST']
     defaults:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::proxyTranslateAction'
+        fromLanguageCode: ~
+
+ezplatform.content.translate:
+    path: /content/{contentId}/translate/{toLanguageCode}/{fromLanguageCode}
+    methods: ['GET', 'POST']
+    defaults:
+        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
+        fromLanguageCode: ~
+
+ibexa.content.translate_with_location:
+    path: /content/{contentId}/location/{locationId}/translate/{toLanguageCode}/{fromLanguageCode}
+    methods: ['GET', 'POST']
+    defaults:
+        _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ContentEditController::translateAction'
         fromLanguageCode: ~
 
 ezplatform.content.check_edit_permission:

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -548,6 +548,7 @@ ezplatform.content.preview:
         languageCode: ~
         locationId: ~
 
+# IBX-1079: Translate routes with proxy suffix have to be prioritized to avoid issues with URL generations
 ezplatform.content.translate.proxy:
     path: /content/{contentId}/translate/proxy/{toLanguageCode}/{fromLanguageCode}
     methods: ['GET', 'POST']

--- a/src/lib/EventListener/ContentProxyCreateDraftListener.php
+++ b/src/lib/EventListener/ContentProxyCreateDraftListener.php
@@ -107,10 +107,11 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
             return;
         }
 
+        $fromLanguageCode = $event->getFromLanguageCode();
         $content = $this->contentService->loadContent(
             $event->getContentId(),
-            $event->getFromLanguageCode() !== null
-                ? [$event->getFromLanguageCode()]
+            $fromLanguageCode !== null
+                ? [$fromLanguageCode]
                 : null
         );
 
@@ -118,7 +119,9 @@ class ContentProxyCreateDraftListener implements EventSubscriberInterface
 
         $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
         $contentUpdateStruct->initialLanguageCode = $toLanguageCode;
-        $contentUpdateStruct->fields = $this->getTranslatedContentFields($content, $toLanguageCode);
+        if ($fromLanguageCode !== null) {
+            $contentUpdateStruct->fields = $this->getTranslatedContentFields($content, $toLanguageCode);
+        }
 
         $contentDraft = $this->contentService->createContentDraft($content->contentInfo);
 

--- a/src/lib/Form/Type/Content/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/Content/Translation/TranslationAddType.php
@@ -241,7 +241,7 @@ class TranslationAddType extends AbstractType
                 ChoiceType::class,
                 [
                     'required' => false,
-                    'placeholder' => false,
+                    'placeholder' => true,
                     'multiple' => false,
                     'expanded' => false,
                     'choice_loader' => new CallbackChoiceLoader(function () use ($contentLanguages) {

--- a/src/lib/Form/Type/ContentType/Translation/TranslationAddType.php
+++ b/src/lib/Form/Type/ContentType/Translation/TranslationAddType.php
@@ -192,7 +192,7 @@ class TranslationAddType extends AbstractType
                 ChoiceType::class,
                 [
                     'required' => false,
-                    'placeholder' => false,
+                    'placeholder' => true,
                     'multiple' => false,
                     'expanded' => false,
                     'choice_loader' => new BaseTranslationLanguageChoiceLoader($this->languageService, $contentLanguages),


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1079
| Bug fix?      | yes

Due to a `placeholder` setting set to `false` for `base_language` ChoiceType, `<select>` field with Languages available as a Base Translation always used the first option on the list, when submitted empty.

Changing `placeholder` to `true` resolves the "HTML" issue, but uncovers some underlying issues:
- When BaseLanguage is `null`, `ibexa.content.translate_with_location.proxy` route generates without the last `fromLanguageCode` part, and URL is matched against `ibexa.content.translate_with_location` with exception "Can't find Language `proxy`". This PR fixes this by changing order in `routing.yaml` so in this case `ibexa.content.translate_with_location.proxy` takes precedense.
- `ContentProxyCreateDraftListener:translate` always sets field values for the struct, therefore even when `fromLanguage` is set to `null`, main language values are used. This is fixed by adding `if ($fromLanguageCode !== null)` check before setting fields in the Struct.

In addition to the original issue, the same fix for translating Content Types is used.
