### PR TITLE
IBX-1464: Added `versionNo` param in the `ezimage` edit form template

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimage.html.twig
@@ -39,7 +39,8 @@
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId')
+                            'contentId' : app.request.get('contentId'),
+                            'versionNo' : app.request.get('versionNo')
                         }
                     ) }}
                 </div>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/edit/ezimageasset.html.twig
@@ -119,7 +119,8 @@
                         'image-edit-actions-after',
                         {
                             'fieldDefinitionIdentifier' : form.parent.vars.value.fieldDefinition.identifier,
-                            'contentId' : app.request.get('contentId')
+                            'contentId' : app.request.get('contentId'),
+                            'versionNo' : app.request.get('versionNo')
                         }
                     ) }}
                 </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1464](https://issues.ibexa.co/browse/IBX-1464)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This param is needed for an Image Editor to be allowed to edit draft content with the `ezimage` fieldtype.

Related PR: https://github.com/ibexa/image-editor/pull/81

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
