### PR TITLE
[Behat] Stability fixes

### DIFF
--- a/src/lib/Behat/BrowserContext/ContentTypeContext.php
+++ b/src/lib/Behat/BrowserContext/ContentTypeContext.php
@@ -234,6 +234,7 @@ class ContentTypeContext implements Context
      */
     public function iCheckBlockInField($blockName)
     {
+        $this->contentTypeUpdatePage->verifyIsLoaded();
         $this->contentTypeUpdatePage->expandLastFieldDefinition();
         $this->contentTypeUpdatePage->expandDefaultBlocksOption();
         $this->contentTypeUpdatePage->selectBlock($blockName);

--- a/src/lib/Behat/Component/IbexaDropdown.php
+++ b/src/lib/Behat/Component/IbexaDropdown.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
+use Ibexa\Behat\Browser\Element\Condition\ElementTransitionHasEndedCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 
@@ -16,7 +17,9 @@ class IbexaDropdown extends Component
 {
     public function verifyIsLoaded(): void
     {
-        $this->getHTMLPage()->find($this->getLocator('isIbexaDropdownVisible'))->assert()->isVisible();
+        $this->getHTMLPage()
+            ->setTimeout(2)
+            ->waitUntilCondition(new ElementTransitionHasEndedCondition($this->getHTMLPage(), $this->getLocator('isIbexaDropdownVisible')));
     }
 
     protected function specifyLocators(): array
@@ -30,9 +33,7 @@ class IbexaDropdown extends Component
 
     public function selectOption(string $value)
     {
-        //TODO: remove usleep
         $this->verifyIsLoaded();
-        usleep(1000000);
         $dropdownOptionLocator = $this->getLocator('ibexaDropdownExtended');
         $listElement = $this->getHTMLPage()
             ->findAll($dropdownOptionLocator)

--- a/src/lib/Behat/Page/ContentTypeUpdatePage.php
+++ b/src/lib/Behat/Page/ContentTypeUpdatePage.php
@@ -27,15 +27,12 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
 
     public function expandLastFieldDefinition(): void
     {
-        usleep(500000);
         $fieldToggleLocator = $this->getLocator('fieldDefinitionToggle');
-        $lastFieldAdded = $this->getHTMLPage()
+        $lastFieldDefinition = $this->getHTMLPage()
             ->findAll($fieldToggleLocator)
             ->last();
-        usleep(500000);
-        $lastFieldAdded->mouseOver();
-        $lastFieldAdded->click();
-        usleep(500000);
+        $lastFieldDefinition->mouseOver();
+        $lastFieldDefinition->click();
         $this->getHTMLPage()->setTimeout(5)
             ->waitUntilCondition(new ElementTransitionHasEndedCondition($this->getHTMLPage(), $fieldToggleLocator));
     }
@@ -119,5 +116,11 @@ class ContentTypeUpdatePage extends AdminUpdateItemPage
         $blockFindingScript = "document.querySelector('.ez-page-select-items__item .form-check .form-check-input[value=\'%s\']').click()";
         $scriptToExecute = sprintf($blockFindingScript, $blockName);
         $this->getSession()->executeScript($scriptToExecute);
+    }
+
+    public function verifyIsLoaded(): void
+    {
+        parent::verifyIsLoaded();
+        $this->getHTMLPage()->find($this->getLocator('contentTypeAddButton'))->assert()->isVisible();
     }
 }


### PR DESCRIPTION
There are two issues happening on Travis right now:
1) Commit: https://github.com/ezsystems/ezplatform-admin-ui/pull/2000/commits/f6a49b264c96a6496539cb3aaf86a7b873c9cc34
```
    When I check "video" block in ezlandingpage field blocks section                                     # Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext::iCheckBlockInField()
      Ibexa\Behat\Browser\Exception\TimeoutException: Transition has not started at all for element with CSS locator 'fieldDefinitionToggle': '.ibexa-collapse:nth-last-child(2) > div.ibexa-collapse__header > button:last-child:not([data-bs-target="#content_collapse"])'. Please make sure the condition is used on the correct element. Timeout value: 5 seconds. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php:59
      Stack trace:
      #0 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Page/ContentTypeUpdatePage.php(40): Ibexa\Behat\Browser\Element\BaseElement->waitUntilCondition()
      #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/BrowserContext/ContentTypeContext.php(237): Ibexa\AdminUi\Behat\Page\ContentTypeUpdatePage->expandLastFieldDefinition()
```

https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/547223694

The error message is telling us that we're waiting for the transition to end, but the transition has not started - it's caused by trying to expand the field definition too fast, before the page is fully loaded. The click is not registered and it has no effect.

I've added the verifyIsLoaded method to make sure the page is loaded. I've also removed the sleeps, as I hope this method will allow us to remove them.

2) Commit: https://github.com/ezsystems/ezplatform-admin-ui/pull/2000/commits/1d1c7958b46b95e6794309591cacf3996a4cc37d
```
      | Email Custom Form        | Email               | Custom email         |
        Ibexa\Behat\Browser\Exception\TimeoutException: CSS selector 'isIbexaDropdownVisible': '.ibexa-dropdown-popover' not found in 1 seconds. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php:79
        Stack trace:
        #0 vendor/ezsystems/behatbundle/src/lib/Browser/Element/BaseElement.php(103): Ibexa\Behat\Browser\Element\BaseElement->waitUntil()
        #1 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/IbexaDropdown.php(19): Ibexa\Behat\Browser\Element\BaseElement->find()
        #2 vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/IbexaDropdown.php(34): Ibexa\AdminUi\Behat\Component\IbexaDropdown->verifyIsLoaded()
        #3 vendor/ezsystems/ezplatform-form-builder/src/lib/Behat/Component/FormFields/FormBuilderField.php(128): Ibexa\AdminUi\Behat\Component\IbexaDropdown->selectOption()
        #4 vendor/ezsystems/ezplatform-form-builder/src/lib/Behat/Component/FormFields/EmailField.php(20): Ibexa\FormBuilder\Behat\Component\FormFields\FormBuilderField->select()
        #5 vendor/ezsystems/ezplatform-form-builder/src/lib/Behat/BrowserContext/FormFieldConfigurationContext.php(41): Ibexa\FormBuilder\Behat\Component\FormFields\EmailField->setDefaultTestingConfiguration()
```
https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/547223698

I've:
1) increased the timeout for the dropdown to appear to 2 seconds
2) Switched to `ElementTransitionHasEndedCondition` for checking if the element is loaded

This should be enough to make sure the dropdown is loaded, so I've removed the sleeps as well.

Regression run with the tests passing: https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/241362421