### PR TITLE
IBX-2942: Added missing edit permission restrictions in UDW response

### DIFF
--- a/src/lib/UniversalDiscovery/UniversalDiscoveryProvider.php
+++ b/src/lib/UniversalDiscovery/UniversalDiscoveryProvider.php
@@ -191,6 +191,11 @@ class UniversalDiscoveryProvider implements Provider
             [Limitation::CONTENTTYPE, Limitation::LANGUAGE]
         );
 
+        $updateLimitationsValues = $this->lookupLimitationsTransformer->getGroupedLimitationValues(
+            $lookupCreateLimitationsResult,
+            [Limitation::CONTENTTYPE, Limitation::LANGUAGE]
+        );
+
         return [
             'create' => [
                 'hasAccess' => $lookupCreateLimitationsResult->hasAccess,
@@ -199,6 +204,8 @@ class UniversalDiscoveryProvider implements Provider
             ],
             'edit' => [
                 'hasAccess' => $lookupUpdateLimitationsResult->hasAccess,
+                'restrictedContentTypeIds' => $updateLimitationsValues[Limitation::CONTENTTYPE],
+                'restrictedLanguageCodes' => $updateLimitationsValues[Limitation::LANGUAGE],
             ],
         ];
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2942
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR does not fix bug described in [IBX-2942](https://issues.ibexa.co/browse/IBX-2942) but only provides backend part to this fix. 
Permission restrictions for content edit were missing in UDW response. This data are needed to limit access to content edit.


![Screen Shot 2023-08-28 at 09 34 32](https://github.com/ezsystems/ezplatform-admin-ui/assets/9850711/0a5ce3f5-54b2-4834-93e8-a68bfb1f30a9)


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
