### PR TITLE
IBX-6592: Allowed `Location` to be a part of permission check for Object State assignment

### DIFF
--- a/src/bundle/Controller/ObjectStateController.php
+++ b/src/bundle/Controller/ObjectStateController.php
@@ -307,7 +307,8 @@ class ObjectStateController extends Controller
     public function updateContentStateAction(
         Request $request,
         ContentInfo $contentInfo,
-        ObjectStateGroup $objectStateGroup
+        ObjectStateGroup $objectStateGroup,
+        Location $location
     ): Response {
         if (!$this->permissionResolver->hasAccess('state', 'assign')) {
             $exception = $this->createAccessDeniedException();
@@ -319,7 +320,7 @@ class ObjectStateController extends Controller
 
         $form = $this->formFactory->create(
             ContentObjectStateUpdateType::class,
-            new ContentObjectStateUpdateData($contentInfo, $objectStateGroup)
+            new ContentObjectStateUpdateData($contentInfo, $objectStateGroup, null, $location)
         );
         $form->handleRequest($request);
 
@@ -328,7 +329,13 @@ class ObjectStateController extends Controller
                 $contentInfo = $data->getContentInfo();
                 $objectStateGroup = $data->getObjectStateGroup();
                 $objectState = $data->getObjectState();
-                $this->objectStateService->setContentState($contentInfo, $objectStateGroup, $objectState);
+                $location = $data->getLocation();
+                $this->objectStateService->setContentState(
+                    $contentInfo,
+                    $objectStateGroup,
+                    $objectState,
+                    $location
+                );
 
                 $this->notificationHandler->success(
                     /** @Desc("Content item's Object state changed to '%name%'.") */

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -821,7 +821,7 @@ ezplatform.object_state.state.bulk_delete:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ObjectStateController::bulkDeleteAction'
 
 ezplatform.object_state.contentstate.update:
-    path: /state/contentstate/update/{contentInfoId}/group/{objectStateGroupId}/{locationId}
+    path: /state/contentstate/update/{locationId}/group/{objectStateGroupId}
     defaults:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ObjectStateController::updateContentStateAction'
 

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -821,7 +821,7 @@ ezplatform.object_state.state.bulk_delete:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ObjectStateController::bulkDeleteAction'
 
 ezplatform.object_state.contentstate.update:
-    path: /state/contentstate/update/{contentInfoId}/group/{objectStateGroupId}
+    path: /state/contentstate/update/{contentInfoId}/group/{objectStateGroupId}/{locationId}
     defaults:
         _controller: 'EzSystems\EzPlatformAdminUiBundle\Controller\ObjectStateController::updateContentStateAction'
 

--- a/src/bundle/Resources/views/themes/admin/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/details.html.twig
@@ -124,13 +124,11 @@
                         {{ form_start(form_state_update[object_state.objectStateGroup.id], {
                             'method': 'POST',
                             'action': path('ezplatform.object_state.contentstate.update', {
-                                'contentInfoId': content_info.id,
                                 'objectStateGroupId': object_state.objectStateGroup.id,
                                 'locationId': location.id,
                             }),
                             'attr': {'class': 'form-inline ez-form-inline ez-form-inline--align-left'}
                         }) }}
-                            {{ form_row(form_state_update[object_state.objectStateGroup.id].contentInfo) }}
                             {{ form_row(form_state_update[object_state.objectStateGroup.id].objectStateGroup) }}
                             {{ form_row(form_state_update[object_state.objectStateGroup.id].objectState, { 'attr': {'class': 'ez-form-autosubmit'} }) }}
                             {% do form_state_update[object_state.objectStateGroup.id].set.setRendered %}

--- a/src/bundle/Resources/views/themes/admin/content/tab/details.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/details.html.twig
@@ -125,7 +125,8 @@
                             'method': 'POST',
                             'action': path('ezplatform.object_state.contentstate.update', {
                                 'contentInfoId': content_info.id,
-                                'objectStateGroupId': object_state.objectStateGroup.id
+                                'objectStateGroupId': object_state.objectStateGroup.id,
+                                'locationId': location.id,
                             }),
                             'attr': {'class': 'form-inline ez-form-inline ez-form-inline--align-left'}
                         }) }}

