### PR TITLE
[Behat] added fix for contentIntegration

### DIFF
--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -12,7 +12,6 @@ use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
-use Ibexa\Behat\Browser\Locator\XPathLocator;
 
 class ContentTypeUpdatePage extends AdminUpdateItemPage
 {
@@ -33,8 +32,7 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
             ->findAll($fieldToggleLocator)
             ->last();
         usleep(500000);
-        $this->getHTMLPage()->find($this->getLocator(contentTypeAddButton))->mouseOver();
-        usleep(500000);
+        $lastFieldAdded->mouseOver();
         $lastFieldAdded->click();
         usleep(500000);
     }
@@ -50,8 +48,7 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
             new VisibleCSSLocator('workspace', '#content_collapse > div.ibexa-collapse__body-content > div'),
             new VisibleCSSLocator('fieldDefinitionToggle', '.ibexa-collapse:nth-last-child(2) > div.ibexa-collapse__header > button:last-child:not([data-bs-target="#content_collapse"])'),
             new VisibleCSSLocator('fieldDefinitionOpenContainer', '[data-collapsed="false"] .ibexa-content-type-edit__field-definition-content'),
-            new XPathLocator('selectBlocksDropdown', '//div[contains(@class,"ez-page-select-items")]/a[contains(text(),"Select blocks")]'),
-            new XPathLocator('selectBlocksDropdownDefault', '//div[contains(@class,"ez-page-select-items__group")]/a[contains(text(),"default")]'),
+            new VisibleCSSLocator('selectBlocksDropdown', '.ez-page-select-items__toggler'),
         ]);
     }
 
@@ -106,8 +103,11 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
 
     public function expandDefaultBlocksOption(): void
     {
-        $this->getHTMLPage()->find($this->getLocator('selectBlocksDropdown'))->click();
-        $this->getHTMLPage()->find($this->getLocator('selectBlocksDropdownDefault'))->click();
+        $dropdownLocator = $this->getLocator('selectBlocksDropdown');
+        $this->getHTMLPage()
+            ->findAll($dropdownLocator)->getByCriterion(new ElementTextCriterion('Select blocks'))->click();
+        $this->getHTMLPage()
+            ->findAll($dropdownLocator)->getByCriterion(new ElementTextCriterion('default'))->click();
     }
 
     public function selectBlock(string $blockName): void


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | related to https://issues.ibexa.co/browse/IBX-1070
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->
This PR is a fix for builds like https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/543923421 where contentIntegration.feature is failed because element is not interactable.
`  WebDriver\Exception\ElementNotVisible: element not interactable`


