### PR TITLE
IBX-5053: Handled deleted Locations in UDW-based limitations

### DIFF
--- a/src/bundle/Resources/config/services/role_form_mappers.yaml
+++ b/src/bundle/Resources/config/services/role_form_mappers.yaml
@@ -200,8 +200,10 @@ services:
     ezplatform.content_forms.limitation.form_mapper.udw_based:
         class: EzSystems\EzPlatformAdminUi\Limitation\Mapper\UDWBasedMapper
         arguments:
-            - "@ezpublish.api.service.location"
-            - "@ezpublish.api.service.search"
+            $locationService: "@ezpublish.api.service.location"
+            $searchService: "@ezpublish.api.service.search"
+            $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
+            $repository: '@ezpublish.api.repository'
         calls:
             - [setFormTemplate, ["%ezplatform.content_forms.limitation.udw.template%"]]
 

--- a/src/bundle/Resources/public/js/scripts/admin.limitation.pick.js
+++ b/src/bundle/Resources/public/js/scripts/admin.limitation.pick.js
@@ -144,8 +144,9 @@
     };
     const attachTagEventHandlers = (limitationBtn, tag) => {
         const removeTagBtn = tag.querySelector('.ez-tag__remove-btn');
-
-        removeTagBtn.addEventListener('click', () => handleTagRemove(limitationBtn, tag), false);
+        if (removeTagBtn !== null) {
+            removeTagBtn.addEventListener('click', () => handleTagRemove(limitationBtn, tag), false);
+        }
     };
     const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
     const handleUdwConfirm = (limitationBtn, selectedItems) => {

--- a/src/bundle/Resources/translations/ezplatform_content_forms_role.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_role.en.xliff
@@ -46,6 +46,12 @@
         <target state="new">Select Location(s) to use as Limitation</target>
         <note>key: role.policy.limitation.location.udw_title</note>
       </trans-unit>
+      <trans-unit id="290f48ccc1eb2889852b730ac62b2b148594c85f" resname="role.policy.limitation.location_deleted">
+        <source>Location deleted</source>
+        <target state="new">Location deleted</target>
+        <note>key: role.policy.limitation.location_deleted</note>
+        <jms:reference-file line="41">/vendor/ezsystems/ezplatform-admin-ui/src/bundle/DependencyInjection/../../../src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="be8159ab7985797bd281cb0f7f58bb4d2c925159" resname="role.policy.limitation.not_implemented">
         <source>Editing Limitations for '%limitationTypeIdentifier%' is not available.</source>
         <target state="new">Editing Limitations for '%limitationTypeIdentifier%' is not available.</target>

--- a/src/bundle/Resources/translations/ezplatform_content_forms_role.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_role.en.xliff
@@ -50,7 +50,6 @@
         <source>Location deleted</source>
         <target state="new">Location deleted</target>
         <note>key: role.policy.limitation.location_deleted</note>
-        <jms:reference-file line="41">/vendor/ezsystems/ezplatform-admin-ui/src/bundle/DependencyInjection/../../../src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="be8159ab7985797bd281cb0f7f58bb4d2c925159" resname="role.policy.limitation.not_implemented">
         <source>Editing Limitations for '%limitationTypeIdentifier%' is not available.</source>

--- a/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
@@ -4,17 +4,17 @@
     {{ form_widget(form.limitationValues) }}
 
     <button type="button" data-universaldiscovery-title="{{ "role.policy.limitation.location.udw_title"
-    |trans({}, "ezplatform_content_forms_role")
-    |desc("Select Location(s) to use as Limitation") }}"
-            class="btn btn-secondary d-block ez-pick-location-limitation-button"
-            data-location-input-selector="#{{ form.limitationValues.vars.id }}"
-            data-selected-location-list-selector="#{{ form.limitationValues.vars.id }}-selected-location"
-            data-udw-config="{{ ez_udw_config('multiple', {}) }}"
-            data-value-template="{{ include('@ezdesign/limitation/udw_limitation_value_list_item.html.twig', {
-                'content_breadcrumbs': '',
-                'location_id': '{{ location_id }}',
-                'is_loading_state': true
-            })|e('html_attr') }}">
+        |trans({}, "ezplatform_content_forms_role")
+        |desc("Select Location(s) to use as Limitation") }}"
+        class="btn btn-secondary d-block ez-pick-location-limitation-button"
+        data-location-input-selector="#{{ form.limitationValues.vars.id }}"
+        data-selected-location-list-selector="#{{ form.limitationValues.vars.id }}-selected-location"
+        data-udw-config="{{ ez_udw_config('multiple', {}) }}"
+        data-value-template="{{ include('@ezdesign/limitation/udw_limitation_value_list_item.html.twig', {
+            'content_breadcrumbs': '',
+            'location_id': '{{ location_id }}',
+            'is_loading_state': true
+        })|e('html_attr') }}">
         {{ "role.policy.limitation.location.udw_button"|trans({}, "ezplatform_content_forms_role")|desc("Select Locations") }}
     </button>
 

