### PR TITLE
IBX-10186 Limit impact of heavy count queries on the CMS

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -297,7 +297,7 @@ class LocationController extends Controller
                 $currentLocation = $data->getCurrentLocation();
                 $newLocation = $data->getNewLocation();
 
-                $childCount = $this->locationService->getLocationChildCount($currentLocation);
+                $childCount = $this->locationService->getLocationChildCount($currentLocation, 1);
                 $contentType = $newLocation->getContent()->getContentType();
 
                 if (!$contentType->isContainer && $childCount) {

--- a/src/bundle/DependencyInjection/Configuration/Parser/SubtreeOperations.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SubtreeOperations.php
@@ -30,17 +30,23 @@ class SubtreeOperations extends AbstractParser
     /**
      * @inheritdoc
      */
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    public function mapConfig(array & $scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
-        if (!isset($scopeSettings['subtree_operations']['copy_subtree']['limit'])) {
-            return;
+        if (isset($scopeSettings['subtree_operations']['copy_subtree']['limit'])) {
+            $contextualizer->setContextualParameter(
+                'subtree_operations.copy_subtree.limit',
+                $currentScope,
+                $scopeSettings['subtree_operations']['copy_subtree']['limit']
+            );
         }
 
-        $contextualizer->setContextualParameter(
-            'subtree_operations.copy_subtree.limit',
-            $currentScope,
-            $scopeSettings['subtree_operations']['copy_subtree']['limit']
-        );
+        if (isset($scopeSettings['subtree_operations']['query_subtree']['limit'])) {
+            $contextualizer->setContextualParameter(
+                'subtree_operations.query_subtree.limit',
+                $currentScope,
+                $scopeSettings['subtree_operations']['query_subtree']['limit']
+            );
+        }
     }
 
     public function addSemanticConfig(NodeBuilder $nodeBuilder): void
@@ -57,6 +63,14 @@ class SubtreeOperations extends AbstractParser
                             ->end()
                         ->end()
                     ->end()
+                    ->arrayNode('query_subtree')
+                        ->children()
+                            ->integerNode('limit')
+                                ->info('Limit the total count of items queried for when calculating the the number of direct children a node has. -1 for no limit. Default is 500 for performance reasons.')
+                                ->defaultValue(500)
+                                ->isRequired()
+                            ->end()
+                        ->end()
                 ->end()
             ->end();
     }

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -41,6 +41,7 @@ parameters:
 
     # Subtree Operations
     ezsettings.admin_group.subtree_operations.copy_subtree.limit: 100
+    ezsettings.admin_group.subtree_operations.query_subtree.limit: 500
 
     # Notifications
     ezsettings.admin_group.notifications.error.timeout: 0

--- a/src/bundle/Resources/views/themes/admin/content/tab/locations/tab.html.twig
+++ b/src/bundle/Resources/views/themes/admin/content/tab/locations/tab.html.twig
@@ -34,7 +34,7 @@
                         <td class="ez-table__cell">
                             {% include '@ezdesign/ui/location_path.html.twig' with {'locations': location.pathLocations, 'link_last_element': true} %}
                         </td>
-                        <td class="ez-table__cell">{{ location.childCount }}</td>
+                        <td class="ez-table__cell">{% if sub_item_query_limit is not null and location.childCount > sub_item_query_limit %}{{ location.childCount -1 }}+{% else %}{{location.childCount}}{% endif %}</td>
                         <td class="ez-table__cell">
                             <label class="ez-checkbox-icon {{ not location.explicitlyHidden ? 'is-checked' }}{% if not can_hide[location.id] %} disabled{% endif %}"
                                    title="{{ 'tab.locations.visibility'|trans|desc('Visibility') }}">

--- a/src/lib/Form/TrashLocationOptionProvider/HasChildren.php
+++ b/src/lib/Form/TrashLocationOptionProvider/HasChildren.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformAdminUi\Form\TrashLocationOptionProvider;
 
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformAdminUi\Specification\Location\HasChildren as HasChildrenSpec;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
@@ -23,10 +24,14 @@ final class HasChildren implements TrashLocationOptionProvider
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
 
-    public function __construct(LocationService $locationService, TranslatorInterface $translator)
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(LocationService $locationService, TranslatorInterface $translator, ConfigResolverInterface $configResolver)
     {
         $this->locationService = $locationService;
         $this->translator = $translator;
+        $this->configResolver = $configResolver;
     }
 
     public function supports(Location $location): bool
@@ -36,10 +41,15 @@ final class HasChildren implements TrashLocationOptionProvider
 
     public function addOptions(FormInterface $form, Location $location): void
     {
-        $childCount = $this->locationService->getLocationChildCount($location);
+        $limit = $this->configResolver->getParameter('subtree_operations.query_subtree.limit');
+
+        $useLimit = $limit > 0;
+        $childCount = $this->locationService->getLocationChildCount($location, $useLimit ? $limit + 1 : null);
 
         $translatorParameters = [
-            '%children_count%' => $childCount,
+            '%children_count%' => ($useLimit && $childCount >= $limit) ?
+                sprintf('%d+', $limit) :
+                $childCount,
             '%content_name%' => $location->getContent()->getName(),
         ];
 

--- a/src/lib/Specification/Location/HasChildren.php
+++ b/src/lib/Specification/Location/HasChildren.php
@@ -31,7 +31,7 @@ class HasChildren extends AbstractSpecification
      */
     public function isSatisfiedBy($item): bool
     {
-        $childCount = $this->locationService->getLocationChildCount($item);
+        $childCount = $this->locationService->getLocationChildCount($item, 1);
 
         return 0 < $childCount;
     }

--- a/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
+++ b/src/lib/Specification/Location/IsWithinCopySubtreeLimit.php
@@ -44,7 +44,7 @@ class IsWithinCopySubtreeLimit extends AbstractSpecification
             return false;
         }
 
-        return $this->copyLimit >= $this->locationService->getSubtreeSize($item);
+        return $this->copyLimit >= $this->locationService->getSubtreeSize($item, $this->copyLimit + 1);
     }
 
     private function isContainer(Location $location): bool

