### PR TITLE
IBX-3320: Unified content versions edit buttons logic

### DIFF
--- a/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/versions/table.html.twig
@@ -84,6 +84,7 @@
                                 </svg>
                             </a>
                         {% elseif is_draft %}
+                            {% set edit_draft_disabled = (version.author and version.author.id != ez_admin_ui_config.user.user.id) %}
                             <button
                                     data-content-draft-edit-url="{{ edit_url }}"
                                     data-version-has-conflict-url="{{ path('ezplatform.version.has_no_conflict', {
@@ -93,7 +94,8 @@
                                     }) }}"
                                     data-content-id="{{ version.contentInfo.id }}"
                                     data-language-code="{{ version.initialLanguageCode }}"
-                                    class="btn btn-icon mx-2 ez-btn--content-draft-edit"
+                                    class="btn btn-icon mx-2 ez-btn--content-draft-edit {% if edit_draft_disabled %}ez-btn--prevented{% endif %}"
+                                    {% if edit_draft_disabled %}disabled{% endif %}
                                     title="{{ 'tab.versions.table.action.draft.edit'|trans|desc('Edit draft') }}">
                                 <svg class="ez-icon ez-icon--secondary ez-icon-edit">
                                     <use xlink:href="{{ ez_icon_path('edit') }}"></use>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-3320
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Not sure about the desired behavior (right now we are forbidding from editing someone else's draft in the Back Office during conflict modal, unlike API - **is this correct or should we allow it?**) but the logic should be unified when it comes to version editing.

Related PR: https://github.com/ezsystems/ezplatform-page-builder/pull/961

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
