### PR TITLE
[CI] Forced branches to be always treated as strings in API calls

### DIFF
--- a/.github/workflows/pr_check.yaml
+++ b/.github/workflows/pr_check.yaml
@@ -16,7 +16,7 @@ jobs:
         name: Get PR's composer.json
         id: pr
         with:
-          branch: ${{ github.event.pull_request.head.ref }}
+          branch: "!!str ${{ github.event.pull_request.head.ref }}"
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           route: /repos/{repository}/contents/composer.json?ref={branch}
         env:
@@ -25,7 +25,7 @@ jobs:
         name: Get base's composer.json
         id: base
         with:
-          branch: ${{ github.event.pull_request.base.ref }}
+          branch: "!!str ${{ github.event.pull_request.base.ref }}"
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           route: /repos/{repository}/contents/composer.json?ref={branch}
         env:


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | n/a
| Bug fix?      | yes (in CI)
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

This PR fixes an edge case (bug) in base branch correctness job. You can see it in action here:
https://github.com/ezsystems/ezplatform-matrix-fieldtype/pull/67

```
Run octokit/request-action@v2.x
  with:
    branch: 1.0
    repository: ezsystems/ezplatform-matrix-fieldtype
    route: /repos/{repository}/contents/composer.json?ref={branch}
    mediaType: {}
  env:
    GITHUB_TOKEN: ***
/repos/{repository}/contents/composer.json?ref={branch}
> branch: 1
> repository: ezsystems/ezplatform-matrix-fieldtype
> mediaType: [object Object]
< 404 197ms
```

When the branch is named like `x.0` then the value (when treated as a numeric value) gets rounded to `x`. The API call fails, because there's no branch named `x`.

Under the hood the action loads input values using a YAML parser:
https://github.com/octokit/request-action/blob/master/index.js#L66

And by default the value is treated as a numeric one, as you can see here:
https://runkit.com/mnocon/yaml-parsing

Manually indicating (with `!!str`) the type of data we're dealing with solves the issue - I've verified it in https://github.com/ezsystems/ezplatform-design-engine/pull/33 with a successful run: https://github.com/ezsystems/ezplatform-design-engine/pull/33/checks?check_run_id=3828719016

```
Run octokit/request-action@v2.x
  with:
    branch: !!str 2.0
    repository: ezsystems/ezplatform-design-engine
    route: /repos/{repository}/contents/composer.json?ref={branch}
    mediaType: {}
  env:
    GITHUB_TOKEN: ***
/repos/{repository}/contents/composer.json?ref={branch}
> branch: 2.0
> repository: ezsystems/ezplatform-design-engine
> mediaType: [object Object]
< 200 185ms
```

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
