### PR TITLE
[Tests] Fixed SiteAccessLimitationMapperTest generate mock

### DIFF
--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -10,13 +10,12 @@ use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzPlatformAdminUi\Limitation\Mapper\SiteAccessLimitationMapper;
-use EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator;
 use EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
 class SiteAccessLimitationMapperTest extends TestCase
 {
-    public function testMapLimitationValue()
+    public function testMapLimitationValue(): void
     {
         $siteAccessList = [
             '2356372769' => 'foo',
@@ -40,14 +39,17 @@ class SiteAccessLimitationMapperTest extends TestCase
         $siteAccessesGeneratorInterface = $this->createMock(SiteAccessKeyGeneratorInterface::class);
         $siteAccessesGeneratorInterface
             ->method('generate')
-            ->willReturn(new SiteAccessKeyGenerator());
+            // re-map SiteAccess crc32 identifiers back to string, as the keys get stored as integers
+            ->willReturnOnConsecutiveCalls(...array_map('strval', array_keys($siteAccessList)));
 
         $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $siteAccessService->method('getAll')->willReturn($siteAccesses);
 
-        $mapper = new SiteAccessLimitationMapper($siteAccessService, $siteAccessesGeneratorInterface);
+        $mapper = new SiteAccessLimitationMapper(
+            $siteAccessService, $siteAccessesGeneratorInterface
+        );
         $result = $mapper->mapLimitationValue($limitation);
 
-        $this->assertEquals(array_values($siteAccessList), $result);
+        self::assertEquals(array_values($siteAccessList), $result);
     }
 }

--- a/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SiteAccessLimitationMapperTest.php
@@ -46,7 +46,8 @@ class SiteAccessLimitationMapperTest extends TestCase
         $siteAccessService->method('getAll')->willReturn($siteAccesses);
 
         $mapper = new SiteAccessLimitationMapper(
-            $siteAccessService, $siteAccessesGeneratorInterface
+            $siteAccessService,
+            $siteAccessesGeneratorInterface
         );
         $result = $mapper->mapLimitationValue($limitation);
 


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | n/a
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+ |
| **BC breaks**                          | no |

`SiteAccessKeyGeneratorInterface::generate(string)` returns `string`, not `SiteAccessKeyGenerator` as previously mocked.
This results in a silent error:
```
Method generate may not return value of type EzSystems\EzPlatformAdminUi\Siteaccess\SiteAccessKeyGenerator, its return declaration is ": string"
```

Noticed while working on the other PR. Worth fixing to avoid spending time investigating if the failure is related or not to the current changes.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review