### PR TITLE
[Behat] Added scrolling to the bottom in UDW when not all items are l…

### DIFF
--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
-use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
 use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
@@ -119,7 +118,9 @@ class UniversalDiscoveryWidget extends Component
                     '.c-finder-branch:nth-of-type(%d) .c-finder-branch__items-wrapper', $level)
             );
             $this->getHTMLPage()->find($scrollableElement)->scrollToBottom($this->getSession());
-            $this->getHTMLPage()->waitUntilCondition(new ElementNotExistsCondition($this->getHTMLPage(), $this->getLocator('loadMoreSpinner')));
+            $this->getHTMLPage()
+                ->setTimeout(3)
+                ->waitUntilCondition(new ElementNotExistsCondition($this->getHTMLPage(), $this->getLocator('loadMoreSpinner')));
         }
 
         $this->getHTMLPage()->findAll($treeElementsLocator)->getByCriterion(new ElementTextCriterion($itemName))->click();

--- a/src/lib/Behat/Component/UniversalDiscoveryWidget.php
+++ b/src/lib/Behat/Component/UniversalDiscoveryWidget.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\AdminUi\Behat\Component;
 
 use Ibexa\Behat\Browser\Component\Component;
+use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
+use Ibexa\Behat\Browser\Element\Condition\ElementNotExistsCondition;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
@@ -112,6 +114,14 @@ class UniversalDiscoveryWidget extends Component
         $treeElementsLocator = new CSSLocator('', sprintf($this->getLocator('treeLevelElementsFormat')->getSelector(), $level));
         $selectedTreeElementLocator = new CSSLocator('', sprintf($this->getLocator('treeLevelSelectedFormat')->getSelector(), $level));
 
+        if ($this->getHTMLPage()->findAll($treeElementsLocator)->count() % 50 === 0) {
+            $scrollableElement = new VisibleCSSLocator('scrollable', sprintf(
+                    '.c-finder-branch:nth-of-type(%d) .c-finder-branch__items-wrapper', $level)
+            );
+            $this->getHTMLPage()->find($scrollableElement)->scrollToBottom($this->getSession());
+            $this->getHTMLPage()->waitUntilCondition(new ElementNotExistsCondition($this->getHTMLPage(), $this->getLocator('loadMoreSpinner')));
+        }
+
         $this->getHTMLPage()->findAll($treeElementsLocator)->getByCriterion(new ElementTextCriterion($itemName))->click();
         $this->getHTMLPage()->findAll($selectedTreeElementLocator)->getByCriterion(new ElementTextCriterion($itemName))->assert()->isVisible();
 
@@ -183,6 +193,7 @@ class UniversalDiscoveryWidget extends Component
             new CSSLocator('treeLevelFormat', '.c-finder-branch:nth-child(%d)'),
             new CSSLocator('treeLevelElementsFormat', '.c-finder-branch:nth-of-type(%d) .c-finder-leaf'),
             new CSSLocator('treeLevelSelectedFormat', '.c-finder-branch:nth-of-type(%d) .c-finder-leaf--marked'),
+            new VisibleCSSLocator('loadMoreSpinner', '.c-finder-branch__loading-spinner'),
             // selectors for multiitem selection
             new CSSLocator('multiSelectAddButton', '.c-toggle-selection-button'),
             // itemActions


### PR DESCRIPTION
Requires https://github.com/ezsystems/BehatBundle/pull/271

Tested in:
https://github.com/ibexa/commerce/pull/63
https://github.com/ibexa/experience/pull/31
https://github.com/ibexa/content/pull/37

Example failure: https://github.com/ibexa/experience/runs/6056424261?check_suite_focus=true
```
     When I select content "root/BookmarkUDW" through UDW                             # Ibexa\AdminUi\Behat\BrowserContext\UDWContext::iSelectContent()
      Ibexa\Behat\Browser\Exception\ElementNotFoundException: Could not find element named: 'BookmarkUDW'. Found names: Ibexa Platform,Destination,NewArticle,FolderGrandParent,Edited Lorem ipsum,Bielefeld,Melbourne,Test Name Edited,0,Files,Editors Multimedia,Argentina,Monday 30 December 2019,Mon 2019-30-12 15:15:00,edited.email@example.com,12.34,0-13-048257-9,1234,keyword2,Edited Lorem ipsum dolor sit,Edited Lorem ipsum dolor,3:15:00 pm,Edited Test URL,video2.mp4,image2.png,binary2.txt,Matrix,imageasset2.png,ImageAssetImage,New Content query,VideoBlock,GalleryBlock,RSSBlock,CodeBlock,EmbedBlock,ContentListBlock,CollectionBlock,ContentSchedulerBlock,TextBlock,BannerBlock,CodeLink,TestLink,TestSection,LandingPageDeleteDraft,CreatedLandingPage,Test Folder Short,TestNavigation,blockVisibilityTestLP,launchModeTestLP,BookmarkFolder instead. CSS locator '': '.c-finder-branch:nth-of-type(2) .c-finder-leaf'. in vendor/ezsystems/behatbundle/src/lib/Browser/Element/ElementCollection.php:60
```

This failure happens because of UDW behaviour - when the number of child Content Items is bigger than 50 then not all items are loaded at once. UDW loads only the first 50 Content Items and the rest is loaded on demand, when user scrolls to the bottom of the item list.

Video:

https://user-images.githubusercontent.com/10993858/163960435-21213ee2-4370-49fe-beb9-eafc5dff5359.mp4

(notice how the scroll moves when user scrolls to the bottom - new items are loaded)

This PR implements this behaviour - when there's a chance that not all child Content Items are loaded (the displayed number of items is 50,100,150 etc.) then we scroll to the bottom and wait until more items are loaded.

