### PR TITLE
IBX-10174 Add fetch limit to Is Within Copy Subtree Limit

### DIFF
--- a/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
+++ b/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
@@ -44,7 +44,7 @@ class IsWithinCopySubtreeLimit extends AbstractSpecification
             return false;
         }
 
-        return $this->copyLimit >= $this->locationService->getSubtreeSize($item);
+        return $this->copyLimit >= $this->locationService->getSubtreeSize($item, $this->copyLimit + 1);
     }
 
     private function isContainer(Location $location): bool


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-10174](https://issues.ibexa.co/browse/IBX-10174)
| Bug fix?      | yes
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
| Requires     | https://github.com/ezsystems/ezplatform-kernel/pull/412

# What
Explained in more detail in https://github.com/ezsystems/ezplatform-kernel/pull/412 , this PR leverages the new "limitation" addition to the public API to update the IsWithinCopySubtreeLimit check to query for exactly how many items it needs to know before terminating the query

# Why
See the other PR (Query that underpins this does not scale well)

# How
See other PR (Limiting the query makes it significantly faster)


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
