### PR TITLE
IBX-2275: Refactor UDW configuration subscribers

### DIFF
--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ContentCreateTest.php
@@ -46,7 +46,7 @@ class ContentCreateTest extends TestCase
     public function testUdwConfigResolveWithCreateTab(array $config): void
     {
         $event = new ConfigResolveEvent();
-        $event->setConfigName('some_config');
+        $event->setConfigName('create');
         $event->setConfig($config);
 
         $subscriber = $this->getSubscriberWithRestrictions();

--- a/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypesTest.php
+++ b/src/lib/Tests/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypesTest.php
@@ -53,7 +53,7 @@ final class ReadAllowedContentTypesTest extends TestCase
 
     public function testUdwConfigResolveOnUnsupportedConfigName(): void
     {
-        $this->permissionResolver->expects($this->never())->method('hasAccess');
+        $this->permissionResolver->method('hasAccess')->with('content', 'read')->willReturn(true);
         $this->permissionChecker->expects($this->never())->method('getRestrictions');
         $this->contentTypeService->expects($this->never())->method('loadContentTypeList');
 
@@ -61,7 +61,11 @@ final class ReadAllowedContentTypesTest extends TestCase
 
         $this->subscriber->onUdwConfigResolve($event);
 
-        $this->assertEquals([], $event->getConfig());
+        $expectedConfig = [
+            'allowed_content_types' => null,
+        ];
+
+        $this->assertEquals($expectedConfig, $event->getConfig());
     }
 
     public function testUdwConfigResolveWhenThereIsNoContentReadLimitations(): void

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -14,16 +14,6 @@ class ConfigResolveEvent extends Event
 {
     public const NAME = 'udw.resolve.config';
 
-    private const READ_SPECIFIC_CONFIGURATIONS = [
-        'richtext_embed',
-        'richtext_embed_image',
-        'browse',
-        'subtree_search',
-        'single',
-        'multiple',
-        'single_container',
-    ];
-
     /** @var string */
     protected $configName;
 
@@ -79,10 +69,5 @@ class ConfigResolveEvent extends Event
     public function setContext(array $context): void
     {
         $this->context = $context;
-    }
-
-    public function isReadOnlyEvent(): bool
-    {
-        return in_array($this->getConfigName(), self::READ_SPECIFIC_CONFIGURATIONS, true);
     }
 }

--- a/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
+++ b/src/lib/UniversalDiscovery/Event/ConfigResolveEvent.php
@@ -21,6 +21,7 @@ class ConfigResolveEvent extends Event
         'subtree_search',
         'single',
         'multiple',
+        'single_container',
     ];
 
     /** @var string */

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ContentCreate.php
@@ -66,7 +66,7 @@ class ContentCreate implements EventSubscriberInterface
      */
     public function onUdwConfigResolve(ConfigResolveEvent $event): void
     {
-        if ($event->isReadOnlyEvent()) {
+        if ($event->getConfigName() !== 'create') {
             return;
         }
 

--- a/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
+++ b/src/lib/UniversalDiscovery/Event/Subscriber/ReadAllowedContentTypes.php
@@ -79,10 +79,6 @@ final class ReadAllowedContentTypes implements EventSubscriberInterface
     {
         $config = $event->getConfig();
 
-        if (!$event->isReadOnlyEvent()) {
-            return;
-        }
-
         $this->allowedContentTypesIdentifiers = $this->getAllowedContentTypesIdentifiers(
             $config['allowed_content_types'] ?? []
         );


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-2275](https://issues.ibexa.co/browse/IBX-2275)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

From the UDW standpoint this might look tricky because usually the swap/move actions are validated using targets like:
`$this->permissionResolver->canUser('content', 'create', $location->getContentInfo(), [$newParentLocation])`, so the outcome can differ for each content. Therefore we cannot lock this permission to `content/create` as `allowedContentTypes` are global for UDW. The check will be done after all in the API.

//Edit Okay, at this point I feel like `content/create` should be used only for `create` configuration. Therefore, solution has been refactored.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
