### PR TITLE
[Behat] Changed assertions removed in PHPUnit 10

### DIFF
--- a/src/lib/Behat/Component/Fields/ContentRelationMultiple.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationMultiple.php
@@ -81,12 +81,12 @@ class ContentRelationMultiple extends FieldTypeComponent
         $secondValue = $explodedValue[count($explodedValue) - 1];
 
         $viewPatternRegex = '/Multiple relations:[\w\/,: ]* %s [\w \/,:]*/';
-        Assert::assertRegExp(
+        Assert::assertMatchesRegularExpression(
             sprintf($viewPatternRegex, $firstValue),
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Field has wrong value'
         );
-        Assert::assertRegExp(
+        Assert::assertMatchesRegularExpression(
             sprintf($viewPatternRegex, $secondValue),
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Field has wrong value'

--- a/src/lib/Behat/Component/Fields/ContentRelationSingle.php
+++ b/src/lib/Behat/Component/Fields/ContentRelationSingle.php
@@ -98,7 +98,7 @@ class ContentRelationSingle extends FieldTypeComponent
 
         $viewPatternRegex = '/Single relation:[\w\/,: ]* %s [\w \/,:]*/';
 
-        Assert::assertRegExp(
+        Assert::assertMatchesRegularExpression(
             sprintf($viewPatternRegex, $value),
             $this->getHTMLPage()->find($this->parentLocator)->getText(),
             'Field has wrong value'


### PR DESCRIPTION
Failing tests:
```
       | ezobjectrelation     | Content relation (single)    | Images       | Media/Images       | Media             | value     | Media/Images  |            |               | Media        |              |
        Failed step: Then I should see correct data for the right side comparison
        Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Call to undefined method PHPUnit\Framework\Assert::assertRegExp() in vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/Component/Fields/ContentRelationSingle.php:101
```
(https://github.com/ibexa/commerce/actions/runs/4102522082/jobs/7077909870)

`assertRegExp` has been removed in PHPUnit 10, `assertMatchesRegularExpression` should be used instead

See: https://github.com/sebastianbergmann/phpunit/issues/4087
Tested in https://github.com/ibexa/commerce/pull/211

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