--- a/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
+++ b/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
@@ -8,16 +8,12 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformAdminUi\Form\Data\ObjectState;
 
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 
 class ContentObjectStateUpdateData
 {
-    /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo|null */
-    private $contentInfo;
-
     /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup|null */
     private $objectStateGroup;
 
@@ -28,25 +24,13 @@ class ContentObjectStateUpdateData
     private $location;
 
     public function __construct(
-        ContentInfo $contentInfo = null,
         ObjectStateGroup $objectStateGroup = null,
         ObjectState $objectState = null,
         Location $location = null
     ) {
-        $this->contentInfo = $contentInfo;
         $this->objectStateGroup = $objectStateGroup;
         $this->objectState = $objectState;
         $this->location = $location;
-    }
-
-    public function getContentInfo(): ContentInfo
-    {
-        return $this->contentInfo;
-    }
-
-    public function setContentInfo(ContentInfo $contentInfo)
-    {
-        $this->contentInfo = $contentInfo;
     }
 
     public function getObjectStateGroup(): ObjectStateGroup

--- a/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
+++ b/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
@@ -21,7 +21,7 @@ class ContentObjectStateUpdateData
     /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup|null */
     private $objectStateGroup;
 
-    /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectState|null rm -r*/
+    /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectState|null */
     private $objectState;
 
     /** @var \eZ\Publish\API\Repository\Values\Content\Location|null */

--- a/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
+++ b/src/lib/Form/Data/ObjectState/ContentObjectStateUpdateData.php
@@ -9,86 +9,73 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\Form\Data\ObjectState;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 
 class ContentObjectStateUpdateData
 {
-    /**
-     * @var \eZ\Publish\API\Repository\Values\Content\ContentInfo
-     */
+    /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo|null */
     private $contentInfo;
 
-    /**
-     * @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
-     */
+    /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup|null */
     private $objectStateGroup;
 
-    /**
-     * @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
-     */
+    /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectState|null rm -r*/
     private $objectState;
 
-    /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo|null $contentInfo
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup|null $objectStateGroup
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState|null $objectState
-     */
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location|null */
+    private $location;
+
     public function __construct(
         ContentInfo $contentInfo = null,
         ObjectStateGroup $objectStateGroup = null,
-        ObjectState $objectState = null
+        ObjectState $objectState = null,
+        Location $location = null
     ) {
         $this->contentInfo = $contentInfo;
         $this->objectStateGroup = $objectStateGroup;
         $this->objectState = $objectState;
+        $this->location = $location;
     }
 
-    /**
-     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
-     */
     public function getContentInfo(): ContentInfo
     {
         return $this->contentInfo;
     }
 
-    /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     */
     public function setContentInfo(ContentInfo $contentInfo)
     {
         $this->contentInfo = $contentInfo;
     }
 
-    /**
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
-     */
     public function getObjectStateGroup(): ObjectStateGroup
     {
         return $this->objectStateGroup;
     }
 
-    /**
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     */
     public function setObjectStateGroup(ObjectStateGroup $objectStateGroup)
     {
         $this->objectStateGroup = $objectStateGroup;
     }
 
-    /**
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState|null
-     */
     public function getObjectState(): ?ObjectState
     {
         return $this->objectState;
     }
 
-    /**
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
-     */
     public function setObjectState(ObjectState $objectState)
     {
         $this->objectState = $objectState;
+    }
+
+    public function getLocation(): ?Location
+    {
+        return $this->location;
+    }
+
+    public function setLocation(Location $location)
+    {
+        $this->location = $location;
     }
 }

--- a/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
+++ b/src/lib/Form/Type/ObjectState/ContentObjectStateUpdateType.php
@@ -60,20 +60,25 @@ class ContentObjectStateUpdateType extends AbstractType
             $contentObjectStateUpdateData = $event->getData();
             $objectStateGroup = $contentObjectStateUpdateData->getObjectStateGroup();
             $contentInfo = $contentObjectStateUpdateData->getContentInfo();
+            $location = $contentObjectStateUpdateData->getLocation();
             $form = $event->getForm();
 
             $form->add('objectState', ObjectStateChoiceType::class, [
                 'label' => false,
-                'choice_loader' => new CallbackChoiceLoader(function () use ($objectStateGroup, $contentInfo) {
-                    $contentState = $this->objectStateService->getContentState($contentInfo, $objectStateGroup);
-
-                    return array_filter(
-                        $this->objectStateService->loadObjectStates($objectStateGroup),
-                        function (ObjectState $objectState) use ($contentInfo, $contentState) {
-                            return $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]);
-                        }
-                    );
-                }),
+                'choice_loader' => new CallbackChoiceLoader(
+                    function () use ($objectStateGroup, $contentInfo, $location) {
+                        return array_filter(
+                            $this->objectStateService->loadObjectStates($objectStateGroup),
+                            function (ObjectState $objectState) use ($contentInfo, $location) {
+                                return $this->permissionResolver->canUser(
+                                    'state',
+                                    'assign',
+                                    $contentInfo,
+                                    [$location, $objectState],
+                                );
+                            }
+                        );
+                    }),
             ]);
         });
     }

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -133,7 +133,7 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
         ]);
 
         $this->supplySectionParameters($viewParameters, $contentInfo, $location);
