### PR TITLE
IBX-2880: Changed CredentialsExpiredListener to expect PasswordExpiredException

### DIFF
--- a/src/lib/EventListener/CredentialsExpiredListener.php
+++ b/src/lib/EventListener/CredentialsExpiredListener.php
@@ -12,10 +12,10 @@ use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\View\LoginFormView;
 use EzSystems\EzPlatformAdminUi\Specification\SiteAccess\IsAdmin;
+use Ibexa\Core\MVC\Symfony\Security\Exception\PasswordExpiredException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 
 final class CredentialsExpiredListener implements EventSubscriberInterface
 {
@@ -54,7 +54,7 @@ final class CredentialsExpiredListener implements EventSubscriberInterface
             return;
         }
 
-        if ($view->getLastAuthenticationException() instanceof CredentialsExpiredException) {
+        if ($view->getLastAuthenticationException() instanceof PasswordExpiredException) {
             $view->setTemplateIdentifier('@ezdesign/account/error/credentials_expired.html.twig');
         }
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2880](https://issues.ibexa.co/browse/IBX-2880)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

[CredentialsExpiredListener](https://github.com/ezsystems/ezplatform-admin-ui/blob/2.3/src/lib/EventListener/CredentialsExpiredListener.php#L57) expects `CredentialsExpiredException` which will never happen, as the Exception is immediately replaced with `BadCredentialsException` in  https://github.com/symfony/security-core/blob/5.4/Authentication/Provider/UserAuthenticationProvider.php#L90

This PR adds changes `CredentialsExpredListener` to expect the `PasswordExpiredException` exception which extends `CustomUserMessageAccountStatusException` which allows it to set a proper "password expired" template.

Kernel part of PR: https://github.com/ezsystems/ezplatform-kernel/pull/309

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
