### PR TITLE
IBX-3828: The limit has been set to a valid value when calling findLocationsById for the selected locations

### DIFF
--- a/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
+++ b/src/bundle/ui-dev/src/modules/universal-discovery/universal.discovery.module.js
@@ -166,7 +166,7 @@ const UniversalDiscoveryModule = (props) => {
             return;
         }
 
-        findLocationsById({ ...restInfo, id: props.selectedLocations.join(',') }, (locations) => {
+        findLocationsById({ ...restInfo, id: props.selectedLocations.join(','), limit: props.selectedLocations.length }, (locations) => {
             const mappedLocation = props.selectedLocations.map((locationId) => {
                 const location = locations.find((location) => location.id === parseInt(locationId, 10));
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-3828](https://issues.ibexa.co/browse/IBX-3828)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Currently, if we do not set a limit, it is set to 50 by default, so to get all locations at once, we must set a limit to the number of selected locations


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
