### PR TITLE
IBX-5143: Fixed autosave default value

### DIFF
--- a/src/lib/UserSetting/Autosave.php
+++ b/src/lib/UserSetting/Autosave.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\UserSetting;
 
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformUser\UserSetting\FormMapperInterface;
 use EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface;
 use JMS\TranslationBundle\Annotation\Desc;
@@ -24,10 +25,15 @@ class Autosave implements ValueDefinitionInterface, FormMapperInterface
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
     public function __construct(
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        ConfigResolverInterface $configResolver
     ) {
         $this->translator = $translator;
+        $this->configResolver = $configResolver;
     }
 
     public function getName(): string
@@ -57,7 +63,7 @@ class Autosave implements ValueDefinitionInterface, FormMapperInterface
 
     public function getDefaultValue(): string
     {
-        return self::ENABLED_OPTION;
+        return $this->configResolver->getParameter('autosave.enabled') == false ? self::DISABLED_OPTION : self::ENABLED_OPTION;
     }
 
     public function mapFieldForm(


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5143
| Bug fix?      | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Setting autosave to false via  yaml config ( `ezsettings.admin_group.autosave.enabled: false` ) has no effect.
Autosave is still active.



#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
