### PR TITLE
IBX-8079: Inconsistent redirect point after role assignment action

### DIFF
--- a/src/bundle/Controller/RoleAssignmentController.php
+++ b/src/bundle/Controller/RoleAssignmentController.php
@@ -132,6 +132,7 @@ class RoleAssignmentController extends Controller
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
                     'roleId' => $role->id,
+                    '_fragment' => 'users-and-groups',
                 ]));
             });
 
@@ -220,6 +221,7 @@ class RoleAssignmentController extends Controller
 
                 return new RedirectResponse($this->generateUrl('ezplatform.role.view', [
                     'roleId' => $role->id,
+                    '_fragment' => 'users-and-groups',
                 ]));
             });
 

--- a/src/lib/Menu/Admin/Role/RoleAssignmentCreateRightSidebarBuilder.php
+++ b/src/lib/Menu/Admin/Role/RoleAssignmentCreateRightSidebarBuilder.php
@@ -66,6 +66,7 @@ class RoleAssignmentCreateRightSidebarBuilder extends AbstractBuilder implements
                     'route' => 'ezplatform.role.view',
                     'routeParameters' => [
                         'roleId' => $role->id,
+                        '_fragment' => 'users-and-groups',
                     ],
                     'extras' => ['icon' => 'circle-close'],
                 ]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-8079](https://issues.ibexa.co/browse/IBX-8079)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Dealing with assignments in Role configurations, redirects you to the "Policies" tab after every action. The "Assigments" tab should automatically be selected after adding/removing role assigments

For instance, when clicking the "Delete" button in the modal below, the user should see the content of the "Assigments" tab when the page refreshes
![image](https://github.com/ezsystems/ezplatform-admin-ui/assets/289778/f63372c8-c72d-4642-b305-fcdd3e206d9e)


Note when merging up: Anchor is named `ibexa-tab-users-and-groups` (not `users-and-groups`) in Ibexa 4.x

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
