### PR TITLE
IBX-7983: Handled previewing `ezimage` field with height of 0

### DIFF
--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -433,10 +433,12 @@
                         <td>{{ 'ezimage.master_dimensions'|trans|desc('Master dimensions') }}:</td>
                         <td>{{ 'ezimage.width_and_height'|trans({'%width%': field.value.width, '%height%': field.value.height})|desc('Width: %width%px height: %height%px') }}</td>
                     </tr>
-                    <tr class="ez-field-preview__meta-value-row">
-                        <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
-                        <td>{{ (field.value.width/field.value.height)|round(2) }}</td>
-                    </tr>
+                    {% if (field.value.height is not same as '0') %}
+                        <tr class="ez-field-preview__meta-value-row">
+                            <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
+                            <td>{{ (field.value.width/field.value.height)|round(2) }}</td>
+                        </tr>
+                    {% endif %}
                 </tbody>
             </table>
         </div>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -433,7 +433,7 @@
                         <td>{{ 'ezimage.master_dimensions'|trans|desc('Master dimensions') }}:</td>
                         <td>{{ 'ezimage.width_and_height'|trans({'%width%': field.value.width, '%height%': field.value.height})|desc('Width: %width%px height: %height%px') }}</td>
                     </tr>
-                    {% if (field.value.height != '0') %}
+                    {% if field.value.height != '0' %}
                         <tr class="ez-field-preview__meta-value-row">
                             <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
                             <td>{{ (field.value.width/field.value.height)|round(2) }}</td>

--- a/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/ui/field_type/preview/content_fields.html.twig
@@ -433,7 +433,7 @@
                         <td>{{ 'ezimage.master_dimensions'|trans|desc('Master dimensions') }}:</td>
                         <td>{{ 'ezimage.width_and_height'|trans({'%width%': field.value.width, '%height%': field.value.height})|desc('Width: %width%px height: %height%px') }}</td>
                     </tr>
-                    {% if (field.value.height is not same as '0') %}
+                    {% if (field.value.height != '0') %}
                         <tr class="ez-field-preview__meta-value-row">
                             <td>{{ 'ezimage.ratio'|trans|desc('Ratio') }}:</td>
                             <td>{{ (field.value.width/field.value.height)|round(2) }}</td>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-7983](https://issues.ibexa.co/browse/IBX-7983)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Division by `0` is impossible, hence, the change.

 `.avif` files in later PHP versions should be handled properly by the `getimagesize` method (since PHP 8.1 RC3), but we still have to handle older files somehow (dimension values are stored in .xmls in a database).

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
