### PR TITLE
[Tests] Fixed incorrect type hint after 37da8d2b8 changes

### DIFF
--- a/src/lib/Tests/Validator/Constraint/LocationIsWithinCopySubtreeLimitValidatorTest.php
+++ b/src/lib/Tests/Validator/Constraint/LocationIsWithinCopySubtreeLimitValidatorTest.php
@@ -21,7 +21,7 @@ class LocationIsWithinCopySubtreeLimitValidatorTest extends TestCase
 {
     private const COPY_LIMIT = 10;
 
-    /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
     private $locationService;
 
     /** @var \Symfony\Component\Validator\Context\ExecutionContextInterface */


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | Related to [IBX-3794](https://issues.ibexa.co/browse/IBX-3794) |
| **Type**                                   | bug |
| **Target Ibexa version** | `v3.3` |
| **BC breaks**                          | no |

Fixed incorrect type hint for `LocationIsWithinCopySubtreeLimitValidatorTest::$locationService` property when working on https://github.com/ezsystems/ezplatform-admin-ui/pull/2072