### PR TITLE
IBX-6540: Added Depth sort to breadcrumbs

### DIFF
--- a/src/lib/QueryType/LocationPathQueryType.php
+++ b/src/lib/QueryType/LocationPathQueryType.php
@@ -45,7 +45,7 @@ final class LocationPathQueryType extends OptionsResolverBasedQueryType
 
         return new LocationQuery([
             'filter' => $filter,
-            'sortClauses' => [new Depth()]
+            'sortClauses' => [new Depth()],
         ]);
     }
 

--- a/src/lib/QueryType/LocationPathQueryType.php
+++ b/src/lib/QueryType/LocationPathQueryType.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformAdminUi\QueryType;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth;
 use eZ\Publish\Core\QueryType\OptionsResolverBasedQueryType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -42,7 +43,10 @@ final class LocationPathQueryType extends OptionsResolverBasedQueryType
             ? new Query\Criterion\ParentLocationId($rootLocationId)
             : new Query\Criterion\LocationId($this->getParentLocationPath($location));
 
-        return new LocationQuery(['filter' => $filter]);
+        return new LocationQuery([
+            'filter' => $filter,
+            'sortClauses' => [new Depth()]
+        ]);
     }
 
     private function getParentLocationPath(Location $location): array


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-6450
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

UDW columns are currently ordered based on the sequence of breadcrumbs in AccordionData. Typically, everything ran smoothly when utilizing IDs associated with deeper levels in the tree structure, where nested elements consistently had higher IDs than their parent counterparts. However, inconsistencies emerged in some cases, particularly when IDs did not follow this pattern. This issue is likely to recur in UDW if locations are moved.

The problem surfaced on Postgres, where the default sort order does not rely on IDs.

Proposing a solution by sorting columns based on depth, ensuring consistent breadcrumb order. There may be debates about whether JS/UDW should handle this, but I believe it's acceptable.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
