### PR TITLE
Fix "avalable" to "available"

### DIFF
--- a/src/bundle/Resources/translations/content_type.en.xliff
+++ b/src/bundle/Resources/translations/content_type.en.xliff
@@ -82,8 +82,8 @@
         <note>key: content_type.default_availability.available</note>
       </trans-unit>
       <trans-unit id="3b3fc626a669a5462ec9fa7c94280a3573d8b106" resname="content_type.default_availability.help">
-        <source>Content of this Content Type will be avalable in the main language even if there is no translation.</source>
-        <target state="new">Content of this Content Type will be avalable in the main language even if there is no translation.</target>
+        <source>Content of this Content Type will be available in the main language even if there is no translation.</source>
+        <target state="new">Content of this Content Type will be available in the main language even if there is no translation.</target>
         <note>key: content_type.default_availability.help</note>
       </trans-unit>
       <trans-unit id="da6afb475bbd2efbe3929af770d0fc17e6e86132" resname="content_type.default_availability.not_available">

--- a/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content_type/tab/view.html.twig
@@ -80,7 +80,7 @@
                     <td class="ez-table__cell">
                         {{ "content_type.default_availability"|trans|desc('Make content available even with missing translations') }}
                         <p class="small">
-                            {{ "content_type.default_availability.help"|trans|desc("Content of this Content Type will be avalable in the main language even if there is no translation.") }}
+                            {{ "content_type.default_availability.help"|trans|desc("Content of this Content Type will be available in the main language even if there is no translation.") }}
                         </p>
                     </td>
                     <td class="ez-table__cell">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | N/A
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixing a small typo in the expiation text below "Make content available even with missing translations" when viewing a content type: "avalable" replaced by "available".

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
