### PR TITLE
IBX-2559: Added new style to ez-extra-actions__content class to allow scrolling language list

### DIFF
--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -52,13 +52,11 @@
     }
 
     &__content {
+        max-height: calc(100% - #{calculateRem(90px)});
+        overflow: auto;
+
         .form-group {
             margin-bottom: 0;
-        }
-
-        &__scroller {
-            max-height: 90%;
-            overflow-x: auto;
         }
     }
 

--- a/src/bundle/Resources/public/scss/_extra-actions.scss
+++ b/src/bundle/Resources/public/scss/_extra-actions.scss
@@ -55,6 +55,11 @@
         .form-group {
             margin-bottom: 0;
         }
+
+        &__scroller {
+            max-height: 90%;
+            overflow-x: auto;
+        }
     }
 
     &--edit-user,

--- a/src/bundle/Resources/views/themes/admin/content/widget/content_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/widget/content_edit.html.twig
@@ -2,7 +2,7 @@
 
 <div class="ez-extra-actions ez-extra-actions--edit ez-extra-actions--hidden {% if form.language.vars.choices|length == 1 %} ez-extra-actions--prevent-show {% endif %}" data-actions="edit">
     <div class="ez-extra-actions__header">{{ 'content.edit.select_language'|trans|desc('Select translation') }} ({{ form.language.vars.choices|length }})</div>
-    <div class="ez-extra-actions__content">
+    <div class="ez-extra-actions__content ez-extra-actions__content__scroller">
         {{ form_start(form, { 'action': path('ezplatform.content.edit') }) }}
         {{ form_widget(form.content_info, { 'attr': {
             'hidden': 'hidden',

--- a/src/bundle/Resources/views/themes/admin/content/widget/content_edit.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/widget/content_edit.html.twig
@@ -2,7 +2,7 @@
 
 <div class="ez-extra-actions ez-extra-actions--edit ez-extra-actions--hidden {% if form.language.vars.choices|length == 1 %} ez-extra-actions--prevent-show {% endif %}" data-actions="edit">
     <div class="ez-extra-actions__header">{{ 'content.edit.select_language'|trans|desc('Select translation') }} ({{ form.language.vars.choices|length }})</div>
-    <div class="ez-extra-actions__content ez-extra-actions__content__scroller">
+    <div class="ez-extra-actions__content">
         {{ form_start(form, { 'action': path('ezplatform.content.edit') }) }}
         {{ form_widget(form.content_info, { 'attr': {
             'hidden': 'hidden',


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-2559](https://issues.ibexa.co/browse/IBX-2559)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added new class to scrolling language lists


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
