### PR TITLE
[Behat] IBX-1548: Added spike coverage for content item translation

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -16,5 +16,6 @@ jobs:
             project-version: '^3.3.x-dev'
             test-suite:  '--profile=browser --suite=admin-ui-full'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'
+            test-setup-phase-2: '--profile=setup --suite=content-translation --mode=standard'
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/features/personas/ChangePassword.feature
+++ b/features/personas/ChangePassword.feature
@@ -1,4 +1,4 @@
-@javascript @changePassword
+@javascript @changePassword @IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
 Feature: Verify that an User allowed to change password can change his password
 
   Scenario: I can change my password

--- a/features/standard/ContentTranslation.feature
+++ b/features/standard/ContentTranslation.feature
@@ -1,0 +1,56 @@
+@javascript @translation @IbexaOSS @IbexaContent @IbexaExperience @IbexaCommerce
+Feature: Content item transation
+
+  @APIUser:admin
+  Scenario: Publish new translation based on existing translation
+    Given I create "folder" Content items in root in "eng-GB"
+      | name             | short_name       | short_description | description      |
+      | EnglishPublished | EnglishPublished | EnglishPublished  | EnglishPublished |
+    And I am logged as admin
+    And I'm on Content view Page for "EnglishPublished"
+    When I switch to "Translations" tab in Content structure
+    And I add new translation "French" basing on "English (United Kingdom)" translation
+    And I set content fields
+      | label      | value           |
+      | Name       | FrenchPublished |
+      | Short name | FrenchPublished |
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And content attributes equal
+      | label             | value            |
+      | Name              | EnglishPublished |
+      | Short name        | EnglishPublished |
+      | Short description | EnglishPublished |
+      | Description       | EnglishPublished |
+    And I choose "French" preview in Content View
+    And content attributes equal
+      | label             | value            |
+      | Name              | FrenchPublished  |
+      | Short name        | FrenchPublished  |
+      | Short description | EnglishPublished |
+      | Description       | EnglishPublished |
+
+  @APIUser:admin
+  Scenario: Publish new translation without base translation
+    Given I create "folder" Content items in root in "eng-GB"
+      | name            | short_name       | short_description | description      |
+      | NoBasePublished | NoBasePublished  | NoBasePublished   | NoBasePublished  |
+    And I am logged as admin
+    And I'm on Content view Page for "NoBasePublished"
+    When I switch to "Translations" tab in Content structure
+    And I add new translation "French" without base translation
+    And I click on the edit action bar button "Publish"
+    Then success notification that "Content published." appears
+    And content attributes equal
+      | label             | value           |
+      | Name              | NoBasePublished |
+      | Short name        | NoBasePublished |
+      | Short description | NoBasePublished |
+      | Description       | NoBasePublished |
+    And I choose "French" preview in Content View
+    And content attributes equal
+      | label             | value               | fieldTypeIdentifier |
+      | Name              | Folder              |                     |
+      | Short name        | This field is empty | ezstring            |
+      | Short description | This field is empty | ezrichtext          |
+      | Description       | This field is empty | ezrichtext          |

--- a/src/bundle/Resources/config/services/test/components.yaml
+++ b/src/bundle/Resources/config/services/test/components.yaml
@@ -15,6 +15,8 @@ services:
 
   Ibexa\AdminUi\Behat\Component\Dialog: ~
 
+  Ibexa\AdminUi\Behat\Component\TranslationDialog: ~
+
   Ibexa\AdminUi\Behat\Component\Pagination: ~
 
   Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget: ~

--- a/src/lib/Behat/BrowserContext/ContentViewContext.php
+++ b/src/lib/Behat/BrowserContext/ContentViewContext.php
@@ -74,6 +74,23 @@ class ContentViewContext implements Context
     }
 
     /**
+     * @Given I add new translation :language without base translation
+     * @Given I add new translation :language basing on :base translation
+     */
+    public function iAddNewTranslation(string $language, string $base = 'none'): void
+    {
+        $this->contentViewPage->addTranslation($language, $base);
+    }
+
+    /**
+     * @Given I choose :language preview in Content View
+     */
+    public function iChoosePreview(string $language): void
+    {
+        $this->contentViewPage->choosePreview($language);
+    }
+
+    /**
      * @Given I start creating a new User
      */
     public function startCreatingUser(): void

--- a/src/lib/Behat/Component/TranslationDialog.php
+++ b/src/lib/Behat/Component/TranslationDialog.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AdminUi\Behat\Component;
+
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
+use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
+
+class TranslationDialog extends Dialog
+{
+    protected function chooseFromDropdown(string $language): void
+    {
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('dropdownItem'))
+            ->getByCriterion(new ElementTextCriterion($language))
+            ->click();
+    }
+
+    public function selectNewTranslation(string $languageName): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('expandNewTranslationDropdown'))->click();
+        $this->chooseFromDropdown($languageName);
+    }
+
+    public function selectBaseTranslation(string $languageName): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('expandBaseTranslationDropdown'))->click();
+        $this->chooseFromDropdown($languageName);
+    }
+
+    public function verifyIsLoaded(): void
+    {
+        $this->getHTMLPage()->setTimeout(3)
+            ->find($this->getLocator('addTranslationPopupModalTitle'))
+            ->assert()->textEquals('Create a new translation');
+    }
+
+    protected function specifyLocators(): array
+    {
+        return array_merge(parent::specifyLocators(), [
+            new VisibleCSSLocator('expandNewTranslationDropdown', '.ez-custom-dropdown[data-source-selector=".ez-translation__language-wrapper--language"] .ez-custom-dropdown__selection-info'),
+            new VisibleCSSLocator('expandBaseTranslationDropdown', '.ez-custom-dropdown[data-source-selector=".ez-translation__language-wrapper--base-language"] .ez-custom-dropdown__selection-info'),
+            new VisibleCSSLocator('dropdownItem', '.ez-custom-dropdown__item .ez-custom-dropdown__item-label'),
+            new VisibleCSSLocator('addTranslationPopupModalTitle', '#add-translation-modal .modal-title'),
+        ]);
+    }
+}

