### PR TITLE
IBX-8350: Text line fields which is not marked as required, but has a minimum length constraint set, is basically treated as required

### DIFF
--- a/src/bundle/Resources/public/js/scripts/fieldType/ezstring.js
+++ b/src/bundle/Resources/public/js/scripts/fieldType/ezstring.js
@@ -17,7 +17,7 @@
             const isEmpty = !event.target.value;
             const isTooShort = event.target.value.length < parseInt(event.target.dataset.min, 10);
             const isTooLong = event.target.value.length > parseInt(event.target.dataset.max, 10);
-            const isError = (isEmpty && isRequired) || isTooShort || isTooLong;
+            const isError = (isEmpty && isRequired) || (!isEmpty && (isTooShort || isTooLong));
             const label = event.target.closest(SELECTOR_FIELD).querySelector('.ez-field-edit__label').innerHTML;
             const result = { isError };
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-8350](https://issues.ibexa.co/browse/IBX-8350)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

When input is checked for length constrains in JS, it is not taken into account whatever the field is empty or not. ( As long as the field is not required, it is okay that the value is empty even if it has a constrain on minimum characters )

This PR is a re-make of https://github.com/ezsystems/ezplatform-admin-ui/pull/2120 which closed due to a comma in branch name which caused problems for CI

PR 2120 is already reviewed and approved by QA

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
