### PR TITLE
[Behat] Added waiting until the menu is fully opened

### DIFF
--- a/src/lib/Behat/Component/LeftMenu.php
+++ b/src/lib/Behat/Component/LeftMenu.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
+use Ibexa\Behat\Browser\Element\Condition\ElementTransitionHasEndedCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\LogicalOrCriterion;
@@ -34,11 +35,9 @@ class LeftMenu extends Component
     {
         $this->getHTMLPage()
             ->setTimeout(3)
-            ->waitUntil(function () {
-                return $this->getMenuWidth() < 100;
-            }, sprintf('Left menu did not collapse in time. Current width: %d', $this->getMenuWidth()));
-
-        $this->getHTMLPage()
+            ->waitUntilCondition(
+                new ElementTransitionHasEndedCondition($this->getHTMLPage(), $this->getLocator('menuFirstLevel'))
+                )
             ->findAll($this->getLocator('expandedMenuItem'))
             ->getByCriterion(new ElementTextCriterion($tabName))
             ->click();
@@ -55,11 +54,7 @@ class LeftMenu extends Component
             new VisibleCSSLocator('menuItem', '.ibexa-main-menu__navbar--first-level .ibexa-main-menu__item'),
             new VisibleCSSLocator('expandedMenuItem', '.ibexa-main-menu__item-action--second-level .ibexa-main-menu__item-text-column'),
             new VisibleCSSLocator('menuSelector', '.ibexa-main-menu'),
+            new VisibleCSSLocator('menuFirstLevel', '.ibexa-main-menu__navbar--first-level'),
         ];
-    }
-
-    private function getMenuWidth(): int
-    {
-        return (int) $this->getHTMLPage()->executeJavaScript("return document.querySelector('.ibexa-main-menu__navbar--collapsed').clientWidth.toString()");
     }
 }


### PR DESCRIPTION
Example failure:
https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/543573510
```
    And I go to "Content structure" in "Content" tab            # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iGoToTab()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'Content structure'. Found names: Calendar instead. CSS locator 'expandedMenuItem': '.ibexa-main-menu__item-action--second-level .ibexa-main-menu__item-text-column'. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/ElementCollection.php:59
      Stack trace:
      #0 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/LeftMenu.php(43): Ibexa\Behat\Browser\Element\ElementCollection->getByCriterion()
      #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/BrowserContext/NavigationContext.php(106): Ibexa\AdminUi\Behat\Component\LeftMenu->goToSubTab()
```

Requires:
https://github.com/ezsystems/BehatBundle/pull/220/

I've reworked the solution from https://github.com/ezsystems/ezplatform-admin-ui/pull/1939 , this time we wait until the menu transition is finished instead of relying on menu's width.

Passing builds:
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/240010625
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/240011975
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/240014009
https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/240016715