### PR TITLE
IBX-1243: Fixed issue with missing translation for dropdown fields on the search

### DIFF
--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -634,11 +634,6 @@
         <target state="new">Do you want to unassign the Users/Groups?</target>
         <note>key: role_assignments.modal.message</note>
       </trans-unit>
-      <trans-unit id="08232f4c5c3ca88a7f2fd8e29eda7e20ec346aae" resname="search.any_time">
-        <source>Any time</source>
-        <target state="new">Any time</target>
-        <note>key: search.any_time</note>
-      </trans-unit>
       <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
         <source>From date - to date</source>
         <target state="new">From date - to date</target>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -16,6 +16,11 @@
         <target state="new">Any Content Type</target>
         <note>key: search.any.content.type</note>
       </trans-unit>
+      <trans-unit id="08232f4c5c3ca88a7f2fd8e29eda7e20ec346aae" resname="search.any_time">
+        <source>Any time</source>
+        <target state="new">Any time</target>
+        <note>key: search.any_time</note>
+      </trans-unit>
       <trans-unit id="8605c5030193beebc7097a652f6c9dcb648cccec" resname="search.apply">
         <source>Apply</source>
         <target state="new">Apply</target>

--- a/src/lib/Form/Type/Search/SearchType.php
+++ b/src/lib/Form/Type/Search/SearchType.php
@@ -74,6 +74,7 @@ final class SearchType extends AbstractType
                 'created' => 'created_select',
                 'last_modified' => 'last_modified_select',
             ],
+            'translation_domain' => 'search',
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-1243
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The problem occurred due to a missing translation domain in the FormType class. Related PR https://github.com/ezsystems/ezplatform-search/pull/21

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