--- a/src/lib/Behat/Page/ContentViewPage.php
+++ b/src/lib/Behat/Page/ContentViewPage.php
@@ -20,6 +20,7 @@ use Ibexa\AdminUi\Behat\Component\Dialog;
 use Ibexa\AdminUi\Behat\Component\LanguagePicker;
 use Ibexa\AdminUi\Behat\Component\RightMenu;
 use Ibexa\AdminUi\Behat\Component\SubItemsList;
+use Ibexa\AdminUi\Behat\Component\TranslationDialog;
 use Ibexa\AdminUi\Behat\Component\UniversalDiscoveryWidget;
 use Ibexa\AdminUi\Behat\Component\UpperMenu;
 use Ibexa\Behat\Browser\Element\Condition\ElementExistsCondition;
@@ -58,6 +59,9 @@ class ContentViewPage extends Page
     /** @var \Ibexa\AdminUi\Behat\Component\Dialog */
     private $dialog;
 
+    /** @var \Ibexa\AdminUi\Behat\Component\TranslationDialog */
+    private $translationDialog;
+
     private $route;
 
     /** @var \Ibexa\AdminUi\Behat\Component\Breadcrumb */
@@ -92,6 +96,7 @@ class ContentViewPage extends Page
         ContentUpdateItemPage $contentUpdatePage,
         LanguagePicker $languagePicker,
         Dialog $dialog,
+        TranslationDialog $translationDialog,
         Repository $repository,
         Breadcrumb $breadcrumb,
         ContentItemAdminPreview $contentItemAdminPreview,
@@ -108,6 +113,7 @@ class ContentViewPage extends Page
         $this->contentUpdatePage = $contentUpdatePage;
         $this->languagePicker = $languagePicker;
         $this->dialog = $dialog;
+        $this->translationDialog = $translationDialog;
         $this->breadcrumb = $breadcrumb;
         $this->contentItemAdminPreview = $contentItemAdminPreview;
         $this->userUpdatePage = $userUpdatePage;
@@ -148,6 +154,27 @@ class ContentViewPage extends Page
         $this->universalDiscoveryWidget->verifyIsLoaded();
         $this->universalDiscoveryWidget->selectContent($newLocationPath);
         $this->universalDiscoveryWidget->confirm();
+    }
+
+    public function addTranslation(string $language, string $base): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('addTranslationButton'))->click();
+        $this->translationDialog->verifyIsLoaded();
+        $this->translationDialog->selectNewTranslation($language);
+        if ($base != 'none') {
+            $this->translationDialog->selectBaseTranslation($base);
+        }
+        $this->translationDialog->confirm();
+    }
+
+    public function choosePreview(string $language): void
+    {
+        $this->getHTMLPage()->find($this->getLocator('previewDropdown'))->click();
+        $this->getHTMLPage()
+            ->findAll($this->getLocator('previewLanguage'))
+            ->getByCriterion(new ElementTextCriterion($language))
+            ->click();
+        $this->verifyIsLoaded();
     }
 
     public function goToSubItem(string $contentItemName): void
@@ -298,6 +325,9 @@ class ContentViewPage extends Page
             new VisibleCSSLocator('addLocationButton', '#ez-tab-location-view-locations .ez-table-header__tools .btn--udw-add'),
             new VisibleCSSLocator('bookmarkButton', '.ez-add-to-bookmarks'),
             new VisibleCSSLocator('isBookmarked', '.ez-add-to-bookmarks--checked'),
+            new VisibleCSSLocator('addTranslationButton', '#ez-tab-location-view-translations .ez-table-header__tools .ez-btn--add-translation'),
+            new VisibleCSSLocator('previewDropdown', '.ez-location-language-change'),
+            new VisibleCSSLocator('previewLanguage', '.ez-location-language-change option'),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1548](https://issues.ibexa.co/browse/IBX-1548) 
| Bug fix?      | no
| New feature?  | tests
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds two scenarios publishing new translation:
- based on existing translation
- without base translation

The scenarios are added to admin-ui tests in this bundle, in behatbundle and to regression builds in 4 editions.

Things covered:
- [x] add new step for adding translation (with and without base translation)
- [x] add new step for switching preview language in Admin UI
- [x] add TranslationDialog component (with selectNewTranslation & selectBaseTranslation methods)
- [x] add new language to configuration - in second phase of tests setup (https://github.com/ezsystems/BehatBundle/pull/279)

Extra:
- [x] add missing DXP edition tags for Change Password scenarios 🙈 (https://github.com/ezsystems/ezplatform-admin-ui/pull/2057/commits/bfecb6301f8f92e6e04354dbed22bf5fa53cd2fe)

Builds on DXP editions:
- https://github.com/ibexa/oss/pull/73
- https://github.com/ibexa/commerce/pull/133

In case of theses builds language configuration is appended to first phase of tests setup.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
