### PR TITLE
IBX-1604: Fixed deprecation warning thrown by PHP8

### DIFF
--- a/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.php
+++ b/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.php
@@ -32,8 +32,8 @@ class RedirectToDashboardAuthenticationSuccessHandler extends DefaultAuthenticat
      */
     public function __construct(
         HttpUtils $httpUtils,
-        array $options = [],
-        array $siteAccessGroups = [],
+        array $options,
+        array $siteAccessGroups,
         string $defaultTargetPath
     ) {
         parent::__construct($httpUtils, $options);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1604](https://issues.ibexa.co/browse/IBX-1604)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | possibly
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


```vendor/ezsystems/ezplatform-admin-ui/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.phponline33
Deprecated: Optional parameter $siteAccessGroups declared before required parameter defaultTargetPath is implicitly treated as a required parameter in
vendor/ezsystems/ezplatform-admin-ui/src/lib/Security/Authentication/RedirectToDashboardAuthenticationSuccessHandler.php
```

Not sure about potential BC break, but this approach seems to be more defensive than reordering constructor parameters. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
