### PR TITLE
[Behat] Increase stability for contentType.feature

### DIFF
--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -69,17 +69,13 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
             true
         ) + 1; // CSS selectors are 1-indexed
 
-        $availableFieldLabelsScript = "document.querySelector('.ibexa-available-field-types__fields > li:nth-child(%d) > .ibexa-label')";
+        $availableFieldLabelsScript = "document.querySelector('.ibexa-available-field-types__fields > li:nth-child(%d) > .ibexa-available-field-types__field-label')";
         $scriptToExecute = sprintf($availableFieldLabelsScript, $fieldPosition);
         $this->getSession()->executeScript($scriptToExecute);
 
         $workspace = sprintf('document.querySelector(\'%s\')', $this->getLocator('workspace')->getSelector());
         $this->getHTMLPage()->dragAndDrop($scriptToExecute, $workspace, $workspace);
-        $this->getHTMLPage()
-            ->setTimeout(3)
-            ->waitUntilCondition(
-                new ElementExistsCondition($this->getHTMLPage(), $this->getLocator('fieldDefinitionContainer'))
-            );
+        usleep(1500000); //TODO: add proper wait condition
     }
 
     public function clickAddButton(): void


### PR DESCRIPTION
The purpose of this fix is to prevent situations like in https://app.travis-ci.com/github/ezsystems/ezplatform-admin-ui/jobs/545195658

Fixes: 
- changed locator in _$availableFieldLabelsScript_
- removed waiting condition, it was not working properly when more than 1 field was dragged to workspace (new condition will have to be implemented, may need changes in _ElementTransitionHasEndedCondition_) 
