### PR TITLE
IBX-857: Added call invalidateSize on each map when tab clicked and if tab contains any map

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -1,4 +1,4 @@
-(function(global, doc, eZ, Leaflet) {
+(function(global, doc, eZ, Leaflet, $) {
     const SELECTOR_FIELD = '.ez-field-edit--ezgmaplocation';
     const SELECTOR_ADDRESS_INPUT = '.ez-data-source__field--address .ez-data-source__input';
     const SELECTOR_LAT_FIELD = '.ez-data-source__field--latitude';
@@ -18,6 +18,7 @@
     const VALIDATE_LONGITUDE = 'validateLongitude';
     const VALIDATE_LATITUDE = 'validateLatitude';
     const VALIDATE_ADDRESS = 'validateAddress';
+    const maps = [];
 
     class EzGMapLocationValidator extends eZ.BaseFieldValidator {
         /**
@@ -463,6 +464,7 @@
         };
         const map = Leaflet.map(field.querySelector('.ez-data-source__map'), mapConfig);
 
+        maps.push(map);
         longitudeInput.value = longitudeInput.dataset.value.replace(',', '.');
         latitudeInput.value = latitudeInput.dataset.value.replace(',', '.');
 
@@ -618,5 +620,14 @@
         }
     });
 
+    $('.ez-tabs a').on('shown.bs.tab', (event) => {
+        const id = event.target.getAttribute('href');
+        const element = doc.querySelector(id);
+
+        if (element.querySelectorAll(SELECTOR_FIELD).length > 0) {
+            maps.forEach(map => map.invalidateSize(true));
+        }
+    });
+
     eZ.addConfig('fieldTypeValidators', [validator], true);
-})(window, window.document, window.eZ, window.L);
+})(window, window.document, window.eZ, window.L, window.jQuery);

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezgmaplocation.js
@@ -620,12 +620,12 @@
         }
     });
 
-    $('.ez-tabs a').on('shown.bs.tab', (event) => {
-        const id = event.target.getAttribute('href');
-        const element = doc.querySelector(id);
+    $('.ez-tabs .nav-link').on('shown.bs.tab', (event) => {
+        const tabPaneSelector = event.target.getAttribute('href');
+        const tabPane = doc.querySelector(tabPaneSelector);
 
-        if (element.querySelectorAll(SELECTOR_FIELD).length > 0) {
-            maps.forEach(map => map.invalidateSize(true));
+        if (tabPane.querySelectorAll(SELECTOR_FIELD).length > 0) {
+            maps.forEach((map) => map.invalidateSize(true));
         }
     });
 


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-857](https://issues.ibexa.co/browse/IBX-857)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Because the map is not visible immediately (display:none;) the map can't compute the correct position, therefore the call invalidateSize(true); has been added for maps when changing the tab, thanks to which it is able to calculate the correct position


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
