### PR TITLE
IBX-4486: Disabled Autosave feature for content creation

### DIFF
--- a/src/lib/Form/Processor/Content/AutosaveProcessor.php
+++ b/src/lib/Form/Processor/Content/AutosaveProcessor.php
@@ -47,7 +47,7 @@ class AutosaveProcessor implements EventSubscriberInterface
         }
 
         $event->setResponse(
-        // Response content is irrelevant as it will be overwritten by ViewRenderer anyway
+            // Response content is irrelevant as it will be overwritten by ViewRenderer anyway
             new Response(null, $statusCode)
         );
     }

--- a/src/lib/Form/Processor/Content/AutosaveProcessor.php
+++ b/src/lib/Form/Processor/Content/AutosaveProcessor.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Form\Processor\Content;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as APIException;
 use EzSystems\EzPlatformAdminUi\Event\AutosaveEvents;
+use EzSystems\EzPlatformContentForms\Data\Content\ContentUpdateData;
 use EzSystems\EzPlatformContentForms\Event\FormActionEvent;
 use EzSystems\EzPlatformContentForms\Form\Processor\ContentFormProcessor;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -35,15 +36,18 @@ class AutosaveProcessor implements EventSubscriberInterface
 
     public function processAutosave(FormActionEvent $event): void
     {
+        $statusCode = Response::HTTP_OK;
+
         try {
-            $this->innerContentFormProcessor->processSaveDraft($event);
-            $statusCode = Response::HTTP_OK;
+            if ($event->getData() instanceof ContentUpdateData) {
+                $this->innerContentFormProcessor->processSaveDraft($event);
+            }
         } catch (APIException $exception) {
             $statusCode = Response::HTTP_BAD_REQUEST;
         }
 
         $event->setResponse(
-            // Response content is irrelevant as it will be overwritten by ViewRenderer anyway
+        // Response content is irrelevant as it will be overwritten by ViewRenderer anyway
             new Response(null, $statusCode)
         );
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4486
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Autosave shouldn't be enabled for `nodraft` requests.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
