### PR TITLE
[Doc] Dropped obsolete link to a tutorial and fixed 3.3 doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ To use this package, [install Ibexa DXP](https://doc.ibexa.co/en/latest/install/
 
 ## Extending Back Office:
 
-- [General extensibility](https://doc.ibexa.co/en/latest/extending/extending_back_office/).
-- [Extending Back Office tutorial](https://doc.ibexa.co/en/latest/tutorials/extending_admin_ui/extending_admin_ui//).
+- [General extensibility](https://doc.ibexa.co/en/3.3/extending/extending_back_office/).
 
 ## COPYRIGHT
 


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **Type**                                   | bug |
| **Target Ibexa version** | `v3.3` |
| **BC breaks**                          | no |

Fixing bug reported by external. The linked tutorial existed in v2.5. Doc page link should point out to a specific version instead of the latest.