--- a/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
+++ b/src/bundle/Resources/views/themes/admin/limitation/udw_limitation_value.html.twig
@@ -4,17 +4,17 @@
     {{ form_widget(form.limitationValues) }}
 
     <button type="button" data-universaldiscovery-title="{{ "role.policy.limitation.location.udw_title"
-        |trans({}, "ezplatform_content_forms_role")
-        |desc("Select Location(s) to use as Limitation") }}"
-        class="btn btn-secondary d-block ez-pick-location-limitation-button"
-        data-location-input-selector="#{{ form.limitationValues.vars.id }}"
-        data-selected-location-list-selector="#{{ form.limitationValues.vars.id }}-selected-location"
-        data-udw-config="{{ ez_udw_config('multiple', {}) }}"
-        data-value-template="{{ include('@ezdesign/limitation/udw_limitation_value_list_item.html.twig', {
-            'content_breadcrumbs': '',
-            'location_id': '{{ location_id }}',
-            'is_loading_state': true
-        })|e('html_attr') }}">
+    |trans({}, "ezplatform_content_forms_role")
+    |desc("Select Location(s) to use as Limitation") }}"
+            class="btn btn-secondary d-block ez-pick-location-limitation-button"
+            data-location-input-selector="#{{ form.limitationValues.vars.id }}"
+            data-selected-location-list-selector="#{{ form.limitationValues.vars.id }}-selected-location"
+            data-udw-config="{{ ez_udw_config('multiple', {}) }}"
+            data-value-template="{{ include('@ezdesign/limitation/udw_limitation_value_list_item.html.twig', {
+                'content_breadcrumbs': '',
+                'location_id': '{{ location_id }}',
+                'is_loading_state': true
+            })|e('html_attr') }}">
         {{ "role.policy.limitation.location.udw_button"|trans({}, "ezplatform_content_forms_role")|desc("Select Locations") }}
     </button>
 
@@ -29,12 +29,18 @@
                         {% set content_breadcrumbs = content_breadcrumbs ~ ' / ' %}
                     {% endif %}
                 {% endfor %}
-                
+
                 {{ include('@ezdesign/limitation/udw_limitation_value_list_item.html.twig', {
                     'content_breadcrumbs': content_breadcrumbs,
                     'location_id': limitationValue.id,
                     'is_loading_state': false
                 }) }}
+            {% else %}
+                <li class="mt-2">
+                    <div class="ez-tag">
+                        {{ "role.policy.limitation.location_deleted"|trans({}, "ezplatform_content_forms_role")|desc("Location deleted") }}
+                    </div>
+                </li>
             {% endif %}
         {% endfor %}
     </ul>

