### PR TITLE
IBX-5076: Fixed disabling ability to copy subtree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
         }
     },
     "autoload-dev": {
-        "psr-4": { "EzSystems\\EzPlatformAdminUi\\Tests\\": "src/lib/Tests" }
+        "psr-4": {
+            "EzSystems\\EzPlatformAdminUi\\Tests\\": "src/lib/Tests",
+            "Ibexa\\Tests\\Bundle\\AdminUi\\": "tests/bundle/"
+        }
     },
     "require": {
         "php": "^7.3 || ^8.0",

--- a/src/bundle/DependencyInjection/Configuration/Parser/SubtreeOperations.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SubtreeOperations.php
@@ -30,34 +30,20 @@ class SubtreeOperations extends AbstractParser
     /**
      * @inheritdoc
      */
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
-        if (empty($scopeSettings['subtree_operations'])) {
+        if (!isset($scopeSettings['subtree_operations']['copy_subtree']['limit'])) {
             return;
         }
 
-        $settings = $scopeSettings['subtree_operations'];
-        $nodes = ['copy_subtree' => ['limit']];
-
-        foreach ($nodes as $node => $keys) {
-            foreach ($keys as $key) {
-                if (!isset($settings[$node][$key]) || empty($settings[$node][$key])) {
-                    continue;
-                }
-
-                $contextualizer->setContextualParameter(
-                    sprintf('subtree_operations.%s.%s', $node, $key),
-                    $currentScope,
-                    $settings[$node][$key]
-                );
-            }
-        }
+        $contextualizer->setContextualParameter(
+            'subtree_operations.copy_subtree.limit',
+            $currentScope,
+            $scopeSettings['subtree_operations']['copy_subtree']['limit']
+        );
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('subtree_operations')

--- a/tests/bundle/DependencyInjection/Configuration/Parser/SubtreeOperationsTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/SubtreeOperationsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\AdminUi\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations
+ */
+final class SubtreeOperationsTest extends TestCase
+{
+    /** @var \EzSystems\EzPlatformAdminUiBundle\DependencyInjection\Configuration\Parser\SubtreeOperations */
+    private $parser;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $contextualizer;
+
+    /**
+     * @return array<string, array{int}>
+     */
+    public function getExpectedCopySubtreeLimit(): iterable
+    {
+        yield 'default = 100' => [100];
+        yield 'no limit = -1' => [-1];
+        yield 'disabled = 0' => [0];
+    }
+
+    protected function setUp(): void
+    {
+        $this->parser = new SubtreeOperations();
+        $this->contextualizer = $this->createMock(ContextualizerInterface::class);
+    }
+
+    /**
+     * @dataProvider getExpectedCopySubtreeLimit
+     */
+    public function testCopySubtreeLimit(int $expectedCopySubtreeLimit): void
+    {
+        $scopeSettings = [
+            'subtree_operations' => [
+                'copy_subtree' => [
+                    'limit' => $expectedCopySubtreeLimit,
+                ],
+            ],
+        ];
+        $currentScope = 'admin_group';
+
+        $this->contextualizer
+            ->expects(self::once())
+            ->method('setContextualParameter')
+            ->with(
+                'subtree_operations.copy_subtree.limit',
+                $currentScope,
+                $expectedCopySubtreeLimit
+            );
+
+        $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
+    }
+
+    public function testCopySubtreeLimitNotSet(): void
+    {
+        $scopeSettings = [
+            'subtree_operations' => null,
+        ];
+        $currentScope = 'admin_group';
+
+        $this->contextualizer
+            ->expects(self::never())
+            ->method('setContextualParameter');
+
+        $this->parser->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | [IBX-5076](https://issues.ibexa.co/browse/IBX-5076) |
| **Type**                                   | bug |
| **Target Ibexa version** | `v3.3`+ |
| **BC breaks**                          | no |

We checked emptiness of `subtree_operations.copy_subtree.limit` contextual setting which disallowed setting it to 0.

Given this is till this day the only one setting for that Config Parser, I've simplified the code to reduce cognitive complexity which probably led to this error.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review