-        $this->supplyObjectStateParameters($viewParameters, $contentInfo);
+        $this->supplyObjectStateParameters($viewParameters, $contentInfo, $location);
         $this->supplyTranslations($viewParameters, $versionInfo);
         $this->supplyFormLocationUpdate($viewParameters, $location);
         $this->supplyCreator($viewParameters, $contentInfo);
@@ -185,14 +185,13 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
         }
     }
 
-    /**
-     * @param \ArrayObject $parameters
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     */
-    private function supplyObjectStateParameters(ArrayObject &$parameters, ContentInfo $contentInfo): void
-    {
+    private function supplyObjectStateParameters(
+        ArrayObject &$parameters,
+        ContentInfo $contentInfo,
+        Location $location
+    ): void {
         $objectStatesDataset = $this->datasetFactory->objectStates();
-        $objectStatesDataset->load($contentInfo);
+        $objectStatesDataset->load($contentInfo, $location);
 
         $canAssignObjectState = $this->canUserAssignObjectState();
 
@@ -206,7 +205,10 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
                 $objectStateUpdateForm = $this->formFactory->create(
                     ContentObjectStateUpdateType::class,
                     new ContentObjectStateUpdateData(
-                        $contentInfo, $objectStateGroup, $objectState
+                        $contentInfo,
+                        $objectStateGroup,
+                        $objectState,
+                        $location,
                     )
                 )->createView();
 

--- a/src/lib/Tab/LocationView/DetailsTab.php
+++ b/src/lib/Tab/LocationView/DetailsTab.php
@@ -116,6 +116,8 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
 
     /**
      * @inheritdoc
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function getTemplateParameters(array $contextParameters = []): array
     {
@@ -133,7 +135,7 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
         ]);
 
         $this->supplySectionParameters($viewParameters, $contentInfo, $location);
-        $this->supplyObjectStateParameters($viewParameters, $contentInfo, $location);
+        $this->supplyObjectStateParameters($viewParameters, $location);
         $this->supplyTranslations($viewParameters, $versionInfo);
         $this->supplyFormLocationUpdate($viewParameters, $location);
         $this->supplyCreator($viewParameters, $contentInfo);
@@ -185,13 +187,15 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
         }
     }
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     private function supplyObjectStateParameters(
         ArrayObject &$parameters,
-        ContentInfo $contentInfo,
         Location $location
     ): void {
         $objectStatesDataset = $this->datasetFactory->objectStates();
-        $objectStatesDataset->load($contentInfo, $location);
+        $objectStatesDataset->load($location);
 
         $canAssignObjectState = $this->canUserAssignObjectState();
 
@@ -205,7 +209,6 @@ class DetailsTab extends AbstractEventDispatchingTab implements OrderedTabInterf
                 $objectStateUpdateForm = $this->formFactory->create(
                     ContentObjectStateUpdateType::class,
                     new ContentObjectStateUpdateData(
-                        $contentInfo,
                         $objectStateGroup,
                         $objectState,
                         $location,

--- a/src/lib/UI/Dataset/ObjectStatesDataset.php
+++ b/src/lib/UI/Dataset/ObjectStatesDataset.php
@@ -31,6 +31,7 @@ class ObjectStatesDataset
         $this->objectStateService = $objectStateService;
         $this->valueFactory = $valueFactory;
     }
+
     public function load(ContentInfo $contentInfo, Location $location): self
     {
         $data = array_map(

--- a/src/lib/UI/Dataset/ObjectStatesDataset.php
+++ b/src/lib/UI/Dataset/ObjectStatesDataset.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
 
 use eZ\Publish\API\Repository\ObjectStateService;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use EzSystems\EzPlatformAdminUi\UI\Value as UIValue;
@@ -32,16 +31,16 @@ class ObjectStatesDataset
         $this->valueFactory = $valueFactory;
     }
 
-    public function load(ContentInfo $contentInfo, Location $location): self
+    public function load(Location $location): self
     {
         $data = array_map(
-            function (ObjectStateGroup $objectStateGroup) use ($contentInfo, $location) {
+            function (ObjectStateGroup $objectStateGroup) use ($location) {
                 $hasObjectStates = !empty($this->objectStateService->loadObjectStates($objectStateGroup));
                 if (!$hasObjectStates) {
                     return [];
                 }
 
-                return $this->valueFactory->createObjectState($contentInfo, $objectStateGroup, $location);
+                return $this->valueFactory->createObjectState($objectStateGroup, $location);
             },
             $this->objectStateService->loadObjectStateGroups()
         );

--- a/src/lib/UI/Dataset/ObjectStatesDataset.php
+++ b/src/lib/UI/Dataset/ObjectStatesDataset.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\UI\Dataset;
 
 use eZ\Publish\API\Repository\ObjectStateService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use EzSystems\EzPlatformAdminUi\UI\Value as UIValue;
 use EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory;
@@ -25,31 +26,21 @@ class ObjectStatesDataset
     /** @var UIValue\ObjectState\ObjectState[] */
     protected $data;
 
-    /**
-     * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
-     * @param \EzSystems\EzPlatformAdminUi\UI\Value\ValueFactory $valueFactory
-     */
     public function __construct(ObjectStateService $objectStateService, ValueFactory $valueFactory)
     {
         $this->objectStateService = $objectStateService;
         $this->valueFactory = $valueFactory;
     }
-
-    /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return ObjectStatesDataset
-     */
-    public function load(ContentInfo $contentInfo): self
+    public function load(ContentInfo $contentInfo, Location $location): self
     {
         $data = array_map(
-            function (ObjectStateGroup $objectStateGroup) use ($contentInfo) {
+            function (ObjectStateGroup $objectStateGroup) use ($contentInfo, $location) {
                 $hasObjectStates = !empty($this->objectStateService->loadObjectStates($objectStateGroup));
                 if (!$hasObjectStates) {
                     return [];
                 }
 
-                return $this->valueFactory->createObjectState($contentInfo, $objectStateGroup);
+                return $this->valueFactory->createObjectState($contentInfo, $objectStateGroup, $location);
             },
             $this->objectStateService->loadObjectStateGroups()
         );

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -16,7 +16,6 @@ use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\DraftList\Item\ContentDraftListItem;
 use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem;
 use eZ\Publish\API\Repository\Values\Content\Language;
@@ -257,10 +256,10 @@ class ValueFactory
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function createObjectState(
-        ContentInfo $contentInfo,
         ObjectStateGroup $objectStateGroup,
         Location $location
     ): UIValue\ObjectState\ObjectState {
+        $contentInfo = $location->getContentInfo();
         $objectState = $this->objectStateService->getContentState($contentInfo, $objectStateGroup);
 
         return new UIValue\ObjectState\ObjectState($objectState, [

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -253,22 +253,23 @@ class ValueFactory
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     *
-     * @return UIValue\ObjectState\ObjectState
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function createObjectState(
         ContentInfo $contentInfo,
-        ObjectStateGroup $objectStateGroup
+        ObjectStateGroup $objectStateGroup,
+        Location $location
     ): UIValue\ObjectState\ObjectState {
         $objectState = $this->objectStateService->getContentState($contentInfo, $objectStateGroup);
 
         return new UIValue\ObjectState\ObjectState($objectState, [
-            'userCanAssign' => $this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState]),
+            'userCanAssign' => $this->permissionResolver->canUser(
+                'state',
+                'assign',
+                $contentInfo,
+                [$location, $objectState],
+            ),
         ]);
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-6592](https://issues.ibexa.co/browse/IBX-6592)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Requires: https://github.com/ezsystems/ezplatform-kernel/pull/391

Currently, Content Object State assignment is done utilizing `ContentInfo`, which in my opinion is wrong, as that leaves Subtree Limitation pretty much useless, and yet, this limitation is available for a choosing when we are dealing with the `state/assign` policy.

Therefore, `ContentInfo` was replaced with `Location` everywhere where it touches Object States assignment.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
