### PR TITLE
IBX-3012: Relation list "Created" column label update

### DIFF
--- a/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
+++ b/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
@@ -186,6 +186,11 @@
         <target state="new">Single relation</target>
         <note>key: ezobjectrelation.single_relation</note>
       </trans-unit>
+      <trans-unit id="6e9daae620a603c0ae30c9f97f7c1963f51f261a" resname="ezobjectrelation.version_created">
+        <source>Version created</source>
+        <target state="new">Version created</target>
+        <note>key: ezobjectrelation.version_created</note>
+      </trans-unit>
       <trans-unit id="61c7580e3e4d4547527322089f577eca2ff1ea5b" resname="ezobjectrelationlist.content_type">
         <source>Content Type</source>
         <target state="new">Content Type</target>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -487,7 +487,7 @@
                     <tr>
                         <th>{{ 'ezobjectrelation.name'|trans|desc('Name') }}</th>
                         <th>{{ 'ezobjectrelation.content_type'|trans|desc('Content Type') }}</th>
-                        <th>{{ 'ezobjectrelation.created'|trans|desc('Created') }}</th>
+                        <th>{{ 'ezobjectrelation.version_created'|trans|desc('Version created') }}</th>
                     </tr>
                 </thead>
                 <tr>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-3012](https://issues.ibexa.co/browse/IBX-3012)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As the title suggests, the mentioned column is in fact version creation date.

Related PR: https://github.com/ezsystems/ezplatform-version-comparison/pull/78

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
