### PR TITLE
IBX-1514: Refactored 'read' UDW config resolvers

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
@@ -119,7 +119,7 @@
                     data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
                     data-location-path-input-selector="#{{form.subtree.vars.id}}"
                     data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
-                    data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+                    data-udw-config="{{ ez_udw_config('browse', {}) }}"
                     >{{'search.select_content'|trans|desc('Select Content')}}</button>
 
                 {{ include('@ezdesign/ui/tag.html.twig', {

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-type-selector/content.type.selector.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-type-selector/content.type.selector.js
@@ -2,9 +2,11 @@ import React, { useState, useContext } from 'react';
 
 import { createCssClassNames } from '../../../common/helpers/css.class.names';
 import { SelectedContentTypesContext } from '../search/search';
+import { AllowedContentTypesContext } from '../../universal.discovery.module';
 
 const ContentTypeSelector = () => {
     const { contentTypes: contentTypesMap } = window.eZ.adminUiConfig;
+    const allowedContentTypes = useContext(AllowedContentTypesContext);
     const [selectedContentTypes, dispatchSelectedContentTypesAction] = useContext(SelectedContentTypesContext);
     const [collapsedGroups, setCollapsedGroups] = useState(() => {
         return Object.keys(contentTypesMap).reduce((collapsedGroups, contentTypeGroup, index) => {
@@ -28,6 +30,14 @@ const ContentTypeSelector = () => {
     return (
         <div className="ez-content-type-selector c-content-type-selector">
             {Object.entries(contentTypesMap).map(([contentTypeGroup, contentTypes]) => {
+                const isHidden = contentTypes.every(
+                    (contentType) => allowedContentTypes && !allowedContentTypes.includes(contentType.identifier)
+                );
+
+                if (isHidden) {
+                    return null;
+                }
+
                 const groupSelectorClassName = createCssClassNames({
                     'ez-content-type-selector__group': true,
                     'ez-content-type-selector__group--collapsed': collapsedGroups[contentTypeGroup],
@@ -40,6 +50,11 @@ const ContentTypeSelector = () => {
                         </span>
                         <ul className="ez-content-type-selector__list">
                             {contentTypes.map((contentType) => {
+                                const isHidden = allowedContentTypes && !allowedContentTypes.includes(contentType.identifier);
+
+                                if (isHidden) {
+                                    return null;
+                                }
 
                                 return (
                                     <li key={contentType.identifier} className="ez-content-type-selector__item">

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-type-selector/content.type.selector.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-type-selector/content.type.selector.js
@@ -2,11 +2,9 @@ import React, { useState, useContext } from 'react';
 
 import { createCssClassNames } from '../../../common/helpers/css.class.names';
 import { SelectedContentTypesContext } from '../search/search';
-import { AllowedContentTypesContext } from '../../universal.discovery.module';
 
 const ContentTypeSelector = () => {
     const { contentTypes: contentTypesMap } = window.eZ.adminUiConfig;
-    const allowedContentTypes = useContext(AllowedContentTypesContext);
     const [selectedContentTypes, dispatchSelectedContentTypesAction] = useContext(SelectedContentTypesContext);
     const [collapsedGroups, setCollapsedGroups] = useState(() => {
         return Object.keys(contentTypesMap).reduce((collapsedGroups, contentTypeGroup, index) => {
@@ -30,14 +28,6 @@ const ContentTypeSelector = () => {
     return (
         <div className="ez-content-type-selector c-content-type-selector">
             {Object.entries(contentTypesMap).map(([contentTypeGroup, contentTypes]) => {
-                const isHidden = contentTypes.every(
-                    (contentType) => allowedContentTypes && !allowedContentTypes.includes(contentType.identifier)
-                );
-
-                if (isHidden) {
-                    return null;
-                }
-
                 const groupSelectorClassName = createCssClassNames({
                     'ez-content-type-selector__group': true,
                     'ez-content-type-selector__group--collapsed': collapsedGroups[contentTypeGroup],
@@ -50,11 +40,6 @@ const ContentTypeSelector = () => {
                         </span>
                         <ul className="ez-content-type-selector__list">
                             {contentTypes.map((contentType) => {
-                                const isHidden = allowedContentTypes && !allowedContentTypes.includes(contentType.identifier);
-
-                                if (isHidden) {
-                                    return null;
-                                }
 
                                 return (
                                     <li key={contentType.identifier} className="ez-content-type-selector__item">

--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
@@ -46,6 +46,7 @@ class ContentCreateTest extends TestCase
     public function testUdwConfigResolveWithCreateTab(array $config): void
     {
         $event = new ConfigResolveEvent();
+        $event->setConfigName('some_config');
         $event->setConfig($config);
 
         $subscriber = $this->getSubscriberWithRestrictions();
@@ -68,6 +69,7 @@ class ContentCreateTest extends TestCase
     public function testUdwConfigResolveWithoutCreateTab($config): void
     {
         $event = new ConfigResolveEvent();
+        $event->setConfigName('some_config');
         $event->setConfig($config);
 
         $subscriber = $this->getSubscriberWithRestrictions();

--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypesTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypesTest.php
@@ -14,10 +14,10 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
 use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
 use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
-use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\RichTextEmbedAllowedContentTypes;
+use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\ReadAllowedContentTypes;
 use PHPUnit\Framework\TestCase;
 
-final class RichTextEmbedAllowedContentTypesTest extends TestCase
+final class ReadAllowedContentTypesTest extends TestCase
 {
     private const EXAMPLE_LIMITATIONS = [/* Some limitations */];
 
@@ -35,7 +35,7 @@ final class RichTextEmbedAllowedContentTypesTest extends TestCase
     /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
     private $contentTypeService;
 
-    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\RichTextEmbedAllowedContentTypes */
+    /** @var \EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\Subscriber\ReadAllowedContentTypes */
     private $subscriber;
 
     protected function setUp(): void
@@ -44,7 +44,7 @@ final class RichTextEmbedAllowedContentTypesTest extends TestCase
         $this->permissionChecker = $this->createMock(PermissionCheckerInterface::class);
         $this->contentTypeService = $this->createMock(ContentTypeService::class);
 
-        $this->subscriber = new RichTextEmbedAllowedContentTypes(
+        $this->subscriber = new ReadAllowedContentTypes(
             $this->permissionResolver,
             $this->permissionChecker,
             $this->contentTypeService

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -14,6 +14,8 @@ class ConfigResolveEvent extends Event
 {
     public const NAME = 'udw.resolve.config';
 
+    public const READ_SPECIFIC_CONFIGURATIONS = ['richtext_embed', 'richtext_embed_image', 'browse'];
+
     /** @var string */
     protected $configName;
 

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -14,7 +14,7 @@ class ConfigResolveEvent extends Event
 {
     public const NAME = 'udw.resolve.config';
 
-    public const READ_SPECIFIC_CONFIGURATIONS = ['richtext_embed', 'richtext_embed_image', 'browse'];
+    private const READ_SPECIFIC_CONFIGURATIONS = ['richtext_embed', 'richtext_embed_image', 'browse'];
 
     /** @var string */
     protected $configName;

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -72,4 +72,9 @@ class ConfigResolveEvent extends Event
     {
         $this->context = $context;
     }
+
+    public function isReadOnlyEvent(): bool
+    {
+        return in_array($this->getConfigName(), self::READ_SPECIFIC_CONFIGURATIONS, true);
+    }
 }

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
@@ -66,7 +66,7 @@ class ContentCreate implements EventSubscriberInterface
      */
     public function onUdwConfigResolve(ConfigResolveEvent $event): void
     {
-        if (in_array($event->getConfigName(), $event::READ_SPECIFIC_CONFIGURATIONS)) {
+        if ($event->isReadOnlyEvent()) {
             return;
         }
 

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
@@ -66,6 +66,10 @@ class ContentCreate implements EventSubscriberInterface
      */
     public function onUdwConfigResolve(ConfigResolveEvent $event): void
     {
+        if (in_array($event->getConfigName(), $event::READ_SPECIFIC_CONFIGURATIONS)) {
+            return;
+        }
+
         $config = $event->getConfig();
 
         if ($this->hasContentTypeRestrictions()) {

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
@@ -79,7 +79,7 @@ final class ReadAllowedContentTypes implements EventSubscriberInterface
     {
         $config = $event->getConfig();
 
-        if (!in_array($event->getConfigName(), $event::READ_SPECIFIC_CONFIGURATIONS)) {
+        if (!$event->isReadOnlyEvent()) {
             return;
         }
 

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
@@ -15,7 +15,7 @@ use EzSystems\EzPlatformAdminUi\Permission\PermissionCheckerInterface;
 use EzSystems\EzPlatformAdminUi\UniversalDiscovery\Event\ConfigResolveEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
+final class ReadAllowedContentTypes implements EventSubscriberInterface
 {
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
     private $permissionResolver;
@@ -79,7 +79,7 @@ final class RichTextEmbedAllowedContentTypes implements EventSubscriberInterface
     {
         $config = $event->getConfig();
 
-        if (!in_array($event->getConfigName(), ['richtext_embed', 'richtext_embed_image'])) {
+        if (!in_array($event->getConfigName(), $event::READ_SPECIFIC_CONFIGURATIONS)) {
             return;
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1514](https://jira.ez.no/browse/IBX-1514)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Additional `browse` configuration has been handled in the renamed `ReadAllowedContentTypesTest` class. This is to ensure that browse/read specific UDW actions are not overridden by `ContentRead` resolver which has nothing to do with browsing or searching UDW when not selecting any content (for example selecting a Subtree in Search module, or "Browse" button in main left menu).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
