### PR TITLE
Extend PHP version constraint to include 8.1-8.5 and fix XSS vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "ext-json": "*",
         "symfony/http-foundation": "^5.0",
         "symfony/security-core": "^5.0",


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Coding standards (`$ composer fix-cs`)
- [ ] Ready for Code Review
