### PR TITLE
IBX-1648: Added allow_extra_fields to allow remove image with extra form fields

### DIFF
--- a/src/lib/Form/Type/Location/LocationTrashType.php
+++ b/src/lib/Form/Type/Location/LocationTrashType.php
@@ -108,6 +108,7 @@ class LocationTrashType extends AbstractType
         $resolver->setDefaults([
             'data_class' => LocationTrashData::class,
             'translation_domain' => 'forms',
+            'allow_extra_fields' => true,
         ]);
     }
 }


### PR DESCRIPTION

| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1648](https://issues.ibexa.co/browse/IBX-1648)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added allow_extra_fields to allow send a form with extra data like confirm that "I understand the consequences of this action." even if that field is no need anymore and move to trash item

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
