### PR TITLE
IBX-5472: Missing translation for search.date.range

### DIFF
--- a/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_content_forms_policies.en.xliff
@@ -111,6 +111,11 @@
         <target>Subtree</target>
         <note>key: policy.limitation.identifier.subtree</note>
       </trans-unit>
+      <trans-unit id="ae8d9836b92dd7d303929104953d877fa9c14fed" resname="policy.limitation.identifier.versionlock">
+        <source>VersionLock</source>
+        <target>VersionLock</target>
+        <note>key: policy.limitation.identifier.versionlock</note>
+      </trans-unit>
       <trans-unit id="920f6a0525d6ba93ff83f46e22baa981ff0b483c" resname="policy.limitation.identifier.workflowstage">
         <source>WorkflowStage</source>
         <target>WorkflowStage</target>

--- a/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
+++ b/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
@@ -171,11 +171,6 @@
         <target state="new">Content Type</target>
         <note>key: ezobjectrelation.content_type</note>
       </trans-unit>
-      <trans-unit id="79f0c6856a30e0436b61aa28cfc859df8289edfb" resname="ezobjectrelation.created">
-        <source>Created</source>
-        <target state="new">Created</target>
-        <note>key: ezobjectrelation.created</note>
-      </trans-unit>
       <trans-unit id="feb25b24199466f077038c5e6e38209deae21471" resname="ezobjectrelation.name">
         <source>Name</source>
         <target state="new">Name</target>

--- a/src/bundle/Resources/translations/forms.en.xliff
+++ b/src/bundle/Resources/translations/forms.en.xliff
@@ -331,6 +331,11 @@
         <target>Content / Translations</target>
         <note>key: role.policy.content.translations</note>
       </trans-unit>
+      <trans-unit id="74ccbb06e1226201f9642eefa451b67360a4145b" resname="role.policy.content.unlock">
+        <source>Content / Unlock</source>
+        <target>Content / Unlock</target>
+        <note>key: role.policy.content.unlock</note>
+      </trans-unit>
       <trans-unit id="79ffa7a2f2449d08574ef7c5b1f447b439db97b2" resname="role.policy.content.urltranslator">
         <source>Content / Urltranslator</source>
         <target>Content / Urltranslator</target>

--- a/src/bundle/Resources/translations/messages.en.xliff
+++ b/src/bundle/Resources/translations/messages.en.xliff
@@ -354,11 +354,6 @@
         <target state="new">Any time</target>
         <note>key: search.any_time</note>
       </trans-unit>
-      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
-        <source>From date - to date</source>
-        <target state="new">From date - to date</target>
-        <note>key: search.date.range</note>
-      </trans-unit>
       <trans-unit id="9567771350aff93580f743089937b0c8fe31058e" resname="section.assign,content">
         <source>Assign Content</source>
         <target state="new">Assign Content</target>

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -51,6 +51,11 @@
         <target state="new">Custom range</target>
         <note>key: search.custom_range</note>
       </trans-unit>
+      <trans-unit id="f32993c555744e5c203137f3ee0e380d27e9cfef" resname="search.date.range">
+        <source>From date - to date</source>
+        <target state="new">From date - to date</target>
+        <note>key: search.date.range</note>
+      </trans-unit>
       <trans-unit id="bf24ae2c9083c948931ad1b4d4405b6261eb9bc6" resname="search.filters">
         <source>Filters</source>
         <target state="new">Filters</target>

--- a/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/form_fields.html.twig
@@ -197,7 +197,7 @@
         <input 
             type="text"
             class="ez-filters__range-select form-control"
-            placeholder="{{ 'search.date.range'|trans(domain='search')|desc('From date - to date') }}"
+            placeholder="{{ 'search.date.range'|trans({}, 'search')|desc('From date - to date') }}"
             data-start="{{ form.parent.vars.data.lastModified.start_date is defined ? form.parent.vars.data.lastModified.start_date|date("Y-m-d") : '' }}"
             data-end="{{ form.parent.vars.data.lastModified.end_date is defined ? form.parent.vars.data.lastModified.end_date|date("Y-m-d") : '' }}"
         />
@@ -214,7 +214,7 @@
         <input 
             type="text"
             class="ez-filters__range-select form-control"
-            placeholder="{{ 'search.date.range'|trans(domain='search')|desc('From date - to date') }}"
+            placeholder="{{ 'search.date.range'|trans({}, 'search')|desc('From date - to date') }}"
             data-start="{{ form.parent.vars.data.created.start_date is defined ? form.parent.vars.data.created.start_date|date("Y-m-d") : '' }}"
             data-end="{{ form.parent.vars.data.created.end_date is defined ? form.parent.vars.data.created.end_date|date("Y-m-d") : '' }}"
         />
@@ -233,7 +233,7 @@
         <input 
             type="text"
             class="ez-trash-search-form__range-select form-control"
-            placeholder="{{ 'search.date.range'|trans(domain='search')|desc('From date - to date') }}"
+            placeholder="{{ 'search.date.range'|trans({}, 'search')|desc('From date - to date') }}"
             data-start="{{ form.parent.vars.data.trashedInterval.start_date is defined ? form.parent.vars.data.trashedInterval.start_date|date("Y-m-d") : '' }}"
             data-end="{{ form.parent.vars.data.trashedInterval.end_date is defined ? form.parent.vars.data.trashedInterval.end_date|date("Y-m-d") : '' }}"
         />


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-5472
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Except search.date.range there are some other translation extracted, they probably should stay here as well?
"Created" translation was removed here https://github.com/ezsystems/ezplatform-admin-ui/pull/2067/files#diff-03a88b29d0af2169f521b6db3be86937e4791cfa8d844d022acd2a3646927d96R490


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
