### PR TITLE
[Behat] Adjusted Richtext button positions

### DIFF
--- a/src/lib/Behat/Component/Fields/RichText.php
+++ b/src/lib/Behat/Component/Fields/RichText.php
@@ -127,14 +127,14 @@ class RichText extends FieldTypeComponent
 
     public function clickEmbedInlineButton(): void
     {
-        $buttonPosition = 12 + $this->getCustomStylesOffset();
+        $buttonPosition = 11 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }
 
     public function clickEmbedButton(): void
     {
-        $buttonPosition = 10 + $this->getCustomStylesOffset();
+        $buttonPosition = 9 + $this->getCustomStylesOffset();
         $this->openElementsToolbar();
         $this->clickElementsToolbarButton($buttonPosition);
     }


### PR DESCRIPTION
Failing build: https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/543377059

```
 TextBlock             | Text              |
        WebDriver\Exception\JavaScriptError: javascript error: Cannot read property 'click' of undefined
          (Session info: chrome=90.0.4430.85)
          (Driver info: chromedriver=90.0.4430.24 (4c6d850f087da467d926e8eddb76550aed655991-refs/branch-heads/4430@{#429}),platform=Linux 4.4.0-101-generic x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:156
```

Looks like the buttons visible in richtext screen changes changed somewhere during the redesign, this PR adjusted their positions.

Passing test on local:
```
  Background:                  # vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Blocks.feature:4
    Given I am logged as admin # Ibexa\Behat\Browser\Context\AuthenticationContext::loggedAsAdmin()

  @javascript @test
  Scenario Outline: Block can be added to Page Builder and published                   # vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Blocks.feature:8
    Given I'm on Content view Page for root                                            # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iMOnContentViewPageFor()
    And I start creating a new Landing Page "<blockName>"                              # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::startCreatingNewLandingPage()
    When I set up block "<blockName>" "<blockType>" with default testing configuration # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::addBlockWithDefaultTestingConfiguration()
    And I see the "<blockName>" "<blockType>" block and its preview                    # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::iSeeTheBlockAndItsPreview()
    And I publish the Landing Page                                                     # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::publishPage()
    Then success notification that "Content published." appears                        # Ibexa\AdminUi\Behat\BrowserContext\NotificationContext::specificNotificationAppears()
    And I should be on Content view Page for "<blockName>"                             # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iShouldBeOnContentViewPage()

    Examples:
      | blockName | blockType |
      | TextBlock | Text      |

1 scenariusz (1 udany)
8 kroków (8 udanych)
1m15.51s (95.44Mb)
```