--- a/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\DataTransformer;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
@@ -24,12 +26,20 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
-    /**
-     * @param \eZ\Publish\API\Repository\LocationService $locationService
-     */
-    public function __construct(LocationService $locationService)
-    {
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
+    /** @var \eZ\Publish\API\Repository\Repository */
+    private $repository;
+
+    public function __construct(
+        LocationService $locationService,
+        PermissionResolver $permissionResolver,
+        Repository $repository
+    ) {
         $this->locationService = $locationService;
+        $this->permissionResolver = $permissionResolver;
+        $this->repository = $repository;
     }
 
     /**
@@ -43,16 +53,24 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
             return null;
         }
 
+        return array_map([$this, 'mapPathToLocation'], $value);
+    }
+
+    private function mapPathToLocation(string $path): ?Location
+    {
+        $locationId = $this->extractLocationIdFromPath($path);
+
         try {
-            return array_map(function (string $path) {
-                return $this->locationService->loadLocation(
-                    $this->extractLocationIdFromPath($path)
-                );
-            }, $value);
+            // Sudo is necessary as skipping non-accessible Locations
+            // will prevent an administrator from editing policies
+            return $this->permissionResolver->sudo(
+                function (Repository $repository) use ($locationId): Location {
+                    return $this->locationService->loadLocation($locationId);
+                },
+                $this->repository
+            );
         } catch (NotFoundException $e) {
             return null;
-        } catch (UnauthorizedException $e) {
-            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }
     }
 

--- a/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
+++ b/src/lib/Form/DataTransformer/UDWBasedValueModelTransformer.php
@@ -64,7 +64,7 @@ class UDWBasedValueModelTransformer implements DataTransformerInterface
             // Sudo is necessary as skipping non-accessible Locations
             // will prevent an administrator from editing policies
             return $this->permissionResolver->sudo(
-                function (Repository $repository) use ($locationId): Location {
+                function () use ($locationId): Location {
                     return $this->locationService->loadLocation($locationId);
                 },
                 $this->repository

--- a/src/lib/Limitation/Mapper/SubtreeLimitationMapper.php
+++ b/src/lib/Limitation/Mapper/SubtreeLimitationMapper.php
@@ -7,7 +7,7 @@
 namespace EzSystems\EzPlatformAdminUi\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 
@@ -33,13 +33,17 @@ class SubtreeLimitationMapper extends UDWBasedMapper
 
         foreach ($limitation->limitationValues as $pathString) {
             $query = new LocationQuery([
-                'filter' => new Ancestor($pathString),
+                'filter' => new Subtree($pathString),
                 'sortClauses' => [new Path()],
             ]);
 
             $path = [];
             foreach ($this->searchService->findLocations($query)->searchHits as $hit) {
                 $path[] = $hit->valueObject->getContentInfo();
+            }
+
+            if (empty($path)) {
+                continue;
             }
 
             $values[] = $path;

--- a/src/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/src/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\EzPlatformAdminUi\Form\DataTransformer\UDWBasedValueModelTransformer;
@@ -107,7 +107,7 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
             $location = $this->locationService->loadLocation($id);
 
             $query = new LocationQuery([
-                'filter' => new Subtree($location->pathString),
+                'filter' => new Ancestor($location->pathString),
                 'sortClauses' => [new Path()],
             ]);
 

--- a/src/lib/Limitation/Mapper/UDWBasedMapper.php
+++ b/src/lib/Limitation/Mapper/UDWBasedMapper.php
@@ -7,9 +7,11 @@
 namespace EzSystems\EzPlatformAdminUi\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use EzSystems\EzPlatformAdminUi\Form\DataTransformer\UDWBasedValueModelTransformer;
@@ -42,15 +44,22 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
      */
     private $template;
 
-    /**
-     * UDWBasedMapper constructor.
-     *
-     * @param \eZ\Publish\API\Repository\SearchService $searchService
-     */
-    public function __construct(LocationService $locationService, SearchService $searchService)
-    {
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
+    /** @var \eZ\Publish\API\Repository\Repository */
+    private $repository;
+
+    public function __construct(
+        LocationService $locationService,
+        SearchService $searchService,
+        PermissionResolver $permissionResolver,
+        Repository $repository
+    ) {
         $this->locationService = $locationService;
         $this->searchService = $searchService;
+        $this->permissionResolver = $permissionResolver;
+        $this->repository = $repository;
     }
 
     public function setFormTemplate($template)
@@ -74,7 +83,13 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
                     'label' => LimitationTranslationExtractor::identifierToLabel($data->getIdentifier()),
                 ])
                 ->addViewTransformer(new UDWBasedValueViewTransformer($this->locationService))
-                ->addModelTransformer(new UDWBasedValueModelTransformer($this->locationService))
+                ->addModelTransformer(
+                    new UDWBasedValueModelTransformer(
+                        $this->locationService,
+                        $this->permissionResolver,
+                        $this->repository
+                    )
+                )
                 // Deactivate auto-initialize as we're not on the root form.
                 ->setAutoInitialize(false)->getForm()
         );
@@ -92,7 +107,7 @@ class UDWBasedMapper implements LimitationFormMapperInterface, LimitationValueMa
             $location = $this->locationService->loadLocation($id);
 
             $query = new LocationQuery([
-                'filter' => new Ancestor($location->pathString),
+                'filter' => new Subtree($location->pathString),
                 'sortClauses' => [new Path()],
             ]);
 

--- a/src/lib/Tests/Limitation/Mapper/SubtreeLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SubtreeLimitationMapperTest.php
@@ -7,11 +7,13 @@
 namespace EzSystems\EzPlatformAdminUi\Tests\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -44,10 +46,12 @@ class SubtreeLimitationMapperTest extends TestCase
 
         $locationServiceMock = $this->createMock(LocationService::class);
         $searchServiceMock = $this->createMock(SearchService::class);
