### PR TITLE
[Behat] IBX-2321-behat-coverage-for-autosave

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -9,32 +9,35 @@ browser:
             filters:
                 tags: "~@broken"
             contexts: 
-                - EzSystems\Behat\API\Context\ContentTypeContext
                 - EzSystems\Behat\API\Context\ContentContext
+                - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
-                - Ibexa\Behat\Browser\Context\DebuggingContext
-                - Ibexa\Behat\Browser\Context\AuthenticationContext
-                - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
-                - Ibexa\AdminUi\Behat\BrowserContext\RightMenuContext
-                - Ibexa\AdminUi\Behat\BrowserContext\UDWContext
-                - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
+                - EzSystems\Behat\API\Context\UserContext
                 - Ibexa\AdminUi\Behat\BrowserContext\AdminUpdateContext
-                - Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext
-                - Ibexa\AdminUi\Behat\BrowserContext\ContentPreviewContext
-                - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
-                - Ibexa\AdminUi\Behat\BrowserContext\TrashContext
-                - Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext
-                - Ibexa\AdminUi\Behat\BrowserContext\RolesContext
-                - Ibexa\AdminUi\Behat\BrowserContext\SystemInfoContext
-                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
-                - Ibexa\AdminUi\Behat\BrowserContext\SectionsContext
-                - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
-                - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext
-                - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
-                - Ibexa\AdminUi\Behat\BrowserContext\SearchContext
                 - Ibexa\AdminUi\Behat\BrowserContext\BookmarkContext
-                - EzSystems\Behat\API\Context\RoleContext
+                - Ibexa\AdminUi\Behat\BrowserContext\ContentPreviewContext
+                - Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext
+                - Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext
+                - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
+                - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
+                - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
+                - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
+                - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext
+                - Ibexa\AdminUi\Behat\BrowserContext\RightMenuContext
+                - Ibexa\AdminUi\Behat\BrowserContext\RolesContext
+                - Ibexa\AdminUi\Behat\BrowserContext\SearchContext
+                - Ibexa\AdminUi\Behat\BrowserContext\SectionsContext
+                - Ibexa\AdminUi\Behat\BrowserContext\SystemInfoContext
+                - Ibexa\AdminUi\Behat\BrowserContext\TrashContext
+                - Ibexa\AdminUi\Behat\BrowserContext\UDWContext
+                - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
+                - Ibexa\Behat\Browser\Context\AuthenticationContext
+                - Ibexa\Behat\Browser\Context\DebuggingContext
+                - Ibexa\User\Behat\Context\UserSettingsContext
 
         personas:
             paths:
@@ -62,7 +65,10 @@ browser:
                 - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
+                - EzSystems\Behat\API\Context\UserContext
+                - EzSystems\Behat\API\Context\UserContext
                 - Ibexa\AdminUi\Behat\BrowserContext\AdminUpdateContext
+                - Ibexa\AdminUi\Behat\BrowserContext\BookmarkContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentPreviewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentUpdateContext
@@ -83,4 +89,4 @@ browser:
                 - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
-                - Ibexa\AdminUi\Behat\BrowserContext\BookmarkContext
+                - Ibexa\User\Behat\Context\UserSettingsContext

