### PR TITLE
IBX-2928: Provided tooltip fallback for Content fieldtype description

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -102,10 +102,7 @@
     <div {% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
         <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {% with { 'compound': false } %}{{- block('form_label') }}{% endwith %}
-            {% set description = field_type_descriptions[fieldtype.vars.languageCode] is defined
-                and field_type_descriptions[fieldtype.vars.languageCode] != ''
-                ? field_type_descriptions[fieldtype.vars.languageCode]
-                : field_type_descriptions|first %}
+            {% set description = field_type_descriptions[fieldtype.vars.languageCode]|default(field_type_descriptions|first) %}
             {% if description is not null %}
                 <span class="ez-field-edit__icon-wrapper" title="{{ description }}">
                     <svg class="ez-icon ez-icon--medium">

--- a/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/form_fields.html.twig
@@ -102,8 +102,12 @@
     <div {% with { attr: wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
         <div{% with { attr: label_wrapper_attr } %}{{ block('attributes') }}{% endwith %}>
             {% with { 'compound': false } %}{{- block('form_label') }}{% endwith %}
-            {% if field_type_descriptions[fieldtype.vars.languageCode] is defined and field_type_descriptions[fieldtype.vars.languageCode] != '' %}
-                <span class="ez-field-edit__icon-wrapper" title="{{ field_type_descriptions[fieldtype.vars.languageCode] }}">
+            {% set description = field_type_descriptions[fieldtype.vars.languageCode] is defined
+                and field_type_descriptions[fieldtype.vars.languageCode] != ''
+                ? field_type_descriptions[fieldtype.vars.languageCode]
+                : field_type_descriptions|first %}
+            {% if description is not null %}
+                <span class="ez-field-edit__icon-wrapper" title="{{ description }}">
                     <svg class="ez-icon ez-icon--medium">
                         <use xlink:href="{{ ez_icon_path('system-information') }}"></use>
                     </svg>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2928
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x]  Ready for Code Review
