### PR TITLE
[CI] Removed composer-package-version argument

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -16,6 +16,5 @@ jobs:
             project-version: '^3.3.x-dev'
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'
-            composer-package-version: '2.3.x-dev'
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This argument is removed in https://github.com/ibexa/gh-workflows/pull/5 (and is no longer needed)

Status:
https://github.com/ibexa/gh-workflows/pull/5 needs to be merged first