--- a/features/standard/Autosave.feature
+++ b/features/standard/Autosave.feature
@@ -1,0 +1,51 @@
+@IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+Feature: Content Items creation
+  As an administrator
+  In order to manage content to my site
+  I want to check autosave feature during creation of Content Items
+
+  @javascript @APIUser:admin
+  Scenario: Content item is visible in draft dashboard after being autosaved
+    Given I create a user group "AutosaveEnabledTestGroup"
+    And I create a role "autosaveEnabledTestRole" with policies
+      | module | function |
+      | *      | *        |
+    And I create a user "AutosaveEnabledTestUser" with last name "AutosaveEnabledTestLastName" in group "AutosaveEnabledTestGroup"
+    And I assign user "AutosaveEnabledTestUser" to role "autosaveEnabledTestRole"
+    And I set autosave interval value to "5" for user "AutosaveEnabledTestUser"
+    And I open Login page in admin SiteAccess
+    And I log in as "AutosaveEnabledTestUser" with password "Passw0rd-42"
+    And I'm on Content view Page for root
+    When I start creating a new content "Article"
+    And I set content fields
+      | label       | value                       |
+      | Title       | Test Article Autosave draft |
+      | Short title | Test Article Autosave draft |
+    And I wait for 5 seconds for Content Item to be autosaved
+    And I click on the close button
+    And I open the "Dashboard" page in admin SiteAccess
+    Then there's draft "Test Article Autosave draft" on Dashboard list
+
+  @javascript @APIUser:admin
+  Scenario: Content item is not autosaved and draft is not visible in dashboard when autosave is disabled
+    Given I create a user group "AutosaveDisabledTestGroup"
+    And I create a role "autosaveDisabledTestRole" with policies
+      | module | function |
+      | *      | *        |
+    And I create a user "AutosaveDisabledTestUser" with last name "AutosaveDisabledTestLastName" in group "AutosaveDisabledTestGroup"
+    And I assign user "AutosaveDisabledTestUser" to role "autosaveDisabledTestRole"
+    And I open Login page in admin SiteAccess
+    And I log in as "AutosaveDisabledTestUser" with password "Passw0rd-42"
+    And I'm on Content view Page for root
+    And I go to user settings
+    And I disable autosave
+    And I click on the edit action bar button "Save"
+    And I'm on Content view Page for root
+    When I start creating a new content "Article"
+    And I set content fields
+      | label       | value                       |
+      | Title       | Test Article Autosave Off draft |
+      | Short title | Test Article Autosave Off draft |
+    And I click on the close button
+    And I open the "Dashboard" page in admin SiteAccess
+    Then there's no draft "Test Article Autosave Off draft" on Dashboard list

--- a/src/bundle/Resources/config/services/test/pages.yaml
+++ b/src/bundle/Resources/config/services/test/pages.yaml
@@ -57,3 +57,5 @@ services:
   Ibexa\AdminUi\Behat\Page\ChangePasswordPage: ~
 
   Ibexa\AdminUi\Behat\Page\BookmarksPage: ~
+
+  Ibexa\AdminUi\Behat\Page\UserSettingsPage: ~

--- a/src/lib/Behat/BrowserContext/ContentUpdateContext.php
+++ b/src/lib/Behat/BrowserContext/ContentUpdateContext.php
@@ -112,4 +112,15 @@ class ContentUpdateContext implements Context
         $this->contentUpdateItemPage->verifyIsLoaded();
         $this->contentUpdateItemPage->switchToFieldGroup($tabName);
     }
+
+    /**
+     * @When I wait for :autosaveIntervalTime seconds for Content Item to be autosaved
+     */
+    public function iWaitForAutosaveNotification(int $autosaveIntervalTime): void
+    {
+        $this->contentUpdateItemPage->verifyIsLoaded();
+        $this->contentUpdateItemPage->verifyAutosaveNotificationIsDisplayed();
+        sleep($autosaveIntervalTime + 3);
+        $this->contentUpdateItemPage->verifyAutosaveDraftIsSavedNotificationIsDisplayed();
+    }
 }

--- a/src/lib/Behat/BrowserContext/NavigationContext.php
+++ b/src/lib/Behat/BrowserContext/NavigationContext.php
@@ -144,6 +144,14 @@ class NavigationContext implements Context
     }
 
     /**
+     * @Given I go to user settings
+     */
+    public function iGoToUserSettings()
+    {
+        $this->upperMenu->chooseFromUserDropdown('User Settings');
+    }
+
+    /**
      * @Given I'm on Content view Page for :path
      * @Given there exists Content view Page for :path
      */

--- a/src/lib/Behat/BrowserContext/UserPreferencesContext.php
+++ b/src/lib/Behat/BrowserContext/UserPreferencesContext.php
@@ -11,7 +11,9 @@ use Ibexa\AdminUi\Behat\Page\ChangePasswordPage;
 
 class UserPreferencesContext implements Context
 {
-    /** @var \Ibexa\AdminUi\Behat\Page\ChangePasswordPage */
+    /**
+     * @var \Ibexa\AdminUi\Behat\Page\ChangePasswordPage
+     */
     private $changePasswordPage;
 
     public function __construct(ChangePasswordPage $changePasswordPage)
@@ -28,5 +30,15 @@ class UserPreferencesContext implements Context
         $this->changePasswordPage->setOldPassword($oldPassword);
         $this->changePasswordPage->setNewPassword($newPassword);
         $this->changePasswordPage->setConfirmPassword($newPassword);
+    }
+
+    /**
+     * @When I disable autosave
+     */
+    public function iSetAutosaveDraftValue(): void
+    {
+        $this->userSettingsPage->verifyIsLoaded();
+        $this->userSettingsPage->openAutosaveDraftEditionPage();
+        $this->userSettingsPage->disableAutosave();
     }
 }