+        $permissionResolverMock = $this->createMock(PermissionResolver::class);
+        $repositoryMock = $this->createMock(Repository::class);
 
         foreach ($values as $i => $pathString) {
             $query = new LocationQuery([
-                'filter' => new Ancestor($pathString),
+                'filter' => new Subtree($pathString),
                 'sortClauses' => [new Path()],
             ]);
 
@@ -58,7 +62,12 @@ class SubtreeLimitationMapperTest extends TestCase
                 ->willReturn($this->createSearchResultsMock($expected[$i]));
         }
 
-        $mapper = new SubtreeLimitationMapper($locationServiceMock, $searchServiceMock);
+        $mapper = new SubtreeLimitationMapper(
+            $locationServiceMock,
+            $searchServiceMock,
+            $permissionResolverMock,
+            $repositoryMock
+        );
         $result = $mapper->mapLimitationValue(new SubtreeLimitation([
             'limitationValues' => $values,
         ]));

--- a/src/lib/Tests/Limitation/Mapper/SubtreeLimitationMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/SubtreeLimitationMapperTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -51,7 +51,7 @@ class SubtreeLimitationMapperTest extends TestCase
 
         foreach ($values as $i => $pathString) {
             $query = new LocationQuery([
-                'filter' => new Subtree($pathString),
+                'filter' => new Ancestor($pathString),
                 'sortClauses' => [new Path()],
             ]);
 

--- a/src/lib/Tests/Limitation/Mapper/UDWBasedMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/UDWBasedMapperTest.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -61,7 +61,7 @@ class UDWBasedMapperTest extends TestCase
                 ->willReturn($location);
 
             $query = new LocationQuery([
-                'filter' => new Subtree($location->pathString),
+                'filter' => new Ancestor($location->pathString),
                 'sortClauses' => [new Path()],
             ]);
 

--- a/src/lib/Tests/Limitation/Mapper/UDWBasedMapperTest.php
+++ b/src/lib/Tests/Limitation/Mapper/UDWBasedMapperTest.php
@@ -7,21 +7,23 @@
 namespace EzSystems\EzPlatformAdminUi\Tests\Limitation\Mapper;
 
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use EzSystems\EzPlatformAdminUi\Limitation\Mapper\UDWBasedMapper;
 use PHPUnit\Framework\TestCase;
 
 class UDWBasedMapperTest extends TestCase
 {
-    public function testMapLimitationValue()
+    public function testMapLimitationValue(): void
     {
         $values = [5, 7, 11];
         $expected = [
@@ -44,6 +46,8 @@ class UDWBasedMapperTest extends TestCase
 
         $locationServiceMock = $this->createMock(LocationService::class);
         $searchServiceMock = $this->createMock(SearchService::class);
+        $permissionResolverMock = $this->createMock(PermissionResolver::class);
+        $repositoryMock = $this->createMock(Repository::class);
 
         foreach ($values as $i => $id) {
             $location = new Location([
@@ -57,32 +61,37 @@ class UDWBasedMapperTest extends TestCase
                 ->willReturn($location);
 
             $query = new LocationQuery([
-                'filter' => new Ancestor($location->pathString),
+                'filter' => new Subtree($location->pathString),
                 'sortClauses' => [new Path()],
             ]);
 
             $searchServiceMock
-                ->expects($this->at($i))
+                ->expects(self::at($i))
                 ->method('findLocations')
                 ->with($query)
                 ->willReturn($this->createSearchResultsMock($expected[$i]));
         }
 
-        $mapper = new UDWBasedMapper($locationServiceMock, $searchServiceMock);
+        $mapper = new UDWBasedMapper(
+            $locationServiceMock,
+            $searchServiceMock,
+            $permissionResolverMock,
+            $repositoryMock
+        );
         $result = $mapper->mapLimitationValue(new SubtreeLimitation([
             'limitationValues' => $values,
         ]));
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
-    private function createSearchResultsMock($expected)
+    private function createSearchResultsMock(array $expected): SearchResult
     {
         $hits = [];
         foreach ($expected as $contentInfo) {
             $locationMock = $this->createMock(Location::class);
             $locationMock
-                ->expects($this->atLeastOnce())
+                ->expects(self::atLeastOnce())
                 ->method('getContentInfo')
                 ->willReturn($contentInfo);
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-5053](https://issues.ibexa.co/browse/IBX-5053)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Currently, when a Location in a Subtree Limitation is not-accessible (because of current user's permissions) policy form will throw an exception and when a Location is deleted form will behave like no values were there in the first place. This can be misleading and lead to broken policies and administrators being unaware that policies were removed after saving a non-touched form (that includes removal of still valid limitations).

Additional information was added to the policy form that a Location is deleted:
![image](https://user-images.githubusercontent.com/22300504/217863725-85c2cb18-5d7f-4c0c-98bc-37246da890c7.png)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
