### PR TITLE
IBX-1035: Removing white-space: nowrap property for content name

### DIFF
--- a/src/bundle/Resources/public/scss/_page-title.scss
+++ b/src/bundle/Resources/public/scss/_page-title.scss
@@ -16,7 +16,6 @@
     }
 
     &__content-name {
-        white-space: nowrap;
         overflow: hidden;
         font-weight: normal;
         font-size: calculateRem(26px);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1035
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Wrapping long content names
![Screenshot 2021-10-06 at 10 05 54](https://user-images.githubusercontent.com/24355391/136164128-f8a34f99-87e2-42df-bc3b-4a07e524b200.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
