### PR TITLE
IBX-6451: Calculating the size of the dropdown element has been changed

### DIFF
--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -142,14 +142,9 @@
             }
 
             if (this.itemsContainer.closest(SELECTOR_MODAL)) {
-                const heightModal = this.itemsContainer.closest('.modal-content').getBoundingClientRect().height;
-                const leftToBottom = heightModal - itemsContainerTop;
+                const modalHeight = this.itemsContainer.closest('.modal-content').getBoundingClientRect().height;
 
-                if (leftToBottom < itemsContainerTop) {
-                    return leftToBottom;
-                }
-
-                return itemsContainerTop - DROPDOWN_MARGIN;
+                return modalHeight - itemsContainerTop;
             }
 
             return documentElementHeight - itemsContainerTop - DROPDOWN_MARGIN;

--- a/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
+++ b/src/bundle/Resources/public/js/scripts/core/custom.dropdown.js
@@ -142,6 +142,13 @@
             }
 
             if (this.itemsContainer.closest(SELECTOR_MODAL)) {
+                const heightModal = this.itemsContainer.closest('.modal-content').getBoundingClientRect().height;
+                const leftToBottom = heightModal - itemsContainerTop;
+
+                if (leftToBottom < itemsContainerTop) {
+                    return leftToBottom;
+                }
+
                 return itemsContainerTop - DROPDOWN_MARGIN;
             }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6451](https://issues.ibexa.co/browse/IBX-6451)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


as itemsContainerTop may be too large relative to the remaining height of the bottom element at times. Therefore, a calculation was added on how much is left from the top of the modal to a given element. To check whether this value is greater or smaller than itemsContainerTop, also I did not subtract DROPDOWN_MARGIN from this value, because the margin is the size of the element

#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
