### PR TITLE
IBX-3681 - Added selectedLanguage update on location change in UDW

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
@@ -78,6 +78,9 @@ const ContentCreateWidget = () => {
     });
 
     useEffect(() => {
+        setSelectedLanguage(preselectedLanguage || firstLanguageCode)
+    }, [preselectedLanguage, firstLanguageCode]);
+    useEffect(() => {
         window.eZ.helpers.tooltips.parse(refContentTree.current);
     }, []);
 

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
@@ -80,6 +80,7 @@ const ContentCreateWidget = () => {
     useEffect(() => {
         setSelectedLanguage(preselectedLanguage || firstLanguageCode)
     }, [preselectedLanguage, firstLanguageCode]);
+    
     useEffect(() => {
         window.eZ.helpers.tooltips.parse(refContentTree.current);
     }, []);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-3681](https://issues.ibexa.co/browse/IBX-3681)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

When a location is clicked inside UDW the languageSelected is set by
```
    const [selectedLanguage, setSelectedLanguage] = useState(preselectedLanguage || firstLanguageCode);
```
Unfortunately, `useState` only sets the value of the hook and won't update it with the next elements clicked, which can end up in a different Language used by Content on the Fly, when the default element in the Language Selected form is the one that user wants to use (so no `onClick` event).
The change introduced ensures that `languageSelected` const has a proper value set.
