### PR TITLE
IBX-2588: Sorted mapped languages by priority in `content.create` widget

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
@@ -13,7 +13,10 @@ import {
     AllowedContentTypesContext,
 } from '../../universal.discovery.module';
 
-const languages = Object.values(window.eZ.adminUiConfig.languages.mappings);
+const configLanguages = window.eZ.adminUiConfig.languages;
+const languages = configLanguages.priority.map((value) => {
+    return configLanguages.mappings[value];
+});
 const contentTypes = Object.entries(window.eZ.adminUiConfig.contentTypes);
 
 const ContentCreateWidget = () => {

--- a/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/components/content-create-widget/content.create.widget.js
@@ -14,8 +14,8 @@ import {
 } from '../../universal.discovery.module';
 
 const configLanguages = window.eZ.adminUiConfig.languages;
-const languages = configLanguages.priority.map((value) => {
-    return configLanguages.mappings[value];
+const languages = configLanguages.priority.map((languageCode) => {
+    return configLanguages.mappings[languageCode];
 });
 const contentTypes = Object.entries(window.eZ.adminUiConfig.contentTypes);
 

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -91,18 +91,15 @@ class Languages implements ProviderInterface
     protected function getLanguagesPriority(array $languagesMap): array
     {
         $priority = [];
-        $fallback = [];
         $siteAccessName = $this->siteAccessService->getCurrent()->name;
         $siteAccesses = array_unique(array_merge([$siteAccessName], $this->siteAccesses));
 
         foreach ($siteAccesses as $siteAccess) {
             $siteAccessLanguages = $this->configResolver->getParameter('languages', null, $siteAccess);
-            $priority[] = array_shift($siteAccessLanguages);
-            $fallback = array_merge($fallback, $siteAccessLanguages);
+            $priority = array_merge($priority, $siteAccessLanguages);
         }
 
-        // Append fallback languages at the end of priority language list
-        $languageCodes = array_unique(array_merge($priority, $fallback));
+        $languageCodes = array_unique($priority);
 
         $languages = array_filter(array_values($languageCodes), static function ($languageCode) use ($languagesMap) {
             // Get only Languages defined and enabled in Admin

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -52,9 +52,11 @@ class Languages implements ProviderInterface
      */
     public function getConfig(): array
     {
+        $languagesMap = $this->getLanguagesMap();
+        $priority = $this->getLanguagesPriority($languagesMap);
+
         return [
-            'mappings' => $languagesMap = $this->getLanguagesMap(),
-            'priority' => $this->getLanguagesPriority($languagesMap),
+            'mappings' => array_merge(array_flip($priority), $languagesMap),
         ];
     }
 

--- a/src/lib/UI/Config/Provider/Languages.php
+++ b/src/lib/UI/Config/Provider/Languages.php
@@ -52,11 +52,9 @@ class Languages implements ProviderInterface
      */
     public function getConfig(): array
     {
-        $languagesMap = $this->getLanguagesMap();
-        $priority = $this->getLanguagesPriority($languagesMap);
-
         return [
-            'mappings' => array_merge(array_flip($priority), $languagesMap),
+            'mappings' => $languagesMap = $this->getLanguagesMap(),
+            'priority' => $this->getLanguagesPriority($languagesMap),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-2588](https://issues.ibexa.co/browse/IBX-2588)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Also, the languages priority has been refactored in `UI\Config\Provider` as a current site accesses languages config should be prioritized, not just a first language from an array.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
