### PR TITLE
IBX-1157: Fixed issue with missing translation in the trash

### DIFF
--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -769,21 +769,6 @@
         <target state="new">Are you sure you want to send this Content item to Trash?</target>
         <note>key: trash.modal.send_to_trash.message</note>
       </trans-unit>
-      <trans-unit id="3a46b65a9b678fb947285b2c9509943ee6764195" resname="trash.search.any_content_types">
-        <source>Any Content Types</source>
-        <target state="new">Any Content Types</target>
-        <note>key: trash.search.any_content_types</note>
-      </trans-unit>
-      <trans-unit id="9a88e9a17cd461dcd7d54dca50c6d3b981aba7fc" resname="trash.search.any_time">
-        <source>Any time</source>
-        <target state="new">Any time</target>
-        <note>key: trash.search.any_time</note>
-      </trans-unit>
-      <trans-unit id="c2b2679781ad4a22bb232e2ab34669ffe49c760b" resname="trash.search.section.any">
-        <source>Any Section</source>
-        <target state="new">Any Section</target>
-        <note>key: trash.search.section.any</note>
-      </trans-unit>
       <trans-unit id="bd97a738137e75de44544db1104bab3a46222791" resname="trash_asset.modal.message_body">
         <source>If you wish to delete these assets too, first make sure they are not used by other content. To check, go to the asset preview and look at its content Relations in the Relations tab.</source>
         <target state="new">If you wish to delete these assets too, first make sure they are not used by other content. To check, go to the asset preview and look at its content Relations in the Relations tab.</target>

--- a/src/bundle/Resources/translations/trash.en.xliff
+++ b/src/bundle/Resources/translations/trash.en.xliff
@@ -91,6 +91,21 @@
         <target state="new">Restored content to its original Location.</target>
         <note>key: trash.restore_original_location.success</note>
       </trans-unit>
+      <trans-unit id="3a46b65a9b678fb947285b2c9509943ee6764195" resname="trash.search.any_content_types">
+        <source>Any Content Types</source>
+        <target state="new">Any Content Types</target>
+        <note>key: trash.search.any_content_types</note>
+      </trans-unit>
+      <trans-unit id="9a88e9a17cd461dcd7d54dca50c6d3b981aba7fc" resname="trash.search.any_time">
+        <source>Any time</source>
+        <target state="new">Any time</target>
+        <note>key: trash.search.any_time</note>
+      </trans-unit>
+      <trans-unit id="c2b2679781ad4a22bb232e2ab34669ffe49c760b" resname="trash.search.section.any">
+        <source>Any Section</source>
+        <target state="new">Any Section</target>
+        <note>key: trash.search.section.any</note>
+      </trans-unit>
       <trans-unit id="8b64a1510f907791766cbccffcff7898bda76bde" resname="trash.section">
         <source>Section</source>
         <target state="new">Section</target>

--- a/src/lib/Form/Type/Search/TrashSearchType.php
+++ b/src/lib/Form/Type/Search/TrashSearchType.php
@@ -98,6 +98,7 @@ class TrashSearchType extends AbstractType
             'data_class' => TrashSearchData::class,
             'method' => Request::METHOD_GET,
             'csrf_protection' => false,
+            'translation_domain' => 'trash',
         ]);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1157
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The problem occurred due to a missing translation domain in the FormType class


![Screenshot 2021-10-15 at 13-03-28 Trash](https://user-images.githubusercontent.com/1654712/137477662-6e04212a-f5fa-4704-b0a0-088341432824.png)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
