### PR TITLE
IBX-3814: Added checks if the image is not SVG to prevent adding alternativeText

### DIFF
--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -147,7 +147,7 @@ const prepareStruct = ({ parentInfo, config, languageCode }, data) => {
                 data: data.fileReader.result.replace(/^.*;base64,/, ''),
             };
 
-            if (data.file.type.startsWith('image/')) {
+            if (data.file.type.startsWith('image/') && !data.file.type.startsWith('image/svg')) {
                 fileValue.alternativeText = data.file.name;
             }
 

--- a/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
+++ b/src/bundle/ui-dev/src/modules/multi-file-upload/services/multi.file.upload.service.js
@@ -147,7 +147,9 @@ const prepareStruct = ({ parentInfo, config, languageCode }, data) => {
                 data: data.fileReader.result.replace(/^.*;base64,/, ''),
             };
 
-            if (data.file.type.startsWith('image/') && !data.file.type.startsWith('image/svg')) {
+            const contentType = response.ContentTypeInfoList.ContentType[0];
+
+            if (contentType.imageFields.identifier.includes(mapping.contentFieldIdentifier)) {
                 fileValue.alternativeText = data.file.name;
             }
 
@@ -158,7 +160,7 @@ const prepareStruct = ({ parentInfo, config, languageCode }, data) => {
 
             const struct = {
                 ContentCreate: {
-                    ContentType: { _href: response.ContentTypeInfoList.ContentType[0]._href },
+                    ContentType: { _href: contentType._href },
                     mainLanguageCode: languageCode || parentInfo.language,
                     LocationCreate: { ParentLocation: { _href: parentLocation }, sortField: 'PATH', sortOrder: 'ASC' },
                     Section: null,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-3814](https://issues.ibexa.co/browse/IBX-3814)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Related to https://github.com/ezsystems/ezplatform-rest/pull/98

Currently, the response from rest API has been changed to add information about fields that are of the ezimage type, then we verify whether the mapped field is in the new field with rest API, which will allow us to add the alternativeText field more dynamically



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
