### PR TITLE
IBX-6017: Avoid loading whole content in the Content Tree

### DIFF
--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -79,15 +79,22 @@ final class NodeFactory
     ): Node {
         $uninitializedContentInfoList = [];
         $containerLocations = [];
-        $node = $this->buildNode($location, $uninitializedContentInfoList, $containerLocations, $loadSubtreeRequestNode, $loadChildren, $depth, $sortClause, $sortOrder);
-        $contentById = $this->contentService->loadContentListByContentInfo($uninitializedContentInfoList);
+        $node = $this->buildNode(
+            $location,
+            $uninitializedContentInfoList,
+            $containerLocations,
+            $loadSubtreeRequestNode,
+            $loadChildren,
+            $depth,
+            $sortClause,
+            $sortOrder
+        );
 
         $aggregatedChildrenCount = null;
         if ($this->searchService->supports(SearchService::CAPABILITY_AGGREGATIONS)) {
             $aggregatedChildrenCount = $this->countAggregatedSubitems($containerLocations);
         }
 
-        $this->supplyTranslatedContentName($node, $contentById);
         $this->supplyChildrenCount($node, $aggregatedChildrenCount);
 
         return $node;
@@ -338,7 +345,7 @@ final class NodeFactory
             $depth,
             $location->id,
             $location->contentId,
-            '', // node name will be provided later by `supplyTranslatedContentName` method
+            $contentInfo->name,
             $contentType ? $contentType->identifier : '',
             $contentType ? $contentType->isContainer : true,
             $location->invisible || $location->hidden,
@@ -346,20 +353,6 @@ final class NodeFactory
             $totalChildrenCount,
             $children
         );
-    }
-
-    /**
-     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $contentById
-     */
-    private function supplyTranslatedContentName(Node $node, array $contentById): void
-    {
-        if ($node->contentId !== self::TOP_NODE_CONTENT_ID) {
-            $node->name = $this->translationHelper->getTranslatedContentName($contentById[$node->contentId]);
-        }
-
-        foreach ($node->children as $child) {
-            $this->supplyTranslatedContentName($child, $contentById);
-        }
     }
 
     /**

--- a/src/lib/UI/Module/ContentTree/NodeFactory.php
+++ b/src/lib/UI/Module/ContentTree/NodeFactory.php
@@ -96,7 +96,6 @@ final class NodeFactory
             $aggregatedChildrenCount = $this->countAggregatedSubitems($containerLocations);
         }
 
-
         $this->supplyTranslatedContentName($node, $versionInfoById);
         $this->supplyChildrenCount($node, $aggregatedChildrenCount);
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6017](https://issues.ibexa.co/browse/IBX-6017)
| Improvement?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

The idea is that we could implement `loadVersionInfos` PAPI method and get translated name based on this, just like it's done in `loadContentListByContentInfo` - this would have a much higher impact on performance though.

Blackfire profiles are included in the ticket's comments.

Requires:  https://github.com/ezsystems/ezplatform-kernel/pull/375

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
