### PR TITLE
IBX-1799: Added new UDW configuration for Subtree filter

### DIFF
--- a/src/bundle/Resources/config/universal_discovery_widget.yaml
+++ b/src/bundle/Resources/config/universal_discovery_widget.yaml
@@ -74,3 +74,5 @@ system:
                     allowed_content_types: ['user_group']
                 add_location:
                     multiple: false
+                subtree_search:
+                    multiple: false

--- a/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/search/form.html.twig
@@ -119,7 +119,7 @@
                     data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
                     data-location-path-input-selector="#{{form.subtree.vars.id}}"
                     data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
-                    data-udw-config="{{ ez_udw_config('browse', {}) }}"
+                    data-udw-config="{{ ez_udw_config('subtree_search', {}) }}"
                     >{{'search.select_content'|trans|desc('Select Content')}}</button>
 
                 {{ include('@ezdesign/ui/tag.html.twig', {

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -14,7 +14,7 @@ class ConfigResolveEvent extends Event
 {
     public const NAME = 'udw.resolve.config';
 
-    private const READ_SPECIFIC_CONFIGURATIONS = ['richtext_embed', 'richtext_embed_image', 'browse'];
+    private const READ_SPECIFIC_CONFIGURATIONS = ['richtext_embed', 'richtext_embed_image', 'browse', 'subtree_search'];
 
     /** @var string */
     protected $configName;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1514](https://jira.ez.no/browse/IBX-1799)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

`browse` configuration was not really fitting to Subtree filter as it has confirmation turned off. New configuration has been added.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