--- a/src/lib/Behat/Page/ContentUpdateItemPage.php
+++ b/src/lib/Behat/Page/ContentUpdateItemPage.php
@@ -97,6 +97,8 @@ class ContentUpdateItemPage extends Page
             new VisibleCSSLocator('noneditableFieldClass', 'ez-field-edit--eznoneditable'),
             new VisibleCSSLocator('fieldOfType', '.ez-field-edit--%s'),
             new VisibleCSSLocator('navigationTabs', '.nav-item.ez-tabs__nav-item'),
+            new VisibleCSSLocator('autosaveInfo', '.ez-content-edit-page-title__autosave-info'),
+            new VisibleCSSLocator('autosaveLastSavedInfo', '.ez-content-edit-page-title__autosave-last-saved'),
         ];
     }
 
@@ -169,5 +171,19 @@ class ContentUpdateItemPage extends Page
     {
         $fieldLocator = new VisibleCSSLocator('', sprintf($this->getLocator('activeNthField')->getSelector(), $this->getFieldPosition($fieldName)));
         $this->getHTMLPage()->find($fieldLocator)->assert()->hasClass('ez-field-edit--disabled');
+    }
+
+    public function verifyAutosaveNotificationIsDisplayed(): void
+    {
+        $this->getHTMLPage()
+            ->find($this->getLocator('autosaveInfo'))
+            ->assert()->textContains('Autosave is on.');
+    }
+
+    public function verifyAutosaveDraftIsSavedNotificationIsDisplayed(): void
+    {
+        $this->getHTMLPage()
+            ->find($this->getLocator('autosaveLastSavedInfo'))
+            ->assert()->textContains('Last saved draft was on');
     }
 }

--- a/src/lib/Behat/Page/UserSettingsPage.php
+++ b/src/lib/Behat/Page/UserSettingsPage.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\AdminUi\Behat\Page;
+
+use Behat\Mink\Session;
+use Ibexa\AdminUi\Behat\Component\RightMenu;
+use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
+use Ibexa\Behat\Browser\Page\Page;
+use Ibexa\Behat\Browser\Routing\Router;
+
+class UserSettingsPage extends Page
+{
+    /** @var \Ibexa\AdminUi\Behat\Component\RightMenu */
+    private $rightMenu;
+
+    public function __construct(Session $session, Router $router, RightMenu $rightMenu)
+    {
+        parent::__construct($session, $router);
+        $this->rightMenu = $rightMenu;
+    }
+
+    public function verifyIsLoaded(): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('title'))->assert()->textEquals('User Settings');
+    }
+
+    protected function specifyLocators(): array
+    {
+        return [
+            new VisibleCSSLocator('title', '.ez-page-title__content-name'),
+            new VisibleCSSLocator('autosaveDraftEditButton', 'a[href$="autosave"]'),
+            new VisibleCSSLocator('autosaveDraftValueDropdown', '#user_setting_update_value'),
+            new VisibleCSSLocator('autosaveIntervalEdit', 'a[href$="interval"]'),
+        ];
+    }
+
+    public function openAutosaveDraftEditionPage(): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('autosaveDraftEditButton'))->click();
+    }
+
+    public function openAutosaveDraftIntervalEditionPage(): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('autosaveIntervalEdit'))->click();
+    }
+
+    public function disableAutosave(): void
+    {
+        $this->rightMenu->verifyIsLoaded();
+        $this->getHTMLPage()->find($this->getLocator('autosaveDraftValueDropdown'))->selectOption('disabled');
+    }
+
+    public function getName(): string
+    {
+        return 'User Settings';
+    }
+
+    protected function getRoute(): string
+    {
+        return '/user/settings/list';
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2321
This PR is connected to: https://github.com/ezsystems/ezplatform-user/pull/112

The following scenarios are added in this PR:
1. With autosave feature On. Create new Content item, wait until interval passed, exit editor (discard), verify draft was created.
2. With autosave feature Off. Create new Content item, wait, exit editor, verify draft was not created.

Default autosave interval value is 60 seconds so i left it at that value. Also, ive added 3 seconds just to be sure autosave confirmation notification is displayed. On v3 it is not possible to assert if autosave is off during content item creation (because no notification that autosave is off appears).

Successful build: https://github.com/ezsystems/ezplatform-admin-ui/runs/6291247923?check_suite_focus=true