### PR TITLE
IBX-7954: Show error message on empty image asset

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -98,6 +98,18 @@
                 return field.fieldDefinitionIdentifier === imageAssetMapping['contentFieldIdentifier'];
             });
 
+            if (imageField.fieldValue === null) {
+                showErrorNotification(
+                    Translator.trans(
+                        /* @Desc("The chosen asset has no image data available.") */ 'ezimageasset.empty_data.message.error',
+                        {},
+                        'fieldtypes_preview'
+                    )
+                );
+
+                return;
+            }
+
             this.updateData(
                 response.ContentInfo.Content._id,
                 response.ContentInfo.Content.TranslatedName,
@@ -126,18 +138,6 @@
          * @param {Object} image
          */
         updateData(destinationContentId, destinationContentName, destinationLocationId, image) {
-            if (image === null) {
-                showErrorNotification(
-                    Translator.trans(
-                        /* @Desc("The chosen asset has no image data available.") */ 'ezimageasset.empty_data.message.error',
-                        {},
-                        'fieldtypes_preview'
-                    )
-                );
-
-                return;
-            }
-
             const preview = this.fieldContainer.querySelector('.ez-field-edit__preview');
             const previewVisual = preview.querySelector('.ez-field-edit-preview__visual');
             const previewImg = preview.querySelector('.ez-field-edit-preview__media');

--- a/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezimageasset.js
@@ -126,6 +126,18 @@
          * @param {Object} image
          */
         updateData(destinationContentId, destinationContentName, destinationLocationId, image) {
+            if (image === null) {
+                showErrorNotification(
+                    Translator.trans(
+                        /* @Desc("The chosen asset has no image data available.") */ 'ezimageasset.empty_data.message.error',
+                        {},
+                        'fieldtypes_preview'
+                    )
+                );
+
+                return;
+            }
+
             const preview = this.fieldContainer.querySelector('.ez-field-edit__preview');
             const previewVisual = preview.querySelector('.ez-field-edit-preview__visual');
             const previewImg = preview.querySelector('.ez-field-edit-preview__media');

--- a/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
+++ b/src/bundle/Resources/translations/fieldtypes_preview.en.xliff
@@ -81,6 +81,11 @@
         <target state="new">Alternative text</target>
         <note>key: ezimageasset.alternative_text</note>
       </trans-unit>
+      <trans-unit id="75c1175bca5f2a2334ffe321afdaedf7fa6887bd" resname="ezimageasset.empty_data.message.error">
+        <source>The chosen asset has no image data available.</source>
+        <target state="new">The chosen asset has no image data available.</target>
+        <note>key: ezimageasset.empty_data.message.error</note>
+      </trans-unit>
       <trans-unit id="6ccdfa3f93ea5a6c0c17a7a9f6fe8fac4d5b6926" resname="ezimageasset.file_name">
         <source>File name</source>
         <target state="new">File name</target>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-7954](https://issues.ibexa.co/browse/IBX-7954)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

In case a chosen related asset has no image instead of JS console error we should show a message.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