--- a/src/lib/Tab/LocationView/LocationsTab.php
+++ b/src/lib/Tab/LocationView/LocationsTab.php
@@ -184,12 +184,18 @@ class LocationsTab extends AbstractEventDispatchingTab implements OrderedTabInte
             );
         }
 
+        $subItemQueryLimit = $this->configResolver->getParameter('subtree_operations.query_subtree.limit');
+        if ($subItemQueryLimit <= 0) {
+            $subItemQueryLimit = null;
+        }
+
         $viewParameters = [
             'pager' => $pagination,
             'pager_options' => [
                 'pageParameter' => sprintf('[%s]', self::PAGINATION_PARAM_NAME),
             ],
             'locations' => $locations,
+            'sub_item_query_limit' => $subItemQueryLimit,
             'form_content_location_add' => $formLocationAdd->createView(),
             'form_content_location_remove' => $formLocationRemove->createView(),
             'form_content_location_swap' => $formLocationSwap->createView(),

--- a/src/lib/UI/Module/Subitems/ContentViewParameterSupplier.php
+++ b/src/lib/UI/Module/Subitems/ContentViewParameterSupplier.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\Query\QueryFactoryInterface;
 use EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypeMappings;
@@ -71,6 +72,9 @@ class ContentViewParameterSupplier
     /** @var \eZ\Publish\API\Repository\SearchService */
     private $searchService;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
     public function __construct(
         Visitor $outputVisitor,
         JsonOutputGenerator $outputGenerator,
@@ -83,7 +87,8 @@ class ContentViewParameterSupplier
         ContentTypeMappings $contentTypeMappings,
         UserSettingService $userSettingService,
         QueryFactoryInterface $queryFactory,
-        SearchService $searchService
+        SearchService $searchService,
+        ConfigResolverInterface $configResolver
     ) {
         $this->outputVisitor = $outputVisitor;
         $this->outputGenerator = $outputGenerator;
@@ -97,6 +102,7 @@ class ContentViewParameterSupplier
         $this->userSettingService = $userSettingService;
         $this->queryFactory = $queryFactory;
         $this->searchService = $searchService;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -187,7 +193,12 @@ class ContentViewParameterSupplier
     {
         return new RestLocation(
             $location,
-            $this->locationService->getLocationChildCount($location)
+            $this->locationService->getLocationChildCount(
+                $location,
+                 // For the sub items module we only ever use the count to determine if there are children (0 or 1+),
+                 // hence setting a limit of 1 is sufficient here.
+                1
+            )
         );
     }
 

--- a/src/lib/UI/Value/ValueFactory.php
+++ b/src/lib/UI/Value/ValueFactory.php
@@ -30,6 +30,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
 use eZ\Publish\SPI\Limitation\Target;
@@ -74,6 +75,9 @@ class ValueFactory
     /** @var \eZ\Publish\Core\Repository\LocationResolver\LocationResolver */
     protected $locationResolver;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    protected $configResolver;
+
     /**
      * @param \eZ\Publish\API\Repository\UserService $userService
      * @param \eZ\Publish\API\Repository\LanguageService $languageService
@@ -86,6 +90,7 @@ class ValueFactory
      * @param \EzSystems\EzPlatformAdminUi\UI\Dataset\DatasetFactory $datasetFactory
      * @param \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider
      * @param \eZ\Publish\Core\Repository\LocationResolver\LocationResolver $locationResolver
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      */
     public function __construct(
         UserService $userService,
@@ -98,7 +103,8 @@ class ValueFactory
         PathService $pathService,
         DatasetFactory $datasetFactory,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
-        LocationResolver $locationResolver
+        LocationResolver $locationResolver,
+        ConfigResolverInterface $configResolver
     ) {
         $this->userService = $userService;
         $this->languageService = $languageService;
@@ -111,6 +117,7 @@ class ValueFactory
         $this->datasetFactory = $datasetFactory;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->locationResolver = $locationResolver;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -235,9 +242,11 @@ class ValueFactory
     {
         $translations = $location->getContent()->getVersionInfo()->languageCodes;
         $target = (new Target\Version())->deleteTranslations($translations);
+        $limit = $this->configResolver->getParameter('subtree_operations.query_subtree.limit');
+        $useLimit = $limit > 0;
 
         return new UIValue\Content\Location($location, [
-            'childCount' => $this->locationService->getLocationChildCount($location),
+            'childCount' => $this->locationService->getLocationChildCount($location, $useLimit ? $limit + 1 : null),
             'pathLocations' => $this->pathService->loadPathLocations($location),
             'userCanManage' => $this->permissionResolver->canUser(
                 'content', 'manage_locations', $location->getContentInfo()


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-10186](https://issues.ibexa.co/browse/IBX-10186)
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | ...Possibly?
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

>[!WARNING]
> This PR does result in UI changes to the admin (Mainly surrounding the rendering of certain sub item counts by overall showing the limitations as given)
> Also note the fact that everything in https://github.com/ezsystems/ezplatform-admin-ui/pull/2124 is still relevant to this PR. Read the description of that PR given it's chages are included in this PR

# What
This PR leverages changes made in https://github.com/ezsystems/ezplatform-kernel/pull/413 in order to limit the performance impact of loading sub item counts.

This includes:
 * Limiting `EXISTS` style queries to "1" instead of scanning the entire table
 * Limiting Sub Item counts in the CMS overall to a configurable value sat under `subtree_operations.query_subtree.limit`. Everywhere wherre a sub-item count is taken from the database has been updated to respect this new parameter. Always fetching the `subtree_operations.query_subtree.limit + 1` and in the event of there being more than the limts worth of items adding a "+" to the end of the displayed value. This might be

# How
This PR leverages the changes made in https://github.com/ezsystems/ezplatform-kernel/pull/413 by fetching suitable amount of data when performing CMS fetches.

A default global limit has been set in configuration of 500 items for rendering "subitem" results. This _should_ be enough to allow for CMS users to see all relevant values for the numbers in the sense that 4 -> 5 sub items is likely more important information than `565 -> 566` given this value is configurable this cap can be removed as need be. 

For the UDW  `'c-finder-leaf--has-children': !!location.childCount,` is the only use case for the supplied subquery counts resulting in large amounts of DB overhead verses other given queries

# Why
The overhead of these count queries is significant in relation to the effects they have on the CMS. See a side by side view for the same request with and without this PR on a page with many sub items. Doctrine usage drops from 50% of the overall wall time for the CMS to load a request.
![image (5)](https://github.com/user-attachments/assets/e1f087dd-5841-4ac6-943b-a820ee9ac6eb)

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
